### PR TITLE
Migrate delegate-dispatch branch to TypeInfo.isDelegate

### DIFF
--- a/WoofWare.PawPrint/AbstractMachine.fs
+++ b/WoofWare.PawPrint/AbstractMachine.fs
@@ -28,15 +28,8 @@ module AbstractMachine =
             let targetType =
                 targetAssy.TypeDefs.[instruction.ExecutingMethod.DeclaringType.Definition.Get]
 
-            let baseType =
-                DumpedAssembly.resolveBaseType
-                    baseClassTypes
-                    state._LoadedAssemblies
-                    targetAssy.Name
-                    targetType.BaseType
-
-            match baseType with
-            | ResolvedBaseType.Delegate ->
+            match DumpedAssembly.isDelegate baseClassTypes state._LoadedAssemblies targetType with
+            | true ->
                 match instruction.ReturnState with
                 | None -> failwith "How come we don't have a return point from a delegate?!"
                 | Some {
@@ -116,7 +109,7 @@ module AbstractMachine =
                             state
 
                     ExecutionResult.Stepped (state, WhatWeDid.Executed)
-            | _ ->
+            | false ->
 
             let outcome =
                 match


### PR DESCRIPTION
Stage 3d of the type-predicate refactor in
docs/plans/2026-04-16-type-predicates.md. AbstractMachine's no-IL path dispatches to delegate handling iff the executing method's declaring type is a concrete delegate. `isDelegate` encodes exactly that (excluding exact System.Delegate and System.MulticastDelegate, neither of which should take the user-delegate ctor/invoke branch). Pure refactor.