### PR TITLE
Migrate Newobj/Box/push-kind callers to TypeInfo.isValueType

### DIFF
--- a/WoofWare.PawPrint/BasicCliType.fs
+++ b/WoofWare.PawPrint/BasicCliType.fs
@@ -774,13 +774,7 @@ module CliType =
         : CliType * AllConcreteTypes
         =
 
-        // Determine if this is a value type by checking inheritance
-        let isValueType =
-            match DumpedAssembly.resolveBaseType corelib assemblies typeDef.Assembly typeDef.BaseType with
-            | ResolvedBaseType.ValueType
-            | ResolvedBaseType.Enum -> true
-            | ResolvedBaseType.Delegate -> false // Delegates are reference types
-            | ResolvedBaseType.Object -> false
+        let isValueType = DumpedAssembly.isValueType corelib assemblies typeDef
 
         if isValueType then
             // It's a value type - need to create zero values for all non-static fields

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -772,17 +772,12 @@ module IlMachineState =
                 |> Option.get
                 |> fun a -> a.TypeDefs.[ty.Definition.Get]
 
-            let resolvedBaseType =
-                DumpedAssembly.resolveBaseType baseClassTypes state._LoadedAssemblies ty.Assembly ty'.BaseType
-
-            match resolvedBaseType with
-            | ResolvedBaseType.Delegate
-            | ResolvedBaseType.Object -> state |> pushToEvalStack (CliType.ofManagedObject constructing) currentThread
-            | ResolvedBaseType.ValueType ->
+            if DumpedAssembly.isValueType baseClassTypes state._LoadedAssemblies ty' then
                 state
                 // TODO: ordering of fields probably important
                 |> pushToEvalStack (CliType.ValueType constructed.Contents) currentThread
-            | ResolvedBaseType.Enum -> failwith "TODO"
+            else
+                state |> pushToEvalStack (CliType.ofManagedObject constructing) currentThread
         | None ->
             match threadStateAtEndOfMethod.MethodState.EvaluationStack.Values with
             | [] ->

--- a/WoofWare.PawPrint/UnaryMetadataIlOp.fs
+++ b/WoofWare.PawPrint/UnaryMetadataIlOp.fs
@@ -281,13 +281,6 @@ module internal UnaryMetadataIlOp =
             let ctorAssembly = state.LoadedAssembly ctor.DeclaringType.Assembly |> Option.get
             let ctorType = ctorAssembly.TypeDefs.[ctor.DeclaringType.Definition.Get]
 
-            let ctorBaseType =
-                DumpedAssembly.resolveBaseType
-                    baseClassTypes
-                    state._LoadedAssemblies
-                    ctorAssembly.Name
-                    ctorType.BaseType
-
             do
                 logger.LogDebug (
                     "Creating object of type {ConstructorAssembly}.{ConstructorType}",
@@ -345,15 +338,12 @@ module internal UnaryMetadataIlOp =
                 IlMachineState.allocateManagedObject ty fields state
 
             let state =
-                match ctorBaseType with
-                | ResolvedBaseType.ValueType
-                | ResolvedBaseType.Enum ->
+                if DumpedAssembly.isValueType baseClassTypes state._LoadedAssemblies ctorType then
                     state
                     |> IlMachineState.pushToEvalStack'
                         (EvalStackValue.ManagedPointer (heapValueByref allocatedAddr))
                         thread
-                | ResolvedBaseType.Object
-                | ResolvedBaseType.Delegate ->
+                else
                     state
                     |> IlMachineState.pushToEvalStack (CliType.ObjectRef (Some allocatedAddr)) thread
 
@@ -456,15 +446,11 @@ module internal UnaryMetadataIlOp =
             let defn =
                 state._LoadedAssemblies.[targetType.Assembly.FullName].TypeDefs.[targetType.Definition.Get]
 
-            let baseType =
-                DumpedAssembly.resolveBaseType baseClassTypes state._LoadedAssemblies targetType.Assembly defn.BaseType
-
             let toPush =
-                match baseType with
-                | ResolvedBaseType.Enum
-                | ResolvedBaseType.ValueType -> failwith "TODO: implement Box"
-                | ResolvedBaseType.Object
-                | ResolvedBaseType.Delegate -> toBox
+                if DumpedAssembly.isValueType baseClassTypes state._LoadedAssemblies defn then
+                    failwith "TODO: implement Box"
+                else
+                    toBox
 
             state
             |> IlMachineState.pushToEvalStack' toPush thread
@@ -1436,17 +1422,11 @@ module internal UnaryMetadataIlOp =
             let defn =
                 state._LoadedAssemblies.[targetType.Assembly.FullName].TypeDefs.[targetType.Definition.Get]
 
-            let baseType =
-                DumpedAssembly.resolveBaseType baseClassTypes state._LoadedAssemblies targetType.Assembly defn.BaseType
-
             let toPush =
-                match baseType with
-                | ResolvedBaseType.Enum
-                | ResolvedBaseType.ValueType ->
+                if DumpedAssembly.isValueType baseClassTypes state._LoadedAssemblies defn then
                     failwith
                         $"TODO: push %O{obj} as type %s{targetType.Assembly.Name}.%s{targetType.Namespace}.%s{targetType.Name}"
-                | ResolvedBaseType.Object
-                | ResolvedBaseType.Delegate ->
+                else
                     // III.4.13: reference types are just copied as pointers.
                     // We should have received a pointer, so let's just pass it back.
                     obj


### PR DESCRIPTION
Stage 3b of the type-predicate refactor in
docs/plans/2026-04-16-type-predicates.md. Replaces the `match resolveBaseType with ValueType | Enum -> ... | Object | Delegate -> ...` pattern at five Newobj/Box/push-kind call sites with the intent-named predicate. Pure refactor: the callers were already correct by coincidence (unconstructible corelib bases can't flow through these paths), and the predicate semantics coincide on the inputs that actually arrive.