### PR TITLE
Remove deprecated dereferencePointer API

### DIFF
--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -1777,11 +1777,6 @@ module IlMachineState =
         | false, _ -> None
         | true, v -> Map.tryFind field v
 
-    /// Deprecated: use readManagedByref instead.
-    /// This function is retained only for call sites that still construct temporary ManagedPointerSource values;
-    /// it delegates to readManagedByref.
-    let dereferencePointer (state : IlMachineState) (src : ManagedPointerSource) : CliType = readManagedByref state src
-
     let evalStackValueToObjectRef (state : IlMachineState) (value : EvalStackValue) : ManagedHeapAddress option =
         match value with
         | EvalStackValue.NullObjectRef -> None

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -199,9 +199,8 @@ module Intrinsics =
             let this =
                 match this with
                 | EvalStackValue.ObjectRef ptr ->
-                    ManagedHeap.get ptr state.ManagedHeap
-                    |> fun obj -> CliType.ValueType obj.Contents
-                | EvalStackValue.ManagedPointer ptr -> IlMachineState.dereferencePointer state ptr
+                    IlMachineState.readManagedByref state (ManagedPointerSource.Byref (ByrefRoot.HeapValue ptr, []))
+                | EvalStackValue.ManagedPointer ptr -> IlMachineState.readManagedByref state ptr
                 | EvalStackValue.NullObjectRef -> failwith "TODO: throw NRE"
                 | EvalStackValue.Float _
                 | EvalStackValue.Int32 _
@@ -448,7 +447,7 @@ module Intrinsics =
             let v : CliType =
                 let rec go ptr =
                     match ptr with
-                    | EvalStackValue.ManagedPointer src -> IlMachineState.dereferencePointer state src
+                    | EvalStackValue.ManagedPointer src -> IlMachineState.readManagedByref state src
                     | EvalStackValue.NativeInt src -> failwith "TODO"
                     | EvalStackValue.NullObjectRef -> failwith "TODO: ReadUnaligned on null"
                     | EvalStackValue.ObjectRef ptr -> failwith "TODO"

--- a/WoofWare.PawPrint/UnaryMetadataIlOp.fs
+++ b/WoofWare.PawPrint/UnaryMetadataIlOp.fs
@@ -1424,7 +1424,7 @@ module internal UnaryMetadataIlOp =
                 | EvalStackValue.NullObjectRef -> failwith "TODO: throw NullReferenceException"
                 | EvalStackValue.ObjectRef _ ->
                     failwith "Ldobj on an object reference is invalid; expected a managed pointer"
-                | EvalStackValue.ManagedPointer ptr -> IlMachineState.dereferencePointer state ptr
+                | EvalStackValue.ManagedPointer ptr -> IlMachineState.readManagedByref state ptr
                 | EvalStackValue.Float _
                 | EvalStackValue.Int64 _
                 | EvalStackValue.Int32 _ -> failwith "refusing to interpret constant as address"


### PR DESCRIPTION
This, with #156, completes the migration in #152 .