### PR TITLE
Implement RuntimeHelpers.InitializeArray intrinsic

### DIFF
--- a/.claude/commands/raise-guest-exception.md
+++ b/.claude/commands/raise-guest-exception.md
@@ -1,0 +1,84 @@
+# How to raise a guest exception in the PawPrint runtime
+
+This skill describes how to make the PawPrint IL interpreter throw an exception *inside the guest program* (i.e. a managed .NET exception that the guest's own `try`/`catch` can handle), as opposed to a host `failwith` that crashes the interpreter.
+
+## Overview
+
+There are two tiers of complexity:
+
+1. **You already have an exception object on the managed heap** (e.g. a cached `TypeInitializationException`). This is the simple case.
+2. **You need to construct a new exception object** (e.g. `NullReferenceException`, `ArgumentException`). This requires allocating and initialising an object first.
+
+Most call sites in the codebase today still use `failwith "TODO: throw SomeException"` because tier 2 hasn't been generalised yet. When you encounter one of those, upgrading it is welcome but not required for every change.
+
+## Tier 1: Dispatching an existing exception object
+
+If you already have a `ManagedHeapAddress` for the exception object and its `ConcreteTypeHandle`:
+
+```fsharp
+match
+    ExceptionDispatching.throwExceptionObject
+        loggerFactory
+        baseClassTypes   // BaseClassTypes<DumpedAssembly>
+        state            // IlMachineState
+        currentThread    // ThreadId
+        exceptionAddr    // ManagedHeapAddress
+        exceptionType    // ConcreteTypeHandle
+with
+| ExceptionDispatchResult.HandlerFound state ->
+    // The guest has a handler; execution will resume there.
+    // Return `state` (and appropriate WhatWeDid/ExecutionResult).
+| ExceptionDispatchResult.ExceptionUnhandled (state, exn) ->
+    // No handler anywhere on the call stack.
+    // Propagate as ExecutionResult.UnhandledException or similar.
+```
+
+**Where this is used today:** `IlMachineStateExecution.loadClass` (line ~524) re-throws a cached `TypeInitializationException` when a `.cctor` previously failed. The `NullaryIlOp.fs` `Throw` opcode implementation (line ~818) also follows this pattern.
+
+## Tier 2: Constructing a new exception object
+
+To throw a *new* exception (e.g. `NullReferenceException`), you need to:
+
+1. **Look up the exception type** from `BaseClassTypes`. All common exception types are already fields on the record (see `Corelib.fs`):
+   - `baseClassTypes.NullReferenceException`
+   - `baseClassTypes.IndexOutOfRangeException`
+   - `baseClassTypes.InvalidCastException`
+   - `baseClassTypes.OverflowException`
+   - `baseClassTypes.DivideByZeroException`
+   - `baseClassTypes.MissingFieldException`
+   - `baseClassTypes.MissingMethodException`
+   - `baseClassTypes.OutOfMemoryException`
+   - etc.
+
+2. **Concretize the type** to get a `ConcreteTypeHandle`, and compute its fields' zero values.
+
+3. **Allocate the object** on the managed heap via `IlMachineState.allocateManagedObject` (or the lower-level `ManagedHeap.allocateNonArray`).
+
+4. **Run the constructor** (`.ctor`) on the allocated object. Most exception types have a parameterless constructor. This would typically be done via `IlMachineStateExecution.callMethod` or `callMethodInActiveAssembly`, pushing the allocated object as `this`.
+
+5. **Dispatch** using `ExceptionDispatching.throwExceptionObject` as in tier 1.
+
+This is currently not factored into a reusable helper. If you need to implement this, the `Newobj` opcode implementation in `UnaryMetadataIlOp.fs` (around line 240) shows the full pattern for allocating + constructing an object. The steps are:
+- Resolve the constructor method
+- Compute zero values for all instance fields
+- Allocate via `IlMachineState.allocateManagedObject`
+- Push the object ref and call the constructor
+- After construction completes, dispatch the exception
+
+**A reusable `raiseNewException` helper would be very welcome** — it would replace dozens of `failwith "TODO: throw ..."` sites across the codebase.
+
+## Return type considerations
+
+Where you raise an exception affects what you return:
+
+- **In `Intrinsics.call`** (returns `IlMachineState option`): Return `Some state` after dispatch.
+- **In `NullaryIlOp.execute`** (returns `ExecutionResult`): Return `ExecutionResult.Stepped (state, WhatWeDid.Executed)` for `HandlerFound`, or `ExecutionResult.UnhandledException` for unhandled.
+- **In `UnaryMetadataIlOp.execute`** (returns `IlMachineState * WhatWeDid`): Return `(state, WhatWeDid.Executed)` for `HandlerFound`. For unhandled, the pattern isn't established yet — this would need plumbing.
+
+## Key files
+
+- `ExceptionDispatching.fs` — `throwExceptionObject`, `dispatchException`, handler search
+- `NullaryIlOp.fs` — `Throw` opcode (line ~818), the canonical example of guest exception dispatch
+- `IlMachineStateExecution.fs` — `loadClass` (line ~520), cached TIE rethrow example
+- `Corelib.fs` — `BaseClassTypes` record with all pre-resolved exception types
+- `UnaryMetadataIlOp.fs` — `Newobj` (line ~240), pattern for allocating + constructing objects

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 @AGENTS.md
 
-Once you think you're finished making a change, please commit it.
+Once you think you're finished making a change, please commit it (not to `main`; create a branch if necessary to leave `main`).
 Then invoke OpenAI Codex to perform a review of your work, and address any of its findings that you think are appropriate: `codex review --base main` (this can take many minutes).
 
 I think this project is super exciting! Real deterministic simulation and reproduction; all flakiness shall be banished!

--- a/WoofWare.PawPrint.Domain/FieldInfo.fs
+++ b/WoofWare.PawPrint.Domain/FieldInfo.fs
@@ -36,6 +36,10 @@ type FieldInfo<'typeGeneric, 'fieldGeneric> =
         /// Static fields don't have an offset at all; also, instance fields which don't have an explicit offset (but
         /// which of course do have one implicitly, which is most fields) are None here.
         Offset : int option
+
+        /// The Relative Virtual Address for fields with the HasFieldRVA attribute.
+        /// This points to the raw data in the PE image for fields used in array initialization, etc.
+        RelativeVirtualAddress : int option
     }
 
     member this.HasFieldRVA = this.Attributes.HasFlag FieldAttributes.HasFieldRVA
@@ -72,6 +76,10 @@ module FieldInfo =
             | -1 -> None
             | s -> Some s
 
+        let rva =
+            let v = def.GetRelativeVirtualAddress ()
+            if v = 0 then None else Some v
+
         {
             Name = name
             Signature = fieldSig
@@ -79,6 +87,7 @@ module FieldInfo =
             Handle = handle
             Attributes = def.Attributes
             Offset = offset
+            RelativeVirtualAddress = rva
         }
 
     let mapTypeGenerics<'a, 'b, 'field> (f : int -> 'a -> 'b) (input : FieldInfo<'a, 'field>) : FieldInfo<'b, 'field> =
@@ -91,4 +100,5 @@ module FieldInfo =
             Signature = input.Signature
             Attributes = input.Attributes
             Offset = input.Offset
+            RelativeVirtualAddress = input.RelativeVirtualAddress
         }

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -21,7 +21,6 @@ module TestPureCases =
             "EnumSemantics.cs"
             "OverlappingStructs.cs"
             "AdvancedStructLayout.cs"
-            "InitializeArray.cs"
             "Threads.cs"
             "ComplexTryCatch.cs"
             "ResizeArray.cs"

--- a/WoofWare.PawPrint.Test/sourcesPure/InitializeArray.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/InitializeArray.cs
@@ -1,5 +1,3 @@
-using System.Linq;
-
 namespace HelloWorldApp
 {
     class Program
@@ -8,9 +6,30 @@ namespace HelloWorldApp
         {
             int[] array = new[] { 1, 2, 3 };
 
-            if (array.Sum() != 6)
+            int sum = 0;
+            for (int i = 0; i < array.Length; i++)
+            {
+                sum += array[i];
+            }
+
+            if (sum != 6)
             {
                 return 1;
+            }
+
+            if (array[0] != 1)
+            {
+                return 2;
+            }
+
+            if (array[1] != 2)
+            {
+                return 3;
+            }
+
+            if (array[2] != 3)
+            {
+                return 4;
             }
 
             return 0;

--- a/WoofWare.PawPrint/FieldHandleRegistry.fs
+++ b/WoofWare.PawPrint/FieldHandleRegistry.fs
@@ -12,6 +12,9 @@ type FieldHandle =
             FieldHandle : ComparableFieldDefinitionHandle
         }
 
+    member this.GetAssemblyFullName () : string = this.AssemblyFullName
+    member this.GetFieldDefinitionHandle () : ComparableFieldDefinitionHandle = this.FieldHandle
+
 type FieldHandleRegistry =
     private
         {
@@ -164,3 +167,7 @@ module FieldHandleRegistry =
             }
 
         runtimeFieldHandle alloc, reg, state
+
+    /// Given the ManagedHeapAddress of a RuntimeFieldInfoStub, resolve it to the FieldHandle.
+    let resolveFieldFromAddress (addr : ManagedHeapAddress) (reg : FieldHandleRegistry) : FieldHandle option =
+        Map.tryFind addr reg.FieldHandleToField

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -528,10 +528,105 @@ module Intrinsics =
               ConcreteVoid state.ConcreteTypes -> ()
             | _ -> failwith "bad signature for System.Private.CoreLib.RuntimeHelpers.InitializeArray"
 
-            failwith "TODO: if arg0 is null, throw NRE"
-            failwith "TODO: if arg1 contains null handle, throw ArgumentException"
+            // Pop args: arg1 (RuntimeFieldHandle) is on top, then arg0 (array ref)
+            let fldHandle, state = IlMachineState.popEvalStack currentThread state
+            let arrayRef, state = IlMachineState.popEvalStack currentThread state
 
-            failwith "TODO: array initialization"
+            // Extract the array address
+            let arrayAddr : ManagedHeapAddress =
+                match arrayRef with
+                | EvalStackValue.NullObjectRef ->
+                    failwith "TODO: throw NullReferenceException for InitializeArray on null array"
+                | EvalStackValue.ObjectRef addr -> addr
+                | other -> failwith $"InitializeArray: expected array object ref, got %O{other}"
+
+            // Navigate the RuntimeFieldHandle struct to find the RuntimeFieldInfoStub address.
+            // RuntimeFieldHandle is a struct with one field: m_ptr (an ObjectRef to RuntimeFieldInfoStub)
+            let runtimeFieldInfoStubAddr : ManagedHeapAddress =
+                match fldHandle with
+                | EvalStackValue.UserDefinedValueType vt ->
+                    match CliValueType.DereferenceField "m_ptr" vt with
+                    | CliType.ObjectRef (Some addr) -> addr
+                    | CliType.ObjectRef None ->
+                        failwith "TODO: throw ArgumentException for InitializeArray with null field handle"
+                    | other -> failwith $"InitializeArray: unexpected m_ptr contents: %O{other}"
+                | other -> failwith $"InitializeArray: expected RuntimeFieldHandle value type, got %O{other}"
+
+            // Look up the FieldHandle from the registry using the RuntimeFieldInfoStub address
+            let fieldHandle : FieldHandle =
+                match FieldHandleRegistry.resolveFieldFromAddress runtimeFieldInfoStubAddr state.FieldHandles with
+                | Some fh -> fh
+                | None ->
+                    failwith
+                        $"InitializeArray: RuntimeFieldInfoStub at %O{runtimeFieldInfoStubAddr} not found in field handle registry"
+
+            // Get the assembly and field definition
+            let assemblyFullName = fieldHandle.GetAssemblyFullName ()
+            let fieldDefHandle = fieldHandle.GetFieldDefinitionHandle().Get
+
+            let assembly : DumpedAssembly =
+                match state.LoadedAssembly' assemblyFullName with
+                | Some a -> a
+                | None -> failwith $"InitializeArray: assembly %s{assemblyFullName} not loaded"
+
+            let fieldInfo = assembly.Fields.[fieldDefHandle]
+
+            let rva : int =
+                match fieldInfo.RelativeVirtualAddress with
+                | Some rva -> rva
+                | None -> failwith $"InitializeArray: field %s{fieldInfo.Name} has no RVA"
+
+            // Read the raw bytes from the PE image
+            let sectionData = assembly.PeReader.GetSectionData rva
+
+            // Get the array and decode elements from the raw bytes
+            let arr = state.ManagedHeap.Arrays.[arrayAddr]
+
+            let state =
+                if arr.Length = 0 then
+                    state
+                else
+                    let reader = sectionData.GetReader ()
+                    // Decode each element from raw bytes based on its current CliType
+                    let firstElement = arr.Elements.[0]
+
+                    let state =
+                        (state, seq { 0 .. arr.Length - 1 })
+                        ||> Seq.fold (fun (state : IlMachineState) (i : int) ->
+                            let decoded : CliType =
+                                match firstElement with
+                                | CliType.Numeric (CliNumericType.Int8 _) ->
+                                    CliType.Numeric (CliNumericType.Int8 (reader.ReadSByte ()))
+                                | CliType.Numeric (CliNumericType.UInt8 _) ->
+                                    CliType.Numeric (CliNumericType.UInt8 (reader.ReadByte ()))
+                                | CliType.Numeric (CliNumericType.Int16 _) ->
+                                    CliType.Numeric (CliNumericType.Int16 (reader.ReadInt16 ()))
+                                | CliType.Numeric (CliNumericType.UInt16 _) ->
+                                    CliType.Numeric (CliNumericType.UInt16 (reader.ReadUInt16 ()))
+                                | CliType.Numeric (CliNumericType.Int32 _) ->
+                                    CliType.Numeric (CliNumericType.Int32 (reader.ReadInt32 ()))
+                                | CliType.Numeric (CliNumericType.Int64 _) ->
+                                    CliType.Numeric (CliNumericType.Int64 (reader.ReadInt64 ()))
+                                | CliType.Numeric (CliNumericType.Float32 _) ->
+                                    CliType.Numeric (CliNumericType.Float32 (reader.ReadSingle ()))
+                                | CliType.Numeric (CliNumericType.Float64 _) ->
+                                    CliType.Numeric (CliNumericType.Float64 (reader.ReadDouble ()))
+                                | CliType.Bool _ -> CliType.Bool (reader.ReadByte ())
+                                | CliType.Char _ ->
+                                    let lo = reader.ReadByte ()
+                                    let hi = reader.ReadByte ()
+                                    CliType.Char (hi, lo)
+                                | other ->
+                                    failwith
+                                        $"InitializeArray: unsupported array element type for RVA initialization: %O{other}"
+
+                            IlMachineState.setArrayValue arrayAddr decoded i state
+                        )
+
+                    state
+
+            let state = state |> IlMachineState.advanceProgramCounter currentThread
+            Some state
         | "System.Private.CoreLib", "Unsafe", "As" ->
             // https://github.com/dotnet/runtime/blob/721fdf6dcb032da1f883d30884e222e35e3d3c99/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/Unsafe.cs#L64
             let inputType, retType =


### PR DESCRIPTION
Read RVA data from PE image via field handles and copy raw bytes into newly-allocated arrays, supporting all primitive element types and bool.

Also adds a Claude skill documenting how to raise guest exceptions.