### PR TITLE
Stop keying static fields by name

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/StaticFieldShadowing.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/StaticFieldShadowing.cs
@@ -1,0 +1,31 @@
+class Base
+{
+    public static int X = 1;
+}
+
+class Derived : Base
+{
+    public new static int X = 2;
+}
+
+class Program
+{
+    static int Main(string[] argv)
+    {
+        // Verify base and derived each see their own static field
+        if (Base.X != 1) return 1;
+        if (Derived.X != 2) return 2;
+
+        // Mutate derived, base should be unaffected
+        Derived.X = 42;
+        if (Base.X != 1) return 3;
+        if (Derived.X != 42) return 4;
+
+        // Mutate base, derived should be unaffected
+        Base.X = 99;
+        if (Base.X != 99) return 5;
+        if (Derived.X != 42) return 6;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -23,8 +23,10 @@ type IlMachineState =
         _LoadedAssemblies : ImmutableDictionary<string, DumpedAssembly>
         /// Tracks initialization state of types across assemblies
         TypeInitTable : TypeInitTable
-        /// For each type, specialised to each set of generic args, a map of string field name to static value contained therein.
-        _Statics : ImmutableDictionary<ConcreteTypeHandle, ImmutableDictionary<string, CliType>>
+        /// For each concrete type, a map of field definition handle to static value.
+        /// The FieldDefinitionHandle is scoped to the assembly that defines the outer ConcreteTypeHandle's type;
+        /// do not mix handles from different assemblies under the same key.
+        _Statics : ImmutableDictionary<ConcreteTypeHandle, Map<ComparableFieldDefinitionHandle, CliType>>
         DotnetRuntimeDirs : string ImmutableArray
         TypeHandles : TypeHandleRegistry
         FieldHandles : FieldHandleRegistry
@@ -1629,27 +1631,29 @@ module IlMachineState =
 
     let setStatic
         (ty : ConcreteTypeHandle)
-        (field : string)
+        (field : ComparableFieldDefinitionHandle)
         (value : CliType)
         (this : IlMachineState)
         : IlMachineState
         =
         let statics =
             match this._Statics.TryGetValue ty with
-            | false, _ -> this._Statics.Add (ty, ImmutableDictionary.Create().Add (field, value))
-            | true, v -> this._Statics.SetItem (ty, v.SetItem (field, value))
+            | false, _ -> this._Statics.Add (ty, Map.ofList [ field, value ])
+            | true, v -> this._Statics.SetItem (ty, Map.add field value v)
 
         { this with
             _Statics = statics
         }
 
-    let getStatic (ty : ConcreteTypeHandle) (field : string) (this : IlMachineState) : CliType option =
+    let getStatic
+        (ty : ConcreteTypeHandle)
+        (field : ComparableFieldDefinitionHandle)
+        (this : IlMachineState)
+        : CliType option
+        =
         match this._Statics.TryGetValue ty with
         | false, _ -> None
-        | true, v ->
-            match v.TryGetValue field with
-            | false, _ -> None
-            | true, v -> Some v
+        | true, v -> Map.tryFind field v
 
     let rec dereferencePointer (state : IlMachineState) (src : ManagedPointerSource) : CliType =
         match src with

--- a/WoofWare.PawPrint/UnaryMetadataIlOp.fs
+++ b/WoofWare.PawPrint/UnaryMetadataIlOp.fs
@@ -623,7 +623,11 @@ module internal UnaryMetadataIlOp =
 
             if field.Attributes.HasFlag FieldAttributes.Static then
                 let state =
-                    IlMachineState.setStatic declaringTypeHandle field.Name valueToStore state
+                    IlMachineState.setStatic
+                        declaringTypeHandle
+                        (ComparableFieldDefinitionHandle.Make field.Handle)
+                        valueToStore
+                        state
 
                 state, WhatWeDid.Executed
             else
@@ -738,7 +742,11 @@ module internal UnaryMetadataIlOp =
             let toStore = EvalStackValue.toCliTypeCoerced zero popped
 
             let state =
-                IlMachineState.setStatic declaringTypeHandle field.Name toStore state
+                IlMachineState.setStatic
+                    declaringTypeHandle
+                    (ComparableFieldDefinitionHandle.Make field.Handle)
+                    toStore
+                    state
                 |> IlMachineState.advanceProgramCounter thread
 
             state, WhatWeDid.Executed
@@ -789,7 +797,12 @@ module internal UnaryMetadataIlOp =
                     IlMachineState.concretizeFieldDeclaringType loggerFactory baseClassTypes field.DeclaringType state
 
                 let state, staticField =
-                    match IlMachineState.getStatic declaringTypeHandle field.Name state with
+                    match
+                        IlMachineState.getStatic
+                            declaringTypeHandle
+                            (ComparableFieldDefinitionHandle.Make field.Handle)
+                            state
+                    with
                     | Some v -> state, v
                     | None ->
                         let state, zero, concreteTypeHandle =
@@ -802,7 +815,13 @@ module internal UnaryMetadataIlOp =
                                 ImmutableArray.Empty // field can't have its own generics
                                 state
 
-                        let state = IlMachineState.setStatic declaringTypeHandle field.Name zero state
+                        let state =
+                            IlMachineState.setStatic
+                                declaringTypeHandle
+                                (ComparableFieldDefinitionHandle.Make field.Handle)
+                                zero
+                                state
+
                         state, zero
 
                 let state = state |> IlMachineState.pushToEvalStack staticField thread
@@ -955,7 +974,12 @@ module internal UnaryMetadataIlOp =
             | NothingToDo state ->
 
             let fieldValue, state =
-                match IlMachineState.getStatic declaringTypeHandle field.Name state with
+                match
+                    IlMachineState.getStatic
+                        declaringTypeHandle
+                        (ComparableFieldDefinitionHandle.Make field.Handle)
+                        state
+                with
                 | None ->
                     let state, newVal, concreteTypeHandle =
                         IlMachineState.cliTypeZeroOf
@@ -967,7 +991,12 @@ module internal UnaryMetadataIlOp =
                             ImmutableArray.Empty // field can't have its own generics
                             state
 
-                    newVal, IlMachineState.setStatic declaringTypeHandle field.Name newVal state
+                    newVal,
+                    IlMachineState.setStatic
+                        declaringTypeHandle
+                        (ComparableFieldDefinitionHandle.Make field.Handle)
+                        newVal
+                        state
                 | Some v -> v, state
 
             do
@@ -1193,7 +1222,9 @@ module internal UnaryMetadataIlOp =
             // TODO: Note that field may be a static global with an assigned relative virtual address
             // (the offset of the field from the base address at which its containing PE file is loaded into memory)
             // where the memory is unmanaged.
-            match IlMachineState.getStatic declaringTypeHandle field.Name state with
+            match
+                IlMachineState.getStatic declaringTypeHandle (ComparableFieldDefinitionHandle.Make field.Handle) state
+            with
             | Some v ->
                 IlMachineState.pushToEvalStack v thread state
                 |> IlMachineState.advanceProgramCounter thread
@@ -1210,7 +1241,11 @@ module internal UnaryMetadataIlOp =
                         ImmutableArray.Empty // field can't have its own generics
                         state
 
-                IlMachineState.setStatic declaringTypeHandle field.Name zero state
+                IlMachineState.setStatic
+                    declaringTypeHandle
+                    (ComparableFieldDefinitionHandle.Make field.Handle)
+                    zero
+                    state
                 |> IlMachineState.pushToEvalStack (CliType.ObjectRef None) thread
                 |> IlMachineState.advanceProgramCounter thread
                 |> Tuple.withRight WhatWeDid.Executed


### PR DESCRIPTION
Not a correctness issue, but a bit more safe for the future.

Opus 4.6.