### PR TITLE
Surface unhandled guest exceptions through the execution pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,3 +2,5 @@
 
 Once you think you're finished making a change, please commit it.
 Then invoke OpenAI Codex to perform a review of your work, and address any of its findings that you think are appropriate: `codex review --base main` (this can take many minutes).
+
+I think this project is super exciting! Real deterministic simulation and reproduction; all flakiness shall be banished!

--- a/WoofWare.PawPrint.App/Program.fs
+++ b/WoofWare.PawPrint.App/Program.fs
@@ -2,6 +2,7 @@ namespace WoofWare.PawPrint
 
 open System.Collections.Immutable
 open System.IO
+open System.Runtime.InteropServices
 open Microsoft.Extensions.Logging
 open WoofWare.DotnetRuntimeLocator
 open WoofWare.PawPrint.ExternImplementations
@@ -27,10 +28,25 @@ module Program =
 
             use fileStream = new FileStream (dllPath, FileMode.Open, FileAccess.Read)
 
-            let terminalState =
-                Program.run loggerFactory (Some dllPath) fileStream dotnetRuntimes impls args
+            match Program.run loggerFactory (Some dllPath) fileStream dotnetRuntimes impls args with
+            | RunOutcome.NormalExit _ -> 0
+            | RunOutcome.GuestUnhandledException (state, _thread, exn) ->
+                let exceptionTypeName =
+                    match state.ManagedHeap.NonArrayObjects |> Map.tryFind exn.ExceptionObject with
+                    | Some obj ->
+                        match AllConcreteTypes.lookup obj.ConcreteType state.ConcreteTypes with
+                        | Some ti -> $"{ti.Namespace}.{ti.Name}"
+                        | None -> $"<unknown type %O{obj.ConcreteType}>"
+                    | None -> $"<heap address %O{exn.ExceptionObject}>"
 
-            0
+                logger.LogCritical $"Unhandled exception in guest program: {exceptionTypeName}"
+
+                // On Windows the .NET runtime exits with 0xE0434352 (SEH);
+                // on Unix it aborts with SIGABRT (exit code 128 + 6 = 134).
+                if RuntimeInformation.IsOSPlatform OSPlatform.Windows then
+                    -532462766
+                else
+                    134
         | _ ->
             logger.LogCritical "Supply exactly one DLL path"
             1

--- a/WoofWare.PawPrint.Test/CrossAssemblyHarness.fs
+++ b/WoofWare.PawPrint.Test/CrossAssemblyHarness.fs
@@ -96,7 +96,7 @@ module CrossAssemblyHarness =
         try
             match Program.run loggerFactory (Some entryPath) peImage dotnetRuntimeDirs nativeImpls [] with
             | RunOutcome.GuestUnhandledException (_, _, exn) ->
-                failwith $"PawPrint threw unhandled exception: %O{exn.ExceptionObject}"
+                failwith $"Guest threw unhandled exception: %O{exn.ExceptionObject}"
             | RunOutcome.NormalExit (terminalState, terminatingThread) ->
 
             getExitCode terminalState terminatingThread

--- a/WoofWare.PawPrint.Test/CrossAssemblyHarness.fs
+++ b/WoofWare.PawPrint.Test/CrossAssemblyHarness.fs
@@ -94,8 +94,10 @@ module CrossAssemblyHarness =
         use peImage = new MemoryStream (entryBytes)
 
         try
-            let terminalState, terminatingThread =
-                Program.run loggerFactory (Some entryPath) peImage dotnetRuntimeDirs nativeImpls []
+            match Program.run loggerFactory (Some entryPath) peImage dotnetRuntimeDirs nativeImpls [] with
+            | RunOutcome.GuestUnhandledException (_, _, exn) ->
+                failwith $"PawPrint threw unhandled exception: %O{exn.ExceptionObject}"
+            | RunOutcome.NormalExit (terminalState, terminatingThread) ->
 
             getExitCode terminalState terminatingThread
         with _ ->

--- a/WoofWare.PawPrint.Test/RealRuntime.fs
+++ b/WoofWare.PawPrint.Test/RealRuntime.fs
@@ -2,17 +2,19 @@ namespace WoofWare.PawPrint.Test
 
 /// Result of executing the program using the real .NET runtime.
 type RealRuntimeResult =
-    {
-        ExitCode : int
-    }
+    /// The program returned normally with an exit code.
+    | NormalExit of exitCode : int
+    /// The program threw an unhandled exception.
+    | UnhandledException of exn : System.Exception
 
 [<RequireQualifiedAccess>]
 module RealRuntime =
     /// Execute an assembly using the real .NET runtime and capture the result.
     let executeWithRealRuntime (args : string[]) (assemblyBytes : byte array) : RealRuntimeResult =
         let assy = System.Reflection.Assembly.Load assemblyBytes
-        let result = assy.EntryPoint.Invoke ((null : obj), [| args |]) |> unbox<int>
 
-        {
-            ExitCode = result
-        }
+        try
+            let result = assy.EntryPoint.Invoke ((null : obj), [| args |]) |> unbox<int>
+            RealRuntimeResult.NormalExit result
+        with :? System.Reflection.TargetInvocationException as tie ->
+            RealRuntimeResult.UnhandledException (tie.InnerException |> Option.ofObj |> Option.defaultValue (tie :> _))

--- a/WoofWare.PawPrint.Test/TestHarness.fs
+++ b/WoofWare.PawPrint.Test/TestHarness.fs
@@ -30,4 +30,5 @@ type EndToEndTestCase =
         FileName : string
         ExpectedReturnCode : int
         NativeImpls : NativeImpls
+        ExpectsUnhandledException : bool
     }

--- a/WoofWare.PawPrint.Test/TestImpureCases.fs
+++ b/WoofWare.PawPrint.Test/TestImpureCases.fs
@@ -65,7 +65,7 @@ module TestImpureCases =
         try
             match Program.run loggerFactory (Some case.FileName) peImage dotnetRuntimes case.NativeImpls [] with
             | RunOutcome.GuestUnhandledException (_, _, exn) ->
-                failwith $"PawPrint threw unhandled exception: %O{exn.ExceptionObject}"
+                failwith $"Guest threw unhandled exception: %O{exn.ExceptionObject}"
             | RunOutcome.NormalExit (terminalState, terminatingThread) ->
 
             let exitCode =

--- a/WoofWare.PawPrint.Test/TestImpureCases.fs
+++ b/WoofWare.PawPrint.Test/TestImpureCases.fs
@@ -61,8 +61,10 @@ module TestImpureCases =
         use peImage = new MemoryStream (image)
 
         try
-            let terminalState, terminatingThread =
-                Program.run loggerFactory (Some case.FileName) peImage dotnetRuntimes case.NativeImpls []
+            match Program.run loggerFactory (Some case.FileName) peImage dotnetRuntimes case.NativeImpls [] with
+            | RunOutcome.GuestUnhandledException (_, _, exn) ->
+                failwith $"PawPrint threw unhandled exception: %O{exn.ExceptionObject}"
+            | RunOutcome.NormalExit (terminalState, terminatingThread) ->
 
             let exitCode =
                 match terminalState.ThreadState.[terminatingThread].MethodState.EvaluationStack.Values with

--- a/WoofWare.PawPrint.Test/TestImpureCases.fs
+++ b/WoofWare.PawPrint.Test/TestImpureCases.fs
@@ -21,6 +21,7 @@ module TestImpureCases =
                 FileName = "WriteLine.cs"
                 ExpectedReturnCode = 1
                 NativeImpls = NativeImpls.PassThru ()
+                ExpectsUnhandledException = false
             }
         ]
 
@@ -29,6 +30,7 @@ module TestImpureCases =
             {
                 FileName = "InstaQuit.cs"
                 ExpectedReturnCode = 1
+                ExpectsUnhandledException = false
                 NativeImpls =
                     let mock = MockEnv.make ()
 

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -119,8 +119,9 @@ module TestPureCases =
 
                 pawPrintExitCode |> shouldEqual exitCode
             | RealRuntimeResult.UnhandledException _, RunOutcome.GuestUnhandledException _ ->
-                // Both threw unhandled exceptions — this is correct behaviour.
-                ()
+                if not case.ExpectsUnhandledException then
+                    failwith
+                        $"Both runtimes threw unhandled exceptions for %s{case.FileName}, but this test was not expected to throw. Add to expectsUnhandledException if intentional."
             | RealRuntimeResult.NormalExit exitCode, RunOutcome.GuestUnhandledException (_, _, exn) ->
                 failwith
                     $"Real runtime exited normally with code %d{exitCode}, but PawPrint threw unhandled exception: %O{exn.ExceptionObject}"
@@ -146,6 +147,7 @@ module TestPureCases =
             FileName = fileName
             ExpectedReturnCode = 0
             NativeImpls = MockEnv.make ()
+            ExpectsUnhandledException = false
         }
         |> runTest
 
@@ -158,6 +160,7 @@ module TestPureCases =
             FileName = fileName
             ExpectedReturnCode = exitCode
             NativeImpls = MockEnv.make ()
+            ExpectsUnhandledException = false
         }
         |> runTest
 
@@ -167,6 +170,7 @@ module TestPureCases =
             FileName = fileName
             ExpectedReturnCode = exitCode
             NativeImpls = mock
+            ExpectsUnhandledException = false
         }
         |> runTest
 
@@ -177,6 +181,7 @@ module TestPureCases =
             FileName = fileName
             ExpectedReturnCode = 0 // not checked; both runtimes are expected to throw
             NativeImpls = MockEnv.make ()
+            ExpectsUnhandledException = true
         }
         |> runTest
 
@@ -187,5 +192,6 @@ module TestPureCases =
             FileName = fileName
             ExpectedReturnCode = 0
             NativeImpls = MockEnv.make ()
+            ExpectsUnhandledException = false
         }
         |> runTest

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -50,6 +50,8 @@ module TestPureCases =
         ]
         |> Map.ofList
 
+    let expectsUnhandledException = [ "UnhandledException.cs" ] |> Set.ofList
+
     let customExitCodes =
         [
             "NoOp.cs", 1
@@ -81,7 +83,8 @@ module TestPureCases =
         |> Seq.filter (fun s ->
             (customExitCodes.ContainsKey s
              || requiresMocks.ContainsKey s
-             || unimplemented.Contains s)
+             || unimplemented.Contains s
+             || expectsUnhandledException.Contains s)
             |> not
         )
         |> Seq.toList
@@ -98,20 +101,38 @@ module TestPureCases =
 
         try
             let realResult = RealRuntime.executeWithRealRuntime [||] image
-            realResult.ExitCode |> shouldEqual case.ExpectedReturnCode
 
-            let terminalState, terminatingThread =
+            let pawPrintResult =
                 Program.run loggerFactory (Some case.FileName) peImage dotnetRuntimes case.NativeImpls []
 
-            let exitCode =
-                match terminalState.ThreadState.[terminatingThread].MethodState.EvaluationStack.Values with
-                | [] -> failwith "expected program to return a value, but it returned void"
-                | head :: _ ->
-                    match head with
-                    | EvalStackValue.Int32 i -> i
-                    | ret -> failwith $"expected program to return an int, but it returned %O{ret}"
+            match realResult, pawPrintResult with
+            | RealRuntimeResult.NormalExit exitCode, RunOutcome.NormalExit (terminalState, terminatingThread) ->
+                exitCode |> shouldEqual case.ExpectedReturnCode
 
-            exitCode |> shouldEqual realResult.ExitCode
+                let pawPrintExitCode =
+                    match terminalState.ThreadState.[terminatingThread].MethodState.EvaluationStack.Values with
+                    | [] -> failwith "expected program to return a value, but it returned void"
+                    | head :: _ ->
+                        match head with
+                        | EvalStackValue.Int32 i -> i
+                        | ret -> failwith $"expected program to return an int, but it returned %O{ret}"
+
+                pawPrintExitCode |> shouldEqual exitCode
+            | RealRuntimeResult.UnhandledException _, RunOutcome.GuestUnhandledException _ ->
+                // Both threw unhandled exceptions — this is correct behaviour.
+                ()
+            | RealRuntimeResult.NormalExit exitCode, RunOutcome.GuestUnhandledException (_, _, exn) ->
+                failwith
+                    $"Real runtime exited normally with code %d{exitCode}, but PawPrint threw unhandled exception: %O{exn.ExceptionObject}"
+            | RealRuntimeResult.UnhandledException realExn, RunOutcome.NormalExit (terminalState, terminatingThread) ->
+                let pawPrintExitCode =
+                    match terminalState.ThreadState.[terminatingThread].MethodState.EvaluationStack.Values with
+                    | [] -> None
+                    | EvalStackValue.Int32 i :: _ -> Some i
+                    | _ -> None
+
+                failwith
+                    $"Real runtime threw unhandled %s{realExn.GetType().Name}, but PawPrint exited normally (code: %O{pawPrintExitCode})"
 
         with _ ->
             for message in messages () do
@@ -149,6 +170,15 @@ module TestPureCases =
         }
         |> runTest
 
+
+    [<TestCaseSource(nameof expectsUnhandledException)>]
+    let ``Tests which throw unhandled exceptions`` (fileName : string) =
+        {
+            FileName = fileName
+            ExpectedReturnCode = 0 // not checked; both runtimes are expected to throw
+            NativeImpls = MockEnv.make ()
+        }
+        |> runTest
 
     [<TestCaseSource(nameof unimplemented)>]
     [<Explicit>]

--- a/WoofWare.PawPrint.Test/sourcesPure/UnhandledException.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/UnhandledException.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace UnhandledExceptionTest
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            throw new InvalidOperationException("This exception is intentionally unhandled.");
+        }
+    }
+}

--- a/WoofWare.PawPrint/AbstractMachine.fs
+++ b/WoofWare.PawPrint/AbstractMachine.fs
@@ -180,6 +180,7 @@ module AbstractMachine =
 
             match outcome with
             | ExecutionResult.Terminated (state, terminating) -> ExecutionResult.Terminated (state, terminating)
+            | ExecutionResult.UnhandledException _ -> outcome
             | ExecutionResult.Stepped (state, whatWeDid) ->
                 ExecutionResult.Stepped (
                     IlMachineState.returnStackFrame loggerFactory baseClassTypes thread state

--- a/WoofWare.PawPrint/ExceptionDispatching.fs
+++ b/WoofWare.PawPrint/ExceptionDispatching.fs
@@ -3,6 +3,13 @@ namespace WoofWare.PawPrint
 open System.Collections.Immutable
 open Microsoft.Extensions.Logging
 
+/// Result of attempting to dispatch an exception to a handler.
+type ExceptionDispatchResult =
+    /// A handler was found and entered; the machine state is positioned at the handler entry.
+    | HandlerFound of IlMachineState
+    /// The exception is unhandled; no handler was found in any frame.
+    | ExceptionUnhandled of IlMachineState * CliException<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>
+
 /// Exception handler dispatch that requires IlMachineState for type resolution.
 [<RequireQualifiedAccess>]
 module ExceptionDispatching =
@@ -214,13 +221,13 @@ module ExceptionDispatching =
         (currentThread : ThreadId)
         (cliException : CliException<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>)
         (exceptionType : ConcreteTypeHandle)
-        : IlMachineState
+        : ExceptionDispatchResult
         =
         let threadState = state.ThreadState.[currentThread]
         let currentMethodState = threadState.MethodState
 
         match currentMethodState.ReturnState with
-        | None -> failwith $"Unhandled exception: %O{exceptionType}. No handler found in any stack frame."
+        | None -> ExceptionDispatchResult.ExceptionUnhandled (state, cliException)
         | Some returnState ->
 
         // If this frame was running a .cctor, mark the type initialisation as failed
@@ -294,14 +301,17 @@ module ExceptionDispatching =
             }
 
         match handlerResult with
-        | Some (handler, _isFinally) -> enterHandler currentThread callerFrame threadState state cliException handler
+        | Some (handler, _isFinally) ->
+            enterHandler currentThread callerFrame threadState state cliException handler
+            |> ExceptionDispatchResult.HandlerFound
         | None ->
             // No handler in this frame either; continue unwinding
             unwindToCallerAndSearch loggerFactory corelib state currentThread cliException exceptionType
 
     /// Dispatch an exception that has been thrown or is being propagated. Searches for a handler
     /// in the current method; if found, enters it; otherwise unwinds to the caller.
-    /// Returns the updated state with the thread positioned at the handler entry point.
+    /// Returns the updated state with the thread positioned at the handler entry point,
+    /// or ExceptionUnhandled if no handler exists in any frame.
     let dispatchException
         (loggerFactory : ILoggerFactory)
         (corelib : BaseClassTypes<DumpedAssembly>)
@@ -309,7 +319,7 @@ module ExceptionDispatching =
         (currentThread : ThreadId)
         (cliException : CliException<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>)
         (exceptionType : ConcreteTypeHandle)
-        : IlMachineState
+        : ExceptionDispatchResult
         =
         let threadState = state.ThreadState.[currentThread]
         let currentMethodState = threadState.MethodState
@@ -329,6 +339,7 @@ module ExceptionDispatching =
         match handlerResult with
         | Some (handler, _isFinally) ->
             enterHandler currentThread currentMethodState threadState state cliException handler
+            |> ExceptionDispatchResult.HandlerFound
         | None -> unwindToCallerAndSearch loggerFactory corelib state currentThread cliException exceptionType
 
     /// Initiate exception dispatch for an exception object already on the heap.
@@ -340,7 +351,7 @@ module ExceptionDispatching =
         (currentThread : ThreadId)
         (exceptionAddr : ManagedHeapAddress)
         (exceptionType : ConcreteTypeHandle)
-        : IlMachineState
+        : ExceptionDispatchResult
         =
         let threadState = state.ThreadState.[currentThread]
         let currentMethodState = threadState.MethodState

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -167,6 +167,18 @@ type WhatWeDid =
 type ExecutionResult =
     | Terminated of IlMachineState * terminatingThread : ThreadId
     | Stepped of IlMachineState * WhatWeDid
+    | UnhandledException of
+        IlMachineState *
+        terminatingThread : ThreadId *
+        CliException<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>
+
+/// Result of a complete program run (the pump loop having finished).
+type RunOutcome =
+    | NormalExit of IlMachineState * terminatingThread : ThreadId
+    | GuestUnhandledException of
+        IlMachineState *
+        terminatingThread : ThreadId *
+        CliException<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>
 
 type StateLoadResult =
     /// The type is loaded; you can proceed.

--- a/WoofWare.PawPrint/IlMachineStateExecution.fs
+++ b/WoofWare.PawPrint/IlMachineStateExecution.fs
@@ -521,7 +521,7 @@ module IlMachineStateExecution =
             // The .cctor previously threw. Per ECMA-335, subsequent access should throw
             // TypeInitializationException. We rethrow the *same* cached instance to match
             // CLR identity semantics (ReferenceEquals across repeated accesses).
-            let state =
+            match
                 ExceptionDispatching.throwExceptionObject
                     loggerFactory
                     baseClassTypes
@@ -529,8 +529,10 @@ module IlMachineStateExecution =
                     currentThread
                     tieAddr
                     tieType
-
-            StateLoadResult.ThrowingTypeInitializationException state
+            with
+            | ExceptionDispatchResult.HandlerFound state -> StateLoadResult.ThrowingTypeInitializationException state
+            | ExceptionDispatchResult.ExceptionUnhandled _ ->
+                failwith $"Unhandled TypeInitializationException during class loading for type with cached TIE"
         | Some (TypeInitState.InProgress tid) when tid = currentThread ->
             // We're already initializing this type on this thread; just proceed with the initialisation, no extra
             // class loading required.
@@ -686,10 +688,13 @@ module IlMachineStateExecution =
         | Some (TypeInitState.Failed (tieAddr, tieType)) ->
             // The .cctor for this type threw. Per ECMA-335, subsequent access should throw
             // TypeInitializationException. Rethrow the cached instance for CLR identity semantics.
-            let state =
+            match
                 ExceptionDispatching.throwExceptionObject loggerFactory baseClassTypes state thread tieAddr tieType
-
-            state, WhatWeDid.ThrowingTypeInitializationException
+            with
+            | ExceptionDispatchResult.HandlerFound state -> state, WhatWeDid.ThrowingTypeInitializationException
+            | ExceptionDispatchResult.ExceptionUnhandled _ ->
+                failwith
+                    "Unhandled TypeInitializationException during ensureTypeInitialised; should have been caught by a handler"
         | Some (TypeInitState.InProgress threadId) ->
             if threadId = thread then
                 // II.10.5.3.2: avoid the deadlock by simply proceeding.

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -799,15 +799,18 @@ module NullaryIlOp =
                     | Some obj -> obj
                     | None -> failwith "Exception object not found in heap during endfinally propagation"
 
-                ExceptionDispatching.dispatchException
-                    loggerFactory
-                    corelib
-                    state
-                    currentThread
-                    exn
-                    heapObject.ConcreteType
-                |> Tuple.withRight WhatWeDid.Executed
-                |> ExecutionResult.Stepped
+                match
+                    ExceptionDispatching.dispatchException
+                        loggerFactory
+                        corelib
+                        state
+                        currentThread
+                        exn
+                        heapObject.ConcreteType
+                with
+                | ExceptionDispatchResult.HandlerFound state -> (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+                | ExceptionDispatchResult.ExceptionUnhandled (state, exn) ->
+                    ExecutionResult.UnhandledException (state, currentThread, exn)
             | Some (ExceptionContinuation.ResumeAfterFilter (handlerPC, exn)) ->
                 // Filter evaluated, continue propagation or jump to handler based on filter result
                 failwith "TODO: ResumeAfterFilter not yet implemented"
@@ -828,15 +831,18 @@ module NullaryIlOp =
                 | Some obj -> obj
                 | None -> failwith "Exception object not found in heap"
 
-            ExceptionDispatching.throwExceptionObject
-                loggerFactory
-                corelib
-                state
-                currentThread
-                addr
-                heapObject.ConcreteType
-            |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            match
+                ExceptionDispatching.throwExceptionObject
+                    loggerFactory
+                    corelib
+                    state
+                    currentThread
+                    addr
+                    heapObject.ConcreteType
+            with
+            | ExceptionDispatchResult.HandlerFound state -> (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            | ExceptionDispatchResult.ExceptionUnhandled (state, exn) ->
+                ExecutionResult.UnhandledException (state, currentThread, exn)
 
         | Localloc -> failwith "TODO: Localloc unimplemented"
         | Stind_I ->

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -55,10 +55,12 @@ module Program =
         impls
         (mainThread : ThreadId)
         (state : IlMachineState)
-        : IlMachineState * ThreadId
+        : RunOutcome
         =
         match AbstractMachine.executeOneStep loggerFactory impls baseClassTypes state mainThread with
-        | ExecutionResult.Terminated (state, terminatingThread) -> state, terminatingThread
+        | ExecutionResult.Terminated (state, terminatingThread) -> RunOutcome.NormalExit (state, terminatingThread)
+        | ExecutionResult.UnhandledException (state, terminatingThread, exn) ->
+            RunOutcome.GuestUnhandledException (state, terminatingThread, exn)
         | ExecutionResult.Stepped (state', whatWeDid) ->
 
         match whatWeDid with
@@ -73,8 +75,7 @@ module Program =
 
         pumpToReturn loggerFactory logger baseClassTypes impls mainThread state'
 
-    /// Returns the abstract machine's state at the end of execution, together with the thread which
-    /// caused execution to end.
+    /// Returns the outcome of the program run: normal exit or unhandled guest exception.
     let run
         (loggerFactory : ILoggerFactory)
         (originalPath : string option)
@@ -82,7 +83,7 @@ module Program =
         (dotnetRuntimeDirs : ImmutableArray<string>)
         impls
         (argv : string list)
-        : IlMachineState * ThreadId
+        : RunOutcome
         =
         let logger = loggerFactory.CreateLogger "Program"
 
@@ -301,8 +302,10 @@ module Program =
         // We might be in the middle of class construction. Pump the static constructors to completion.
         // We haven't yet entered the main method!
 
-        let state, _ =
-            pumpToReturn loggerFactory logger baseClassTypes impls mainThread state
+        let state =
+            match pumpToReturn loggerFactory logger baseClassTypes impls mainThread state with
+            | RunOutcome.NormalExit (state, _) -> state
+            | RunOutcome.GuestUnhandledException _ -> failwith "Unhandled exception during static class initialisation"
 
         logger.LogInformation "Main method class now initialised"
 


### PR DESCRIPTION
Previously, when exception dispatch exhausted all stack frames without finding a handler, the interpreter crashed with a host-side failwith. Now the dispatch functions return ExceptionDispatchResult (HandlerFound or ExceptionUnhandled), which propagates through ExecutionResult and RunOutcome to the test harness and App entry point.

- Add ExceptionDispatchResult DU in ExceptionDispatching.fs
- Add ExecutionResult.UnhandledException and RunOutcome DU
- Update throw/endfinally in NullaryIlOp.fs to convert dispatch results
- Update Program.pumpToReturn and Program.run to return RunOutcome
- Update App to exit with 0xE0434352 on unhandled guest exception
- Update RealRuntime to capture TargetInvocationException
- Update test harness to compare both runtimes' exception behaviour
- Add UnhandledException.cs test (throws and never catches)