### PR TITLE
Delete callMethodInActiveAssembly, inlining at call sites

### DIFF
--- a/.claude/commands/type-concretization.md
+++ b/.claude/commands/type-concretization.md
@@ -30,10 +30,9 @@ let contextTypeGenerics = currentMethod.DeclaringType.Generics
 let contextMethodGenerics = currentMethod.Generics
 ```
 
-### Call vs CallMethod
-- `callMethodInActiveAssembly` expects unconcretized methods and does concretization internally
-- `callMethod` expects already-concretized methods
-- The refactoring changed to concretizing before calling to ensure types are loaded
+### callMethod
+- `callMethod` expects already-concretized methods (of type `MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>`)
+- Callers must concretize (via `concretizeMethodForExecution`) and ensure type initialization before calling
 
 ## Common Pitfalls
 

--- a/WoofWare.PawPrint/IlMachineStateExecution.fs
+++ b/WoofWare.PawPrint/IlMachineStateExecution.fs
@@ -569,9 +569,8 @@ module IlMachineStateExecution =
 
             match cctor with
             | Some cctorMethod ->
-                // Call the class constructor! Note that we *don't* use `callMethodInActiveAssembly`, because that
-                // performs class loading, but we're already in the middle of loading this class.
-                // TODO: factor out the common bit.
+                // Call the class constructor! We concretize manually and call `callMethod` directly,
+                // because we're already in the middle of loading this class.
                 let currentThreadState = state.ThreadState.[currentThread]
 
                 // Convert the method's type generics from TypeDefn to ConcreteTypeHandle
@@ -694,59 +693,6 @@ module IlMachineStateExecution =
             else
                 state, WhatWeDid.BlockedOnClassInit threadId
 
-    /// It may be useful to *not* advance the program counter of the caller, e.g. if you're using `callMethodInActiveAssembly`
-    /// as a convenient way to move to a different method body rather than to genuinely perform a call.
-    /// (Delegates do this, for example: we get a call to invoke the delegate, and then we implement the delegate as
-    /// another call to its function pointer.)
-    let callMethodInActiveAssembly
-        (loggerFactory : ILoggerFactory)
-        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
-        (thread : ThreadId)
-        (performInterfaceResolution : bool)
-        (advanceProgramCounterOfCaller : bool)
-        (methodGenerics : TypeDefn ImmutableArray option)
-        (methodToCall : WoofWare.PawPrint.MethodInfo<TypeDefn, GenericParamFromMetadata, TypeDefn>)
-        (weAreConstructingObj : ManagedHeapAddress option)
-        (typeArgsFromMetadata : TypeDefn ImmutableArray option)
-        (dispatchAsExceptionOnReturn : bool)
-        (state : IlMachineState)
-        : IlMachineState * WhatWeDid
-        =
-        let threadState = state.ThreadState.[thread]
-
-        let state, concretizedMethod, declaringTypeHandle =
-            IlMachineState.concretizeMethodForExecution
-                loggerFactory
-                baseClassTypes
-                thread
-                methodToCall
-                methodGenerics
-                typeArgsFromMetadata
-                state
-
-        let state, typeInit =
-            ensureTypeInitialised loggerFactory baseClassTypes thread declaringTypeHandle state
-
-        match typeInit with
-        | WhatWeDid.Executed ->
-            callMethod
-                loggerFactory
-                baseClassTypes
-                None
-                weAreConstructingObj
-                performInterfaceResolution
-                false
-                advanceProgramCounterOfCaller
-                concretizedMethod.Generics
-                concretizedMethod
-                thread
-                threadState
-                None
-                dispatchAsExceptionOnReturn
-                state,
-            WhatWeDid.Executed
-        | _ -> state, typeInit
-
     /// Allocate a runtime-synthesised exception, push its default constructor frame, and
     /// return to the dispatch loop.  When the ctor completes (Ret), returnStackFrame will
     /// signal DispatchException so the Ret handler can dispatch the exception.
@@ -808,9 +754,9 @@ module IlMachineStateExecution =
                 )
                 // The type has no generic parameters (guarded above), so any GenericParamFromMetadata
                 // in the ctor's type-generic positions is unreachable. Map them to TypeDefn to satisfy
-                // callMethodInActiveAssembly's signature.
+                // concretizeMethodForExecution's signature.
                 |> MethodInfo.mapTypeGenerics (fun _ ->
-                    failwith "raiseManagedException: exception type was unexpectedly generic"
+                    failwith<TypeDefn> "raiseManagedException: exception type was unexpectedly generic"
                 )
 
             // 3. Push the allocated object ref as `this` for the ctor.
@@ -826,16 +772,32 @@ module IlMachineStateExecution =
             let state, _ =
                 state.WithThreadSwitchedToAssembly exceptionTypeInfo.Assembly currentThread
 
-            callMethodInActiveAssembly
+            let state, concretizedCtor, _declaringTypeHandle =
+                IlMachineState.concretizeMethodForExecution
+                    loggerFactory
+                    baseClassTypes
+                    currentThread
+                    ctor
+                    None
+                    None
+                    state
+
+            let threadState = state.ThreadState.[currentThread]
+
+            callMethod
                 loggerFactory
                 baseClassTypes
-                currentThread
-                false // no interface resolution
-                false // do NOT advance caller PC — dispatch needs the faulting instruction's offset
-                None // no method generics
-                ctor
+                None
                 (Some addr) // weAreConstructingObj
-                None // no type args from metadata
+                false // no interface resolution
+                false // wasClassConstructor
+                false // do NOT advance caller PC — dispatch needs the faulting instruction's offset
+                concretizedCtor.Generics
+                concretizedCtor
+                currentThread
+                threadState
+                None
                 true // dispatchAsExceptionOnReturn
-                state
+                state,
+            WhatWeDid.Executed
         | other -> state, other

--- a/WoofWare.PawPrint/UnaryMetadataIlOp.fs
+++ b/WoofWare.PawPrint/UnaryMetadataIlOp.fs
@@ -203,7 +203,6 @@ module internal UnaryMetadataIlOp =
                     | false, _ -> failwith $"could not find method in {activeAssy.Name}"
                 | k -> failwith $"Unrecognised kind: %O{k}"
 
-            // TODO: this is pretty inefficient, we're concretising here and then immediately after in callMethodInActiveAssembly
             let state, concretizedMethod, declaringTypeHandle =
                 IlMachineState.concretizeMethodForExecution
                     loggerFactory
@@ -239,19 +238,28 @@ module internal UnaryMetadataIlOp =
                     state
             else
 
-            state.WithThreadSwitchedToAssembly methodToCall.DeclaringType.Assembly thread
-            |> fst
-            |> IlMachineStateExecution.callMethodInActiveAssembly
+            let state =
+                state.WithThreadSwitchedToAssembly methodToCall.DeclaringType.Assembly thread
+                |> fst
+
+            let threadState = state.ThreadState.[thread]
+
+            IlMachineStateExecution.callMethod
                 loggerFactory
                 baseClassTypes
-                thread
-                true
-                true
-                methodGenerics
-                methodToCall
                 None
-                typeArgsFromMetadata
+                None
+                true
                 false
+                true
+                concretizedMethod.Generics
+                concretizedMethod
+                thread
+                threadState
+                None
+                false
+                state,
+            WhatWeDid.Executed
 
         | Castclass ->
             let actualObj, state = IlMachineState.popEvalStack thread state
@@ -435,27 +443,26 @@ module internal UnaryMetadataIlOp =
                     state
                     |> IlMachineState.pushToEvalStack (CliType.ObjectRef (Some allocatedAddr)) thread
 
-            let state, whatWeDid =
-                state.WithThreadSwitchedToAssembly assy thread
-                |> fst
-                |> IlMachineStateExecution.callMethodInActiveAssembly
-                    loggerFactory
-                    baseClassTypes
-                    thread
-                    false
-                    true
-                    None
-                    ctor
-                    (Some allocatedAddr)
-                    typeArgsFromMetadata
-                    false
+            let state = state.WithThreadSwitchedToAssembly assy thread |> fst
 
-            match whatWeDid with
-            | WhatWeDid.SuspendedForClassInit -> failwith "unexpectedly suspended while initialising constructor"
-            | WhatWeDid.BlockedOnClassInit _ ->
-                failwith "TODO: Newobj blocked on class init synchronization unimplemented"
-            | WhatWeDid.ThrowingTypeInitializationException -> state, WhatWeDid.ThrowingTypeInitializationException
-            | WhatWeDid.Executed -> state, WhatWeDid.Executed
+            let threadState = state.ThreadState.[thread]
+
+            IlMachineStateExecution.callMethod
+                loggerFactory
+                baseClassTypes
+                None
+                (Some allocatedAddr)
+                false
+                false
+                true
+                concretizedCtor.Generics
+                concretizedCtor
+                thread
+                threadState
+                None
+                false
+                state,
+            WhatWeDid.Executed
         | Newarr ->
             let currentState = state.ThreadState.[thread]
             let popped, methodState = MethodState.popFromStack currentState.MethodState


### PR DESCRIPTION
callMethodInActiveAssembly was a wrapper around callMethod that added concretization and type initialization. All three call sites (Callvirt, Newobj, raiseManagedException) already performed concretization and/or type initialization before calling it, making the wrapper's work redundant. Inline the callMethod call directly at each site, using the already-concretized results.

Fixes #87 .