### PR TITLE
Track active-assembly per thread, not globally

### DIFF
--- a/WoofWare.PawPrint/Assembly.fs
+++ b/WoofWare.PawPrint/Assembly.fs
@@ -28,6 +28,7 @@ type DumpedAssembly =
         Logger : ILogger
         TypeDefs : IReadOnlyDictionary<TypeDefinitionHandle, WoofWare.PawPrint.TypeInfo>
         TypeRefs : IReadOnlyDictionary<TypeReferenceHandle, WoofWare.PawPrint.TypeRef>
+        TypeSpecs : IReadOnlyDictionary<TypeSpecificationHandle, WoofWare.PawPrint.TypeSpec>
         Methods : IReadOnlyDictionary<MethodDefinitionHandle, WoofWare.PawPrint.MethodInfo>
         Members : IReadOnlyDictionary<MemberReferenceHandle, WoofWare.PawPrint.MemberReference<MetadataToken>>
         Fields : IReadOnlyDictionary<FieldDefinitionHandle, WoofWare.PawPrint.FieldInfo>
@@ -207,6 +208,15 @@ module Assembly =
                 )
             |> ImmutableDictionary.CreateRange
 
+        let typeSpecs =
+            let result = ImmutableDictionary.CreateBuilder ()
+
+            for i = 1 to metadataReader.GetTableRowCount TableIndex.TypeSpec do
+                let handle = MetadataTokens.TypeSpecificationHandle i
+                result.Add (handle, metadataReader.GetTypeSpecification handle |> TypeSpec.make handle)
+
+            result.ToImmutable ()
+
         let memberReferences =
             let builder = ImmutableDictionary.CreateBuilder ()
 
@@ -270,6 +280,7 @@ module Assembly =
             Logger = logger
             TypeDefs = typeDefs
             TypeRefs = typeRefs
+            TypeSpecs = typeSpecs
             MainMethod = entryPointMethod
             Methods = methods
             MethodDefinitions = methodDefnMetadata

--- a/WoofWare.PawPrint/TypeSpec.fs
+++ b/WoofWare.PawPrint/TypeSpec.fs
@@ -1,0 +1,19 @@
+namespace WoofWare.PawPrint
+
+open System.Reflection.Metadata
+
+type TypeSpec =
+    {
+        Handle : TypeSpecificationHandle
+        Signature : TypeDefn
+    }
+
+[<RequireQualifiedAccess>]
+module TypeSpec =
+    let make (handle : TypeSpecificationHandle) (r : TypeSpecification) : TypeSpec =
+        let spec = r.DecodeSignature (TypeDefn.typeProvider, ())
+
+        {
+            Handle = handle
+            Signature = spec
+        }

--- a/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
+++ b/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="Namespace.fs" />
     <Compile Include="ExportedType.fs" />
     <Compile Include="TypeDefn.fs" />
+    <Compile Include="TypeSpec.fs" />
     <Compile Include="FieldInfo.fs" />
     <Compile Include="IlOp.fs" />
     <Compile Include="MethodInfo.fs" />


### PR DESCRIPTION
It makes no sense to track it globally!