### PR TITLE
Pick correct coercion target for `this` argument

### DIFF
--- a/WoofWare.PawPrint.Test/TestEvalStack.fs
+++ b/WoofWare.PawPrint.Test/TestEvalStack.fs
@@ -1,0 +1,35 @@
+namespace WoofWare.PawPrint.Test
+
+open NUnit.Framework
+open WoofWare.PawPrint
+
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestEvalStack =
+
+    let private runtimePointerTarget : CliType =
+        CliType.RuntimePointer (CliRuntimePointer.Verbatim 0L)
+
+    let private assertDoesNotReturnObjectRef (popped : EvalStackValue) : unit =
+        let outcome : Choice<CliType, exn> =
+            try
+                EvalStackValue.toCliTypeCoerced runtimePointerTarget popped |> Choice1Of2
+            with e ->
+                Choice2Of2 e
+
+        match outcome with
+        | Choice1Of2 (CliType.ObjectRef returned) ->
+            failwith $"Bug: coercing %O{popped} to RuntimePointer returned ObjectRef(%O{returned})"
+        | Choice1Of2 (CliType.RuntimePointer _) -> ()
+        | Choice1Of2 other -> failwith $"Unexpected result from RuntimePointer coercion: %O{other}"
+        | Choice2Of2 _ -> ()
+
+    [<Test>]
+    let ``toCliTypeCoerced RuntimePointer target does not return ObjectRef for NullObjectRef`` () : unit =
+        assertDoesNotReturnObjectRef EvalStackValue.NullObjectRef
+
+    [<Test>]
+    let ``toCliTypeCoerced RuntimePointer target does not return ObjectRef for ObjectRef`` () : unit =
+        ManagedHeapAddress.ManagedHeapAddress 42
+        |> EvalStackValue.ObjectRef
+        |> assertDoesNotReturnObjectRef

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -18,6 +18,7 @@ module TestPureCases =
     let unimplemented =
         [
             "CrossAssemblyTypes.cs"
+            "EnumSemantics.cs"
             "OverlappingStructs.cs"
             "AdvancedStructLayout.cs"
             "InitializeArray.cs"

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -17,6 +17,7 @@
     <Compile Include="AssemblyGraphShape.fs" />
     <Compile Include="TestTypeResolution.fs" />
     <Compile Include="TestTypeIdentityProperties.fs" />
+    <Compile Include="TestEvalStack.fs" />
     <Compile Include="TestPureCases.fs" />
     <Compile Include="TestImpureCases.fs" />
   </ItemGroup>

--- a/WoofWare.PawPrint.Test/sourcesPure/EnumSemantics.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/EnumSemantics.cs
@@ -1,0 +1,37 @@
+using System;
+
+public class Program
+{
+    private enum TestEnum
+    {
+        None = 0,
+        A = 1,
+        B = 2
+    }
+
+    private static bool HasFlagViaEnum(Enum value, Enum flag)
+    {
+        return value.HasFlag(flag);
+    }
+
+    public static int Main(string[] args)
+    {
+        TestEnum value = TestEnum.B;
+
+        // Passing a concrete enum to an Enum-typed parameter forces boxing and then
+        // exercises System.Enum.HasFlag on the boxed receiver.
+        if (!HasFlagViaEnum(value, TestEnum.B)) return 1;
+
+        // Direct enum instance calls go via constrained callvirt and should still behave
+        // like the real runtime.
+        if (value.ToString() != "B") return 2;
+
+        // The nominal framework types System.Enum and System.ValueType are not themselves
+        // value types, even though user-defined enums are.
+        if (typeof(Enum).IsValueType) return 3;
+        if (typeof(ValueType).IsValueType) return 4;
+        if (!typeof(TestEnum).IsValueType) return 5;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/EvalStack.fs
+++ b/WoofWare.PawPrint/EvalStack.fs
@@ -271,8 +271,8 @@ module EvalStackValue =
                     CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.FunctionPointer methodInfo))
                 | NativeIntSource.TypeHandlePtr int64 -> failwith "todo"
                 | NativeIntSource.FieldHandlePtr int64 -> failwith "todo"
-            | EvalStackValue.NullObjectRef -> CliType.ObjectRef None
-            | EvalStackValue.ObjectRef addr -> CliType.ObjectRef (Some addr)
+            | EvalStackValue.NullObjectRef -> failwith "cannot coerce null object reference to runtime pointer"
+            | EvalStackValue.ObjectRef addr -> failwith $"cannot coerce object reference %O{addr} to runtime pointer"
             | _ -> failwith $"TODO: %O{popped}"
         | CliType.Char _ ->
             match popped with

--- a/WoofWare.PawPrint/IlMachineStateExecution.fs
+++ b/WoofWare.PawPrint/IlMachineStateExecution.fs
@@ -377,6 +377,28 @@ module IlMachineStateExecution =
             let value, newState = MethodState.popFromStack methodState
             EvalStackValue.toCliTypeCoerced zeroType value, newState
 
+        let thisArgCoercionTarget
+            (methodToCall : WoofWare.PawPrint.MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>)
+            : CliType
+            =
+            let declaringAssembly =
+                state.LoadedAssembly (methodToCall.DeclaringType.Assembly) |> Option.get
+
+            let declaringType =
+                declaringAssembly.TypeDefs.[methodToCall.DeclaringType.Definition.Get]
+
+            match
+                DumpedAssembly.resolveBaseType
+                    baseClassTypes
+                    state._LoadedAssemblies
+                    methodToCall.DeclaringType.Assembly
+                    declaringType.BaseType
+            with
+            | ResolvedBaseType.Object
+            | ResolvedBaseType.Delegate -> CliType.ObjectRef None
+            | ResolvedBaseType.ValueType
+            | ResolvedBaseType.Enum -> CliType.RuntimePointer (CliRuntimePointer.Managed ManagedPointerSource.Null)
+
         // Collect arguments based on calling convention
         let args, afterPop =
             if methodToCall.IsStatic then
@@ -396,15 +418,13 @@ module IlMachineStateExecution =
                 let argCount = methodToCall.Parameters.Length
                 let args = ImmutableArray.CreateBuilder (argCount + 1)
                 let mutable currentState = activeMethodState
+                let thisArgTarget = thisArgCoercionTarget methodToCall
 
                 match wasConstructing with
                 | Some _ ->
                     // Constructor: `this` is on top of stack, by our own odd little calling convention
                     // where Newobj puts the object pointer on top
-                    let thisArg, newState =
-                        popAndCoerceArg
-                            (CliType.RuntimePointer (CliRuntimePointer.Managed ManagedPointerSource.Null))
-                            currentState
+                    let thisArg, newState = popAndCoerceArg thisArgTarget currentState
 
                     currentState <- newState
 
@@ -424,10 +444,7 @@ module IlMachineStateExecution =
                         args.Add arg
                         currentState <- newState
 
-                    let thisArg, newState =
-                        popAndCoerceArg
-                            (CliType.RuntimePointer (CliRuntimePointer.Managed ManagedPointerSource.Null))
-                            currentState
+                    let thisArg, newState = popAndCoerceArg thisArgTarget currentState
 
                     args.Add thisArg
                     currentState <- newState

--- a/WoofWare.PawPrint/IlMachineStateExecution.fs
+++ b/WoofWare.PawPrint/IlMachineStateExecution.fs
@@ -387,17 +387,10 @@ module IlMachineStateExecution =
             let declaringType =
                 declaringAssembly.TypeDefs.[methodToCall.DeclaringType.Definition.Get]
 
-            match
-                DumpedAssembly.resolveBaseType
-                    baseClassTypes
-                    state._LoadedAssemblies
-                    methodToCall.DeclaringType.Assembly
-                    declaringType.BaseType
-            with
-            | ResolvedBaseType.Object
-            | ResolvedBaseType.Delegate -> CliType.ObjectRef None
-            | ResolvedBaseType.ValueType
-            | ResolvedBaseType.Enum -> CliType.RuntimePointer (CliRuntimePointer.Managed ManagedPointerSource.Null)
+            if DumpedAssembly.isValueType baseClassTypes state._LoadedAssemblies declaringType then
+                CliType.RuntimePointer (CliRuntimePointer.Managed ManagedPointerSource.Null)
+            else
+                CliType.ObjectRef None
 
         // Collect arguments based on calling convention
         let args, afterPop =


### PR DESCRIPTION
Remove the EvalStack fallback that silently returned `CliType.ObjectRef` when coercing an `ObjectRef`/`NullObjectRef` to a `RuntimePointer` target, and fix the one caller that relied on it: when popping `this` for a call, choose the coercion target based on the declaring type's base (Object/Delegate -> ObjectRef, ValueType/Enum -> RuntimePointer).

Add regression tests pinning down that the coercion no longer returns ObjectRef for a RuntimePointer target.