### PR TITLE
Exception assignability refactor

### DIFF
--- a/WoofWare.PawPrint/ExceptionDispatching.fs
+++ b/WoofWare.PawPrint/ExceptionDispatching.fs
@@ -18,7 +18,7 @@ module ExceptionDispatching =
         : IlMachineState * bool
         =
         // TODO: Implement proper type assignability checking
-        failwith "not implemented"
+        state, true
 
     /// Find the first matching exception handler for the given exception at the given PC.
     /// Also returns `isFinally : bool`: whether this is a `finally` block (as opposed to e.g. a `catch`).

--- a/WoofWare.PawPrint/ExceptionDispatching.fs
+++ b/WoofWare.PawPrint/ExceptionDispatching.fs
@@ -1,0 +1,83 @@
+namespace WoofWare.PawPrint
+
+open System.Collections.Immutable
+open Microsoft.Extensions.Logging
+
+/// Exception handler dispatch that requires IlMachineState for type resolution.
+[<RequireQualifiedAccess>]
+module ExceptionDispatching =
+
+    /// Check if an exception type matches a catch handler type.
+    let private isExceptionAssignableTo
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (activeAssy : DumpedAssembly)
+        (exceptionType : ConcreteTypeHandle)
+        (catchTypeToken : MetadataToken)
+        : IlMachineState * bool
+        =
+        // TODO: Implement proper type assignability checking
+        failwith "not implemented"
+
+    /// Find the first matching exception handler for the given exception at the given PC.
+    /// Also returns `isFinally : bool`: whether this is a `finally` block (as opposed to e.g. a `catch`).
+    let findExceptionHandler
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (activeAssy : DumpedAssembly)
+        (currentPC : int)
+        (exceptionType : ConcreteTypeHandle)
+        (method : WoofWare.PawPrint.MethodInfo<'typeGen, 'methodGeneric, 'methodVar>)
+        : IlMachineState * (WoofWare.PawPrint.ExceptionRegion * bool) option
+        =
+        match method.Instructions with
+        | None -> state, None
+        | Some instructions ->
+
+        let state, matches =
+            ((state, []), instructions.ExceptionRegions)
+            ||> Seq.fold (fun (state, acc) region ->
+                match region with
+                | ExceptionRegion.Catch (typeToken, offset) ->
+                    if currentPC >= offset.TryOffset && currentPC < offset.TryOffset + offset.TryLength then
+                        let state, matches =
+                            isExceptionAssignableTo
+                                loggerFactory
+                                baseClassTypes
+                                state
+                                activeAssy
+                                exceptionType
+                                typeToken
+
+                        if matches then
+                            state, (region, false) :: acc
+                        else
+                            state, acc
+                    else
+                        state, acc
+                | ExceptionRegion.Filter (_filterOffset, offset) ->
+                    if currentPC >= offset.TryOffset && currentPC < offset.TryOffset + offset.TryLength then
+                        failwith "TODO: filter needs to be evaluated"
+                    else
+                        state, acc
+                | ExceptionRegion.Finally offset ->
+                    if currentPC >= offset.TryOffset && currentPC < offset.TryOffset + offset.TryLength then
+                        state, (region, true) :: acc
+                    else
+                        state, acc
+                | ExceptionRegion.Fault offset ->
+                    if currentPC >= offset.TryOffset && currentPC < offset.TryOffset + offset.TryLength then
+                        state, (region, true) :: acc
+                    else
+                        state, acc
+            )
+
+        let result =
+            match matches |> List.rev with
+            | [] -> None
+            | [ x ] -> Some x
+            | _ -> failwith "multiple exception regions"
+
+        state, result

--- a/WoofWare.PawPrint/Exceptions.fs
+++ b/WoofWare.PawPrint/Exceptions.fs
@@ -32,65 +32,6 @@ type ExceptionContinuation<'typeGen, 'methodGen, 'methodVar
 [<RequireQualifiedAccess>]
 module ExceptionHandling =
 
-    /// Check if an exception type matches a catch handler type
-    let private isExceptionAssignableTo
-        (exceptionType : ConcreteTypeHandle)
-        (catchTypeToken : MetadataToken)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
-        : bool
-        =
-        // TODO: Implement proper type assignability checking
-        true
-
-    /// Find the first matching exception handler for the given exception at the given PC.
-    /// Also returns `isFinally : bool`: whether this is a `finally` block (as opposed to e.g. a `catch`).
-    let findExceptionHandler
-        (currentPC : int)
-        (exceptionType : ConcreteTypeHandle)
-        (method : WoofWare.PawPrint.MethodInfo<'typeGen, 'methodGeneric, 'methodVar>)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
-        : (WoofWare.PawPrint.ExceptionRegion * bool) option // handler, isFinally
-        =
-        match method.Instructions with
-        | None -> None
-        | Some instructions ->
-
-        // Find all handlers that cover the current PC
-        instructions.ExceptionRegions
-        |> Seq.choose (fun region ->
-            match region with
-            | ExceptionRegion.Catch (typeToken, offset) ->
-                if currentPC >= offset.TryOffset && currentPC < offset.TryOffset + offset.TryLength then
-                    // Check if exception type matches
-                    if isExceptionAssignableTo exceptionType typeToken assemblies then
-                        Some (region, false)
-                    else
-                        None
-                else
-                    None
-            | ExceptionRegion.Filter (filterOffset, offset) ->
-                if currentPC >= offset.TryOffset && currentPC < offset.TryOffset + offset.TryLength then
-                    failwith "TODO: filter needs to be evaluated"
-                else
-                    None
-            | ExceptionRegion.Finally offset ->
-                if currentPC >= offset.TryOffset && currentPC < offset.TryOffset + offset.TryLength then
-                    Some (region, true)
-                else
-                    None
-            | ExceptionRegion.Fault offset ->
-                if currentPC >= offset.TryOffset && currentPC < offset.TryOffset + offset.TryLength then
-                    Some (region, true)
-                else
-                    None
-        )
-        |> Seq.toList
-        |> fun x ->
-            match x with
-            | [] -> None
-            | [ x ] -> Some x
-            | _ -> failwith "multiple exception regions"
-
     /// Find finally blocks that need to run when leaving a try region
     let findFinallyBlocksToRun
         (currentPC : int)

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -1709,3 +1709,23 @@ module IlMachineState =
             resolveTypeFromRef loggerFactory activeAssy ref typeGenerics state
 
         state, DumpedAssembly.typeInfoToTypeDefn baseClassTypes state._LoadedAssemblies resolved, assy
+
+    /// Resolve a MetadataToken (TypeDefinition, TypeReference, or TypeSpecification) to a TypeDefn,
+    /// together with the assembly the type was resolved in.
+    let resolveTypeMetadataToken
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (activeAssy : DumpedAssembly)
+        (typeGenerics : ImmutableArray<ConcreteTypeHandle>)
+        (token : MetadataToken)
+        : IlMachineState * TypeDefn * DumpedAssembly
+        =
+        match token with
+        | MetadataToken.TypeDefinition h ->
+            let state, ty = lookupTypeDefn baseClassTypes state activeAssy h
+            state, ty, activeAssy
+        | MetadataToken.TypeReference ref ->
+            lookupTypeRef loggerFactory baseClassTypes state activeAssy typeGenerics ref
+        | MetadataToken.TypeSpecification spec -> state, activeAssy.TypeSpecs.[spec].Signature, activeAssy
+        | m -> failwith $"unexpected type metadata token {m}"

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -867,13 +867,19 @@ module NullaryIlOp =
                 }
 
             // Search for handler in current method
-            match
-                ExceptionHandling.findExceptionHandler
+            let activeAssy = state.ActiveAssembly currentThread
+
+            let state, handlerResult =
+                ExceptionDispatching.findExceptionHandler
+                    loggerFactory
+                    corelib
+                    state
+                    activeAssy
                     currentMethodState.IlOpIndex
                     heapObject.ConcreteType
                     currentMethodState.ExecutingMethod
-                    state._LoadedAssemblies
-            with
+
+            match handlerResult with
             | Some (handler, isFinally) ->
                 match handler with
                 | ExceptionRegion.Catch (_, offset) ->

--- a/WoofWare.PawPrint/UnaryMetadataIlOp.fs
+++ b/WoofWare.PawPrint/UnaryMetadataIlOp.fs
@@ -386,22 +386,13 @@ module internal UnaryMetadataIlOp =
             let typeGenerics = currentMethod.DeclaringType.Generics
 
             let state, elementType, assy =
-                match metadataToken with
-                | MetadataToken.TypeDefinition defn ->
-                    let state, resolved =
-                        IlMachineState.lookupTypeDefn baseClassTypes state activeAssy defn
-
-                    state, resolved, activeAssy
-                | MetadataToken.TypeSpecification spec -> state, activeAssy.TypeSpecs.[spec].Signature, activeAssy
-                | MetadataToken.TypeReference ref ->
-                    IlMachineState.lookupTypeRef
-                        loggerFactory
-                        baseClassTypes
-                        state
-                        activeAssy
-                        currentMethod.DeclaringType.Generics
-                        ref
-                | x -> failwith $"TODO: Newarr element type resolution unimplemented for {x}"
+                IlMachineState.resolveTypeMetadataToken
+                    loggerFactory
+                    baseClassTypes
+                    state
+                    activeAssy
+                    currentMethod.DeclaringType.Generics
+                    metadataToken
 
             let state, zeroOfType, concreteTypeHandle =
                 IlMachineState.cliTypeZeroOf
@@ -507,29 +498,14 @@ module internal UnaryMetadataIlOp =
         | Isinst ->
             let actualObj, state = IlMachineState.popEvalStack thread state
 
-            let state, targetType =
-                match metadataToken with
-                | MetadataToken.TypeDefinition td ->
-                    let activeAssy = state.ActiveAssembly thread
-                    let ty = activeAssy.TypeDefs.[td]
-
-                    let result =
-                        DumpedAssembly.typeInfoToTypeDefn' baseClassTypes state._LoadedAssemblies ty
-
-                    state, result
-                | MetadataToken.TypeSpecification handle ->
-                    state, state.ActiveAssembly(thread).TypeSpecs.[handle].Signature
-                | MetadataToken.TypeReference handle ->
-                    let state, assy, resol =
-                        IlMachineState.resolveTypeFromRef
-                            loggerFactory
-                            activeAssy
-                            (state.ActiveAssembly(thread).TypeRefs.[handle])
-                            ImmutableArray.Empty
-                            state
-
-                    state, DumpedAssembly.typeInfoToTypeDefn baseClassTypes state._LoadedAssemblies resol
-                | m -> failwith $"unexpected metadata token {m} in IsInst"
+            let state, targetType, _targetAssy =
+                IlMachineState.resolveTypeMetadataToken
+                    loggerFactory
+                    baseClassTypes
+                    state
+                    activeAssy
+                    ImmutableArray.Empty
+                    metadataToken
 
             let state, targetConcreteType =
                 IlMachineState.concretizeType
@@ -1447,20 +1423,13 @@ module internal UnaryMetadataIlOp =
         | Cpobj -> failwith "TODO: Cpobj unimplemented"
         | Ldobj ->
             let state, ty, assy =
-                match metadataToken with
-                | MetadataToken.TypeDefinition h ->
-                    let state, ty = IlMachineState.lookupTypeDefn baseClassTypes state activeAssy h
-                    state, ty, activeAssy
-                | MetadataToken.TypeReference ref ->
-                    IlMachineState.lookupTypeRef
-                        loggerFactory
-                        baseClassTypes
-                        state
-                        activeAssy
-                        currentMethod.DeclaringType.Generics
-                        ref
-                | MetadataToken.TypeSpecification spec -> state, activeAssy.TypeSpecs.[spec].Signature, activeAssy
-                | _ -> failwith $"unexpected token {metadataToken} in Ldobj"
+                IlMachineState.resolveTypeMetadataToken
+                    loggerFactory
+                    baseClassTypes
+                    state
+                    activeAssy
+                    currentMethod.DeclaringType.Generics
+                    metadataToken
 
             let state, typeHandle =
                 IlMachineState.concretizeType
@@ -1511,20 +1480,13 @@ module internal UnaryMetadataIlOp =
             |> Tuple.withRight WhatWeDid.Executed
         | Sizeof ->
             let state, ty, assy =
-                match metadataToken with
-                | MetadataToken.TypeDefinition h ->
-                    let state, ty = IlMachineState.lookupTypeDefn baseClassTypes state activeAssy h
-                    state, ty, activeAssy
-                | MetadataToken.TypeReference ref ->
-                    IlMachineState.lookupTypeRef
-                        loggerFactory
-                        baseClassTypes
-                        state
-                        activeAssy
-                        currentMethod.DeclaringType.Generics
-                        ref
-                | MetadataToken.TypeSpecification spec -> state, activeAssy.TypeSpecs.[spec].Signature, activeAssy
-                | _ -> failwith $"unexpected token {metadataToken} in Sizeof"
+                IlMachineState.resolveTypeMetadataToken
+                    loggerFactory
+                    baseClassTypes
+                    state
+                    activeAssy
+                    currentMethod.DeclaringType.Generics
+                    metadataToken
 
             let state, typeHandle =
                 IlMachineState.concretizeType

--- a/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
+++ b/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
@@ -24,6 +24,7 @@
     <Compile Include="MethodState.fs" />
     <Compile Include="ThreadState.fs" />
     <Compile Include="IlMachineState.fs" />
+    <Compile Include="ExceptionDispatching.fs" />
     <Compile Include="BinaryArithmetic.fs" />
     <Compile Include="Intrinsics.fs" />
     <Compile Include="IlMachineStateExecution.fs" />


### PR DESCRIPTION
No-op refactor to permit eventually implementing isExceptionAssignableTo. Still currently contains the bug "all exceptions are considered equiassignable".