### PR TITLE
Add unimplementedMockTests category and enable TestNullDispatch

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -63,6 +63,18 @@ module TestPureCases =
         ]
         |> Map.ofList
 
+    let unimplementedMockTests =
+        let empty = MockEnv.make ()
+
+        [
+            "InterfaceDispatch.cs",
+            (0,
+             { empty with
+                 System_Threading_Monitor = System_Threading_Monitor.passThru
+             })
+        ]
+        |> Map.ofList
+
     let expectsUnhandledException = [ "UnhandledException.cs" ] |> Set.ofList
 
     let customExitCodes =
@@ -97,6 +109,7 @@ module TestPureCases =
         |> Seq.filter (fun s ->
             (customExitCodes.ContainsKey s
              || requiresMocks.ContainsKey s
+             || unimplementedMockTests.ContainsKey s
              || unimplemented.Contains s
              || expectsUnhandledException.Contains s)
             |> not
@@ -219,6 +232,31 @@ module TestPureCases =
             FileName = fileName
             ExpectedReturnCode = 0
             NativeImpls = MockEnv.make ()
+            ExpectsUnhandledException = false
+        }
+        |> runTest
+
+    [<TestCaseSource(nameof unimplementedMockTests)>]
+    let ``Unimplemented mock tests have correct real-runtime behaviour``
+        (KeyValue (fileName : string, (exitCode : int, _mock : NativeImpls)))
+        =
+        let source = Assembly.getEmbeddedResourceAsString fileName assy
+        let image = Roslyn.compile [ source ]
+
+        match RealRuntime.executeWithRealRuntime [||] image with
+        | RealRuntimeResult.NormalExit actualExitCode -> actualExitCode |> shouldEqual exitCode
+        | RealRuntimeResult.UnhandledException exn ->
+            failwith $"Real runtime threw unhandled %s{exn.GetType().Name} for %s{fileName}: %s{exn.Message}"
+
+    [<TestCaseSource(nameof unimplementedMockTests)>]
+    [<Explicit>]
+    let ``Can evaluate C# files, unimplemented mock tests``
+        (KeyValue (fileName : string, (exitCode : int, mock : NativeImpls)))
+        =
+        {
+            FileName = fileName
+            ExpectedReturnCode = exitCode
+            NativeImpls = mock
             ExpectsUnhandledException = false
         }
         |> runTest

--- a/WoofWare.PawPrint.Test/sourcesPure/InterfaceDispatch.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/InterfaceDispatch.cs
@@ -15,8 +15,8 @@ public class InterfaceDispatchTests
         result |= TestCovariantInterface() << 6;
         result |= TestReimplementation() << 7;
         result |= TestStructInterface() << 8;
-        // TODO: TestNullDispatch needs Monitor.ReliableEnter for NRE construction
-        // result |= TestNullDispatch() << 9;
+        result |= TestNullDispatch() << 9;
+
         result |= TestSharedMethodSignature() << 10;
 
         return result;


### PR DESCRIPTION
Introduce a new test category for tests that need mocks but aren't yet fully passing in PawPrint. Move InterfaceDispatch.cs here (it needs Monitor.passThru for NRE construction in TestNullDispatch) and enable the previously-commented TestNullDispatch test case.