### PR TITLE
Migrate IsReferenceOrContainsReferences to TypeInfo.isValueType

### DIFF
--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -519,19 +519,13 @@ module Intrinsics =
                     |> Option.get
                     |> fun a -> a.TypeDefs.[generic.Definition.Get]
 
-                let baseType =
-                    td.BaseType
-                    |> DumpedAssembly.resolveBaseType baseClassTypes state._LoadedAssemblies generic.Assembly
-
-                match baseType with
-                | ResolvedBaseType.Enum
-                | ResolvedBaseType.ValueType ->
+                if DumpedAssembly.isValueType baseClassTypes state._LoadedAssemblies td then
                     td
                     |> TypeInfo.mapGeneric (fun (par, _) -> TypeDefn.GenericTypeParameter par.SequenceNumber)
                     |> containsRefType loggerFactory baseClassTypes state ImmutableDictionary.Empty
                     |> fun (state, _, result) -> state, result
-                | ResolvedBaseType.Object
-                | ResolvedBaseType.Delegate -> state, true
+                else
+                    state, true
 
             let state =
                 state


### PR DESCRIPTION
Stage 3e of the type-predicate refactor in
docs/plans/2026-04-16-type-predicates.md. The intrinsic for RuntimeHelpers.IsReferenceOrContainsReferences<T> asks "is T a value type (recurse into fields) or a reference type (answer true)?" — the intent-named predicate. Minor behaviour change: if T is exact System.Enum, the answer flips from "recurse into fields" to "return true", which matches real .NET (typeof(Enum).IsValueType is false).