### PR TITLE
Track generics at runtime

### DIFF
--- a/WoofWare.PawPrint.Test/TestBasicLock.fs
+++ b/WoofWare.PawPrint.Test/TestBasicLock.fs
@@ -5,6 +5,7 @@ open System.IO
 open FsUnitTyped
 open NUnit.Framework
 open WoofWare.PawPrint
+open WoofWare.PawPrint.ExternImplementations
 open WoofWare.PawPrint.Test
 open WoofWare.DotnetRuntimeLocator
 
@@ -21,7 +22,7 @@ module TestBasicLock =
         let dotnetRuntimes =
             DotnetRuntime.SelectForDll assy.Location |> ImmutableArray.CreateRange
 
-        let impls = MockEnv.make ()
+        let impls = NativeImpls.PassThru ()
 
         use peImage = new MemoryStream (image)
 

--- a/WoofWare.PawPrint.Test/TestCases.fs
+++ b/WoofWare.PawPrint.Test/TestCases.fs
@@ -41,7 +41,7 @@ module TestCases =
             {
                 FileName = "WriteLine.cs"
                 ExpectedReturnCode = 1
-                NativeImpls = MockEnv.make ()
+                NativeImpls = NativeImpls.PassThru ()
                 LocalVariablesOfMain = []
             }
         ]

--- a/WoofWare.PawPrint.Test/TestHelloWorld.fs
+++ b/WoofWare.PawPrint.Test/TestHelloWorld.fs
@@ -6,6 +6,7 @@ open System.IO
 open FsUnitTyped
 open NUnit.Framework
 open WoofWare.PawPrint
+open WoofWare.PawPrint.ExternImplementations
 open WoofWare.PawPrint.Test
 open WoofWare.DotnetRuntimeLocator
 
@@ -15,14 +16,14 @@ module TestHelloWorld =
 
     [<Test ; Explicit "This test doesn't run yet">]
     let ``Can run Hello World`` () : unit =
-        let source = Assembly.getEmbeddedResourceAsString "HelloWorld.cs" assy
+        let source = Assembly.getEmbeddedResourceAsString "WriteLine.cs" assy
         let image = Roslyn.compile [ source ]
         let messages, loggerFactory = LoggerFactory.makeTest ()
 
         let dotnetRuntimes =
             DotnetRuntime.SelectForDll assy.Location |> ImmutableArray.CreateRange
 
-        let impls = MockEnv.make ()
+        let impls = NativeImpls.PassThru ()
 
         try
             use peImage = new MemoryStream (image)

--- a/WoofWare.PawPrint/AbstractMachine.fs
+++ b/WoofWare.PawPrint/AbstractMachine.fs
@@ -22,10 +22,11 @@ module AbstractMachine =
         match instruction.ExecutingMethod.Instructions with
         | None ->
             let targetAssy =
-                state.LoadedAssembly (snd instruction.ExecutingMethod.DeclaringType)
+                state.LoadedAssembly instruction.ExecutingMethod.DeclaringType.Assembly
                 |> Option.get
 
-            let targetType = targetAssy.TypeDefs.[fst instruction.ExecutingMethod.DeclaringType]
+            let targetType =
+                targetAssy.TypeDefs.[instruction.ExecutingMethod.DeclaringType.Definition.Get]
 
             let outcome =
                 match
@@ -80,10 +81,10 @@ module AbstractMachine =
         | true, executingInstruction ->
 
         let executingInType =
-            match state.LoadedAssembly (snd instruction.ExecutingMethod.DeclaringType) with
+            match state.LoadedAssembly instruction.ExecutingMethod.DeclaringType.Assembly with
             | None -> "<unloaded assembly>"
             | Some assy ->
-                match assy.TypeDefs.TryGetValue (fst instruction.ExecutingMethod.DeclaringType) with
+                match assy.TypeDefs.TryGetValue instruction.ExecutingMethod.DeclaringType.Definition.Get with
                 | true, v -> v.Name
                 | false, _ -> "<unrecognised type>"
 

--- a/WoofWare.PawPrint/Assembly.fs
+++ b/WoofWare.PawPrint/Assembly.fs
@@ -61,7 +61,7 @@ type DumpedAssembly =
         /// <summary>
         /// Dictionary of all method definitions in this assembly, keyed by their handle.
         /// </summary>
-        Methods : IReadOnlyDictionary<MethodDefinitionHandle, WoofWare.PawPrint.MethodInfo>
+        Methods : IReadOnlyDictionary<MethodDefinitionHandle, WoofWare.PawPrint.MethodInfo<FakeUnit>>
 
         /// <summary>
         /// Dictionary of all member references in this assembly, keyed by their handle.

--- a/WoofWare.PawPrint/BasicCliType.fs
+++ b/WoofWare.PawPrint/BasicCliType.fs
@@ -144,7 +144,7 @@ module CliType =
             match signatureTypeKind with
             | SignatureTypeKind.Unknown -> failwith "todo"
             | SignatureTypeKind.ValueType ->
-                let typeDef = assy.TypeDefs.[typeDefinitionHandle]
+                let typeDef = assy.TypeDefs.[typeDefinitionHandle.Get]
 
                 let fields =
                     typeDef.Fields

--- a/WoofWare.PawPrint/ComparableSignatureHeader.fs
+++ b/WoofWare.PawPrint/ComparableSignatureHeader.fs
@@ -1,0 +1,36 @@
+namespace WoofWare.PawPrint
+
+open System
+open System.Reflection.Metadata
+
+[<CustomEquality>]
+[<CustomComparison>]
+type ComparableSignatureHeader =
+    private
+        {
+            _Inner : SignatureHeader
+        }
+
+    member this.Get = this._Inner
+
+    override this.Equals (other : obj) =
+        match other with
+        | :? ComparableSignatureHeader as other -> this._Inner.RawValue = other._Inner.RawValue
+        | _ -> false
+
+    override this.GetHashCode () = this._Inner.RawValue.GetHashCode ()
+
+    interface IComparable<ComparableSignatureHeader> with
+        member this.CompareTo (other : ComparableSignatureHeader) =
+            this._Inner.RawValue.CompareTo other._Inner.RawValue
+
+    interface IComparable with
+        member this.CompareTo (other : obj) =
+            match other with
+            | :? ComparableSignatureHeader as other -> (this :> IComparable<ComparableSignatureHeader>).CompareTo other
+            | _ -> failwith "invalid comparison"
+
+    static member Make x : ComparableSignatureHeader =
+        {
+            _Inner = x
+        }

--- a/WoofWare.PawPrint/ComparableTypeDefinitionHandle.fs
+++ b/WoofWare.PawPrint/ComparableTypeDefinitionHandle.fs
@@ -1,0 +1,37 @@
+namespace WoofWare.PawPrint
+
+open System
+open System.Reflection.Metadata
+
+[<CustomEquality>]
+[<CustomComparison>]
+type ComparableTypeDefinitionHandle =
+    private
+        {
+            _Inner : TypeDefinitionHandle
+        }
+
+    override this.Equals (other) =
+        match other with
+        | :? ComparableTypeDefinitionHandle as other -> this._Inner.GetHashCode () = other._Inner.GetHashCode ()
+        | _ -> false
+
+    override this.GetHashCode () : int = this._Inner.GetHashCode ()
+
+    interface IComparable<ComparableTypeDefinitionHandle> with
+        member this.CompareTo (other : ComparableTypeDefinitionHandle) : int =
+            this._Inner.GetHashCode().CompareTo (other._Inner.GetHashCode ())
+
+    interface IComparable with
+        member this.CompareTo (other : obj) : int =
+            match other with
+            | :? ComparableTypeDefinitionHandle as other ->
+                (this :> IComparable<ComparableTypeDefinitionHandle>).CompareTo other
+            | _ -> failwith "invalid comparison"
+
+    static member Make (h : TypeDefinitionHandle) =
+        {
+            _Inner = h
+        }
+
+    member this.Get = this._Inner

--- a/WoofWare.PawPrint/ConcreteType.fs
+++ b/WoofWare.PawPrint/ConcreteType.fs
@@ -1,0 +1,88 @@
+namespace WoofWare.PawPrint
+
+open System
+open System.Reflection
+open System.Reflection.Metadata
+
+type FakeUnit = private | FakeUnit
+
+/// A type which has been concretised, runtime-representable, etc.
+[<CustomEquality>]
+[<CustomComparison>]
+type ConcreteType<'typeGeneric when 'typeGeneric : comparison and 'typeGeneric :> IComparable<'typeGeneric>> =
+    private
+        {
+            _AssemblyName : AssemblyName
+            _Definition : ComparableTypeDefinitionHandle
+            _Generics : 'typeGeneric list
+        }
+
+    member this.Assembly : AssemblyName = this._AssemblyName
+    member this.Definition : ComparableTypeDefinitionHandle = this._Definition
+    member this.Generics : 'typeGeneric list = this._Generics
+
+    override this.Equals (other : obj) : bool =
+        match other with
+        | :? ConcreteType<'typeGeneric> as other ->
+            this._Generics = other._Generics
+            && this._Definition = other._Definition
+            && this._AssemblyName.FullName = other._AssemblyName.FullName
+        | _ -> false
+
+    override this.GetHashCode () : int =
+        hash (this._AssemblyName.FullName, this._Definition, this._Generics)
+
+    interface IComparable<ConcreteType<'typeGeneric>> with
+        member this.CompareTo (other : ConcreteType<'typeGeneric>) : int =
+            let comp = this._AssemblyName.FullName.CompareTo other._AssemblyName.FullName
+
+            if comp = 0 then
+                let comp =
+                    (this._Definition :> IComparable<ComparableTypeDefinitionHandle>).CompareTo other._Definition
+
+                if comp = 0 then
+                    let thisGen = (this._Generics : 'typeGeneric list) :> IComparable<'typeGeneric list>
+                    thisGen.CompareTo other._Generics
+                else
+                    comp
+            else
+                comp
+
+    interface IComparable with
+        member this.CompareTo other =
+            match other with
+            | :? ConcreteType<'typeGeneric> as other ->
+                (this :> IComparable<ConcreteType<'typeGeneric>>).CompareTo other
+            | _ -> failwith "bad comparison"
+
+type RuntimeConcreteType = ConcreteType<TypeDefn>
+
+[<RequireQualifiedAccess>]
+module ConcreteType =
+    let make (assemblyName : AssemblyName) (defn : TypeDefinitionHandle) (generics : TypeDefn list) =
+        {
+            _AssemblyName = assemblyName
+            _Definition = ComparableTypeDefinitionHandle.Make defn
+            _Generics = generics
+        }
+
+    let make' (assemblyName : AssemblyName) (defn : TypeDefinitionHandle) : ConcreteType<FakeUnit> =
+        {
+            _AssemblyName = assemblyName
+            _Definition = ComparableTypeDefinitionHandle.Make defn
+            _Generics = []
+        }
+
+    let mapGeneric<'a, 'b
+        when 'a : comparison and 'a :> IComparable<'a> and 'b : equality and 'b : comparison and 'b :> IComparable<'b>>
+        (f : int -> 'a -> 'b)
+        (x : ConcreteType<'a>)
+        : ConcreteType<'b>
+        =
+        let generics = x._Generics |> List.mapi f
+
+        {
+            _AssemblyName = x._AssemblyName
+            _Definition = x._Definition
+            _Generics = generics
+        }

--- a/WoofWare.PawPrint/ConcreteType.fs
+++ b/WoofWare.PawPrint/ConcreteType.fs
@@ -66,11 +66,16 @@ module ConcreteType =
             _Generics = generics
         }
 
-    let make' (assemblyName : AssemblyName) (defn : TypeDefinitionHandle) : ConcreteType<FakeUnit> =
+    let make'
+        (assemblyName : AssemblyName)
+        (defn : TypeDefinitionHandle)
+        (genericParamCount : int)
+        : ConcreteType<FakeUnit>
+        =
         {
             _AssemblyName = assemblyName
             _Definition = ComparableTypeDefinitionHandle.Make defn
-            _Generics = []
+            _Generics = List.replicate genericParamCount FakeUnit.FakeUnit
         }
 
     let mapGeneric<'a, 'b

--- a/WoofWare.PawPrint/EvalStack.fs
+++ b/WoofWare.PawPrint/EvalStack.fs
@@ -75,7 +75,10 @@ module EvalStackValue =
             | CliNumericType.Int64 int64 -> failwith "todo"
             | CliNumericType.NativeInt int64 -> failwith "todo"
             | CliNumericType.NativeFloat f -> failwith "todo"
-            | CliNumericType.Int8 b -> failwith "todo"
+            | CliNumericType.Int8 _ ->
+                match popped with
+                | EvalStackValue.Int32 i -> CliType.Numeric (CliNumericType.Int8 (i % 256 |> int8))
+                | i -> failwith $"TODO: %O{i}"
             | CliNumericType.Int16 s -> failwith "todo"
             | CliNumericType.UInt8 b -> failwith "todo"
             | CliNumericType.UInt16 s -> failwith "todo"

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -553,15 +553,14 @@ module IlMachineState =
                 |> List.tryFind (fun method -> method.Name = ".cctor" && method.IsStatic && method.Parameters.IsEmpty)
 
             match cctor with
-            | Some ctorMethod ->
+            | Some cctorMethod ->
                 // Call the class constructor! Note that we *don't* use `callMethodInActiveAssembly`, because that
                 // performs class loading, but we're already in the middle of loading this class.
                 // TODO: factor out the common bit.
                 let currentThreadState = state.ThreadState.[currentThread]
 
-                let ctorMethod =
-                    ctorMethod
-                    |> MethodInfo.mapTypeGenerics (fun _ -> failwith "constructor can't have generics")
+                let cctorMethod =
+                    cctorMethod |> MethodInfo.mapTypeGenerics (fun i _ -> ty.Generics.[i])
 
                 callMethod
                     loggerFactory
@@ -570,7 +569,7 @@ module IlMachineState =
                     true
                     // constructor is surely not generic
                     None
-                    ctorMethod
+                    cctorMethod
                     currentThread
                     currentThreadState
                     state

--- a/WoofWare.PawPrint/MethodInfo.fs
+++ b/WoofWare.PawPrint/MethodInfo.fs
@@ -612,6 +612,9 @@ module MethodInfo =
 
         let declaringType = methodDef.GetDeclaringType ()
 
+        let declaringTypeGenericParams =
+            metadataReader.GetTypeDefinition(declaringType).GetGenericParameters().Count
+
         let attrs =
             let result = ImmutableArray.CreateBuilder ()
             let attrs = methodDef.GetCustomAttributes ()
@@ -631,7 +634,7 @@ module MethodInfo =
             GenericParameter.readAll metadataReader (methodDef.GetGenericParameters ())
 
         {
-            DeclaringType = ConcreteType.make' assemblyName declaringType
+            DeclaringType = ConcreteType.make' assemblyName declaringType declaringTypeGenericParams
             Handle = methodHandle
             Name = methodName
             Instructions = methodBody
@@ -644,3 +647,47 @@ module MethodInfo =
             ImplAttributes = implAttrs
         }
         |> Some
+
+    let rec resolveBaseType
+        (methodGenerics : TypeDefn ImmutableArray option)
+        (executingMethod : MethodInfo<TypeDefn>)
+        (td : TypeDefn)
+        : ResolvedBaseType
+        =
+        match td with
+        | TypeDefn.Void -> failwith "Void isn't a type that appears at runtime and has no base type"
+        | TypeDefn.PrimitiveType ty ->
+            match ty with
+            | PrimitiveType.SByte
+            | PrimitiveType.Byte
+            | PrimitiveType.Int16
+            | PrimitiveType.UInt16
+            | PrimitiveType.Int32
+            | PrimitiveType.UInt32
+            | PrimitiveType.Int64
+            | PrimitiveType.UInt64
+            | PrimitiveType.Single
+            | PrimitiveType.Double
+            | PrimitiveType.Char
+            | PrimitiveType.Boolean -> ResolvedBaseType.ValueType
+            | PrimitiveType.String -> ResolvedBaseType.Object
+            | PrimitiveType.TypedReference -> failwith "todo"
+            | PrimitiveType.IntPtr -> failwith "todo"
+            | PrimitiveType.UIntPtr -> failwith "todo"
+            | PrimitiveType.Object -> failwith "todo"
+        | TypeDefn.Array (elt, shape) -> failwith "todo"
+        | TypeDefn.Pinned typeDefn -> failwith "todo"
+        | TypeDefn.Pointer typeDefn -> failwith "todo"
+        | TypeDefn.Byref typeDefn -> failwith "todo"
+        | TypeDefn.OneDimensionalArrayLowerBoundZero elements -> failwith "todo"
+        | TypeDefn.Modified (original, afterMod, modificationRequired) -> failwith "todo"
+        | TypeDefn.FromReference (typeRef, signatureTypeKind) -> failwith "todo"
+        | TypeDefn.FromDefinition (comparableTypeDefinitionHandle, signatureTypeKind) -> failwith "todo"
+        | TypeDefn.GenericInstantiation (generic, args) -> failwith "todo"
+        | TypeDefn.FunctionPointer typeMethodSignature -> failwith "todo"
+        | TypeDefn.GenericTypeParameter index ->
+            resolveBaseType methodGenerics executingMethod executingMethod.DeclaringType.Generics.[index]
+        | TypeDefn.GenericMethodParameter index ->
+            match methodGenerics with
+            | None -> failwith "unexpectedly asked for a generic method parameter when we had none"
+            | Some generics -> resolveBaseType methodGenerics executingMethod generics.[index]

--- a/WoofWare.PawPrint/TypeDefn.fs
+++ b/WoofWare.PawPrint/TypeDefn.fs
@@ -1,10 +1,15 @@
 namespace WoofWare.PawPrint
 
-open System
 open System.Collections.Immutable
 open System.Reflection.Metadata
 open System.Reflection.Metadata.Ecma335
 open Microsoft.FSharp.Core
+
+type ResolvedBaseType =
+    | Enum
+    | ValueType
+    | Object
+    | Delegate
 
 /// <summary>
 /// Represents a method signature with type parameters.
@@ -93,6 +98,7 @@ type PrimitiveType =
 
 type TypeDefn =
     | PrimitiveType of PrimitiveType
+    // TODO: array shapes
     | Array of elt : TypeDefn * shape : unit
     | Pinned of TypeDefn
     | Pointer of TypeDefn

--- a/WoofWare.PawPrint/TypeInfo.fs
+++ b/WoofWare.PawPrint/TypeInfo.fs
@@ -39,7 +39,7 @@ type TypeInfo<'generic> =
         /// <summary>
         /// All methods defined within this type.
         /// </summary>
-        Methods : WoofWare.PawPrint.MethodInfo list
+        Methods : WoofWare.PawPrint.MethodInfo<FakeUnit> list
 
         /// <summary>
         /// Method implementation mappings for this type, often used for interface implementations

--- a/WoofWare.PawPrint/TypeInfo.fs
+++ b/WoofWare.PawPrint/TypeInfo.fs
@@ -14,12 +14,6 @@ type BaseTypeInfo =
     | TypeSpec of TypeSpecificationHandle
     | ForeignAssemblyType of assemblyName : AssemblyName * TypeDefinitionHandle
 
-type ResolvedBaseType =
-    | Enum
-    | ValueType
-    | Object
-    | Delegate
-
 type MethodImplParsed =
     | MethodImplementation of MethodImplementationHandle
     | MethodDefinition of MethodDefinitionHandle

--- a/WoofWare.PawPrint/TypeInitialisation.fs
+++ b/WoofWare.PawPrint/TypeInitialisation.fs
@@ -11,32 +11,22 @@ type TypeInitState =
 
 /// Tracks the initialization state of types across assemblies. The string in the key is the FullName of the AssemblyName where the type comes from.
 // TODO: need a better solution than string here! AssemblyName didn't work, we had nonequal assembly names.
-type TypeInitTable = ImmutableDictionary<TypeDefinitionHandle * string, TypeInitState>
+type TypeInitTable = ImmutableDictionary<RuntimeConcreteType, TypeInitState>
 
 [<RequireQualifiedAccess>]
 module TypeInitTable =
-    let tryGet (typeDef : TypeDefinitionHandle, assy : AssemblyName) (t : TypeInitTable) =
-        match t.TryGetValue ((typeDef, assy.FullName)) with
+    let tryGet (ty : RuntimeConcreteType) (t : TypeInitTable) =
+        match t.TryGetValue ty with
         | true, v -> Some v
         | false, _ -> None
 
-    let beginInitialising
-        (thread : ThreadId)
-        (typeDef : TypeDefinitionHandle, assy : AssemblyName)
-        (t : TypeInitTable)
-        : TypeInitTable
-        =
-        match t.TryGetValue ((typeDef, assy.FullName)) with
-        | false, _ -> t.Add ((typeDef, assy.FullName), TypeInitState.InProgress thread)
+    let beginInitialising (thread : ThreadId) (ty : RuntimeConcreteType) (t : TypeInitTable) : TypeInitTable =
+        match t.TryGetValue ty with
+        | false, _ -> t.Add (ty, TypeInitState.InProgress thread)
         | true, v -> failwith "Logic error: tried initialising a type which has already started initialising"
 
-    let markInitialised
-        (thread : ThreadId)
-        (typeDef : TypeDefinitionHandle, assy : AssemblyName)
-        (t : TypeInitTable)
-        : TypeInitTable
-        =
-        match t.TryGetValue ((typeDef, assy.FullName)) with
+    let markInitialised (thread : ThreadId) (ty : RuntimeConcreteType) (t : TypeInitTable) : TypeInitTable =
+        match t.TryGetValue ty with
         | false, _ -> failwith "Logic error: completing initialisation of a type which never started initialising"
         | true, TypeInitState.Initialized ->
             failwith "Logic error: completing initialisation of a type which has already finished initialising"
@@ -45,4 +35,4 @@ module TypeInitTable =
                 failwith
                     "Logic error: completed initialisation of a type on a different thread to the one which started it!"
             else
-                t.SetItem ((typeDef, assy.FullName), TypeInitState.Initialized)
+                t.SetItem (ty, TypeInitState.Initialized)

--- a/WoofWare.PawPrint/TypeRef.fs
+++ b/WoofWare.PawPrint/TypeRef.fs
@@ -1,11 +1,59 @@
 namespace WoofWare.PawPrint
 
+open System
 open System.Reflection.Metadata
+open Microsoft.FSharp.Core
 
+[<CustomComparison>]
+[<CustomEquality>]
 type TypeRefResolutionScope =
     | Assembly of AssemblyReferenceHandle
     | ModuleRef of ModuleReferenceHandle
     | TypeRef of TypeReferenceHandle
+
+    override this.Equals (other : obj) : bool =
+        let other =
+            match other with
+            | :? TypeRefResolutionScope as other -> other
+            | _ -> failwith "should never compare with non-TypeRefResolutionScope"
+
+        match this, other with
+        | TypeRefResolutionScope.Assembly a1, TypeRefResolutionScope.Assembly a2 -> a1 = a2
+        | TypeRefResolutionScope.Assembly _, _ -> false
+        | TypeRefResolutionScope.ModuleRef m1, TypeRefResolutionScope.ModuleRef m2 -> m1 = m2
+        | TypeRefResolutionScope.ModuleRef _, _ -> false
+        | TypeRefResolutionScope.TypeRef t1, TypeRefResolutionScope.TypeRef t2 -> t1 = t2
+        | TypeRefResolutionScope.TypeRef _, _ -> false
+
+    override this.GetHashCode () : int =
+        match this with
+        | TypeRefResolutionScope.Assembly h -> hash (1, h)
+        | TypeRefResolutionScope.ModuleRef h -> hash (2, h)
+        | TypeRefResolutionScope.TypeRef h -> hash (3, h)
+
+    interface IComparable<TypeRefResolutionScope> with
+        member this.CompareTo other =
+            match this, other with
+            | TypeRefResolutionScope.Assembly h1, TypeRefResolutionScope.Assembly h2 ->
+                // this happens to get the underlying int
+                h1.GetHashCode().CompareTo (h2.GetHashCode ())
+            | TypeRefResolutionScope.Assembly _, TypeRefResolutionScope.ModuleRef _ -> -1
+            | TypeRefResolutionScope.Assembly _, TypeRefResolutionScope.TypeRef _ -> -1
+            | TypeRefResolutionScope.ModuleRef _, Assembly _ -> 1
+            | TypeRefResolutionScope.ModuleRef m1, ModuleRef m2 -> m1.GetHashCode().CompareTo (m2.GetHashCode ())
+            | TypeRefResolutionScope.ModuleRef _, TypeRef _ -> -1
+            | TypeRefResolutionScope.TypeRef _, Assembly _ -> 1
+            | TypeRefResolutionScope.TypeRef _, ModuleRef _ -> 1
+            | TypeRefResolutionScope.TypeRef t1, TypeRef t2 -> t1.GetHashCode().CompareTo (t2.GetHashCode ())
+
+    interface IComparable with
+        member this.CompareTo (other : obj) : int =
+            let other =
+                match other with
+                | :? TypeRefResolutionScope as other -> other
+                | _ -> failwith "unexpectedly comparing TypeRefResolutionScope with something else"
+
+            (this :> IComparable<TypeRefResolutionScope>).CompareTo other
 
 /// <summary>
 /// Represents a type reference in a .NET assembly metadata.

--- a/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
+++ b/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <WoofWareMyriadPluginsVersion>7.0.7</WoofWareMyriadPluginsVersion>
@@ -15,8 +15,11 @@
     <Compile Include="CustomAttribute.fs" />
     <Compile Include="AssemblyReference.fs" />
     <Compile Include="EventDefn.fs" />
+    <Compile Include="ComparableTypeDefinitionHandle.fs" />
+    <Compile Include="ComparableSignatureHeader.fs" />
     <Compile Include="TypeDefn.fs" />
     <Compile Include="FieldInfo.fs" />
+    <Compile Include="ConcreteType.fs" />
     <Compile Include="MethodInfo.fs" />
     <Compile Include="TypeInfo.fs" />
     <Compile Include="MethodSpec.fs" />


### PR DESCRIPTION
This is still incomplete - `FieldInfo` notably needs to know its defining type.