### PR TITLE
Adjust cctor ordering to match .NET 9

### DIFF
--- a/WoofWare.PawPrint.Test/CrossAssemblyHarness.fs
+++ b/WoofWare.PawPrint.Test/CrossAssemblyHarness.fs
@@ -1,0 +1,161 @@
+namespace WoofWare.PawPrint.Test
+
+open System
+open System.Collections.Immutable
+open System.IO
+open System.Runtime.Loader
+open FsUnitTyped
+open Microsoft.CodeAnalysis
+open WoofWare.DotnetRuntimeLocator
+open WoofWare.PawPrint
+open WoofWare.PawPrint.ExternImplementations
+
+type CrossAssemblySpec =
+    {
+        Name : string
+        OutputKind : OutputKind
+        References : string list
+        Sources : string list
+    }
+
+[<RequireQualifiedAccess>]
+module CrossAssemblySpec =
+    let library (name : string) (references : string list) (sources : string list) : CrossAssemblySpec =
+        {
+            Name = name
+            OutputKind = OutputKind.DynamicallyLinkedLibrary
+            References = references
+            Sources = sources
+        }
+
+    let entryPoint (name : string) (references : string list) (sources : string list) : CrossAssemblySpec =
+        {
+            Name = name
+            OutputKind = OutputKind.ConsoleApplication
+            References = references
+            Sources = sources
+        }
+
+type CrossAssemblyEndToEndTestCase =
+    {
+        Assemblies : CrossAssemblySpec list
+        EntryAssemblyName : string
+        ExpectedReturnCode : int
+        NativeImpls : NativeImpls
+    }
+
+[<RequireQualifiedAccess>]
+module CrossAssemblyHarness =
+
+    let private getExitCode (terminalState : IlMachineState) (terminatingThread : ThreadId) : int =
+        match terminalState.ThreadState.[terminatingThread].MethodState.EvaluationStack.Values with
+        | [] -> failwith "expected program to return an int, but it returned void"
+        | head :: _ ->
+            match head with
+            | EvalStackValue.Int32 i -> i
+            | ret -> failwith $"expected program to return an int, but it returned %O{ret}"
+
+    let private compileAssemblies (assemblies : CrossAssemblySpec list) : Map<string, byte[]> =
+        (Map.empty, assemblies)
+        ||> List.fold (fun built spec ->
+            let references =
+                spec.References
+                |> List.map (fun referenceName ->
+                    match Map.tryFind referenceName built with
+                    | Some bytes -> MetadataReference.CreateFromImage bytes :> MetadataReference
+                    | None ->
+                        failwithf
+                            "Assembly %s references %s before it has been compiled; order assemblies topologically"
+                            spec.Name
+                            referenceName
+                )
+
+            let bytes = Roslyn.compileAssembly spec.Name spec.OutputKind references spec.Sources
+            built |> Map.add spec.Name bytes
+        )
+
+    let private writeAssemblies (tempDir : string) (assemblies : Map<string, byte[]>) : unit =
+        assemblies
+        |> Map.iter (fun assemblyName bytes ->
+            File.WriteAllBytes (Path.Combine (tempDir, assemblyName + ".dll"), bytes)
+        )
+
+    let private executeWithPawPrint (entryPath : string) (entryBytes : byte[]) (nativeImpls : NativeImpls) : int =
+        let assy = typeof<RunResult>.Assembly
+        let messages, loggerFactory = LoggerFactory.makeTest ()
+
+        let dotnetRuntimeDirs =
+            seq {
+                yield Path.GetDirectoryName entryPath
+                yield! DotnetRuntime.SelectForDll assy.Location
+            }
+            |> ImmutableArray.CreateRange
+
+        use peImage = new MemoryStream (entryBytes)
+
+        try
+            let terminalState, terminatingThread =
+                Program.run loggerFactory (Some entryPath) peImage dotnetRuntimeDirs nativeImpls []
+
+            getExitCode terminalState terminatingThread
+        with _ ->
+            for message in messages () do
+                Console.Error.WriteLine $"{message}"
+
+            reraise ()
+
+    let private executeWithRealRuntime (entryPath : string) : int =
+        let tempDir = Path.GetDirectoryName entryPath
+
+        let loadContext =
+            new AssemblyLoadContext ("CrossAssemblyEndToEnd", isCollectible = true)
+
+        loadContext.add_Resolving (fun context assemblyName ->
+            let candidate = Path.Combine (tempDir, assemblyName.Name + ".dll")
+
+            if File.Exists candidate then
+                context.LoadFromAssemblyPath candidate
+            else
+                null
+        )
+
+        try
+            let entry : Reflection.Assembly = loadContext.LoadFromAssemblyPath entryPath
+            let entryPoint : Reflection.MethodInfo = entry.EntryPoint
+            let mainArgs : string[] = [||]
+            let invokeArgs : obj[] = [| mainArgs :> obj |]
+            let result : obj = entryPoint.Invoke ((null : obj), invokeArgs)
+            unbox<int> result
+        finally
+            loadContext.Unload ()
+
+    let runTest (case : CrossAssemblyEndToEndTestCase) : unit =
+        let compiled = compileAssemblies case.Assemblies
+
+        let entryBytes =
+            compiled
+            |> Map.tryFind case.EntryAssemblyName
+            |> Option.defaultWith (fun () ->
+                failwithf "Entry assembly %s was not among the compiled assemblies" case.EntryAssemblyName
+            )
+
+        let tempDir = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ())
+        Directory.CreateDirectory tempDir |> ignore
+
+        try
+            writeAssemblies tempDir compiled
+
+            let entryPath = Path.Combine (tempDir, case.EntryAssemblyName + ".dll")
+
+            let realResult = executeWithRealRuntime entryPath
+            realResult |> shouldEqual case.ExpectedReturnCode
+
+            let pawPrintResult = executeWithPawPrint entryPath entryBytes case.NativeImpls
+            pawPrintResult |> shouldEqual realResult
+        finally
+            try
+                if Directory.Exists tempDir then
+                    Directory.Delete (tempDir, true)
+            with
+            | :? IOException
+            | :? UnauthorizedAccessException -> ()

--- a/WoofWare.PawPrint.Test/TestCrossAssemblyTypeInitialisation.fs
+++ b/WoofWare.PawPrint.Test/TestCrossAssemblyTypeInitialisation.fs
@@ -5,16 +5,12 @@ open NUnit.Framework
 [<TestFixture>]
 module TestCrossAssemblyTypeInitialisation =
 
-    [<Test>]
-    let ``constructing a derived type runs its cctor before a base type from another assembly`` () : unit =
-        {
-            Assemblies =
-                [
-                    CrossAssemblySpec.library
-                        "CrossAssemblyTypeInitialisation.BaseNewobj"
-                        []
-                        [
-                            """
+    let private baseLibrary : CrossAssemblySpec =
+        CrossAssemblySpec.library
+            "CrossAssemblyTypeInitialisation.BaseLib"
+            []
+            [
+                """
 namespace CrossAssemblyTypeInitialisation;
 
 public static class Recorder
@@ -24,16 +20,25 @@ public static class Recorder
 
 public class Base
 {
+    public static int BaseField = 5;
+
     static Base()
     {
         Recorder.Value = Recorder.Value * 10 + 2;
     }
 }
 """
-                        ]
+            ]
+
+    [<Test>]
+    let ``constructing a derived type runs its cctor before a base type from another assembly`` () : unit =
+        {
+            Assemblies =
+                [
+                    baseLibrary
                     CrossAssemblySpec.entryPoint
                         "CrossAssemblyTypeInitialisation.DerivedNewobj"
-                        [ "CrossAssemblyTypeInitialisation.BaseNewobj" ]
+                        [ "CrossAssemblyTypeInitialisation.BaseLib" ]
                         [
                             """
 using CrossAssemblyTypeInitialisation;
@@ -58,6 +63,89 @@ class Program
                         ]
                 ]
             EntryAssemblyName = "CrossAssemblyTypeInitialisation.DerivedNewobj"
+            ExpectedReturnCode = 0
+            NativeImpls = MockEnv.make ()
+        }
+        |> CrossAssemblyHarness.runTest
+
+    [<Test>]
+    [<Ignore "Pre-existing: Ldsfld on a type whose base is in a foreign assembly fails because getTypeRef assumes the foreign assembly is already loaded">]
+    let ``derived cctor reading base static triggers base cctor across assemblies`` () : unit =
+        {
+            Assemblies =
+                [
+                    baseLibrary
+                    CrossAssemblySpec.entryPoint
+                        "CrossAssemblyTypeInitialisation.DerivedReadsBase"
+                        [ "CrossAssemblyTypeInitialisation.BaseLib" ]
+                        [
+                            """
+using CrossAssemblyTypeInitialisation;
+
+class Derived : Base
+{
+    public static int Sum;
+
+    static Derived()
+    {
+        Recorder.Value = Recorder.Value * 10 + 1;
+        Sum = BaseField + 3;
+    }
+}
+
+class Program
+{
+    static int Main(string[] argv)
+    {
+        int sum = Derived.Sum;
+        return sum == 8 && Recorder.Value == 12 ? 0 : Recorder.Value * 100 + sum;
+    }
+}
+"""
+                        ]
+                ]
+            EntryAssemblyName = "CrossAssemblyTypeInitialisation.DerivedReadsBase"
+            ExpectedReturnCode = 0
+            NativeImpls = MockEnv.make ()
+        }
+        |> CrossAssemblyHarness.runTest
+
+    [<Test>]
+    [<Ignore "Pre-existing: Ldsfld on a type whose base is in a foreign assembly fails because getTypeRef assumes the foreign assembly is already loaded">]
+    let ``accessing derived static does not initialise base from another assembly`` () : unit =
+        {
+            Assemblies =
+                [
+                    baseLibrary
+                    CrossAssemblySpec.entryPoint
+                        "CrossAssemblyTypeInitialisation.DerivedStaticOnly"
+                        [ "CrossAssemblyTypeInitialisation.BaseLib" ]
+                        [
+                            """
+using CrossAssemblyTypeInitialisation;
+
+class Derived : Base
+{
+    public static int Y = 7;
+
+    static Derived()
+    {
+        Recorder.Value = Recorder.Value * 10 + 1;
+    }
+}
+
+class Program
+{
+    static int Main(string[] argv)
+    {
+        int y = Derived.Y;
+        return y == 7 && Recorder.Value == 1 ? 0 : Recorder.Value * 10 + y;
+    }
+}
+"""
+                        ]
+                ]
+            EntryAssemblyName = "CrossAssemblyTypeInitialisation.DerivedStaticOnly"
             ExpectedReturnCode = 0
             NativeImpls = MockEnv.make ()
         }

--- a/WoofWare.PawPrint.Test/TestCrossAssemblyTypeInitialisation.fs
+++ b/WoofWare.PawPrint.Test/TestCrossAssemblyTypeInitialisation.fs
@@ -1,0 +1,64 @@
+namespace WoofWare.PawPrint.Test
+
+open NUnit.Framework
+
+[<TestFixture>]
+module TestCrossAssemblyTypeInitialisation =
+
+    [<Test>]
+    let ``constructing a derived type runs its cctor before a base type from another assembly`` () : unit =
+        {
+            Assemblies =
+                [
+                    CrossAssemblySpec.library
+                        "CrossAssemblyTypeInitialisation.BaseNewobj"
+                        []
+                        [
+                            """
+namespace CrossAssemblyTypeInitialisation;
+
+public static class Recorder
+{
+    public static int Value;
+}
+
+public class Base
+{
+    static Base()
+    {
+        Recorder.Value = Recorder.Value * 10 + 2;
+    }
+}
+"""
+                        ]
+                    CrossAssemblySpec.entryPoint
+                        "CrossAssemblyTypeInitialisation.DerivedNewobj"
+                        [ "CrossAssemblyTypeInitialisation.BaseNewobj" ]
+                        [
+                            """
+using CrossAssemblyTypeInitialisation;
+
+class Derived : Base
+{
+    static Derived()
+    {
+        Recorder.Value = Recorder.Value * 10 + 1;
+    }
+}
+
+class Program
+{
+    static int Main(string[] argv)
+    {
+        new Derived();
+        return Recorder.Value == 12 ? 0 : Recorder.Value;
+    }
+}
+"""
+                        ]
+                ]
+            EntryAssemblyName = "CrossAssemblyTypeInitialisation.DerivedNewobj"
+            ExpectedReturnCode = 0
+            NativeImpls = MockEnv.make ()
+        }
+        |> CrossAssemblyHarness.runTest

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -12,12 +12,14 @@
     <Compile Include="Roslyn.fs" />
     <Compile Include="RealRuntime.fs" />
     <Compile Include="TestHarness.fs"/>
+    <Compile Include="CrossAssemblyHarness.fs" />
     <Compile Include="TypeIdentityTestHelpers.fs" />
     <Compile Include="AssemblyShape.fs" />
     <Compile Include="AssemblyGraphShape.fs" />
     <Compile Include="TestTypeResolution.fs" />
     <Compile Include="TestTypeIdentityProperties.fs" />
     <Compile Include="TestEvalStack.fs" />
+    <Compile Include="TestCrossAssemblyTypeInitialisation.fs" />
     <Compile Include="TestPureCases.fs" />
     <Compile Include="TestImpureCases.fs" />
   </ItemGroup>

--- a/WoofWare.PawPrint.Test/sourcesPure/DerivedCctorAccessesBaseStatic.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/DerivedCctorAccessesBaseStatic.cs
@@ -1,0 +1,38 @@
+class Recorder
+{
+    public static int Value;
+}
+
+class Base
+{
+    public static int BaseField = 5;
+
+    static Base()
+    {
+        Recorder.Value = Recorder.Value * 10 + 2;
+    }
+}
+
+class Derived : Base
+{
+    public static int Sum;
+
+    static Derived()
+    {
+        Recorder.Value = Recorder.Value * 10 + 1;
+        Sum = BaseField + 3;
+    }
+}
+
+class Program
+{
+    static int Main(string[] argv)
+    {
+        int sum = Derived.Sum;
+        // Accessing Derived.Sum triggers Derived.cctor, which reads Base.BaseField,
+        // triggering Base.cctor mid-way through Derived.cctor.
+        // Order: Derived.cctor starts (Value = 1), Base.cctor runs (Value = 12),
+        // Derived.cctor finishes (Sum = 5 + 3 = 8).
+        return sum == 8 && Recorder.Value == 12 ? 0 : Recorder.Value * 100 + sum;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/DerivedStaticAccessDoesNotInitializeBase.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/DerivedStaticAccessDoesNotInitializeBase.cs
@@ -1,0 +1,31 @@
+class Recorder
+{
+    public static int Value;
+}
+
+class Base
+{
+    static Base()
+    {
+        Recorder.Value = Recorder.Value * 10 + 2;
+    }
+}
+
+class Derived : Base
+{
+    public static int Y = 7;
+
+    static Derived()
+    {
+        Recorder.Value = Recorder.Value * 10 + 1;
+    }
+}
+
+class Program
+{
+    static int Main(string[] argv)
+    {
+        int y = Derived.Y;
+        return y == 7 && Recorder.Value == 1 ? 0 : Recorder.Value * 10 + y;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/NewobjStaticInitializationOrder.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/NewobjStaticInitializationOrder.cs
@@ -1,0 +1,29 @@
+class Recorder
+{
+    public static int Value;
+}
+
+class Base
+{
+    static Base()
+    {
+        Recorder.Value = Recorder.Value * 10 + 2;
+    }
+}
+
+class Derived : Base
+{
+    static Derived()
+    {
+        Recorder.Value = Recorder.Value * 10 + 1;
+    }
+}
+
+class Program
+{
+    static int Main(string[] argv)
+    {
+        new Derived();
+        return Recorder.Value == 12 ? 0 : Recorder.Value;
+    }
+}

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -125,6 +125,9 @@ holds the lock.
 initialized state for the type, but no deadlock will arise.
 2.2.3 If not, block until the type is initialized then return.
 2.3 Initialize the base class type and then all interfaces implemented by this type.
+    NOTE: The real CLR does not eagerly run base type initializers here. Base types get
+    initialized lazily when their own constructors or static members are touched. We follow
+    the CLR's actual behaviour, not the spec text.
 2.4 Execute the type initialization code for this type.
 2.5 Mark the type as initialized, release the initialization lock, awaken any threads waiting for this type
 to be initialized, and return.

--- a/WoofWare.PawPrint/IlMachineStateExecution.fs
+++ b/WoofWare.PawPrint/IlMachineStateExecution.fs
@@ -548,10 +548,9 @@ module IlMachineStateExecution =
 
             // The CLR does not eagerly run base type initializers before the current type's .cctor.
             // Base types get initialized later when their own constructors or static members are touched.
-            // TODO: also need to initialise any prerequisites that the CLI genuinely requires here
-
-            // Only mark the type as in-progress once all prerequisite initialisation has completed.
-            // Otherwise a suspended prerequisite load causes retries to skip this type's own .cctor.
+            // TODO: also need to initialise any prerequisites that the CLI genuinely requires here;
+            // if so, do them *before* WithTypeBeginInit, otherwise a suspended prerequisite causes
+            // retries to see "in-progress" and skip this type's own .cctor.
             let state = state.WithTypeBeginInit currentThread ty
 
             // Find the class constructor (.cctor) if it exists

--- a/WoofWare.PawPrint/IlMachineStateExecution.fs
+++ b/WoofWare.PawPrint/IlMachineStateExecution.fs
@@ -546,101 +546,13 @@ module IlMachineStateExecution =
 
             logger.LogDebug ("Resolving type {TypeDefNamespace}.{TypeDefName}", typeDef.Namespace, typeDef.Name)
 
-            // First mark as in-progress to detect cycles
+            // The CLR does not eagerly run base type initializers before the current type's .cctor.
+            // Base types get initialized later when their own constructors or static members are touched.
+            // TODO: also need to initialise any prerequisites that the CLI genuinely requires here
+
+            // Only mark the type as in-progress once all prerequisite initialisation has completed.
+            // Otherwise a suspended prerequisite load causes retries to skip this type's own .cctor.
             let state = state.WithTypeBeginInit currentThread ty
-
-            // Check if the type has a base type that needs initialization
-            let firstDoBaseClass =
-                match typeDef.BaseType with
-                | Some baseTypeInfo ->
-                    // Determine if base type is in the same or different assembly
-                    match baseTypeInfo with
-                    | BaseTypeInfo.ForeignAssemblyType _ -> failwith "TODO"
-                    //logger.LogDebug (
-                    //    "Resolved base type of {TypeDefNamespace}.{TypeDefName} to foreign assembly {ForeignAssemblyName}",
-                    //    typeDef.Namespace,
-                    //    typeDef.Name,
-                    //    baseAssemblyName.Name
-                    //)
-
-                    //match loadClass loggerFactory baseTypeHandle baseAssemblyName currentThread state with
-                    //| FirstLoadThis state -> Error state
-                    //| NothingToDo state -> Ok state
-                    | BaseTypeInfo.TypeDef typeDefinitionHandle ->
-                        logger.LogDebug (
-                            "Resolved base type of {TypeDefNamespace}.{TypeDefName} to this assembly, typedef",
-                            typeDef.Namespace,
-                            typeDef.Name
-                        )
-
-                        let baseTypeDefn =
-                            DumpedAssembly.typeInfoToTypeDefn' baseClassTypes state._LoadedAssemblies typeDef
-
-                        // Concretize the base type
-                        let state, baseTypeHandle =
-                            IlMachineState.concretizeType
-                                loggerFactory
-                                baseClassTypes
-                                state
-                                sourceAssembly.Name
-                                concreteType.Generics
-                                // TODO: surely we have generics in scope here?
-                                ImmutableArray.Empty
-                                baseTypeDefn
-
-                        // Recursively load the base class
-                        match loadClass loggerFactory baseClassTypes baseTypeHandle currentThread state with
-                        | FirstLoadThis state -> Error state
-                        | NothingToDo state -> Ok state
-                    | BaseTypeInfo.TypeRef typeReferenceHandle ->
-                        let state, assy, targetType =
-                            // TypeRef won't have any generics; it would be a TypeSpec if it did
-                            IlMachineState.resolveType
-                                loggerFactory
-                                typeReferenceHandle
-                                ImmutableArray.Empty
-                                (state.ActiveAssembly currentThread)
-                                state
-
-                        logger.LogDebug (
-                            "Resolved base type of {TypeDefNamespace}.{TypeDefName} to a typeref in assembly {ResolvedAssemblyName}, {BaseTypeNamespace}.{BaseTypeName}",
-                            typeDef.Namespace,
-                            typeDef.Name,
-                            assy.Name.Name,
-                            targetType.Namespace,
-                            targetType.Name
-                        )
-
-                        // Create a TypeDefn from the resolved TypeRef
-                        let baseTypeDefn =
-                            targetType
-                            |> DumpedAssembly.typeInfoToTypeDefn baseClassTypes state._LoadedAssemblies
-
-                        // Concretize the base type
-                        let state, baseTypeHandle =
-                            IlMachineState.concretizeType
-                                loggerFactory
-                                baseClassTypes
-                                state
-                                sourceAssembly.Name
-                                concreteType.Generics
-                                // TODO: surely we have generics in scope here?
-                                ImmutableArray.Empty
-                                baseTypeDefn
-
-                        // Recursively load the base class
-                        match loadClass loggerFactory baseClassTypes baseTypeHandle currentThread state with
-                        | FirstLoadThis state -> Error state
-                        | NothingToDo state -> Ok state
-                    | BaseTypeInfo.TypeSpec typeSpecificationHandle ->
-                        failwith "TODO: TypeSpec base type loading unimplemented"
-                | None -> Ok state // No base type (or it's System.Object)
-
-            match firstDoBaseClass with
-            | Error state -> FirstLoadThis state
-            | Ok state ->
-
-            // TODO: also need to initialise all interfaces implemented by the type
 
             // Find the class constructor (.cctor) if it exists
             let cctor =


### PR DESCRIPTION
I believe this behaviour is contrary to the spec? But it's what net9 does.