### PR TITLE
Throw NRE at loads of call sites

### DIFF
--- a/.claude/commands/raise-guest-exception.md
+++ b/.claude/commands/raise-guest-exception.md
@@ -35,37 +35,21 @@ with
 
 **Where this is used today:** `IlMachineStateExecution.loadClass` (line ~524) re-throws a cached `TypeInitializationException` when a `.cctor` previously failed. The `NullaryIlOp.fs` `Throw` opcode implementation (line ~818) also follows this pattern.
 
-## Tier 2: Constructing a new exception object
+## Tier 2: Constructing and throwing a new exception object
 
-To throw a *new* exception (e.g. `NullReferenceException`), you need to:
+Use `IlMachineStateExecution.raiseManagedException`. It takes a `TypeInfo` from `BaseClassTypes` (e.g. `baseClassTypes.NullReferenceException`) and returns `IlMachineState * WhatWeDid`. Do NOT advance the program counter after calling it — exception dispatch uses the faulting instruction's PC to determine which exception handler regions are active and to build the stack trace.
 
-1. **Look up the exception type** from `BaseClassTypes`. All common exception types are already fields on the record (see `Corelib.fs`):
-   - `baseClassTypes.NullReferenceException`
-   - `baseClassTypes.IndexOutOfRangeException`
-   - `baseClassTypes.InvalidCastException`
-   - `baseClassTypes.OverflowException`
-   - `baseClassTypes.DivideByZeroException`
-   - `baseClassTypes.MissingFieldException`
-   - `baseClassTypes.MissingMethodException`
-   - `baseClassTypes.OutOfMemoryException`
-   - etc.
+```fsharp
+IlMachineStateExecution.raiseManagedException
+    loggerFactory
+    baseClassTypes
+    baseClassTypes.NullReferenceException
+    currentThread
+    state
+```
 
-2. **Concretize the type** to get a `ConcreteTypeHandle`, and compute its fields' zero values.
-
-3. **Allocate the object** on the managed heap via `IlMachineState.allocateManagedObject` (or the lower-level `ManagedHeap.allocateNonArray`).
-
-4. **Run the constructor** (`.ctor`) on the allocated object. Most exception types have a parameterless constructor. This would typically be done via `IlMachineStateExecution.callMethod` or `callMethodInActiveAssembly`, pushing the allocated object as `this`.
-
-5. **Dispatch** using `ExceptionDispatching.throwExceptionObject` as in tier 1.
-
-This is currently not factored into a reusable helper. If you need to implement this, the `Newobj` opcode implementation in `UnaryMetadataIlOp.fs` (around line 240) shows the full pattern for allocating + constructing an object. The steps are:
-- Resolve the constructor method
-- Compute zero values for all instance fields
-- Allocate via `IlMachineState.allocateManagedObject`
-- Push the object ref and call the constructor
-- After construction completes, dispatch the exception
-
-**A reusable `raiseNewException` helper would be very welcome** — it would replace dozens of `failwith "TODO: throw ..."` sites across the codebase.
+All common exception types are fields on `BaseClassTypes` (see `Corelib.fs`):
+`NullReferenceException`, `IndexOutOfRangeException`, `InvalidCastException`, `OverflowException`, `DivideByZeroException`, `MissingFieldException`, `MissingMethodException`, `OutOfMemoryException`, etc.
 
 ## Return type considerations
 

--- a/.claude/commands/raise-guest-exception.md
+++ b/.claude/commands/raise-guest-exception.md
@@ -37,7 +37,7 @@ with
 
 ## Tier 2: Constructing and throwing a new exception object
 
-Use `IlMachineStateExecution.raiseManagedException`. It takes a `TypeInfo` from `BaseClassTypes` (e.g. `baseClassTypes.NullReferenceException`) and returns `IlMachineState * WhatWeDid`. Do NOT advance the program counter after calling it — exception dispatch uses the faulting instruction's PC to determine which exception handler regions are active and to build the stack trace.
+Use `IlMachineStateExecution.raiseManagedException`. It takes a `TypeInfo`, e.g. as from `BaseClassTypes` (such as `baseClassTypes.NullReferenceException`) and returns `IlMachineState * WhatWeDid`. Do NOT advance the program counter after calling it — exception dispatch uses the faulting instruction's PC to determine which exception handler regions are active and to build the stack trace.
 
 ```fsharp
 IlMachineStateExecution.raiseManagedException
@@ -48,7 +48,7 @@ IlMachineStateExecution.raiseManagedException
     state
 ```
 
-All common exception types are fields on `BaseClassTypes` (see `Corelib.fs`):
+Many common exception types are fields on `BaseClassTypes` (see `Corelib.fs`):
 `NullReferenceException`, `IndexOutOfRangeException`, `InvalidCastException`, `OverflowException`, `DivideByZeroException`, `MissingFieldException`, `MissingMethodException`, `OutOfMemoryException`, etc.
 
 ## Return type considerations
@@ -62,7 +62,7 @@ Where you raise an exception affects what you return:
 ## Key files
 
 - `ExceptionDispatching.fs` — `throwExceptionObject`, `dispatchException`, handler search
-- `NullaryIlOp.fs` — `Throw` opcode (line ~818), the canonical example of guest exception dispatch
-- `IlMachineStateExecution.fs` — `loadClass` (line ~520), cached TIE rethrow example
+- `NullaryIlOp.fs` — `Throw` opcode, the canonical example of guest exception dispatch
+- `IlMachineStateExecution.fs` — `loadClass`, cached TypeInitializationException rethrow example
 - `Corelib.fs` — `BaseClassTypes` record with all pre-resolved exception types
-- `UnaryMetadataIlOp.fs` — `Newobj` (line ~240), pattern for allocating + constructing objects
+- `UnaryMetadataIlOp.fs` — `Newobj`, pattern for allocating + constructing objects

--- a/WoofWare.PawPrint.Test/TestCrossAssemblyCastclass.fs
+++ b/WoofWare.PawPrint.Test/TestCrossAssemblyCastclass.fs
@@ -1,0 +1,213 @@
+namespace WoofWare.PawPrint.Test
+
+open NUnit.Framework
+
+[<TestFixture>]
+module TestCrossAssemblyCastclass =
+
+    [<Test>]
+    let ``castclass to a type defined in another assembly`` () : unit =
+        {
+            Assemblies =
+                [
+                    CrossAssemblySpec.library
+                        "CastclassCross.BaseLib"
+                        []
+                        [
+                            """
+namespace CastclassCross;
+
+public class Animal
+{
+}
+
+public class Dog : Animal
+{
+}
+"""
+                        ]
+                    CrossAssemblySpec.entryPoint
+                        "CastclassCross.Entry"
+                        [ "CastclassCross.BaseLib" ]
+                        [
+                            """
+using CastclassCross;
+
+class Program
+{
+    static int Main(string[] argv)
+    {
+        // The castclass target type (Animal) is in CastclassCross.BaseLib,
+        // not in this assembly. If the interpreter concretizes the target
+        // type against the wrong assembly, this will fail.
+        object o = new Dog();
+        Animal a = (Animal)o;
+        if (!ReferenceEquals(o, a)) return 1;
+        return 0;
+    }
+}
+"""
+                        ]
+                ]
+            EntryAssemblyName = "CastclassCross.Entry"
+            ExpectedReturnCode = 0
+            NativeImpls = MockEnv.make ()
+        }
+        |> CrossAssemblyHarness.runTest
+
+    [<Test>]
+    let ``castclass to a generic type from another assembly`` () : unit =
+        {
+            Assemblies =
+                [
+                    CrossAssemblySpec.library
+                        "CastclassCrossGeneric.BaseLib"
+                        []
+                        [
+                            """
+namespace CastclassCrossGeneric;
+
+public class Container<T>
+{
+}
+
+public class SpecialContainer : Container<int>
+{
+}
+"""
+                        ]
+                    CrossAssemblySpec.entryPoint
+                        "CastclassCrossGeneric.Entry"
+                        [ "CastclassCrossGeneric.BaseLib" ]
+                        [
+                            """
+using CastclassCrossGeneric;
+
+class Program
+{
+    static int Main(string[] argv)
+    {
+        // Cast to a generic instantiation Container<int> from another assembly.
+        // This exercises TypeSpec resolution in the correct assembly context.
+        object o = new SpecialContainer();
+        Container<int> c = (Container<int>)o;
+        if (!ReferenceEquals(o, c)) return 1;
+        return 0;
+    }
+}
+"""
+                        ]
+                ]
+            EntryAssemblyName = "CastclassCrossGeneric.Entry"
+            ExpectedReturnCode = 0
+            NativeImpls = MockEnv.make ()
+        }
+        |> CrossAssemblyHarness.runTest
+
+    [<Test>]
+    let ``castclass to an interface defined in another assembly`` () : unit =
+        {
+            Assemblies =
+                [
+                    CrossAssemblySpec.library
+                        "CastclassCrossInterface.BaseLib"
+                        []
+                        [
+                            """
+namespace CastclassCrossInterface;
+
+public interface IFlyable
+{
+}
+
+public class Bird : IFlyable
+{
+}
+"""
+                        ]
+                    CrossAssemblySpec.entryPoint
+                        "CastclassCrossInterface.Entry"
+                        [ "CastclassCrossInterface.BaseLib" ]
+                        [
+                            """
+using CastclassCrossInterface;
+
+class Program
+{
+    static int Main(string[] argv)
+    {
+        object o = new Bird();
+        IFlyable f = (IFlyable)o;
+        if (!ReferenceEquals(o, f)) return 1;
+        return 0;
+    }
+}
+"""
+                        ]
+                ]
+            EntryAssemblyName = "CastclassCrossInterface.Entry"
+            ExpectedReturnCode = 0
+            NativeImpls = MockEnv.make ()
+        }
+        |> CrossAssemblyHarness.runTest
+
+    [<Test>]
+    let ``castclass across a three-assembly chain`` () : unit =
+        // Type defined in assembly A, derived in assembly B, cast performed in assembly C.
+        {
+            Assemblies =
+                [
+                    CrossAssemblySpec.library
+                        "CastclassChain.Root"
+                        []
+                        [
+                            """
+namespace CastclassChain;
+
+public class Root
+{
+}
+"""
+                        ]
+                    CrossAssemblySpec.library
+                        "CastclassChain.Middle"
+                        [ "CastclassChain.Root" ]
+                        [
+                            """
+using CastclassChain;
+
+namespace CastclassChain.Middle;
+
+public class Middle : Root
+{
+}
+"""
+                        ]
+                    CrossAssemblySpec.entryPoint
+                        "CastclassChain.Entry"
+                        [ "CastclassChain.Root" ; "CastclassChain.Middle" ]
+                        [
+                            """
+using CastclassChain;
+using CastclassChain.Middle;
+
+class Program
+{
+    static int Main(string[] argv)
+    {
+        // The object is Middle (assembly B), cast target is Root (assembly A),
+        // performed in assembly C.
+        object o = new Middle();
+        Root r = (Root)o;
+        if (!ReferenceEquals(o, r)) return 1;
+        return 0;
+    }
+}
+"""
+                        ]
+                ]
+            EntryAssemblyName = "CastclassChain.Entry"
+            ExpectedReturnCode = 0
+            NativeImpls = MockEnv.make ()
+        }
+        |> CrossAssemblyHarness.runTest

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -29,6 +29,7 @@ module TestPureCases =
             "UnsafeAs.cs"
             "ThrowingCctorProperties.cs"
             "ThrowingCctorStackTrace.cs"
+            "NullDereferenceTest.cs"
         ]
         |> Set.ofList
 

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -30,6 +30,7 @@ module TestPureCases =
             "ThrowingCctorProperties.cs"
             "ThrowingCctorStackTrace.cs"
             "NullDereferenceTest.cs"
+            "CastclassFailures.cs"
         ]
         |> Set.ofList
 

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -20,6 +20,7 @@
     <Compile Include="TestTypeIdentityProperties.fs" />
     <Compile Include="TestEvalStack.fs" />
     <Compile Include="TestCrossAssemblyTypeInitialisation.fs" />
+    <Compile Include="TestCrossAssemblyCastclass.fs" />
     <Compile Include="TestNativeMethodDetection.fs" />
     <Compile Include="TestPureCases.fs" />
     <Compile Include="TestImpureCases.fs" />

--- a/WoofWare.PawPrint.Test/sourcesPure/CastclassFailures.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/CastclassFailures.cs
@@ -1,0 +1,178 @@
+using System;
+
+// Exercises castclass (explicit cast) failure paths — each must throw InvalidCastException.
+// Every test returns 0 on success, nonzero on failure.
+
+interface IChild
+{
+}
+
+class Base
+{
+}
+
+class Middle : Base, IChild
+{
+}
+
+class Leaf : Middle
+{
+}
+
+class Unrelated
+{
+}
+
+class Program
+{
+    static int TestFailUnrelatedType()
+    {
+        // Cast Base to Unrelated — completely unrelated types.
+        object o = new Base();
+        try
+        {
+            Unrelated u = (Unrelated)o;
+            return 1; // should not reach
+        }
+        catch (InvalidCastException)
+        {
+            return 0;
+        }
+    }
+
+    static int TestFailDowncastActualBase()
+    {
+        // Runtime type is Base, trying to downcast to Middle — must throw.
+        object o = new Base();
+        try
+        {
+            Middle m = (Middle)o;
+            return 1;
+        }
+        catch (InvalidCastException)
+        {
+            return 0;
+        }
+    }
+
+    static int TestFailDowncastMiddleToLeaf()
+    {
+        // Runtime type is Middle, trying to downcast to Leaf — must throw.
+        object o = new Middle();
+        try
+        {
+            Leaf l = (Leaf)o;
+            return 1;
+        }
+        catch (InvalidCastException)
+        {
+            return 0;
+        }
+    }
+
+    static int TestFailCastToUnimplementedInterface()
+    {
+        // Base does not implement IChild.
+        object o = new Base();
+        try
+        {
+            IChild i = (IChild)o;
+            return 1;
+        }
+        catch (InvalidCastException)
+        {
+            return 0;
+        }
+    }
+
+    static int TestFailCastUnrelatedToInterface()
+    {
+        // Unrelated does not implement IChild.
+        object o = new Unrelated();
+        try
+        {
+            IChild i = (IChild)o;
+            return 1;
+        }
+        catch (InvalidCastException)
+        {
+            return 0;
+        }
+    }
+
+    static int TestFailCastBetweenSiblings()
+    {
+        // Middle and Unrelated are siblings (both derive from object), not related.
+        object o = new Middle();
+        try
+        {
+            Unrelated u = (Unrelated)o;
+            return 1;
+        }
+        catch (InvalidCastException)
+        {
+            return 0;
+        }
+    }
+
+    static int TestFailCastFromInterfaceToWrongClass()
+    {
+        // IChild-typed ref holding a Middle — cast to Unrelated must throw.
+        IChild i = new Middle();
+        try
+        {
+            Unrelated u = (Unrelated)(object)i;
+            return 1;
+        }
+        catch (InvalidCastException)
+        {
+            return 0;
+        }
+    }
+
+    static int TestFailCastFromInterfaceToWrongDerived()
+    {
+        // IChild-typed ref holding a Middle — cast to Leaf must throw (Middle is not Leaf).
+        IChild i = new Middle();
+        try
+        {
+            Leaf l = (Leaf)(object)i;
+            return 1;
+        }
+        catch (InvalidCastException)
+        {
+            return 0;
+        }
+    }
+
+    static int TestInvalidCastIsCatchableAsException()
+    {
+        // InvalidCastException derives from SystemException derives from Exception.
+        // Catch as Exception to verify the type hierarchy works.
+        object o = new Base();
+        try
+        {
+            Middle m = (Middle)o;
+            return 1;
+        }
+        catch (Exception)
+        {
+            return 0;
+        }
+    }
+
+    static int Main(string[] args)
+    {
+        int result = 0;
+        result += TestFailUnrelatedType();
+        result += TestFailDowncastActualBase();
+        result += TestFailDowncastMiddleToLeaf();
+        result += TestFailCastToUnimplementedInterface();
+        result += TestFailCastUnrelatedToInterface();
+        result += TestFailCastBetweenSiblings();
+        result += TestFailCastFromInterfaceToWrongClass();
+        result += TestFailCastFromInterfaceToWrongDerived();
+        result += TestInvalidCastIsCatchableAsException();
+        return result;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/CastclassSemantics.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/CastclassSemantics.cs
@@ -1,0 +1,211 @@
+using System;
+
+// Exercises castclass (explicit cast) success paths.
+// Every test returns 0 on success, nonzero on failure.
+// Avoids field access through cast references (separate PawPrint limitation).
+
+interface IGrandparent
+{
+}
+
+interface IParent : IGrandparent
+{
+}
+
+interface IChild : IParent
+{
+}
+
+interface IUnrelated
+{
+}
+
+class Base
+{
+}
+
+class Middle : Base, IChild
+{
+}
+
+class Leaf : Middle
+{
+}
+
+class Unrelated
+{
+}
+
+class Program
+{
+    static int Main(string[] args)
+    {
+        int result = 0;
+
+        // 1. Null cast to class — must succeed, return null.
+        {
+            object o = null;
+            Base b = (Base)o;
+            if (b != null) result |= 1;
+        }
+
+        // 2. Null cast to interface — must succeed, return null.
+        {
+            object o = null;
+            IChild i = (IChild)o;
+            if (i != null) result |= 2;
+        }
+
+        // 3. Exact type match.
+        {
+            Base b = new Base();
+            object o = b;
+            Base b2 = (Base)o;
+            if (!ReferenceEquals(b, b2)) result |= 4;
+        }
+
+        // 4. Upcast: Middle -> Base.
+        {
+            Middle m = new Middle();
+            object o = m;
+            Base b = (Base)o;
+            if (!ReferenceEquals(m, b)) result |= 8;
+        }
+
+        // 5. Upcast two levels: Leaf -> Base.
+        {
+            Leaf l = new Leaf();
+            object o = l;
+            Base b = (Base)o;
+            if (!ReferenceEquals(l, b)) result |= 0x10;
+        }
+
+        // 6. Upcast one level: Leaf -> Middle.
+        {
+            Leaf l = new Leaf();
+            object o = l;
+            Middle m = (Middle)o;
+            if (!ReferenceEquals(l, m)) result |= 0x20;
+        }
+
+        // 7. Downcast: Base ref holding Middle -> Middle.
+        {
+            Middle m = new Middle();
+            Base b = m;
+            object o = b;
+            Middle m2 = (Middle)o;
+            if (!ReferenceEquals(m, m2)) result |= 0x40;
+        }
+
+        // 8. Downcast: Base ref holding Leaf -> Leaf.
+        {
+            Leaf l = new Leaf();
+            Base b = l;
+            object o = b;
+            Leaf l2 = (Leaf)o;
+            if (!ReferenceEquals(l, l2)) result |= 0x80;
+        }
+
+        // 9. Downcast skipping level: Base ref holding Leaf -> Middle.
+        {
+            Leaf l = new Leaf();
+            Base b = l;
+            object o = b;
+            Middle m = (Middle)o;
+            if (!ReferenceEquals(l, m)) result |= 0x100;
+        }
+
+        // 10. Cast to object — always works.
+        {
+            Leaf l = new Leaf();
+            object o = (object)l;
+            if (!ReferenceEquals(l, o)) result |= 0x200;
+        }
+
+        // 11. Cast to direct interface: Middle implements IChild.
+        {
+            Middle m = new Middle();
+            object o = m;
+            IChild i = (IChild)o;
+            if (!ReferenceEquals(m, i)) result |= 0x400;
+        }
+
+        // 12. Cast to transitive interface: Middle -> IChild -> IParent.
+        {
+            Middle m = new Middle();
+            object o = m;
+            IParent p = (IParent)o;
+            if (!ReferenceEquals(m, p)) result |= 0x800;
+        }
+
+        // 13. Cast to doubly-transitive interface: Middle -> IChild -> IParent -> IGrandparent.
+        {
+            Middle m = new Middle();
+            object o = m;
+            IGrandparent g = (IGrandparent)o;
+            if (!ReferenceEquals(m, g)) result |= 0x1000;
+        }
+
+        // 14. Inherited interface: Leaf inherits IChild from Middle.
+        {
+            Leaf l = new Leaf();
+            object o = l;
+            IChild i = (IChild)o;
+            if (!ReferenceEquals(l, i)) result |= 0x2000;
+        }
+
+        // 15. Inherited transitive interface: Leaf -> IGrandparent via Middle.
+        {
+            Leaf l = new Leaf();
+            object o = l;
+            IGrandparent g = (IGrandparent)o;
+            if (!ReferenceEquals(l, g)) result |= 0x4000;
+        }
+
+        // 16. Chained casts: Leaf -> object -> Base -> Middle -> Leaf, identity preserved.
+        {
+            Leaf l = new Leaf();
+            object o = (object)l;
+            Base b = (Base)o;
+            Middle m = (Middle)b;
+            Leaf l2 = (Leaf)m;
+            if (!ReferenceEquals(l, l2)) result |= 0x8000;
+        }
+
+        // 17. Interface-typed ref cast to object.
+        {
+            Middle m = new Middle();
+            IChild i = m;
+            object o = (object)i;
+            if (!ReferenceEquals(m, o)) result |= 0x10000;
+        }
+
+        // 18. Interface-typed ref downcast back to concrete type.
+        {
+            Middle m = new Middle();
+            IChild i = m;
+            Middle m2 = (Middle)i;
+            if (!ReferenceEquals(m, m2)) result |= 0x20000;
+        }
+
+        // 19. Interface-typed ref cast to base class.
+        {
+            Leaf l = new Leaf();
+            IChild i = l;
+            Base b = (Base)i;
+            if (!ReferenceEquals(l, b)) result |= 0x40000;
+        }
+
+        // 20. Cast between sibling interfaces via object ref
+        //     (Leaf implements IChild; if IChild extends IParent, cast object->IParent should work).
+        {
+            Leaf l = new Leaf();
+            IChild i = l;
+            object o = i;
+            IParent p = (IParent)o;
+            if (!ReferenceEquals(l, p)) result |= 0x80000;
+        }
+
+        return result;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/NullDereferenceTest.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/NullDereferenceTest.cs
@@ -1,0 +1,70 @@
+using System;
+
+class Program
+{
+    private int _field;
+
+    static int TestNullFieldLoad()
+    {
+        Program p = null;
+        try
+        {
+            int x = p._field;
+            return 1; // should not reach
+        }
+        catch (NullReferenceException)
+        {
+            return 0;
+        }
+    }
+
+    static int TestNullFieldStore()
+    {
+        Program p = null;
+        try
+        {
+            p._field = 42;
+            return 1; // should not reach
+        }
+        catch (NullReferenceException)
+        {
+            return 0;
+        }
+    }
+
+    static int TestNullVirtcall()
+    {
+        object o = null;
+        try
+        {
+            o.GetHashCode();
+            return 1; // should not reach
+        }
+        catch (NullReferenceException)
+        {
+            return 0;
+        }
+    }
+
+    static int TestThrowNull()
+    {
+        try
+        {
+            throw null;
+        }
+        catch (NullReferenceException)
+        {
+            return 0;
+        }
+    }
+
+    static int Main(string[] args)
+    {
+        int result = 0;
+        result += TestNullFieldLoad();
+        result += TestNullFieldStore();
+        result += TestNullVirtcall();
+        result += TestThrowNull();
+        return result;
+    }
+}

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -40,6 +40,8 @@ module NullaryIlOp =
 
     // Unified Ldind implementation
     let private executeLdind
+        (loggerFactory : ILoggerFactory)
+        (corelib : BaseClassTypes<DumpedAssembly>)
         (targetType : LdindTargetType)
         (currentThread : ThreadId)
         (state : IlMachineState)
@@ -47,12 +49,24 @@ module NullaryIlOp =
         =
         let popped, state = IlMachineState.popEvalStack currentThread state
 
+        match popped with
+        | EvalStackValue.NullObjectRef
+        | EvalStackValue.ManagedPointer ManagedPointerSource.Null ->
+            IlMachineStateExecution.raiseManagedException
+                loggerFactory
+                corelib
+                corelib.NullReferenceException
+                currentThread
+                state
+            |> ExecutionResult.Stepped
+        | _ ->
+
         let loadedValue =
             match popped with
             | EvalStackValue.ManagedPointer src -> IlMachineState.readManagedByref state src
             | EvalStackValue.NativeInt nativeIntSource ->
                 failwith $"TODO: Native int pointer dereferencing not implemented for {targetType}"
-            | EvalStackValue.NullObjectRef -> failwith "TODO: throw NullReferenceException for Ldind on null"
+            | EvalStackValue.NullObjectRef -> failwith "unreachable: NullObjectRef handled above"
             | EvalStackValue.ObjectRef _ ->
                 failwith "Ldind on an object reference is invalid; expected a managed pointer (byref)"
             | other -> failwith $"Unexpected eval stack value for Ldind operation: {other}"
@@ -69,21 +83,47 @@ module NullaryIlOp =
 
         (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
 
-    let private stind (varType : CliType) (currentThread : ThreadId) (state : IlMachineState) : IlMachineState =
-        // TODO: throw NullReferenceException if unaligned target
+    let private stind
+        (loggerFactory : ILoggerFactory)
+        (corelib : BaseClassTypes<DumpedAssembly>)
+        (varType : CliType)
+        (currentThread : ThreadId)
+        (state : IlMachineState)
+        : ExecutionResult
+        =
         let valueToStore, state = IlMachineState.popEvalStack currentThread state
         let addr, state = IlMachineState.popEvalStack currentThread state
 
         match addr with
-        | EvalStackValue.Int32 _
-        | EvalStackValue.Int64 _
-        | EvalStackValue.UserDefinedValueType _
-        | EvalStackValue.Float _ -> failwith $"unexpectedly tried to store value {valueToStore} in a non-address {addr}"
-        | EvalStackValue.NativeInt nativeIntSource -> failwith "todo"
-        | EvalStackValue.ManagedPointer src ->
-            IlMachineState.writeManagedByref state src (EvalStackValue.toCliTypeCoerced varType valueToStore)
-        | EvalStackValue.NullObjectRef -> failwith "TODO: throw NullReferenceException for stind on null"
-        | EvalStackValue.ObjectRef _ -> failwith "stind on an object reference is invalid; expected a managed pointer"
+        | EvalStackValue.NullObjectRef
+        | EvalStackValue.ManagedPointer ManagedPointerSource.Null ->
+            IlMachineStateExecution.raiseManagedException
+                loggerFactory
+                corelib
+                corelib.NullReferenceException
+                currentThread
+                state
+            |> ExecutionResult.Stepped
+        | _ ->
+
+        let state =
+            match addr with
+            | EvalStackValue.Int32 _
+            | EvalStackValue.Int64 _
+            | EvalStackValue.UserDefinedValueType _
+            | EvalStackValue.Float _ ->
+                failwith $"unexpectedly tried to store value {valueToStore} in a non-address {addr}"
+            | EvalStackValue.NativeInt nativeIntSource -> failwith "todo"
+            | EvalStackValue.ManagedPointer src ->
+                IlMachineState.writeManagedByref state src (EvalStackValue.toCliTypeCoerced varType valueToStore)
+            | EvalStackValue.NullObjectRef -> failwith "unreachable: NullObjectRef handled above"
+            | EvalStackValue.ObjectRef _ ->
+                failwith "stind on an object reference is invalid; expected a managed pointer"
+
+        state
+        |> IlMachineState.advanceProgramCounter currentThread
+        |> Tuple.withRight WhatWeDid.Executed
+        |> ExecutionResult.Stepped
 
     let internal getArrayElt
         (index : EvalStackValue)
@@ -831,10 +871,22 @@ module NullaryIlOp =
             // Pop exception object from stack and begin exception handling
             let exceptionObject, state = IlMachineState.popEvalStack currentThread state
 
+            match exceptionObject with
+            | EvalStackValue.NullObjectRef ->
+                // Per ECMA-335 III.4.31: if the object is null, throw NullReferenceException instead.
+                IlMachineStateExecution.raiseManagedException
+                    loggerFactory
+                    corelib
+                    corelib.NullReferenceException
+                    currentThread
+                    state
+                |> ExecutionResult.Stepped
+            | _ ->
+
             let addr =
                 match exceptionObject with
                 | EvalStackValue.ObjectRef addr -> addr
-                | EvalStackValue.NullObjectRef -> failwith "TODO: throw NullReferenceException for throwing null"
+                | EvalStackValue.NullObjectRef -> failwith "unreachable: NullObjectRef handled above"
                 | existing -> failwith $"Throw instruction requires an object reference on the stack; got %O{existing}"
 
             // Get exception type from heap object
@@ -858,48 +910,29 @@ module NullaryIlOp =
 
         | Localloc -> failwith "TODO: Localloc unimplemented"
         | Stind_I ->
-            let state =
-                stind (CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim 0L))) currentThread state
-                |> IlMachineState.advanceProgramCounter currentThread
-
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
-        | Stind_I1 ->
-            let state =
-                stind (CliType.Numeric (CliNumericType.Int8 0y)) currentThread state
-                |> IlMachineState.advanceProgramCounter currentThread
-
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
-        | Stind_I2 ->
-            let state =
-                stind (CliType.Numeric (CliNumericType.Int16 0s)) currentThread state
-                |> IlMachineState.advanceProgramCounter currentThread
-
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
-        | Stind_I4 ->
-            let state =
-                stind (CliType.Numeric (CliNumericType.Int32 0)) currentThread state
-                |> IlMachineState.advanceProgramCounter currentThread
-
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
-        | Stind_I8 ->
-            let state =
-                stind (CliType.Numeric (CliNumericType.Int64 0L)) currentThread state
-                |> IlMachineState.advanceProgramCounter currentThread
-
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            stind
+                loggerFactory
+                corelib
+                (CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim 0L)))
+                currentThread
+                state
+        | Stind_I1 -> stind loggerFactory corelib (CliType.Numeric (CliNumericType.Int8 0y)) currentThread state
+        | Stind_I2 -> stind loggerFactory corelib (CliType.Numeric (CliNumericType.Int16 0s)) currentThread state
+        | Stind_I4 -> stind loggerFactory corelib (CliType.Numeric (CliNumericType.Int32 0)) currentThread state
+        | Stind_I8 -> stind loggerFactory corelib (CliType.Numeric (CliNumericType.Int64 0L)) currentThread state
         | Stind_R4 -> failwith "TODO: Stind_R4 unimplemented"
         | Stind_R8 -> failwith "TODO: Stind_R8 unimplemented"
-        | Ldind_i -> executeLdind LdindTargetType.LdindI currentThread state
-        | Ldind_i1 -> executeLdind LdindTargetType.LdindI1 currentThread state
-        | Ldind_i2 -> executeLdind LdindTargetType.LdindI2 currentThread state
-        | Ldind_i4 -> executeLdind LdindTargetType.LdindI4 currentThread state
-        | Ldind_i8 -> executeLdind LdindTargetType.LdindI8 currentThread state
-        | Ldind_u1 -> executeLdind LdindTargetType.LdindU1 currentThread state
-        | Ldind_u2 -> executeLdind LdindTargetType.LdindU2 currentThread state
-        | Ldind_u4 -> executeLdind LdindTargetType.LdindU4 currentThread state
+        | Ldind_i -> executeLdind loggerFactory corelib LdindTargetType.LdindI currentThread state
+        | Ldind_i1 -> executeLdind loggerFactory corelib LdindTargetType.LdindI1 currentThread state
+        | Ldind_i2 -> executeLdind loggerFactory corelib LdindTargetType.LdindI2 currentThread state
+        | Ldind_i4 -> executeLdind loggerFactory corelib LdindTargetType.LdindI4 currentThread state
+        | Ldind_i8 -> executeLdind loggerFactory corelib LdindTargetType.LdindI8 currentThread state
+        | Ldind_u1 -> executeLdind loggerFactory corelib LdindTargetType.LdindU1 currentThread state
+        | Ldind_u2 -> executeLdind loggerFactory corelib LdindTargetType.LdindU2 currentThread state
+        | Ldind_u4 -> executeLdind loggerFactory corelib LdindTargetType.LdindU4 currentThread state
         | Ldind_u8 -> failwith "TODO: Ldind_u8 unimplemented"
-        | Ldind_r4 -> executeLdind LdindTargetType.LdindR4 currentThread state
-        | Ldind_r8 -> executeLdind LdindTargetType.LdindR8 currentThread state
+        | Ldind_r4 -> executeLdind loggerFactory corelib LdindTargetType.LdindR4 currentThread state
+        | Ldind_r8 -> executeLdind loggerFactory corelib LdindTargetType.LdindR8 currentThread state
         | Rem ->
             let val2, state = IlMachineState.popEvalStack currentThread state
             let val1, state = IlMachineState.popEvalStack currentThread state
@@ -946,10 +979,22 @@ module NullaryIlOp =
         | Ldind_ref ->
             let addr, state = IlMachineState.popEvalStack currentThread state
 
+            match addr with
+            | EvalStackValue.NullObjectRef
+            | EvalStackValue.ManagedPointer ManagedPointerSource.Null ->
+                IlMachineStateExecution.raiseManagedException
+                    loggerFactory
+                    corelib
+                    corelib.NullReferenceException
+                    currentThread
+                    state
+                |> ExecutionResult.Stepped
+            | _ ->
+
             let referenced =
                 match addr with
                 | EvalStackValue.ManagedPointer src -> IlMachineState.readManagedByref state src
-                | EvalStackValue.NullObjectRef -> failwith "TODO: throw NRE for ldind.ref on null"
+                | EvalStackValue.NullObjectRef -> failwith "unreachable: NullObjectRef handled above"
                 | a -> failwith $"TODO: {a}"
 
             let state =
@@ -964,6 +1009,18 @@ module NullaryIlOp =
             let value, state = IlMachineState.popEvalStack currentThread state
             let addr, state = IlMachineState.popEvalStack currentThread state
 
+            match addr with
+            | EvalStackValue.NullObjectRef
+            | EvalStackValue.ManagedPointer ManagedPointerSource.Null ->
+                IlMachineStateExecution.raiseManagedException
+                    loggerFactory
+                    corelib
+                    corelib.NullReferenceException
+                    currentThread
+                    state
+                |> ExecutionResult.Stepped
+            | _ ->
+
             let state =
                 match addr with
                 | EvalStackValue.ManagedPointer src ->
@@ -971,7 +1028,7 @@ module NullaryIlOp =
                         state
                         src
                         (EvalStackValue.toCliTypeCoerced (CliType.ObjectRef None) value)
-                | EvalStackValue.NullObjectRef -> failwith "TODO: throw NRE for stind.ref on null"
+                | EvalStackValue.NullObjectRef -> failwith "unreachable: NullObjectRef handled above"
                 | addr -> failwith $"TODO: {addr}"
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread

--- a/WoofWare.PawPrint/UnaryMetadataIlOp.fs
+++ b/WoofWare.PawPrint/UnaryMetadataIlOp.fs
@@ -219,6 +219,26 @@ module internal UnaryMetadataIlOp =
             | ThrowingTypeInitializationException state -> state, WhatWeDid.ThrowingTypeInitializationException
             | NothingToDo state ->
 
+            // Callvirt always performs a null check on the receiver, even for non-virtual methods.
+            if
+                not methodToCall.IsStatic
+                && (
+                    match
+                        state.ThreadState.[thread].MethodState.EvaluationStack
+                        |> EvalStack.PeekNthFromTop methodToCall.Parameters.Length
+                    with
+                    | Some EvalStackValue.NullObjectRef -> true
+                    | _ -> false
+                )
+            then
+                IlMachineStateExecution.raiseManagedException
+                    loggerFactory
+                    baseClassTypes
+                    baseClassTypes.NullReferenceException
+                    thread
+                    state
+            else
+
             state.WithThreadSwitchedToAssembly methodToCall.DeclaringType.Assembly thread
             |> fst
             |> IlMachineStateExecution.callMethodInActiveAssembly
@@ -233,7 +253,69 @@ module internal UnaryMetadataIlOp =
                 typeArgsFromMetadata
                 false
 
-        | Castclass -> failwith "TODO: Castclass unimplemented"
+        | Castclass ->
+            let actualObj, state = IlMachineState.popEvalStack thread state
+
+            let state, targetType, _targetAssy =
+                IlMachineState.resolveTypeMetadataToken
+                    loggerFactory
+                    baseClassTypes
+                    state
+                    activeAssy
+                    ImmutableArray.Empty
+                    metadataToken
+
+            let state, targetConcreteType =
+                IlMachineState.concretizeType
+                    loggerFactory
+                    baseClassTypes
+                    state
+                    activeAssy.Name
+                    currentMethod.DeclaringType.Generics
+                    currentMethod.Generics
+                    targetType
+
+            match actualObj with
+            | EvalStackValue.NullObjectRef ->
+                // Per ECMA-335 III.4.3: null ref is always valid for castclass on reference types.
+                let state =
+                    state
+                    |> IlMachineState.pushToEvalStack' EvalStackValue.NullObjectRef thread
+                    |> IlMachineState.advanceProgramCounter thread
+
+                state, WhatWeDid.Executed
+            | EvalStackValue.ObjectRef addr ->
+                let objConcreteType =
+                    match state.ManagedHeap.NonArrayObjects.TryGetValue addr with
+                    | true, v -> v.ConcreteType
+                    | false, _ ->
+                        match state.ManagedHeap.Arrays.TryGetValue addr with
+                        | true, _v -> failwith "TODO: Castclass on array objects"
+                        | false, _ -> failwith $"Castclass: could not find managed object with address {addr}"
+
+                let state, isAssignable =
+                    IlMachineState.isConcreteTypeAssignableTo
+                        loggerFactory
+                        baseClassTypes
+                        state
+                        objConcreteType
+                        targetConcreteType
+
+                if isAssignable then
+                    let state =
+                        state
+                        |> IlMachineState.pushToEvalStack' actualObj thread
+                        |> IlMachineState.advanceProgramCounter thread
+
+                    state, WhatWeDid.Executed
+                else
+                    IlMachineStateExecution.raiseManagedException
+                        loggerFactory
+                        baseClassTypes
+                        baseClassTypes.InvalidCastException
+                        thread
+                        state
+            | other -> failwith $"Castclass: unexpected eval stack value {other}"
         | Newobj ->
             let state, assy, ctor, typeArgsFromMetadata =
                 match metadataToken with
@@ -628,13 +710,23 @@ module internal UnaryMetadataIlOp =
                 state, WhatWeDid.Executed
             else
 
+            match currentObj with
+            | EvalStackValue.NullObjectRef ->
+                IlMachineStateExecution.raiseManagedException
+                    loggerFactory
+                    baseClassTypes
+                    baseClassTypes.NullReferenceException
+                    thread
+                    state
+            | _ ->
+
             let state =
                 match currentObj with
                 | EvalStackValue.Int32 _ -> failwith "unexpectedly setting field on an int"
                 | EvalStackValue.Int64 _ -> failwith "unexpectedly setting field on an int64"
                 | EvalStackValue.NativeInt _ -> failwith "unexpectedly setting field on a nativeint"
                 | EvalStackValue.Float _ -> failwith "unexpectedly setting field on a float"
-                | EvalStackValue.NullObjectRef -> failwith "TODO: raise NullReferenceException"
+                | EvalStackValue.NullObjectRef -> failwith "unreachable: NullObjectRef handled above"
                 | EvalStackValue.ObjectRef addr ->
                     match state.ManagedHeap.NonArrayObjects.TryGetValue addr with
                     | false, _ -> failwith $"todo: array {addr}"
@@ -810,13 +902,23 @@ module internal UnaryMetadataIlOp =
                 state, WhatWeDid.Executed
             else
 
+            match currentObj with
+            | EvalStackValue.NullObjectRef ->
+                IlMachineStateExecution.raiseManagedException
+                    loggerFactory
+                    baseClassTypes
+                    baseClassTypes.NullReferenceException
+                    thread
+                    state
+            | _ ->
+
             let state =
                 match currentObj with
                 | EvalStackValue.Int32 i -> failwith "todo: int32"
                 | EvalStackValue.Int64 int64 -> failwith "todo: int64"
                 | EvalStackValue.NativeInt nativeIntSource -> failwith $"todo: nativeint {nativeIntSource}"
                 | EvalStackValue.Float f -> failwith "todo: float"
-                | EvalStackValue.NullObjectRef -> failwith "TODO: raise NullReferenceException"
+                | EvalStackValue.NullObjectRef -> failwith "unreachable: NullObjectRef handled above"
                 | EvalStackValue.ObjectRef managedHeapAddress ->
                     match state.ManagedHeap.NonArrayObjects.TryGetValue managedHeapAddress with
                     | false, _ -> failwith $"todo: array {managedHeapAddress}"
@@ -867,6 +969,16 @@ module internal UnaryMetadataIlOp =
                     | Choice2Of2 field -> state, field
                 | t -> failwith $"Unexpectedly asked to load from a non-field: {t}"
 
+            match ptr with
+            | NullObjectRef ->
+                IlMachineStateExecution.raiseManagedException
+                    loggerFactory
+                    baseClassTypes
+                    baseClassTypes.NullReferenceException
+                    thread
+                    state
+            | _ ->
+
             let result =
                 match ptr with
                 | Int32 _
@@ -874,7 +986,7 @@ module internal UnaryMetadataIlOp =
                 | Float _ -> failwith "expected pointer type"
                 | NativeInt nativeIntSource -> failwith "todo"
                 | ManagedPointer src -> ManagedPointerSource.appendProjection (ByrefProjection.Field field.Name) src
-                | NullObjectRef -> failwith "TODO: raise NullReferenceException"
+                | NullObjectRef -> failwith "unreachable: NullObjectRef handled above"
                 | ObjectRef addr -> ManagedPointerSource.Byref (ByrefRoot.HeapObjectField (addr, field.Name), [])
                 | UserDefinedValueType evalStackValueUserType -> failwith "todo"
                 |> EvalStackValue.ManagedPointer

--- a/docs/plans/2026-04-16-exceptions.md
+++ b/docs/plans/2026-04-16-exceptions.md
@@ -77,7 +77,7 @@ IlMachineState.raiseManagedException
 which:
 
 1. Concretises the exception type via the existing `concretizeType` path.
-2. Allocates an instance on the heap with all fields zero-initialised (reusing `IlMachineState.allocateManagedObject`, same path `newobj` uses). **The ctor is NOT run.** This keeps synthesis atomic — no nested frame needed. `Exception._message` will be null; that matches what uncaught-exception printers see as "Exception of type X was thrown." Proper ctor invocation can be retro-fitted later if a test needs `.Message`.
+2. Allocates an instance on the heap with all fields zero-initialised (reusing `IlMachineState.allocateManagedObject`, same path `newobj` uses). **The ctor IS run** by pushing the allocated object as `this` and calling the parameterless constructor via the normal method-call machinery.
 3. Builds a `CliException` with the allocated address and initial stack frame.
 4. Delegates to `continuePropagation`.
 
@@ -234,6 +234,6 @@ Low priority — C# doesn't emit them; F# doesn't; only hand-written IL does. Ex
 
 ## Open design decisions worth revisiting
 
-- **Constructor invocation for synthesised exceptions.** Current plan skips the ctor. If a test later needs `Exception.Message` populated, we'll need to thread the synthesis through a suspended-ctor frame. Deferred.
+- **Constructor invocation for synthesised exceptions.** Resolved: the implementation runs the parameterless ctor.
 - **Stack overflow.** `StackOverflowException` requires a frame-depth budget on `ThreadState.MethodStates`. Out of scope for this plan; call it out as a follow-up.
 - **AppDomain unhandled-exception event.** Real .NET raises `AppDomain.UnhandledException` before termination. Out of scope.


### PR DESCRIPTION
The new test fails because we haven't implemented RunClassConstructor in native code.