### PR TITLE
Implement `ret`

### DIFF
--- a/WoofWare.PawPrint/AbstractMachine.fs
+++ b/WoofWare.PawPrint/AbstractMachine.fs
@@ -1090,6 +1090,8 @@ module AbstractMachine =
         | Callvirt -> failwith "todo"
         | Castclass -> failwith "todo"
         | Newobj ->
+            // TODO: allocate the object, and pass it as the first argument to the constructor. Check the rest of what
+            // newobj is supposed to do, and do it.
             let state, assy, ctor =
                 match metadataToken with
                 | MethodDef md ->

--- a/WoofWare.PawPrint/IlOp.fs
+++ b/WoofWare.PawPrint/IlOp.fs
@@ -239,6 +239,10 @@ type NullaryIlOp =
     | Readonly
     | Refanytype
 
+    /// The number of bytes this instruction takes in memory.
+    static member NumberOfBytes (op : NullaryIlOp) : int =
+        TODO
+
 type UnaryConstIlOp =
     | Stloc of uint16
     | Stloc_s of int8
@@ -287,6 +291,11 @@ type UnaryConstIlOp =
     | Ldloca of uint16
     | Ldarg of uint16
 
+    /// The number of bytes this instruction takes in memory, including its constant argument that is inline in the
+    /// byte stream.
+    static member NumberOfBytes (op : UnaryConstIlOp) : int =
+        TODO: check the number of bytes in the argument, and check the special list of multi-byte ops below, and add the count.
+
 type UnaryMetadataTokenIlOp =
     | Call
     | Calli
@@ -319,6 +328,40 @@ type UnaryMetadataTokenIlOp =
     | Mkrefany
     | Refanyval
     | Jmp
+
+    /// The number of bytes this instruction takes in memory, including its metadata token argument.
+    static member NumberOfBytes (op : UnaryMetadataTokenIlOp) : int =
+        4 + TODO: check the list of multi-byte ops below
+
+/// BEGIN LIST OF MULTI-BYTE ARGS
+0xFE 0x00 	arglist 	Return argument list handle for the current method. 	Base instruction
+0xFE 0x01 	ceq 	Push 1 (of type int32) if value1 equals value2, else push 0. 	Base instruction
+0xFE 0x02 	cgt 	Push 1 (of type int32) if value1 greater than value2, else push 0. 	Base instruction
+0xFE 0x03 	cgt.un 	Push 1 (of type int32) if value1 greater than value2, unsigned or unordered, else push 0. 	Base instruction
+0xFE 0x04 	clt 	Push 1 (of type int32) if value1 lower than value2, else push 0. 	Base instruction
+0xFE 0x05 	clt.un 	Push 1 (of type int32) if value1 lower than value2, unsigned or unordered, else push 0. 	Base instruction
+0xFE 0x06 	ldftn <method> 	Push a pointer to a method referenced by method, on the stack. 	Base instruction
+0xFE 0x07 	ldvirtftn <method> 	Push address of virtual method on the stack. 	Object model instruction
+0xFE 0x09 	ldarg <uint16 (num)> 	Load argument numbered num onto the stack. 	Base instruction
+0xFE 0x0A 	ldarga <uint16 (argNum)> 	Fetch the address of argument argNum. 	Base instruction
+0xFE 0x0B 	starg <uint16 (num)> 	Store value to the argument numbered num. 	Base instruction
+0xFE 0x0C 	ldloc <uint16 (indx)> 	Load local variable of index indx onto stack. 	Base instruction
+0xFE 0x0D 	ldloca <uint16 (indx)> 	Load address of local variable with index indx. 	Base instruction
+0xFE 0x0E 	stloc <uint16 (indx)> 	Pop a value from stack into local variable indx. 	Base instruction
+0xFE 0x0F 	localloc 	Allocate space from the local memory pool. 	Base instruction
+0xFE 0x11 	endfilter 	End an exception handling filter clause. 	Base instruction
+0xFE 0x12 	unaligned. (alignment) 	Subsequent pointer instruction might be unaligned. 	Prefix to instruction
+0xFE 0x13 	volatile. 	Subsequent pointer reference is volatile. 	Prefix to instruction
+0xFE 0x14 	tail. 	Subsequent call terminates current method. 	Prefix to instruction
+0xFE 0x15 	initobj <typeTok> 	Initialize the value at address dest. 	Object model instruction
+0xFE 0x16 	constrained. <thisType> 	Call a virtual method on a type constrained to be type T. 	Prefix to instruction
+0xFE 0x17 	cpblk 	Copy data from memory to memory. 	Base instruction
+0xFE 0x18 	initblk 	Set all bytes in a block of memory to a given byte value. 	Base instruction
+0xFE 0x19 	no 	The specified fault check(s) normally performed as part of the execution of the subsequent instruction can/shall be skipped. 	Prefix to instruction
+0xFE 0x1A 	rethrow 	Rethrow the current exception. 	Object model instruction
+0xFE 0x1C 	sizeof <typeTok> 	Push the size, in bytes, of a type as an unsigned int32. 	Object model instruction
+0xFE 0x1D 	refanytype 	Push the type token stored in a typed reference. 	Object model instruction
+0xFE 0x1E 	readonly. 	Specify that the subsequent array address operation performs no type check at runtime, and that it returns a controlled-mutability managed pointer. 	Prefix to instruction
 
 type UnaryStringTokenIlOp = | Ldstr
 

--- a/WoofWare.PawPrint/IlOp.fs
+++ b/WoofWare.PawPrint/IlOp.fs
@@ -242,9 +242,21 @@ type NullaryIlOp =
     /// The number of bytes this instruction takes in memory.
     static member NumberOfBytes (op : NullaryIlOp) : int =
         match op with
-        | Arglist | Ceq | Cgt | Cgt_un | Clt | Clt_un | Localloc
-        | Endfilter | Volatile | Tail | Cpblk | Initblk | Rethrow
-        | Refanytype | Readonly -> 2
+        | Arglist
+        | Ceq
+        | Cgt
+        | Cgt_un
+        | Clt
+        | Clt_un
+        | Localloc
+        | Endfilter
+        | Volatile
+        | Tail
+        | Cpblk
+        | Initblk
+        | Rethrow
+        | Refanytype
+        | Readonly -> 2
         | _ -> 1
 
 type UnaryConstIlOp =
@@ -299,18 +311,49 @@ type UnaryConstIlOp =
     /// byte stream.
     static member NumberOfBytes (op : UnaryConstIlOp) : int =
         match op with
-        | Ldarg _uint16 | Ldarga _uint16 | Starg _uint16
-        | Ldloc _uint16 | Ldloca _uint16 | Stloc _uint16 -> 2 + 2 // Two-byte opcode + two-byte argument
-        | Ldarg_s _ | Ldarga_s _ | Starg_s _
-        | Ldloc_s _ | Ldloca_s _ | Stloc_s _
-        | Ldc_I4_s _ | Br_s _ | Brfalse_s _ | Brtrue_s _
-        | Beq_s _ | Blt_s _ | Ble_s _ | Bgt_s _ | Bge_s _
-        | Bne_un_s _ | Bge_un_s _ | Bgt_un_s _ | Ble_un_s _ | Blt_un_s _
-        | Leave_s _ | Unaligned _ -> 1 + 1 // One-byte opcode + one-byte argument
+        | Ldarg _uint16
+        | Ldarga _uint16
+        | Starg _uint16
+        | Ldloc _uint16
+        | Ldloca _uint16
+        | Stloc _uint16 -> 2 + 2 // Two-byte opcode + two-byte argument
+        | Ldarg_s _
+        | Ldarga_s _
+        | Starg_s _
+        | Ldloc_s _
+        | Ldloca_s _
+        | Stloc_s _
+        | Ldc_I4_s _
+        | Br_s _
+        | Brfalse_s _
+        | Brtrue_s _
+        | Beq_s _
+        | Blt_s _
+        | Ble_s _
+        | Bgt_s _
+        | Bge_s _
+        | Bne_un_s _
+        | Bge_un_s _
+        | Bgt_un_s _
+        | Ble_un_s _
+        | Blt_un_s _
+        | Leave_s _
+        | Unaligned _ -> 1 + 1 // One-byte opcode + one-byte argument
         | Ldc_I8 _ -> 1 + 8 // One-byte opcode + 8-byte argument
-        | Ldc_I4 _ | Br _ | Brfalse _ | Brtrue _
-        | Beq _ | Blt _ | Ble _ | Bgt _ | Bge _
-        | Bne_un _ | Bge_un _ | Bgt_un _ | Ble_un _ | Blt_un _
+        | Ldc_I4 _
+        | Br _
+        | Brfalse _
+        | Brtrue _
+        | Beq _
+        | Blt _
+        | Ble _
+        | Bgt _
+        | Bge _
+        | Bne_un _
+        | Bge_un _
+        | Bgt_un _
+        | Ble_un _
+        | Blt_un _
         | Leave _ -> 1 + 4 // One-byte opcode + 4-byte argument
         | Ldc_R4 _ -> 1 + 4 // One-byte opcode + 4-byte argument
         | Ldc_R8 _ -> 1 + 8 // One-byte opcode + 8-byte argument
@@ -351,7 +394,11 @@ type UnaryMetadataTokenIlOp =
     /// The number of bytes this instruction takes in memory, including its metadata token argument.
     static member NumberOfBytes (op : UnaryMetadataTokenIlOp) : int =
         match op with
-        | Ldftn | Ldvirtftn | Initobj | Constrained | Sizeof -> 2 + 4 // Two-byte opcode + 4-byte token
+        | Ldftn
+        | Ldvirtftn
+        | Initobj
+        | Constrained
+        | Sizeof -> 2 + 4 // Two-byte opcode + 4-byte token
         | Call
         | Calli
         | Callvirt
@@ -379,7 +426,12 @@ type UnaryMetadataTokenIlOp =
         | Refanyval
         | Jmp -> 1 + 4 // One-byte opcode + 4-byte token
 
-type UnaryStringTokenIlOp = | Ldstr
+type UnaryStringTokenIlOp =
+    | Ldstr
+
+    static member NumberOfBytes (op : UnaryStringTokenIlOp) : int =
+        match op with
+        | Ldstr -> 1 + 4
 
 type IlOp =
     | Nullary of NullaryIlOp
@@ -389,3 +441,11 @@ type IlOp =
     | Switch of int32 ImmutableArray
 
     static member Format (opCode : IlOp) (offset : int) : string = $"    IL_%04X{offset}: %-20O{opCode}"
+
+    static member NumberOfBytes (op : IlOp) =
+        match op with
+        | Nullary op -> NullaryIlOp.NumberOfBytes op
+        | UnaryConst op -> UnaryConstIlOp.NumberOfBytes op
+        | UnaryMetadataToken (op, _) -> UnaryMetadataTokenIlOp.NumberOfBytes op
+        | UnaryStringToken (op, _) -> UnaryStringTokenIlOp.NumberOfBytes op
+        | Switch arr -> 1 + 4 + arr.Length * 4


### PR DESCRIPTION
After this PR, the implementation of HelloWorld incorrectly defers loading the Program module until after the `main` call (that's a behavioural bug, although not one that should affect most users), but then we do the following:

* Call `reallyMain`
* Identify that we are loading `System.Console.WriteLine`, looking it up and discovering that it is forwarded to System.Private.CoreLib
* Identify the base class of `System.Console` (namely `obj`), call its static constructor (there is none), call the static constructor of `System.Console` which has three opcodes (`newobj`, `stsfld`, and `ret`: this allocates and stores [a single reference type](https://github.com/dotnet/runtime/blob/5535e31a712343a63f5d7d796cd874e563e5ac14/src/libraries/System.Console/src/System/Console.cs#L27), the others being value types which should be initialised to their default values, but I haven't implemented that bit yet)
* Imperfectly call `newobj`, which in this case is constructing a `System.Object`; that is simply a `ret` opcode, which we execute. Note that we are supposed to have performed an allocation, and I haven't done that yet!
* Identify that we're calling `stsfld`, and throw-with-TODO.