### PR TITLE
Migrate containsRefType walker to TypeInfo.isReferenceType

### DIFF
--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -53,19 +53,11 @@ module Intrinsics =
             // We've already calculated this; return the memoized result.
             state, seenSoFar, v
         | false, _ ->
-            // Check if this type itself is a reference type.
-            let baseType =
-                td.BaseType
-                |> DumpedAssembly.resolveBaseType baseClassTypes state._LoadedAssemblies td.Assembly
-
-            match baseType with
-            | ResolvedBaseType.Delegate
-            | ResolvedBaseType.Object ->
+            if DumpedAssembly.isReferenceType baseClassTypes state._LoadedAssemblies td then
                 // Short-circuit: if the type itself is a reference type, we're done.
                 let seenSoFar = seenSoFar.Add (td, Completed true)
                 state, seenSoFar, true
-            | ResolvedBaseType.Enum
-            | ResolvedBaseType.ValueType ->
+            else
                 // It's a value type, so we must check its fields.
                 // Mark as in progress before recursing.
                 let seenSoFarWithInProgress = seenSoFar.Add (td, InProgress)


### PR DESCRIPTION
Stage 3c of the type-predicate refactor in
docs/plans/2026-04-16-type-predicates.md. The Intrinsics.containsRefType short-circuit asks "is this type itself a reference type?" — replace the hand-rolled `match resolveBaseType` with the intent-named predicate. Pure refactor.