### PR TITLE
Handle CEQ between Verbatim and ManagedPointer NativeInt variants

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/CeqNativeIntNull.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/CeqNativeIntNull.cs
@@ -1,0 +1,25 @@
+using System;
+
+public class Program
+{
+    private static IntPtr nullPtr;
+    private static IntPtr nonNullPtr;
+
+    static int Main(string[] args)
+    {
+        // nullPtr is default-initialized to IntPtr.Zero
+        // nonNullPtr we set to a non-zero value
+        nonNullPtr = new IntPtr(42);
+
+        // Test 1: null IntPtr == IntPtr.Zero
+        if (nullPtr != IntPtr.Zero) return 1;
+
+        // Test 2: non-null IntPtr != IntPtr.Zero
+        if (nonNullPtr == IntPtr.Zero) return 2;
+
+        // Test 3: non-null IntPtr == itself
+        if (nonNullPtr != new IntPtr(42)) return 3;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/EvalStackValueComparisons.fs
+++ b/WoofWare.PawPrint/EvalStackValueComparisons.fs
@@ -164,6 +164,14 @@ module EvalStackValueComparisons =
             | NativeIntSource.TypeHandlePtr f1, NativeIntSource.TypeHandlePtr f2 -> f1 = f2
             | NativeIntSource.Verbatim f1, NativeIntSource.Verbatim f2 -> f1 = f2
             | NativeIntSource.ManagedPointer f1, NativeIntSource.ManagedPointer f2 -> f1 = f2
+            | NativeIntSource.Verbatim 0L, NativeIntSource.ManagedPointer ManagedPointerSource.Null -> true
+            | NativeIntSource.ManagedPointer ManagedPointerSource.Null, NativeIntSource.Verbatim 0L -> true
+            | NativeIntSource.Verbatim _, NativeIntSource.ManagedPointer ManagedPointerSource.Null -> false
+            | NativeIntSource.ManagedPointer ManagedPointerSource.Null, NativeIntSource.Verbatim _ -> false
+            | NativeIntSource.Verbatim v, NativeIntSource.ManagedPointer (ManagedPointerSource.Byref _ as ptr) ->
+                failwith $"TODO (CEQ): Verbatim %i{v} vs non-null ManagedPointer %O{ptr}; concrete address unknown"
+            | NativeIntSource.ManagedPointer (ManagedPointerSource.Byref _ as ptr), NativeIntSource.Verbatim v ->
+                failwith $"TODO (CEQ): non-null ManagedPointer %O{ptr} vs Verbatim %i{v}; concrete address unknown"
             | _, _ -> failwith $"TODO (CEQ): nativeint vs nativeint, {var1} vs {var2}"
         | EvalStackValue.NativeInt var1, EvalStackValue.Int32 var2 -> failwith $"TODO (CEQ): nativeint vs int32"
         | EvalStackValue.NativeInt var1, EvalStackValue.ManagedPointer var2 ->


### PR DESCRIPTION
A null managed pointer is equivalent to Verbatim 0 for equality comparison. Non-null managed pointer vs verbatim integer remains unsupported (failwith) since the concrete address is unknown.

This arises in BCL code like RuntimeType.get_Cache which compares an IntPtr field against zero to check initialization.