### PR TITLE
Implement Beq/Beq_s for object reference comparison

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -36,7 +36,6 @@ module TestPureCases =
             "CastClassCrossAssembly.cs" // GetMethodTable intrinsic unimplemented
             "CastClassArray.cs" // bad generics in Array.Length path
             "CastClassInvalid.cs" // try/catch needs Monitor + RuntimeTypeHandle.GetAssembly
-            "CastClassToObject.cs" // todo in UnaryConstIlOp (ceq on object refs)
             "CastClassSimpleInheritance.cs" // field lookup on base type after castclass
             "IsinstPatternMatching.cs" // conv_i4 from float unimplemented
         ]

--- a/WoofWare.PawPrint/UnaryConstIlOp.fs
+++ b/WoofWare.PawPrint/UnaryConstIlOp.fs
@@ -201,9 +201,12 @@ module internal UnaryConstIlOp =
                 | EvalStackValue.Float f, _ -> failwith $"invalid comparison, {f} with {value2}"
                 | EvalStackValue.ManagedPointer v1, EvalStackValue.ManagedPointer v2 -> failwith "todo"
                 | EvalStackValue.ManagedPointer v1, _ -> failwith $"invalid comparison, {v1} with {value2}"
-                | EvalStackValue.NullObjectRef, _
-                | _, EvalStackValue.NullObjectRef
-                | EvalStackValue.ObjectRef _, _ -> failwith "todo"
+                | EvalStackValue.NullObjectRef, EvalStackValue.NullObjectRef -> true
+                | EvalStackValue.NullObjectRef, EvalStackValue.ObjectRef _
+                | EvalStackValue.ObjectRef _, EvalStackValue.NullObjectRef -> false
+                | EvalStackValue.ObjectRef addr1, EvalStackValue.ObjectRef addr2 -> addr1 = addr2
+                | EvalStackValue.NullObjectRef, _ -> failwith $"invalid comparison, NullObjectRef with {value2}"
+                | EvalStackValue.ObjectRef _, _ -> failwith $"invalid comparison, ObjectRef with {value2}"
                 | EvalStackValue.UserDefinedValueType _, _ ->
                     failwith "unexpectedly tried to compare user-defined value type"
 
@@ -346,9 +349,12 @@ module internal UnaryConstIlOp =
                 | EvalStackValue.Float f, _ -> failwith $"invalid comparison, {f} with {value2}"
                 | EvalStackValue.ManagedPointer v1, EvalStackValue.ManagedPointer v2 -> failwith "todo"
                 | EvalStackValue.ManagedPointer v1, _ -> failwith $"invalid comparison, {v1} with {value2}"
-                | EvalStackValue.NullObjectRef, _
-                | _, EvalStackValue.NullObjectRef
-                | EvalStackValue.ObjectRef _, _ -> failwith "todo"
+                | EvalStackValue.NullObjectRef, EvalStackValue.NullObjectRef -> true
+                | EvalStackValue.NullObjectRef, EvalStackValue.ObjectRef _
+                | EvalStackValue.ObjectRef _, EvalStackValue.NullObjectRef -> false
+                | EvalStackValue.ObjectRef addr1, EvalStackValue.ObjectRef addr2 -> addr1 = addr2
+                | EvalStackValue.NullObjectRef, _ -> failwith $"invalid comparison, NullObjectRef with {value2}"
+                | EvalStackValue.ObjectRef _, _ -> failwith $"invalid comparison, ObjectRef with {value2}"
                 | EvalStackValue.UserDefinedValueType _, _ ->
                     failwith "unexpectedly tried to compare user-defined value type"
 


### PR DESCRIPTION
The Beq and Beq_s IL instructions had a "todo" failwith for object reference operands. Implement reference equality for ObjectRef and NullObjectRef, matching the existing pattern in ceq and Bne_un_s. This enables the CastClassToObject test to pass.