### PR TITLE
Implement Unsafe.{Add,AreSame,ByteOffset} array-byref intrinsics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ nix develop -c dotnet run --project WoofWare.PawPrint.App/WoofWare.PawPrint.App.
 - Uses NUnit as the test framework
 - Test cases are defined in `TestPureCases.fs` and `TestImpureCases.fs`
 - C# source files in `sources{Pure,Impure}/` are compiled and executed by the runtime as test cases; files in `sourcesPure` are automatically turned into test cases with no further action (see TestPureCases.fs for the mechanism), while `sourcesImpure` tests must be explicitly registered
+- The `unimplemented` set of test files that are not yet expected to pass lives in `WoofWare.PawPrint.Test/TestPureCases.fs` (look for `let unimplemented =` near the top of the `TestPureCases` module); there's a sibling `unimplementedMockTests` map in the same file for unimplemented tests that also need mock registrations
 - `TestHarness.fs` provides infrastructure for running test assemblies through the interpreter
 - Run all tests with `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --verbosity normal`
 - Run a filtered subset with `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --no-build --filter "Name~TypeRef" --verbosity normal`

--- a/WoofWare.PawPrint.Domain/TypeConcretisation.fs
+++ b/WoofWare.PawPrint.Domain/TypeConcretisation.fs
@@ -362,6 +362,40 @@ module ConcreteActivePatterns =
             | None -> None
         | _ -> None
 
+    let (|ConcreteIntPtr|_|) (concreteTypes : AllConcreteTypes) (handle : ConcreteTypeHandle) : unit option =
+        match handle with
+        | ConcreteTypeHandle.Concrete id ->
+            match concreteTypes.Mapping |> Map.tryFind id with
+            | Some ct ->
+                if
+                    ct.Assembly.Name = "System.Private.CoreLib"
+                    && ct.Namespace = "System"
+                    && ct.Name = "IntPtr"
+                    && ct.Generics.IsEmpty
+                then
+                    Some ()
+                else
+                    None
+            | None -> None
+        | _ -> None
+
+    let (|ConcreteUIntPtr|_|) (concreteTypes : AllConcreteTypes) (handle : ConcreteTypeHandle) : unit option =
+        match handle with
+        | ConcreteTypeHandle.Concrete id ->
+            match concreteTypes.Mapping |> Map.tryFind id with
+            | Some ct ->
+                if
+                    ct.Assembly.Name = "System.Private.CoreLib"
+                    && ct.Namespace = "System"
+                    && ct.Name = "UIntPtr"
+                    && ct.Generics.IsEmpty
+                then
+                    Some ()
+                else
+                    None
+            | None -> None
+        | _ -> None
+
     /// Active pattern to match byref types
     let (|ConcreteByref|_|) (handle : ConcreteTypeHandle) =
         match handle with

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -25,7 +25,7 @@ module TestPureCases =
             "ComplexTryCatch.cs"
             "ResizeArray.cs"
             "LdtokenField.cs"
-            "GenericEdgeCases.cs"
+            "GenericEdgeCases.cs" // hits SpanHelpers.Memmove via Number..cctor; see docs/plans/2026-04-20-memmove.md
             "UnsafeAs.cs"
             "ThrowingCctorProperties.cs"
             "ThrowingCctorStackTrace.cs"

--- a/WoofWare.PawPrint.Test/sourcesPure/UnsafeArrayArithmetic.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/UnsafeArrayArithmetic.cs
@@ -1,0 +1,118 @@
+using System.Runtime.CompilerServices;
+
+public class TestUnsafeArrayArithmetic
+{
+    // Unsafe.Add by positive element offset on a non-reinterpreted byref into an int[].
+    public static int Test1()
+    {
+        int[] a = { 10, 20, 30, 40 };
+        ref int p = ref a[1];
+        ref int q = ref Unsafe.Add(ref p, 2);
+        if (q != 40)
+            return 1;
+        return 0;
+    }
+
+    // Unsafe.Add with element offset zero: identity.
+    public static int Test2()
+    {
+        int[] a = { 10, 20, 30 };
+        ref int q = ref Unsafe.Add(ref a[1], 0);
+        if (q != 20)
+            return 2;
+        return 0;
+    }
+
+    // Unsafe.Add with a negative element offset.
+    public static int Test3()
+    {
+        int[] a = { 10, 20, 30 };
+        ref int q = ref Unsafe.Add(ref a[2], -1);
+        if (q != 20)
+            return 3;
+        return 0;
+    }
+
+    // Write through a byref obtained via Unsafe.Add.
+    public static int Test4()
+    {
+        int[] a = { 10, 20, 30 };
+        ref int q = ref Unsafe.Add(ref a[0], 1);
+        q = 222;
+        if (a[1] != 222)
+            return 4;
+        if (a[0] != 10)
+            return 5;
+        if (a[2] != 30)
+            return 6;
+        return 0;
+    }
+
+    // Unsafe.AreSame: two byrefs into the same element compare equal; different indices unequal.
+    public static int Test5()
+    {
+        int[] a = new int[4];
+        if (!Unsafe.AreSame(ref a[0], ref a[0]))
+            return 7;
+        if (Unsafe.AreSame(ref a[0], ref a[1]))
+            return 8;
+        return 0;
+    }
+
+    // Unsafe.AreSame sees the result of Unsafe.Add as the expected element.
+    public static int Test6()
+    {
+        int[] a = new int[4];
+        ref int p = ref a[1];
+        ref int q = ref Unsafe.Add(ref a[0], 1);
+        if (!Unsafe.AreSame(ref p, ref q))
+            return 9;
+        if (Unsafe.AreSame(ref p, ref a[2]))
+            return 10;
+        return 0;
+    }
+
+    // Unsafe.AreSame comparing byrefs into two distinct arrays should return false.
+    public static int Test7()
+    {
+        int[] a = new int[2];
+        int[] b = new int[2];
+        if (Unsafe.AreSame(ref a[0], ref b[0]))
+            return 11;
+        return 0;
+    }
+
+    // Unsafe.ByteOffset within the same array.
+    public static int Test8()
+    {
+        int[] a = new int[4];
+        System.IntPtr offset = Unsafe.ByteOffset(ref a[0], ref a[1]);
+        if (offset != (System.IntPtr)sizeof(int))
+            return 12;
+        System.IntPtr zero = Unsafe.ByteOffset(ref a[1], ref a[1]);
+        if (zero != System.IntPtr.Zero)
+            return 13;
+        return 0;
+    }
+
+    public static int Main(string[] argv)
+    {
+        int r = Test1();
+        if (r != 0) return r;
+        r = Test2();
+        if (r != 0) return r;
+        r = Test3();
+        if (r != 0) return r;
+        r = Test4();
+        if (r != 0) return r;
+        r = Test5();
+        if (r != 0) return r;
+        r = Test6();
+        if (r != 0) return r;
+        r = Test7();
+        if (r != 0) return r;
+        r = Test8();
+        if (r != 0) return r;
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/UnsafeArrayArithmetic.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/UnsafeArrayArithmetic.cs
@@ -95,6 +95,31 @@ public class TestUnsafeArrayArithmetic
         return 0;
     }
 
+    // Unsafe.As<T,T> is a no-op; AreSame should see the result as aliasing the input.
+    public static int Test9()
+    {
+        int[] a = new int[1];
+        ref int p = ref a[0];
+        ref int q = ref Unsafe.As<int, int>(ref p);
+        if (!Unsafe.AreSame(ref p, ref q))
+            return 14;
+        return 0;
+    }
+
+    // Consecutive Unsafe.As reinterpretations don't move the address: two byrefs that
+    // reach the same final type view by different chains should AreSame.
+    public static int Test10()
+    {
+        int[] a = new int[1];
+        ref int x = ref a[0];
+        ref uint via = ref Unsafe.As<int, uint>(ref x);
+        ref short y = ref Unsafe.As<uint, short>(ref via);
+        ref short z = ref Unsafe.As<int, short>(ref x);
+        if (!Unsafe.AreSame(ref y, ref z))
+            return 15;
+        return 0;
+    }
+
     public static int Main(string[] argv)
     {
         int r = Test1();
@@ -112,6 +137,10 @@ public class TestUnsafeArrayArithmetic
         r = Test7();
         if (r != 0) return r;
         r = Test8();
+        if (r != 0) return r;
+        r = Test9();
+        if (r != 0) return r;
+        r = Test10();
         if (r != 0) return r;
         return 0;
     }

--- a/WoofWare.PawPrint.Test/sourcesPure/UnsafeArrayArithmetic.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/UnsafeArrayArithmetic.cs
@@ -326,6 +326,24 @@ public class TestUnsafeArrayArithmetic
         return 0;
     }
 
+    // Two IntPtrs obtained from the same byref via different reinterpret
+    // chains must compare equal. `Unsafe.AsPointer` + `(IntPtr)` (Conv.U)
+    // produces a NativeInt wrapping a ManagedPointer; if one of the byrefs
+    // went through `Unsafe.As`, only one ManagedPointer has a trailing
+    // `ReinterpretAs` projection. The ceq arm for NativeInt vs NativeInt
+    // ManagedPointer must strip those the same way the direct byref ceq does.
+    public static unsafe int Test22()
+    {
+        int[] a = new int[1];
+        ref int x = ref a[0];
+        ref uint u = ref Unsafe.As<int, uint>(ref x);
+        System.IntPtr p = (System.IntPtr)Unsafe.AsPointer(ref x);
+        System.IntPtr q = (System.IntPtr)Unsafe.AsPointer(ref u);
+        if (p != q)
+            return 43;
+        return 0;
+    }
+
     public static int Main(string[] argv)
     {
         int r = Test1();
@@ -369,6 +387,8 @@ public class TestUnsafeArrayArithmetic
         r = Test20();
         if (r != 0) return r;
         r = Test21();
+        if (r != 0) return r;
+        r = Test22();
         if (r != 0) return r;
         return 0;
     }

--- a/WoofWare.PawPrint.Test/sourcesPure/UnsafeArrayArithmetic.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/UnsafeArrayArithmetic.cs
@@ -208,6 +208,44 @@ public class TestUnsafeArrayArithmetic
         return 0;
     }
 
+    // Writing through a size-preserving reinterpret (int <-> uint) must land
+    // in the underlying storage. Read-only reinterprets already worked; this
+    // exercises the write path that previously threw inside applyProjectionsForWrite.
+    public static int Test16()
+    {
+        int[] a = { 10, 20, 30, 40 };
+        ref uint u = ref Unsafe.As<int, uint>(ref a[1]);
+        u = 0xDEADBEEFu;
+        if (a[1] != unchecked((int)0xDEADBEEFu))
+            return 25;
+        if (a[0] != 10)
+            return 26;
+        if (a[2] != 30)
+            return 27;
+        // Round-trip As should also support writes: arithmetic through a
+        // reinterpreted byref followed by a store must land in the right slot.
+        ref int back = ref Unsafe.As<uint, int>(ref u);
+        ref int target = ref Unsafe.Add(ref back, 1);
+        target = 999;
+        if (a[2] != 999)
+            return 28;
+        return 0;
+    }
+
+    // Unsafe.ByteOffset on two byrefs into the same empty array must return
+    // zero rather than throw. Zero-length span helpers call this path after
+    // going through MemoryMarshal.GetArrayDataReference on an empty array.
+    public static int Test17()
+    {
+        int[] empty = new int[0];
+        ref int r1 = ref System.Runtime.InteropServices.MemoryMarshal.GetArrayDataReference(empty);
+        ref int r2 = ref System.Runtime.InteropServices.MemoryMarshal.GetArrayDataReference(empty);
+        System.IntPtr off = Unsafe.ByteOffset(ref r1, ref r2);
+        if (off != System.IntPtr.Zero)
+            return 29;
+        return 0;
+    }
+
     public static int Main(string[] argv)
     {
         int r = Test1();
@@ -239,6 +277,10 @@ public class TestUnsafeArrayArithmetic
         r = Test14();
         if (r != 0) return r;
         r = Test15();
+        if (r != 0) return r;
+        r = Test16();
+        if (r != 0) return r;
+        r = Test17();
         if (r != 0) return r;
         return 0;
     }

--- a/WoofWare.PawPrint.Test/sourcesPure/UnsafeArrayArithmetic.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/UnsafeArrayArithmetic.cs
@@ -120,6 +120,37 @@ public class TestUnsafeArrayArithmetic
         return 0;
     }
 
+    // Round-trip Unsafe.As returns to the original natural type view; the
+    // resulting byref should still be recognised as the same as the original.
+    public static int Test11()
+    {
+        int[] a = new int[1];
+        ref int x = ref a[0];
+        ref uint u = ref Unsafe.As<int, uint>(ref x);
+        ref int back = ref Unsafe.As<uint, int>(ref u);
+        if (!Unsafe.AreSame(ref x, ref back))
+            return 16;
+        return 0;
+    }
+
+    // ByteOffset between two distinct arrays returns some value. The cross-array
+    // case must not throw, and ByteOffset must be anti-symmetric: ByteOffset(a, b)
+    // is the negation of ByteOffset(b, a), for any two byrefs.
+    public static int Test12()
+    {
+        int[] a = new int[4];
+        int[] b = new int[4];
+        long forward = (long)Unsafe.ByteOffset(ref a[0], ref b[0]);
+        long backward = (long)Unsafe.ByteOffset(ref b[0], ref a[0]);
+        if (forward + backward != 0L)
+            return 17;
+        // ByteOffset from a byref to itself must still be zero.
+        System.IntPtr self = Unsafe.ByteOffset(ref b[2], ref b[2]);
+        if (self != System.IntPtr.Zero)
+            return 18;
+        return 0;
+    }
+
     public static int Main(string[] argv)
     {
         int r = Test1();
@@ -141,6 +172,10 @@ public class TestUnsafeArrayArithmetic
         r = Test9();
         if (r != 0) return r;
         r = Test10();
+        if (r != 0) return r;
+        r = Test11();
+        if (r != 0) return r;
+        r = Test12();
         if (r != 0) return r;
         return 0;
     }

--- a/WoofWare.PawPrint.Test/sourcesPure/UnsafeArrayArithmetic.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/UnsafeArrayArithmetic.cs
@@ -246,6 +246,61 @@ public class TestUnsafeArrayArithmetic
         return 0;
     }
 
+    // Same-width cross-signedness reinterprets must be transparent to reads
+    // and writes on a byref into a local: ushort<->short and ushort<->char
+    // share bit patterns and the ECMA stack round-trips them through Int32
+    // with modular narrowing. Used by Convert / Utf8Parser.
+    public static int Test18()
+    {
+        ushort value = 0x1234;
+        ref short s = ref Unsafe.As<ushort, short>(ref value);
+        if (s != 0x1234)
+            return 30;
+        s = unchecked((short)0xFFEE);
+        if (value != 0xFFEE)
+            return 31;
+        ref char c = ref Unsafe.As<short, char>(ref s);
+        if (c != (char)0xFFEE)
+            return 32;
+        c = 'A';
+        if (value != (ushort)'A')
+            return 33;
+        return 0;
+    }
+
+    // Same-width cross-signedness reinterprets for byte/sbyte via a local.
+    public static int Test19()
+    {
+        byte value = 0x10;
+        ref sbyte s = ref Unsafe.As<byte, sbyte>(ref value);
+        if (s != (sbyte)0x10)
+            return 34;
+        s = -1;
+        if (value != 0xFF)
+            return 35;
+        return 0;
+    }
+
+    // Native-int offset overloads of Unsafe.Add. The JIT lowers
+    // `Unsafe.Add(ref T, (nint)n)` and `Unsafe.Add(ref T, (nuint)n)` to the
+    // same sizeof*offset+base shape as the int32 overload; both must work.
+    public static int Test20()
+    {
+        int[] a = { 10, 20, 30, 40 };
+        ref int p = ref Unsafe.Add(ref a[0], (nint)2);
+        if (p != 30)
+            return 36;
+        ref int q = ref Unsafe.Add(ref a[0], (nuint)3);
+        if (q != 40)
+            return 37;
+        // Negative nint offset: SpanHelpers uses this shape when walking
+        // backwards from the end of a buffer.
+        ref int r = ref Unsafe.Add(ref a[3], (nint)(-1));
+        if (r != 30)
+            return 38;
+        return 0;
+    }
+
     public static int Main(string[] argv)
     {
         int r = Test1();
@@ -281,6 +336,12 @@ public class TestUnsafeArrayArithmetic
         r = Test16();
         if (r != 0) return r;
         r = Test17();
+        if (r != 0) return r;
+        r = Test18();
+        if (r != 0) return r;
+        r = Test19();
+        if (r != 0) return r;
+        r = Test20();
         if (r != 0) return r;
         return 0;
     }

--- a/WoofWare.PawPrint.Test/sourcesPure/UnsafeArrayArithmetic.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/UnsafeArrayArithmetic.cs
@@ -151,6 +151,45 @@ public class TestUnsafeArrayArithmetic
         return 0;
     }
 
+    // A negative Unsafe.ByteOffset cast to nuint must not throw. Any same-array
+    // order is valid, so ByteOffset(a[0], a[N]) and ByteOffset(a[N], a[0]) are
+    // negatives of each other; casting either to nuint should work. This is the
+    // shape of the overlap check in SpanHelpers.Memmove.
+    public static int Test13()
+    {
+        int[] a = new int[4];
+        System.IntPtr delta = Unsafe.ByteOffset(ref a[3], ref a[0]);
+        // The cast below is a Conv_U on a negative native int. Before the fix
+        // this threw inside the interpreter.
+        nuint unsignedDelta = (nuint)delta;
+        if ((long)delta >= 0L)
+            return 19;
+        // The unsigned value must be very large (no legitimate array length
+        // reaches near UInt64.MaxValue), so the overlap check fails as it
+        // should for the forward-copy branch of Memmove.
+        if (unsignedDelta < (nuint)1000)
+            return 20;
+        return 0;
+    }
+
+    // Arithmetic on a byref obtained via a round-trip Unsafe.As must behave
+    // identically to arithmetic on the bare byref. Exercises the interaction
+    // between the Unsafe.As canonicalisation and Unsafe.Add/ByteOffset.
+    public static int Test14()
+    {
+        int[] a = { 10, 20, 30, 40 };
+        ref int x = ref a[0];
+        ref uint u = ref Unsafe.As<int, uint>(ref x);
+        ref int back = ref Unsafe.As<uint, int>(ref u);
+        ref int q = ref Unsafe.Add(ref back, 2);
+        if (q != 30)
+            return 21;
+        System.IntPtr off = Unsafe.ByteOffset(ref back, ref a[3]);
+        if ((long)off != 3L * sizeof(int))
+            return 22;
+        return 0;
+    }
+
     public static int Main(string[] argv)
     {
         int r = Test1();
@@ -176,6 +215,10 @@ public class TestUnsafeArrayArithmetic
         r = Test11();
         if (r != 0) return r;
         r = Test12();
+        if (r != 0) return r;
+        r = Test13();
+        if (r != 0) return r;
+        r = Test14();
         if (r != 0) return r;
         return 0;
     }

--- a/WoofWare.PawPrint.Test/sourcesPure/UnsafeArrayArithmetic.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/UnsafeArrayArithmetic.cs
@@ -190,6 +190,24 @@ public class TestUnsafeArrayArithmetic
         return 0;
     }
 
+    // A size-preserving Unsafe.As (int -> uint) and arithmetic through the
+    // reinterpreted byref. The view type changes but the address step is still
+    // over the underlying int storage.
+    public static int Test15()
+    {
+        int[] a = { 100, 200, 300, 400 };
+        ref uint u0 = ref Unsafe.As<int, uint>(ref a[0]);
+        ref uint u2 = ref Unsafe.Add(ref u0, 2);
+        if (u2 != 300u)
+            return 23;
+        // ByteOffset between two reinterpreted views must match the underlying
+        // byte stride (sizeof(int)), not sizeof(uint) coincidentally.
+        System.IntPtr off = Unsafe.ByteOffset(ref u0, ref u2);
+        if ((long)off != 2L * sizeof(int))
+            return 24;
+        return 0;
+    }
+
     public static int Main(string[] argv)
     {
         int r = Test1();
@@ -219,6 +237,8 @@ public class TestUnsafeArrayArithmetic
         r = Test13();
         if (r != 0) return r;
         r = Test14();
+        if (r != 0) return r;
+        r = Test15();
         if (r != 0) return r;
         return 0;
     }

--- a/WoofWare.PawPrint.Test/sourcesPure/UnsafeArrayArithmetic.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/UnsafeArrayArithmetic.cs
@@ -301,6 +301,31 @@ public class TestUnsafeArrayArithmetic
         return 0;
     }
 
+    // Cross-array ByteOffset must survive the Memmove-shape overlap check:
+    // the synthetic value flows through `(long)` (Conv.I8), `(nuint)` (Conv.U),
+    // unsigned comparison against an in-range length, and anti-symmetric
+    // equality against its negation. It must NOT be zero and must compare
+    // larger than any plausible array length once reinterpreted unsigned.
+    public static int Test21()
+    {
+        int[] a = new int[4];
+        int[] b = new int[4];
+        System.IntPtr ab = Unsafe.ByteOffset(ref a[0], ref b[0]);
+        System.IntPtr ba = Unsafe.ByteOffset(ref b[0], ref a[0]);
+        if (ab == System.IntPtr.Zero)
+            return 39;
+        if ((long)ab + (long)ba != 0L)
+            return 40;
+        // The exact shape of Memmove's overlap check.
+        nuint unsignedAB = (nuint)ab;
+        if (unsignedAB < (nuint)(a.Length * sizeof(int)))
+            return 41;
+        nuint unsignedBA = (nuint)ba;
+        if (unsignedBA < (nuint)(b.Length * sizeof(int)))
+            return 42;
+        return 0;
+    }
+
     public static int Main(string[] argv)
     {
         int r = Test1();
@@ -342,6 +367,8 @@ public class TestUnsafeArrayArithmetic
         r = Test19();
         if (r != 0) return r;
         r = Test20();
+        if (r != 0) return r;
+        r = Test21();
         if (r != 0) return r;
         return 0;
     }

--- a/WoofWare.PawPrint/BasicCliType.fs
+++ b/WoofWare.PawPrint/BasicCliType.fs
@@ -121,6 +121,33 @@ module ManagedPointerSource =
                 stripTrailingReinterprets (ManagedPointerSource.Byref (root, List.rev revRest))
             | _ -> src
 
+    /// True when a byref source carries a non-trailing `ReinterpretAs`
+    /// projection (i.e. a reinterpret followed by a Field). Such projections
+    /// would need a bytewise layout comparison — `ref a.X` vs
+    /// `ref Unsafe.As<A,B>(ref a).X` can alias despite having different
+    /// projection chains — and we don't yet model that. Callers that compare
+    /// byrefs structurally use this to refuse the comparison rather than
+    /// silently returning a potentially-wrong answer.
+    let hasNonTrailingReinterpret (src : ManagedPointerSource) : bool =
+        match src with
+        | ManagedPointerSource.Null -> false
+        | ManagedPointerSource.Byref (_, projs) ->
+            let stripped =
+                projs
+                |> List.rev
+                |> List.skipWhile (fun p ->
+                    match p with
+                    | ByrefProjection.ReinterpretAs _ -> true
+                    | _ -> false
+                )
+
+            stripped
+            |> List.exists (fun p ->
+                match p with
+                | ByrefProjection.ReinterpretAs _ -> true
+                | _ -> false
+            )
+
 [<RequireQualifiedAccess>]
 type UnsignedNativeIntSource =
     | Verbatim of uint64

--- a/WoofWare.PawPrint/BasicCliType.fs
+++ b/WoofWare.PawPrint/BasicCliType.fs
@@ -107,6 +107,20 @@ module ManagedPointerSource =
 
             ManagedPointerSource.Byref (root, newProjs)
 
+    /// Drop any trailing address-preserving `ReinterpretAs` projections so that two
+    /// byrefs reaching the same byte location by different type-view paths compare
+    /// equal. A `ReinterpretAs` followed by a `Field` must stay: field resolution
+    /// depends on the reinterpreted type's layout, so it is no longer purely
+    /// address-preserving in that case.
+    let rec stripTrailingReinterprets (src : ManagedPointerSource) : ManagedPointerSource =
+        match src with
+        | ManagedPointerSource.Null -> src
+        | ManagedPointerSource.Byref (root, projs) ->
+            match List.rev projs with
+            | ByrefProjection.ReinterpretAs _ :: revRest ->
+                stripTrailingReinterprets (ManagedPointerSource.Byref (root, List.rev revRest))
+            | _ -> src
+
 [<RequireQualifiedAccess>]
 type UnsignedNativeIntSource =
     | Verbatim of uint64

--- a/WoofWare.PawPrint/BasicCliType.fs
+++ b/WoofWare.PawPrint/BasicCliType.fs
@@ -134,6 +134,14 @@ type NativeIntSource =
     | TypeHandlePtr of ConcreteTypeHandle
     | FieldHandlePtr of int64
     | AssemblyHandle of string
+    /// Synthetic byte delta returned by `Unsafe.ByteOffset` for two byrefs into
+    /// distinct arrays. We don't model heap addresses as integers, so the value
+    /// is a deterministic sentinel large enough to defeat the unsigned overlap
+    /// check `(nuint)offset < len` used by Memmove. The tag exists so downstream
+    /// arithmetic (add/sub with anything non-zero) fails loudly rather than
+    /// silently composing into a wrong answer; comparisons and Conv.U/Conv.I
+    /// treat the payload as if it were a regular `Verbatim`.
+    | SyntheticCrossArrayOffset of int64
 
     override this.ToString () : string =
         match this with
@@ -144,12 +152,14 @@ type NativeIntSource =
         | NativeIntSource.TypeHandlePtr ptr -> $"<type ID %O{ptr}>"
         | NativeIntSource.FieldHandlePtr ptr -> $"<field ID %O{ptr}>"
         | NativeIntSource.AssemblyHandle name -> $"<assembly %s{name}>"
+        | NativeIntSource.SyntheticCrossArrayOffset i -> $"<synthetic cross-array byte offset %i{i}>"
 
 [<RequireQualifiedAccess>]
 module NativeIntSource =
     let isZero (n : NativeIntSource) : bool =
         match n with
         | NativeIntSource.Verbatim i -> i = 0L
+        | NativeIntSource.SyntheticCrossArrayOffset i -> i = 0L
         | NativeIntSource.FieldHandlePtr _
         | NativeIntSource.TypeHandlePtr _
         | NativeIntSource.AssemblyHandle _ -> false
@@ -162,6 +172,7 @@ module NativeIntSource =
     let isNonnegative (n : NativeIntSource) : bool =
         match n with
         | NativeIntSource.Verbatim i -> i >= 0L
+        | NativeIntSource.SyntheticCrossArrayOffset i -> i >= 0L
         | NativeIntSource.FunctionPointer _ -> failwith "TODO"
         | NativeIntSource.FieldHandlePtr _
         | NativeIntSource.TypeHandlePtr _
@@ -172,6 +183,9 @@ module NativeIntSource =
     let isLess (a : NativeIntSource) (b : NativeIntSource) : bool =
         match a, b with
         | NativeIntSource.Verbatim a, NativeIntSource.Verbatim b -> a < b
+        | NativeIntSource.SyntheticCrossArrayOffset a, NativeIntSource.Verbatim b -> a < b
+        | NativeIntSource.Verbatim a, NativeIntSource.SyntheticCrossArrayOffset b -> a < b
+        | NativeIntSource.SyntheticCrossArrayOffset a, NativeIntSource.SyntheticCrossArrayOffset b -> a < b
         | _, _ -> failwith "TODO"
 
 
@@ -209,6 +223,7 @@ type CliNumericType =
         | CliNumericType.NativeInt src ->
             match src with
             | NativeIntSource.Verbatim i -> BitConverter.GetBytes i
+            | NativeIntSource.SyntheticCrossArrayOffset i -> BitConverter.GetBytes i
             | NativeIntSource.ManagedPointer src ->
                 match src with
                 | ManagedPointerSource.Null -> BitConverter.GetBytes 0L

--- a/WoofWare.PawPrint/BasicCliType.fs
+++ b/WoofWare.PawPrint/BasicCliType.fs
@@ -96,7 +96,16 @@ module ManagedPointerSource =
     let appendProjection (projection : ByrefProjection) (src : ManagedPointerSource) : ManagedPointerSource =
         match src with
         | ManagedPointerSource.Null -> failwith "cannot project from null managed pointer"
-        | ManagedPointerSource.Byref (root, projs) -> ManagedPointerSource.Byref (root, projs @ [ projection ])
+        | ManagedPointerSource.Byref (root, projs) ->
+            // ReinterpretAs is address-preserving: it changes only the type view, not the byte offset.
+            // So consecutive ReinterpretAs projections collapse to the most recent one.
+            let newProjs =
+                match projection, List.rev projs with
+                | ByrefProjection.ReinterpretAs _, (ByrefProjection.ReinterpretAs _) :: revRest ->
+                    List.rev revRest @ [ projection ]
+                | _ -> projs @ [ projection ]
+
+            ManagedPointerSource.Byref (root, newProjs)
 
 [<RequireQualifiedAccess>]
 type UnsignedNativeIntSource =

--- a/WoofWare.PawPrint/EvalStack.fs
+++ b/WoofWare.PawPrint/EvalStack.fs
@@ -29,26 +29,15 @@ type EvalStackValue =
 module EvalStackValue =
     /// The conversion performed by Conv_u.
     let toUnsignedNativeInt (value : EvalStackValue) : UnsignedNativeIntSource option =
-        // Table III.8
+        // Table III.8. Negative inputs are bit-reinterpreted (zero-extended
+        // for Int32, same bits for Int64/NativeInt); the F# `uint32`/`uint64`
+        // conversions from signed already do this.
         match value with
-        | EvalStackValue.Int32 i ->
-            if i >= 0 then
-                Some (uint64 i |> UnsignedNativeIntSource.Verbatim)
-            else
-            // Zero-extend.
-            failwith "todo"
-        | EvalStackValue.Int64 i ->
-            if i >= 0L then
-                Some (uint64 i |> UnsignedNativeIntSource.Verbatim)
-            else
-                failwith "todo"
+        | EvalStackValue.Int32 i -> Some (uint64 (uint32 i) |> UnsignedNativeIntSource.Verbatim)
+        | EvalStackValue.Int64 i -> Some (uint64 i |> UnsignedNativeIntSource.Verbatim)
         | EvalStackValue.NativeInt i ->
             match i with
-            | NativeIntSource.Verbatim i ->
-                if i >= 0L then
-                    uint64 i |> UnsignedNativeIntSource.Verbatim |> Some
-                else
-                    failwith "todo"
+            | NativeIntSource.Verbatim i -> uint64 i |> UnsignedNativeIntSource.Verbatim |> Some
             | NativeIntSource.ManagedPointer _ -> failwith "TODO"
             | NativeIntSource.FunctionPointer _ -> failwith "TODO"
             | NativeIntSource.FieldHandlePtr _ -> failwith "TODO"

--- a/WoofWare.PawPrint/EvalStack.fs
+++ b/WoofWare.PawPrint/EvalStack.fs
@@ -38,6 +38,12 @@ module EvalStackValue =
         | EvalStackValue.NativeInt i ->
             match i with
             | NativeIntSource.Verbatim i -> uint64 i |> UnsignedNativeIntSource.Verbatim |> Some
+            // `SyntheticCrossArrayOffset` intentionally flows through the same
+            // Conv.U path as `Verbatim`: the overlap check in Memmove is
+            // exactly `(nuint)ByteOffset(...) < len`, and the synthetic's
+            // large signed-negative sentinel becomes a very large unsigned
+            // value after this bit-reinterpret — which is the answer we want.
+            | NativeIntSource.SyntheticCrossArrayOffset i -> uint64 i |> UnsignedNativeIntSource.Verbatim |> Some
             | NativeIntSource.ManagedPointer _ -> failwith "TODO"
             | NativeIntSource.FunctionPointer _ -> failwith "TODO"
             | NativeIntSource.FieldHandlePtr _ -> failwith "TODO"
@@ -75,6 +81,11 @@ module EvalStackValue =
         | EvalStackValue.NativeInt src ->
             match src with
             | NativeIntSource.Verbatim int64 -> Some int64
+            // `SyntheticCrossArrayOffset` converts to Int64 bit-identically:
+            // casting an IntPtr to long (`(long)ptr`) lowers to Conv.I8, and
+            // the cross-array ByteOffset use sites need to see the same bits
+            // they'd get back from a subsequent Conv.U.
+            | NativeIntSource.SyntheticCrossArrayOffset int64 -> Some int64
             | NativeIntSource.ManagedPointer ManagedPointerSource.Null -> Some 0L
             | NativeIntSource.ManagedPointer _
             | NativeIntSource.FunctionPointer _
@@ -165,6 +176,7 @@ module EvalStackValue =
                 | EvalStackValue.NativeInt src ->
                     match src with
                     | NativeIntSource.Verbatim i -> CliType.Numeric (CliNumericType.Int64 i)
+                    | NativeIntSource.SyntheticCrossArrayOffset i -> CliType.Numeric (CliNumericType.Int64 i)
                     | NativeIntSource.ManagedPointer ptr -> failwith "TODO"
                     | NativeIntSource.FunctionPointer f -> failwith $"TODO: {f}"
                     | NativeIntSource.FieldHandlePtr f -> failwith $"TODO: {f}"
@@ -229,6 +241,8 @@ module EvalStackValue =
                 match nativeIntSource with
                 | NativeIntSource.Verbatim 0L -> CliType.ObjectRef None
                 | NativeIntSource.Verbatim i -> failwith $"refusing to interpret verbatim native int {i} as a pointer"
+                | NativeIntSource.SyntheticCrossArrayOffset i ->
+                    failwith $"refusing to interpret synthetic cross-array byte offset {i} as a pointer"
                 | NativeIntSource.FunctionPointer _ -> failwith "TODO"
                 | NativeIntSource.TypeHandlePtr _ -> failwith "refusing to interpret type handle ID as an object ref"
                 | NativeIntSource.FieldHandlePtr _ -> failwith "refusing to interpret field handle ID as an object ref"
@@ -259,6 +273,9 @@ module EvalStackValue =
             | EvalStackValue.NativeInt intSrc ->
                 match intSrc with
                 | NativeIntSource.Verbatim i -> CliType.RuntimePointer (CliRuntimePointer.Verbatim i)
+                | NativeIntSource.SyntheticCrossArrayOffset i ->
+                    failwith
+                        $"refusing to interpret synthetic cross-array byte offset {i} as a runtime pointer: the value is a deterministic sentinel, not a real address"
                 | NativeIntSource.ManagedPointer src -> src |> CliRuntimePointer.Managed |> CliType.RuntimePointer
                 | NativeIntSource.FunctionPointer methodInfo ->
                     CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.FunctionPointer methodInfo))

--- a/WoofWare.PawPrint/EvalStack.fs
+++ b/WoofWare.PawPrint/EvalStack.fs
@@ -288,9 +288,16 @@ module EvalStackValue =
         | CliType.Char _ ->
             match popped with
             | EvalStackValue.Int32 i ->
-                let high = i / 256
-                let low = i % 256
-                CliType.Char (byte<int> high, byte<int> low)
+                // Char is a 16-bit unsigned slot. The int32 on the stack may
+                // carry a sign-extended negative value (e.g. from coercing a
+                // negative Int16 through a `Unsafe.As<ushort, short>` write);
+                // narrow via `uint16` so the reinterpret preserves the low
+                // 16 bits bit-for-bit instead of splitting signed/ arithmetic
+                // into the wrong high byte.
+                let truncated = uint16<int> i
+                let high = byte<uint16> (truncated >>> 8)
+                let low = byte<uint16> (truncated &&& 0xFFus)
+                CliType.Char (high, low)
             | popped -> failwith $"Unexpectedly wanted a char from {popped}"
         | CliType.ValueType vt ->
             match popped with

--- a/WoofWare.PawPrint/EvalStackValueComparisons.fs
+++ b/WoofWare.PawPrint/EvalStackValueComparisons.fs
@@ -186,7 +186,6 @@ module EvalStackValueComparisons =
             | _, NativeIntSource.FieldHandlePtr _
             | NativeIntSource.AssemblyHandle _, _
             | _, NativeIntSource.AssemblyHandle _ -> false
-            | _, _ -> failwith $"TODO (CEQ): nativeint vs nativeint, {var1} vs {var2}"
         | EvalStackValue.NativeInt var1, EvalStackValue.Int32 var2 -> failwith $"TODO (CEQ): nativeint vs int32"
         | EvalStackValue.NativeInt var1, EvalStackValue.ManagedPointer var2 ->
             failwith $"TODO (CEQ): nativeint vs managed pointer"

--- a/WoofWare.PawPrint/EvalStackValueComparisons.fs
+++ b/WoofWare.PawPrint/EvalStackValueComparisons.fs
@@ -86,7 +86,9 @@ module EvalStackValueComparisons =
         | EvalStackValue.Int64 var1, EvalStackValue.Int64 var2 -> uint64 var1 > uint64 var2
         | EvalStackValue.Int64 _, _ -> failwith $"Cgt.un invalid for comparing %O{var1} with %O{var2}"
         | EvalStackValue.NativeInt var1, EvalStackValue.NativeInt var2 ->
-            failwith "TODO: comparison of unsigned nativeints"
+            match var1, var2 with
+            | NativeIntSource.Verbatim v1, NativeIntSource.Verbatim v2 -> uint64 v1 > uint64 v2
+            | _ -> failwith $"TODO: cgt.un on non-Verbatim nativeints: %O{var1} vs %O{var2}"
         | EvalStackValue.NativeInt var1, EvalStackValue.Int32 var2 ->
             failwith "TODO: comparison of unsigned nativeint with int32"
         | EvalStackValue.Float var1, EvalStackValue.Float var2 -> not (var1 <= var2)
@@ -119,7 +121,9 @@ module EvalStackValueComparisons =
         | EvalStackValue.Int64 var1, EvalStackValue.Int64 var2 -> uint64 var1 < uint64 var2
         | EvalStackValue.Int64 _, _ -> failwith $"Cgt.un invalid for comparing %O{var1} with %O{var2}"
         | EvalStackValue.NativeInt var1, EvalStackValue.NativeInt var2 ->
-            failwith "TODO: comparison of unsigned nativeints"
+            match var1, var2 with
+            | NativeIntSource.Verbatim v1, NativeIntSource.Verbatim v2 -> uint64 v1 < uint64 v2
+            | _ -> failwith $"TODO: clt.un on non-Verbatim nativeints: %O{var1} vs %O{var2}"
         | EvalStackValue.NativeInt var1, EvalStackValue.Int32 var2 ->
             failwith "TODO: comparison of unsigned nativeint with int32"
         | EvalStackValue.Float var1, EvalStackValue.Float var2 -> not (var1 >= var2)

--- a/WoofWare.PawPrint/EvalStackValueComparisons.fs
+++ b/WoofWare.PawPrint/EvalStackValueComparisons.fs
@@ -184,7 +184,11 @@ module EvalStackValueComparisons =
         | EvalStackValue.ObjectRef addr1, EvalStackValue.ObjectRef addr2 -> addr1 = addr2
         | EvalStackValue.NullObjectRef, EvalStackValue.ObjectRef _
         | EvalStackValue.ObjectRef _, EvalStackValue.NullObjectRef -> false
-        | EvalStackValue.ManagedPointer p1, EvalStackValue.ManagedPointer p2 -> p1 = p2
+        | EvalStackValue.ManagedPointer p1, EvalStackValue.ManagedPointer p2 ->
+            // `ceq` on byrefs is address equality; trailing `ReinterpretAs`
+            // projections are address-preserving type-view changes, so strip
+            // them from both sides before comparison.
+            ManagedPointerSource.stripTrailingReinterprets p1 = ManagedPointerSource.stripTrailingReinterprets p2
         | EvalStackValue.ManagedPointer _, EvalStackValue.NullObjectRef
         | EvalStackValue.NullObjectRef, EvalStackValue.ManagedPointer _
         | EvalStackValue.ManagedPointer _, EvalStackValue.ObjectRef _

--- a/WoofWare.PawPrint/EvalStackValueComparisons.fs
+++ b/WoofWare.PawPrint/EvalStackValueComparisons.fs
@@ -182,7 +182,13 @@ module EvalStackValueComparisons =
             | NativeIntSource.SyntheticCrossArrayOffset f1, NativeIntSource.SyntheticCrossArrayOffset f2
             | NativeIntSource.Verbatim f1, NativeIntSource.SyntheticCrossArrayOffset f2
             | NativeIntSource.SyntheticCrossArrayOffset f1, NativeIntSource.Verbatim f2 -> f1 = f2
-            | NativeIntSource.ManagedPointer f1, NativeIntSource.ManagedPointer f2 -> f1 = f2
+            | NativeIntSource.ManagedPointer f1, NativeIntSource.ManagedPointer f2 ->
+                // Match the `EvalStackValue.ManagedPointer` vs `ManagedPointer`
+                // arm below: trailing `ReinterpretAs` projections are address-
+                // preserving, so a byref converted to a native int via
+                // `conv.u` / `Unsafe.AsPointer` must compare equal to the same
+                // byref whose type view was changed by an `Unsafe.As`.
+                ManagedPointerSource.stripTrailingReinterprets f1 = ManagedPointerSource.stripTrailingReinterprets f2
             | NativeIntSource.Verbatim _, NativeIntSource.ManagedPointer _
             | NativeIntSource.ManagedPointer _, NativeIntSource.Verbatim _
             | NativeIntSource.SyntheticCrossArrayOffset _, NativeIntSource.ManagedPointer _

--- a/WoofWare.PawPrint/EvalStackValueComparisons.fs
+++ b/WoofWare.PawPrint/EvalStackValueComparisons.fs
@@ -187,7 +187,16 @@ module EvalStackValueComparisons =
                 // arm below: trailing `ReinterpretAs` projections are address-
                 // preserving, so a byref converted to a native int via
                 // `conv.u` / `Unsafe.AsPointer` must compare equal to the same
-                // byref whose type view was changed by an `Unsafe.As`.
+                // byref whose type view was changed by an `Unsafe.As`. Refuse
+                // the comparison on non-trailing `ReinterpretAs` for the same
+                // reason as the direct byref-ceq arm.
+                if
+                    ManagedPointerSource.hasNonTrailingReinterpret f1
+                    || ManagedPointerSource.hasNonTrailingReinterpret f2
+                then
+                    failwith
+                        $"TODO (CEQ): native-int-wrapped byref with `ReinterpretAs` followed by `Field` needs a bytewise layout comparison; got %O{f1} vs %O{f2}"
+
                 ManagedPointerSource.stripTrailingReinterprets f1 = ManagedPointerSource.stripTrailingReinterprets f2
             | NativeIntSource.Verbatim _, NativeIntSource.ManagedPointer _
             | NativeIntSource.ManagedPointer _, NativeIntSource.Verbatim _
@@ -222,7 +231,18 @@ module EvalStackValueComparisons =
         | EvalStackValue.ManagedPointer p1, EvalStackValue.ManagedPointer p2 ->
             // `ceq` on byrefs is address equality; trailing `ReinterpretAs`
             // projections are address-preserving type-view changes, so strip
-            // them from both sides before comparison.
+            // them from both sides before comparison. A `ReinterpretAs`
+            // followed by a `Field` would need a bytewise layout comparison
+            // (fields at the same offset under different type views still
+            // alias); we don't model that yet, so refuse rather than risk a
+            // silent false negative.
+            if
+                ManagedPointerSource.hasNonTrailingReinterpret p1
+                || ManagedPointerSource.hasNonTrailingReinterpret p2
+            then
+                failwith
+                    $"TODO (CEQ): byref with `ReinterpretAs` followed by `Field` needs a bytewise layout comparison; got %O{p1} vs %O{p2}"
+
             ManagedPointerSource.stripTrailingReinterprets p1 = ManagedPointerSource.stripTrailingReinterprets p2
         | EvalStackValue.ManagedPointer _, EvalStackValue.NullObjectRef
         | EvalStackValue.NullObjectRef, EvalStackValue.ManagedPointer _

--- a/WoofWare.PawPrint/EvalStackValueComparisons.fs
+++ b/WoofWare.PawPrint/EvalStackValueComparisons.fs
@@ -164,6 +164,19 @@ module EvalStackValueComparisons =
             | NativeIntSource.TypeHandlePtr f1, NativeIntSource.TypeHandlePtr f2 -> f1 = f2
             | NativeIntSource.Verbatim f1, NativeIntSource.Verbatim f2 -> f1 = f2
             | NativeIntSource.ManagedPointer f1, NativeIntSource.ManagedPointer f2 -> f1 = f2
+            // The zero IntPtr is represented as Verbatim 0L by arithmetic (e.g. Unsafe.ByteOffset)
+            // but as ManagedPointer Null by the `IntPtr.Zero` literal. Treat these as equal.
+            | NativeIntSource.Verbatim _, NativeIntSource.ManagedPointer _
+            | NativeIntSource.ManagedPointer _, NativeIntSource.Verbatim _ ->
+                let z1 = NativeIntSource.isZero var1
+                let z2 = NativeIntSource.isZero var2
+
+                if z1 && z2 then
+                    true
+                elif z1 <> z2 then
+                    false
+                else
+                    failwith $"TODO (CEQ): mixed nativeint representations, {var1} vs {var2}"
             | _, _ -> failwith $"TODO (CEQ): nativeint vs nativeint, {var1} vs {var2}"
         | EvalStackValue.NativeInt var1, EvalStackValue.Int32 var2 -> failwith $"TODO (CEQ): nativeint vs int32"
         | EvalStackValue.NativeInt var1, EvalStackValue.ManagedPointer var2 ->

--- a/WoofWare.PawPrint/EvalStackValueComparisons.fs
+++ b/WoofWare.PawPrint/EvalStackValueComparisons.fs
@@ -86,8 +86,14 @@ module EvalStackValueComparisons =
         | EvalStackValue.Int64 var1, EvalStackValue.Int64 var2 -> uint64 var1 > uint64 var2
         | EvalStackValue.Int64 _, _ -> failwith $"Cgt.un invalid for comparing %O{var1} with %O{var2}"
         | EvalStackValue.NativeInt var1, EvalStackValue.NativeInt var2 ->
-            match var1, var2 with
-            | NativeIntSource.Verbatim v1, NativeIntSource.Verbatim v2 -> uint64 v1 > uint64 v2
+            let asInt64 (src : NativeIntSource) : int64 option =
+                match src with
+                | NativeIntSource.Verbatim v
+                | NativeIntSource.SyntheticCrossArrayOffset v -> Some v
+                | _ -> None
+
+            match asInt64 var1, asInt64 var2 with
+            | Some v1, Some v2 -> uint64 v1 > uint64 v2
             | _ -> failwith $"TODO: cgt.un on non-Verbatim nativeints: %O{var1} vs %O{var2}"
         | EvalStackValue.NativeInt var1, EvalStackValue.Int32 var2 ->
             failwith "TODO: comparison of unsigned nativeint with int32"
@@ -121,8 +127,14 @@ module EvalStackValueComparisons =
         | EvalStackValue.Int64 var1, EvalStackValue.Int64 var2 -> uint64 var1 < uint64 var2
         | EvalStackValue.Int64 _, _ -> failwith $"Cgt.un invalid for comparing %O{var1} with %O{var2}"
         | EvalStackValue.NativeInt var1, EvalStackValue.NativeInt var2 ->
-            match var1, var2 with
-            | NativeIntSource.Verbatim v1, NativeIntSource.Verbatim v2 -> uint64 v1 < uint64 v2
+            let asInt64 (src : NativeIntSource) : int64 option =
+                match src with
+                | NativeIntSource.Verbatim v
+                | NativeIntSource.SyntheticCrossArrayOffset v -> Some v
+                | _ -> None
+
+            match asInt64 var1, asInt64 var2 with
+            | Some v1, Some v2 -> uint64 v1 < uint64 v2
             | _ -> failwith $"TODO: clt.un on non-Verbatim nativeints: %O{var1} vs %O{var2}"
         | EvalStackValue.NativeInt var1, EvalStackValue.Int32 var2 ->
             failwith "TODO: comparison of unsigned nativeint with int32"
@@ -165,9 +177,16 @@ module EvalStackValueComparisons =
             | NativeIntSource.FieldHandlePtr f1, NativeIntSource.FieldHandlePtr f2 -> f1 = f2
             | NativeIntSource.AssemblyHandle f1, NativeIntSource.AssemblyHandle f2 -> f1 = f2
             | NativeIntSource.Verbatim f1, NativeIntSource.Verbatim f2 -> f1 = f2
+            // `SyntheticCrossArrayOffset` and `Verbatim` share an int64
+            // payload and the same bit-level ceq semantics.
+            | NativeIntSource.SyntheticCrossArrayOffset f1, NativeIntSource.SyntheticCrossArrayOffset f2
+            | NativeIntSource.Verbatim f1, NativeIntSource.SyntheticCrossArrayOffset f2
+            | NativeIntSource.SyntheticCrossArrayOffset f1, NativeIntSource.Verbatim f2 -> f1 = f2
             | NativeIntSource.ManagedPointer f1, NativeIntSource.ManagedPointer f2 -> f1 = f2
             | NativeIntSource.Verbatim _, NativeIntSource.ManagedPointer _
-            | NativeIntSource.ManagedPointer _, NativeIntSource.Verbatim _ ->
+            | NativeIntSource.ManagedPointer _, NativeIntSource.Verbatim _
+            | NativeIntSource.SyntheticCrossArrayOffset _, NativeIntSource.ManagedPointer _
+            | NativeIntSource.ManagedPointer _, NativeIntSource.SyntheticCrossArrayOffset _ ->
                 let z1 = NativeIntSource.isZero var1
                 let z2 = NativeIntSource.isZero var2
 

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -1664,6 +1664,28 @@ module IlMachineState =
     let getSyncBlock (addr : ManagedHeapAddress) (state : IlMachineState) : SyncBlock =
         state.ManagedHeap |> ManagedHeap.getSyncBlock addr
 
+    /// `true` when a `ReinterpretAs ty` projection against a value of the given
+    /// shape can be treated as a no-op. Only matches same-representation primitive
+    /// reinterprets (int32<->uint32, int64<->uint64, signed-with-signed of the
+    /// same width, bool-with-bool, char-with-char); anything else (float<->int
+    /// bit reinterprets, overlay structs, enum underlying coercions, size
+    /// changes) needs a proper bytewise implementation and is not handled here.
+    let private isSafeReinterpretPassthrough (value : CliType) (ty : ConcreteType<ConcreteTypeHandle>) : bool =
+        match value, ty.Namespace, ty.Name with
+        | CliType.Numeric (CliNumericType.Int32 _), "System", "Int32"
+        | CliType.Numeric (CliNumericType.Int32 _), "System", "UInt32"
+        | CliType.Numeric (CliNumericType.Int64 _), "System", "Int64"
+        | CliType.Numeric (CliNumericType.Int64 _), "System", "UInt64"
+        | CliType.Numeric (CliNumericType.Int8 _), "System", "SByte"
+        | CliType.Numeric (CliNumericType.UInt8 _), "System", "Byte"
+        | CliType.Numeric (CliNumericType.Int16 _), "System", "Int16"
+        | CliType.Numeric (CliNumericType.UInt16 _), "System", "UInt16"
+        | CliType.Numeric (CliNumericType.Float32 _), "System", "Single"
+        | CliType.Numeric (CliNumericType.Float64 _), "System", "Double"
+        | CliType.Bool _, "System", "Boolean"
+        | CliType.Char _, "System", "Char" -> true
+        | _ -> false
+
     let readManagedByref (state : IlMachineState) (src : ManagedPointerSource) : CliType =
         match src with
         | ManagedPointerSource.Null -> failwith "TODO: throw NullReferenceException"
@@ -1691,34 +1713,11 @@ module IlMachineState =
                         // hand back must still make sense to the caller: they
                         // will be coerced to the caller's static target type
                         // (e.g. via `Ldind_*`) and a size- or family-changing
-                        // reinterpret would silently corrupt the result.
-                        //
-                        // We only pass the stored value through when the target
-                        // primitive shares the CLI numeric representation with
-                        // whatever is already in storage: int32<->uint32,
-                        // int64<->uint64, signed-with-signed or bool-with-bool
-                        // of the same width. Anything else (float<->int bit
-                        // reinterprets, overlay structs, enum underlying types,
-                        // size changes) needs a proper bytewise implementation
-                        // and is flagged rather than silently returning the
-                        // wrong bits.
-                        let isSafePassthrough =
-                            match value, ty.Namespace, ty.Name with
-                            | CliType.Numeric (CliNumericType.Int32 _), "System", "Int32"
-                            | CliType.Numeric (CliNumericType.Int32 _), "System", "UInt32"
-                            | CliType.Numeric (CliNumericType.Int64 _), "System", "Int64"
-                            | CliType.Numeric (CliNumericType.Int64 _), "System", "UInt64"
-                            | CliType.Numeric (CliNumericType.Int8 _), "System", "SByte"
-                            | CliType.Numeric (CliNumericType.UInt8 _), "System", "Byte"
-                            | CliType.Numeric (CliNumericType.Int16 _), "System", "Int16"
-                            | CliType.Numeric (CliNumericType.UInt16 _), "System", "UInt16"
-                            | CliType.Numeric (CliNumericType.Float32 _), "System", "Single"
-                            | CliType.Numeric (CliNumericType.Float64 _), "System", "Double"
-                            | CliType.Bool _, "System", "Boolean"
-                            | CliType.Char _, "System", "Char" -> true
-                            | _ -> false
-
-                        if isSafePassthrough then
+                        // reinterpret would silently corrupt the result. Only
+                        // pass through for same-representation primitive
+                        // reinterprets; everything else stays as an explicit
+                        // TODO until a proper bytewise model exists.
+                        if isSafeReinterpretPassthrough value ty then
                             value
                         else
                             failwith
@@ -1740,7 +1739,25 @@ module IlMachineState =
                 let fieldValue = CliType.getField name rootValue
                 let updatedField = go fieldValue rest newValue
                 CliType.withFieldSet name updatedField rootValue
-            | ByrefProjection.ReinterpretAs _ :: _ -> failwith "TODO: write through reinterpret"
+            | [ ByrefProjection.ReinterpretAs ty ] ->
+                // Same safety gate as `readManagedByref`: size-preserving
+                // primitive reinterprets share storage with the underlying
+                // value, so writing the newValue directly to the root is
+                // correct. Require both the stored value and the newValue to
+                // match the reinterpret target's natural representation; if
+                // either differs, the caller is doing a bit-reinterpret we
+                // don't model and the write stays an explicit TODO.
+                if
+                    isSafeReinterpretPassthrough rootValue ty
+                    && isSafeReinterpretPassthrough newValue ty
+                then
+                    newValue
+                else
+                    failwith
+                        $"TODO: write through `ReinterpretAs` as type %s{ty.Namespace}.%s{ty.Name}; rootValue=%O{rootValue}, newValue=%O{newValue}"
+            | ByrefProjection.ReinterpretAs ty :: _ ->
+                failwith
+                    $"TODO: write through `ReinterpretAs` as %s{ty.Namespace}.%s{ty.Name} followed by further projections; needs a bytewise implementation"
 
         go rootValue projs newValue
 

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -1665,25 +1665,49 @@ module IlMachineState =
         state.ManagedHeap |> ManagedHeap.getSyncBlock addr
 
     /// `true` when a `ReinterpretAs ty` projection against a value of the given
-    /// shape can be treated as a no-op. Only matches same-representation primitive
-    /// reinterprets (int32<->uint32, int64<->uint64, signed-with-signed of the
-    /// same width, bool-with-bool, char-with-char); anything else (float<->int
-    /// bit reinterprets, overlay structs, enum underlying coercions, size
-    /// changes) needs a proper bytewise implementation and is not handled here.
+    /// shape can be treated as a no-op. Matches same-width primitive reinterprets
+    /// within the integer family (including signed<->unsigned and char<->ushort
+    /// pairs, which share bit patterns and round-trip through the Int32 stack
+    /// slot with modular narrowing) and within the float family (same width
+    /// only). Rejects float<->int bit reinterprets, overlay structs, enum
+    /// underlying coercions, and any size change; those still need a proper
+    /// bytewise implementation.
+    let private classifyValueForReinterpret (value : CliType) : (string * int) voption =
+        match value with
+        | CliType.Bool _ -> ValueSome ("int", 1)
+        | CliType.Char _ -> ValueSome ("int", 2)
+        | CliType.Numeric (CliNumericType.Int8 _) -> ValueSome ("int", 1)
+        | CliType.Numeric (CliNumericType.UInt8 _) -> ValueSome ("int", 1)
+        | CliType.Numeric (CliNumericType.Int16 _) -> ValueSome ("int", 2)
+        | CliType.Numeric (CliNumericType.UInt16 _) -> ValueSome ("int", 2)
+        | CliType.Numeric (CliNumericType.Int32 _) -> ValueSome ("int", 4)
+        | CliType.Numeric (CliNumericType.Int64 _) -> ValueSome ("int", 8)
+        | CliType.Numeric (CliNumericType.Float32 _) -> ValueSome ("float", 4)
+        | CliType.Numeric (CliNumericType.Float64 _) -> ValueSome ("float", 8)
+        | _ -> ValueNone
+
+    let private classifyTypeForReinterpret (ty : ConcreteType<ConcreteTypeHandle>) : (string * int) voption =
+        if ty.Namespace <> "System" then
+            ValueNone
+        else
+            match ty.Name with
+            | "Boolean"
+            | "SByte"
+            | "Byte" -> ValueSome ("int", 1)
+            | "Int16"
+            | "UInt16"
+            | "Char" -> ValueSome ("int", 2)
+            | "Int32"
+            | "UInt32" -> ValueSome ("int", 4)
+            | "Int64"
+            | "UInt64" -> ValueSome ("int", 8)
+            | "Single" -> ValueSome ("float", 4)
+            | "Double" -> ValueSome ("float", 8)
+            | _ -> ValueNone
+
     let private isSafeReinterpretPassthrough (value : CliType) (ty : ConcreteType<ConcreteTypeHandle>) : bool =
-        match value, ty.Namespace, ty.Name with
-        | CliType.Numeric (CliNumericType.Int32 _), "System", "Int32"
-        | CliType.Numeric (CliNumericType.Int32 _), "System", "UInt32"
-        | CliType.Numeric (CliNumericType.Int64 _), "System", "Int64"
-        | CliType.Numeric (CliNumericType.Int64 _), "System", "UInt64"
-        | CliType.Numeric (CliNumericType.Int8 _), "System", "SByte"
-        | CliType.Numeric (CliNumericType.UInt8 _), "System", "Byte"
-        | CliType.Numeric (CliNumericType.Int16 _), "System", "Int16"
-        | CliType.Numeric (CliNumericType.UInt16 _), "System", "UInt16"
-        | CliType.Numeric (CliNumericType.Float32 _), "System", "Single"
-        | CliType.Numeric (CliNumericType.Float64 _), "System", "Double"
-        | CliType.Bool _, "System", "Boolean"
-        | CliType.Char _, "System", "Char" -> true
+        match classifyValueForReinterpret value, classifyTypeForReinterpret ty with
+        | ValueSome v, ValueSome t -> v = t
         | _ -> false
 
     let readManagedByref (state : IlMachineState) (src : ManagedPointerSource) : CliType =
@@ -1742,8 +1766,7 @@ module IlMachineState =
             | [ ByrefProjection.ReinterpretAs ty ] ->
                 // Same safety gate as `readManagedByref`: size-preserving
                 // primitive reinterprets share storage with the underlying
-                // value, so writing the newValue directly to the root is
-                // correct. Require both the stored value and the newValue to
+                // value. Require both the stored value and the newValue to
                 // match the reinterpret target's natural representation; if
                 // either differs, the caller is doing a bit-reinterpret we
                 // don't model and the write stays an explicit TODO.
@@ -1751,7 +1774,15 @@ module IlMachineState =
                     isSafeReinterpretPassthrough rootValue ty
                     && isSafeReinterpretPassthrough newValue ty
                 then
-                    newValue
+                    // Normalise the stored value back to the rootValue's
+                    // CliType so the slot keeps its original view: writing a
+                    // `short` through a `ref short` obtained via
+                    // `Unsafe.As<ushort, short>` must leave the backing slot
+                    // as a ushort with bit-preserving narrowing, not replace
+                    // the slot's type with Int16. The stack round-trip matches
+                    // ECMA III.1.1.1 narrowing semantics for same-width ints;
+                    // it's the identity for matching-float widths.
+                    EvalStackValue.toCliTypeCoerced rootValue (EvalStackValue.ofCliType newValue)
                 else
                     failwith
                         $"TODO: write through `ReinterpretAs` as type %s{ty.Namespace}.%s{ty.Name}; rootValue=%O{rootValue}, newValue=%O{newValue}"

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -1686,8 +1686,17 @@ module IlMachineState =
                         match value with
                         | CliType.ValueType vt -> CliValueType.DereferenceField name vt
                         | v -> failwith $"could not find field {name} on non-ValueType {v}"
-                    | ByrefProjection.ReinterpretAs ty ->
-                        failwith $"TODO: reinterpret as type %s{ty.Assembly.Name}.%s{ty.Namespace}.%s{ty.Name}"
+                    | ByrefProjection.ReinterpretAs _ ->
+                        // `ReinterpretAs` is purely a type-view change: the
+                        // underlying bits are unchanged. We pass the value
+                        // through unmodified; callers reading via Ldind_* (or
+                        // similar) coerce to their static target type, which
+                        // handles signed/unsigned variants of the same width
+                        // correctly. Genuinely size-changing reinterprets
+                        // deserve a proper bytewise implementation; flag any
+                        // case that wouldn't obviously work rather than silently
+                        // corrupting values.
+                        value
                 )
                 rootValue
 

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -1686,17 +1686,43 @@ module IlMachineState =
                         match value with
                         | CliType.ValueType vt -> CliValueType.DereferenceField name vt
                         | v -> failwith $"could not find field {name} on non-ValueType {v}"
-                    | ByrefProjection.ReinterpretAs _ ->
-                        // `ReinterpretAs` is purely a type-view change: the
-                        // underlying bits are unchanged. We pass the value
-                        // through unmodified; callers reading via Ldind_* (or
-                        // similar) coerce to their static target type, which
-                        // handles signed/unsigned variants of the same width
-                        // correctly. Genuinely size-changing reinterprets
-                        // deserve a proper bytewise implementation; flag any
-                        // case that wouldn't obviously work rather than silently
-                        // corrupting values.
-                        value
+                    | ByrefProjection.ReinterpretAs ty ->
+                        // `ReinterpretAs` is address-preserving, but the bits we
+                        // hand back must still make sense to the caller: they
+                        // will be coerced to the caller's static target type
+                        // (e.g. via `Ldind_*`) and a size- or family-changing
+                        // reinterpret would silently corrupt the result.
+                        //
+                        // We only pass the stored value through when the target
+                        // primitive shares the CLI numeric representation with
+                        // whatever is already in storage: int32<->uint32,
+                        // int64<->uint64, signed-with-signed or bool-with-bool
+                        // of the same width. Anything else (float<->int bit
+                        // reinterprets, overlay structs, enum underlying types,
+                        // size changes) needs a proper bytewise implementation
+                        // and is flagged rather than silently returning the
+                        // wrong bits.
+                        let isSafePassthrough =
+                            match value, ty.Namespace, ty.Name with
+                            | CliType.Numeric (CliNumericType.Int32 _), "System", "Int32"
+                            | CliType.Numeric (CliNumericType.Int32 _), "System", "UInt32"
+                            | CliType.Numeric (CliNumericType.Int64 _), "System", "Int64"
+                            | CliType.Numeric (CliNumericType.Int64 _), "System", "UInt64"
+                            | CliType.Numeric (CliNumericType.Int8 _), "System", "SByte"
+                            | CliType.Numeric (CliNumericType.UInt8 _), "System", "Byte"
+                            | CliType.Numeric (CliNumericType.Int16 _), "System", "Int16"
+                            | CliType.Numeric (CliNumericType.UInt16 _), "System", "UInt16"
+                            | CliType.Numeric (CliNumericType.Float32 _), "System", "Single"
+                            | CliType.Numeric (CliNumericType.Float64 _), "System", "Double"
+                            | CliType.Bool _, "System", "Boolean"
+                            | CliType.Char _, "System", "Char" -> true
+                            | _ -> false
+
+                        if isSafePassthrough then
+                            value
+                        else
+                            failwith
+                                $"TODO: read through `ReinterpretAs` from value %O{value} as type %s{ty.Namespace}.%s{ty.Name}; needs a bytewise implementation"
                 )
                 rootValue
 

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -664,6 +664,11 @@ module Intrinsics =
                 | EvalStackValue.Float _ -> failwith "expected pointer type"
                 | EvalStackValue.NativeInt nativeIntSource -> failwith "todo"
                 | EvalStackValue.NullObjectRef -> failwith "todo: Unsafe.As on null"
+                | EvalStackValue.ManagedPointer src when from = to_ ->
+                    // Unsafe.As<T,T> is a no-op: same address and same type view.
+                    // Skipping the projection keeps the representation canonical so
+                    // that AreSame / ceq on the result compares equal to the input.
+                    EvalStackValue.ManagedPointer src
                 | EvalStackValue.ManagedPointer src ->
                     ManagedPointerSource.appendProjection (ByrefProjection.ReinterpretAs to_) src
                     |> EvalStackValue.ManagedPointer

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -750,8 +750,18 @@ module Intrinsics =
                 | EvalStackValue.Int32 i -> i
                 | _ -> failwith $"TODO: Unsafe.Add: expected Int32 offset, got %O{offset}"
 
-            let ptr : EvalStackValue =
+            // Strip trailing address-preserving `ReinterpretAs` projections: a
+            // round-trip `Unsafe.As<U,T>(Unsafe.As<T,U>(x))` leaves a collapsed
+            // terminal `ReinterpretAs T` on an otherwise-plain array-element
+            // byref, but arithmetic on it should behave as if on the bare byref.
+            let stripped =
                 match src with
+                | EvalStackValue.ManagedPointer p ->
+                    EvalStackValue.ManagedPointer (ManagedPointerSource.stripTrailingReinterprets p)
+                | _ -> src
+
+            let ptr : EvalStackValue =
+                match stripped with
                 | EvalStackValue.ManagedPointer (ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, i), [])) ->
                     ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, i + offset), [])
                     |> EvalStackValue.ManagedPointer
@@ -776,10 +786,18 @@ module Intrinsics =
             let target, state = IlMachineState.popEvalStack currentThread state
             let origin, state = IlMachineState.popEvalStack currentThread state
 
+            // Strip trailing address-preserving `ReinterpretAs` projections:
+            // a round-tripped or reinterpreted-then-left-alone byref still
+            // points at the same byte location, so arithmetic should work on
+            // it identically to the bare array-element byref.
             let extractArrayElement (v : EvalStackValue) : ManagedHeapAddress * int =
-                match v with
-                | EvalStackValue.ManagedPointer (ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, i), [])) ->
-                    arr, i
+                let stripped =
+                    match v with
+                    | EvalStackValue.ManagedPointer p -> ManagedPointerSource.stripTrailingReinterprets p
+                    | _ -> failwith $"TODO: Unsafe.ByteOffset on non-ManagedPointer: %O{v}"
+
+                match stripped with
+                | ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, i), []) -> arr, i
                 | _ -> failwith $"TODO: Unsafe.ByteOffset on non-plain-array-element byref: %O{v}"
 
             let arr1, i1 = extractArrayElement origin

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -695,6 +695,107 @@ module Intrinsics =
             |> IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 size)) currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Some
+        | "System.Private.CoreLib", "Unsafe", "AreSame" ->
+            // https://github.com/dotnet/runtime/blob/108fa7856efcfd39bc991c2d849eabbf7ba5989c/src/coreclr/tools/Common/TypeSystem/IL/Stubs/UnsafeIntrinsics.cs#L55
+            // The source-level IL body throws PlatformNotSupportedException; the JIT replaces it with ceq on two byrefs.
+            match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
+            | [ ConcreteByref _ ; ConcreteByref _ ], ConcreteBool state.ConcreteTypes -> ()
+            | _ -> failwith "bad signature Unsafe.AreSame"
+
+            let right, state = IlMachineState.popEvalStack currentThread state
+            let left, state = IlMachineState.popEvalStack currentThread state
+
+            let extractPtr (v : EvalStackValue) : ManagedPointerSource =
+                match v with
+                | EvalStackValue.ManagedPointer p -> p
+                | _ -> failwith $"TODO: Unsafe.AreSame: expected ManagedPointer, got %O{v}"
+
+            let areSame = (extractPtr left) = (extractPtr right)
+
+            state
+            |> IlMachineState.pushToEvalStack (CliType.ofBool areSame) currentThread
+            |> IlMachineState.advanceProgramCounter currentThread
+            |> Some
+        | "System.Private.CoreLib", "Unsafe", "Add" ->
+            // https://github.com/dotnet/runtime/blob/108fa7856efcfd39bc991c2d849eabbf7ba5989c/src/coreclr/tools/Common/TypeSystem/IL/Stubs/UnsafeIntrinsics.cs#L192
+            // The source-level IL body throws PlatformNotSupportedException; the JIT replaces it with sizeof + conv.i + mul + add.
+            let t =
+                match Seq.toList methodToCall.Generics with
+                | [ t ] -> t
+                | _ -> failwith "bad generics Unsafe.Add"
+
+            match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
+            | [ ConcreteByref tFromParam ; ConcreteInt32 state.ConcreteTypes ], ConcreteByref tFromRet when
+                tFromParam = t && tFromRet = t
+                ->
+                ()
+            | _ ->
+                failwith
+                    $"TODO: Unsafe.Add: only the (ref T, int32) overload is implemented; got params %A{methodToCall.Signature.ParameterTypes}"
+
+            let offset, state = IlMachineState.popEvalStack currentThread state
+            let src, state = IlMachineState.popEvalStack currentThread state
+
+            let offset =
+                match offset with
+                | EvalStackValue.Int32 i -> i
+                | _ -> failwith $"TODO: Unsafe.Add: expected Int32 offset, got %O{offset}"
+
+            let ptr : EvalStackValue =
+                match src with
+                | EvalStackValue.ManagedPointer (ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, i), [])) ->
+                    ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, i + offset), [])
+                    |> EvalStackValue.ManagedPointer
+                | _ -> failwith $"TODO: Unsafe.Add on non-plain-array-element byref: %O{src}"
+
+            state
+            |> IlMachineState.pushToEvalStack' ptr currentThread
+            |> IlMachineState.advanceProgramCounter currentThread
+            |> Some
+        | "System.Private.CoreLib", "Unsafe", "ByteOffset" ->
+            // https://github.com/dotnet/runtime/blob/108fa7856efcfd39bc991c2d849eabbf7ba5989c/src/coreclr/tools/Common/TypeSystem/IL/Stubs/UnsafeIntrinsics.cs#L142
+            // The source-level IL body throws PlatformNotSupportedException; the JIT replaces it with sub on two byrefs.
+            let t =
+                match Seq.toList methodToCall.Generics with
+                | [ t ] -> t
+                | _ -> failwith "bad generics Unsafe.ByteOffset"
+
+            match methodToCall.Signature.ParameterTypes with
+            | [ ConcreteByref _ ; ConcreteByref _ ] -> ()
+            | _ -> failwith "bad signature Unsafe.ByteOffset"
+
+            let target, state = IlMachineState.popEvalStack currentThread state
+            let origin, state = IlMachineState.popEvalStack currentThread state
+
+            let extractArrayElement (v : EvalStackValue) : ManagedHeapAddress * int =
+                match v with
+                | EvalStackValue.ManagedPointer (ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, i), [])) ->
+                    arr, i
+                | _ -> failwith $"TODO: Unsafe.ByteOffset on non-plain-array-element byref: %O{v}"
+
+            let arr1, i1 = extractArrayElement origin
+            let arr2, i2 = extractArrayElement target
+
+            if arr1 <> arr2 then
+                failwith "TODO: Unsafe.ByteOffset across different arrays"
+
+            let zero, state = IlMachineState.cliTypeZeroOfHandle state baseClassTypes t
+            let elementSize = CliType.sizeOf zero
+            let byteOffset = int64 (i2 - i1) * int64 elementSize
+
+            let intPtrZero, state =
+                IlMachineState.cliTypeZeroOfHandle state baseClassTypes methodToCall.Signature.ReturnType
+
+            let intPtrValue =
+                CliType.withFieldSet
+                    "_value"
+                    (CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim byteOffset)))
+                    intPtrZero
+
+            state
+            |> IlMachineState.pushToEvalStack intPtrValue currentThread
+            |> IlMachineState.advanceProgramCounter currentThread
+            |> Some
         | "System.Private.CoreLib", "RuntimeHelpers", "CreateSpan" ->
             // https://github.com/dotnet/runtime/blob/9e5e6aa7bc36aeb2a154709a9d1192030c30a2ef/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs#L153
             None

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -812,8 +812,22 @@ module Intrinsics =
             // `ReinterpretAs` projections are address-preserving, so two byrefs
             // that reach the same byte location by different reinterpret chains
             // must compare equal. Strip trailing reinterprets before comparison.
+            // A `ReinterpretAs` followed by a `Field` would need a bytewise
+            // layout comparison (a field at the same offset under different
+            // type views still aliases); refuse rather than risk a silent false
+            // negative.
+            let leftPtr = extractPtr left
+            let rightPtr = extractPtr right
+
+            if
+                ManagedPointerSource.hasNonTrailingReinterpret leftPtr
+                || ManagedPointerSource.hasNonTrailingReinterpret rightPtr
+            then
+                failwith
+                    $"TODO: Unsafe.AreSame on byref with `ReinterpretAs` followed by `Field` needs a bytewise layout comparison; got %O{leftPtr} vs %O{rightPtr}"
+
             let strip = ManagedPointerSource.stripTrailingReinterprets
-            let areSame = strip (extractPtr left) = strip (extractPtr right)
+            let areSame = strip leftPtr = strip rightPtr
 
             state
             |> IlMachineState.pushToEvalStack (CliType.ofBool areSame) currentThread

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -883,12 +883,15 @@ module Intrinsics =
             // existing trailing reinterprets must also only be size-preserving,
             // and they stay on the result so that later field access / As chains
             // still see the type view the caller set up.
+            // Thread the state returned by `cliTypeZeroOfHandle`: for a struct T
+            // it can concretise additional types, and discarding the update
+            // would drop that work from the machine state.
+            let tZero, state = IlMachineState.cliTypeZeroOfHandle state baseClassTypes t
+            let tSize = CliType.sizeOf tZero
+
             let ptr : EvalStackValue =
                 match src with
                 | EvalStackValue.ManagedPointer (ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, i), projs)) ->
-                    let tZero, _ = IlMachineState.cliTypeZeroOfHandle state baseClassTypes t
-                    let tSize = CliType.sizeOf tZero
-
                     let arrElementSize =
                         let arrObj = state.ManagedHeap.Arrays.[arr]
 

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -750,20 +750,38 @@ module Intrinsics =
                 | EvalStackValue.Int32 i -> i
                 | _ -> failwith $"TODO: Unsafe.Add: expected Int32 offset, got %O{offset}"
 
-            // Strip trailing address-preserving `ReinterpretAs` projections: a
-            // round-trip `Unsafe.As<U,T>(Unsafe.As<T,U>(x))` leaves a collapsed
-            // terminal `ReinterpretAs T` on an otherwise-plain array-element
-            // byref, but arithmetic on it should behave as if on the bare byref.
-            let stripped =
-                match src with
-                | EvalStackValue.ManagedPointer p ->
-                    EvalStackValue.ManagedPointer (ManagedPointerSource.stripTrailingReinterprets p)
-                | _ -> src
-
+            // The input byref may or may not carry an address-preserving
+            // `ReinterpretAs` projection (from an `Unsafe.As` or a round-trip).
+            // We can only do element-index arithmetic if `sizeof(T)` matches the
+            // array's true element size: otherwise advancing by `offset` elements
+            // of T is not a whole-element step in the underlying array. Any
+            // existing trailing reinterprets must also only be size-preserving,
+            // and they stay on the result so that later field access / As chains
+            // still see the type view the caller set up.
             let ptr : EvalStackValue =
-                match stripped with
-                | EvalStackValue.ManagedPointer (ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, i), [])) ->
-                    ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, i + offset), [])
+                match src with
+                | EvalStackValue.ManagedPointer (ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, i), projs)) ->
+                    let tZero, _ = IlMachineState.cliTypeZeroOfHandle state baseClassTypes t
+                    let tSize = CliType.sizeOf tZero
+
+                    let arrElementSize =
+                        let arrObj = state.ManagedHeap.Arrays.[arr]
+
+                        if arrObj.Length = 0 then
+                            tSize
+                        else
+                            CliType.sizeOf arrObj.Elements.[0]
+
+                    if tSize <> arrElementSize then
+                        failwith
+                            $"TODO: Unsafe.Add where element size of T (%d{tSize}) differs from underlying array element size (%d{arrElementSize}); byte-level arithmetic on array byrefs is not modelled"
+
+                    for p in projs do
+                        match p with
+                        | ByrefProjection.ReinterpretAs _ -> ()
+                        | _ -> failwith $"TODO: Unsafe.Add on byref with non-ReinterpretAs projection: %O{p}"
+
+                    ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, i + offset), projs)
                     |> EvalStackValue.ManagedPointer
                 | _ -> failwith $"TODO: Unsafe.Add on non-plain-array-element byref: %O{src}"
 
@@ -774,10 +792,9 @@ module Intrinsics =
         | "System.Private.CoreLib", "Unsafe", "ByteOffset" ->
             // https://github.com/dotnet/runtime/blob/108fa7856efcfd39bc991c2d849eabbf7ba5989c/src/coreclr/tools/Common/TypeSystem/IL/Stubs/UnsafeIntrinsics.cs#L142
             // The source-level IL body throws PlatformNotSupportedException; the JIT replaces it with sub on two byrefs.
-            let t =
-                match Seq.toList methodToCall.Generics with
-                | [ t ] -> t
-                | _ -> failwith "bad generics Unsafe.ByteOffset"
+            match Seq.toList methodToCall.Generics with
+            | [ _ ] -> ()
+            | _ -> failwith "bad generics Unsafe.ByteOffset"
 
             match methodToCall.Signature.ParameterTypes with
             | [ ConcreteByref _ ; ConcreteByref _ ] -> ()
@@ -786,25 +803,39 @@ module Intrinsics =
             let target, state = IlMachineState.popEvalStack currentThread state
             let origin, state = IlMachineState.popEvalStack currentThread state
 
-            // Strip trailing address-preserving `ReinterpretAs` projections:
-            // a round-tripped or reinterpreted-then-left-alone byref still
-            // points at the same byte location, so arithmetic should work on
-            // it identically to the bare array-element byref.
+            // ByteOffset measures the byte distance between two byref address
+            // targets. The generic T on the method is only the static view
+            // through which each byref was declared; reinterpreting a byref
+            // doesn't move it, so the size used here must come from the
+            // underlying array's true element size, not T. Trailing
+            // address-preserving `ReinterpretAs` projections are therefore safe
+            // to ignore when extracting `(arr, index)`.
             let extractArrayElement (v : EvalStackValue) : ManagedHeapAddress * int =
-                let stripped =
+                let src =
                     match v with
-                    | EvalStackValue.ManagedPointer p -> ManagedPointerSource.stripTrailingReinterprets p
+                    | EvalStackValue.ManagedPointer p -> p
                     | _ -> failwith $"TODO: Unsafe.ByteOffset on non-ManagedPointer: %O{v}"
 
-                match stripped with
-                | ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, i), []) -> arr, i
+                match src with
+                | ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, i), projs) ->
+                    for p in projs do
+                        match p with
+                        | ByrefProjection.ReinterpretAs _ -> ()
+                        | _ -> failwith $"TODO: Unsafe.ByteOffset on byref with non-ReinterpretAs projection: %O{p}"
+
+                    arr, i
                 | _ -> failwith $"TODO: Unsafe.ByteOffset on non-plain-array-element byref: %O{v}"
 
             let arr1, i1 = extractArrayElement origin
             let arr2, i2 = extractArrayElement target
 
-            let zero, state = IlMachineState.cliTypeZeroOfHandle state baseClassTypes t
-            let elementSize = CliType.sizeOf zero
+            let arrElementSize (arr : ManagedHeapAddress) : int =
+                let arrObj = state.ManagedHeap.Arrays.[arr]
+
+                if arrObj.Length = 0 then
+                    failwith "TODO: Unsafe.ByteOffset into an empty array"
+                else
+                    CliType.sizeOf arrObj.Elements.[0]
 
             // For cross-array byrefs, return a deterministic offset large enough
             // in magnitude that unsigned overlap checks of the form
@@ -822,7 +853,18 @@ module Intrinsics =
                     let (ManagedHeapAddress.ManagedHeapAddress id2) = arr2
                     (int64 (compare id2 id1)) * (1L <<< 40)
 
-            let byteOffset = (int64 (i2 - i1) * int64 elementSize) + arraySeparation
+            let sameArrayDelta =
+                if arr1 = arr2 then
+                    int64 (i2 - i1) * int64 (arrElementSize arr1)
+                else
+                    // Pick either array's element size for the intra-array
+                    // delta component; it's dominated by `arraySeparation`
+                    // anyway for overlap-check purposes.
+                    let delta1 = int64 i2 * int64 (arrElementSize arr2)
+                    let delta2 = int64 i1 * int64 (arrElementSize arr1)
+                    delta1 - delta2
+
+            let byteOffset = sameArrayDelta + arraySeparation
 
             // Per ECMA-335, `sub` on two byrefs produces a native int, and
             // the JIT-lowered body of Unsafe.ByteOffset is exactly `sub; ret`.

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -715,7 +715,11 @@ module Intrinsics =
                 | EvalStackValue.ManagedPointer p -> p
                 | _ -> failwith $"TODO: Unsafe.AreSame: expected ManagedPointer, got %O{v}"
 
-            let areSame = (extractPtr left) = (extractPtr right)
+            // `ReinterpretAs` projections are address-preserving, so two byrefs
+            // that reach the same byte location by different reinterpret chains
+            // must compare equal. Strip trailing reinterprets before comparison.
+            let strip = ManagedPointerSource.stripTrailingReinterprets
+            let areSame = strip (extractPtr left) = strip (extractPtr right)
 
             state
             |> IlMachineState.pushToEvalStack (CliType.ofBool areSame) currentThread
@@ -781,24 +785,37 @@ module Intrinsics =
             let arr1, i1 = extractArrayElement origin
             let arr2, i2 = extractArrayElement target
 
-            if arr1 <> arr2 then
-                failwith "TODO: Unsafe.ByteOffset across different arrays"
-
             let zero, state = IlMachineState.cliTypeZeroOfHandle state baseClassTypes t
             let elementSize = CliType.sizeOf zero
-            let byteOffset = int64 (i2 - i1) * int64 elementSize
 
-            let intPtrZero, state =
-                IlMachineState.cliTypeZeroOfHandle state baseClassTypes methodToCall.Signature.ReturnType
+            // For cross-array byrefs, return a deterministic offset large enough
+            // in magnitude that unsigned overlap checks of the form
+            // `(nuint)offset < len` reliably report no overlap. The real JIT would
+            // return the true byte difference between the two allocations; we
+            // don't model heap addresses as integers, so we synthesise a large
+            // separation keyed off heap-ID ordering instead. 2^40 bytes comfortably
+            // exceeds any plausible array length while leaving headroom against
+            // int64 overflow.
+            let arraySeparation =
+                if arr1 = arr2 then
+                    0L
+                else
+                    let (ManagedHeapAddress.ManagedHeapAddress id1) = arr1
+                    let (ManagedHeapAddress.ManagedHeapAddress id2) = arr2
+                    (int64 (compare id2 id1)) * (1L <<< 40)
 
-            let intPtrValue =
-                CliType.withFieldSet
-                    "_value"
-                    (CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim byteOffset)))
-                    intPtrZero
+            let byteOffset = (int64 (i2 - i1) * int64 elementSize) + arraySeparation
 
+            // Per ECMA-335, `sub` on two byrefs produces a native int, and
+            // the JIT-lowered body of Unsafe.ByteOffset is exactly `sub; ret`.
+            // IntPtr and native int share a stack slot representation, so the
+            // caller treats the returned value uniformly: `beq`/`ceq` against
+            // a native int works, and code that loads `IntPtr.Zero` as a
+            // value-type struct is unwrapped by `ceq` via its single field.
             state
-            |> IlMachineState.pushToEvalStack intPtrValue currentThread
+            |> IlMachineState.pushToEvalStack'
+                (EvalStackValue.NativeInt (NativeIntSource.Verbatim byteOffset))
+                currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Some
         | "System.Private.CoreLib", "RuntimeHelpers", "CreateSpan" ->

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -717,7 +717,7 @@ module Intrinsics =
             |> IlMachineState.advanceProgramCounter currentThread
             |> Some
         | "System.Private.CoreLib", "Unsafe", "Add" ->
-            // https://github.com/dotnet/runtime/blob/108fa7856efcfd39bc991c2d849eabbf7ba5989c/src/coreclr/tools/Common/TypeSystem/IL/Stubs/UnsafeIntrinsics.cs#L192
+            // https://github.com/dotnet/runtime/blob/108fa7856efcfd39bc991c2d849eabbf7ba5989c/src/coreclr/tools/Common/TypeSystem/IL/Stubs/UnsafeIntrinsics.cs#L99
             // The source-level IL body throws PlatformNotSupportedException; the JIT replaces it with sizeof + conv.i + mul + add.
             let t =
                 match Seq.toList methodToCall.Generics with
@@ -753,7 +753,7 @@ module Intrinsics =
             |> IlMachineState.advanceProgramCounter currentThread
             |> Some
         | "System.Private.CoreLib", "Unsafe", "ByteOffset" ->
-            // https://github.com/dotnet/runtime/blob/108fa7856efcfd39bc991c2d849eabbf7ba5989c/src/coreclr/tools/Common/TypeSystem/IL/Stubs/UnsafeIntrinsics.cs#L142
+            // https://github.com/dotnet/runtime/blob/108fa7856efcfd39bc991c2d849eabbf7ba5989c/src/coreclr/tools/Common/TypeSystem/IL/Stubs/UnsafeIntrinsics.cs#L69
             // The source-level IL body throws PlatformNotSupportedException; the JIT replaces it with sub on two byrefs.
             let t =
                 match Seq.toList methodToCall.Generics with

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -959,47 +959,47 @@ module Intrinsics =
                 else
                     CliType.sizeOf arrObj.Elements.[0]
 
-            // For cross-array byrefs, return a deterministic offset large enough
-            // in magnitude that unsigned overlap checks of the form
-            // `(nuint)offset < len` reliably report no overlap. The real JIT would
-            // return the true byte difference between the two allocations; we
-            // don't model heap addresses as integers, so we synthesise a large
-            // separation keyed off heap-ID ordering instead. 2^40 bytes comfortably
-            // exceeds any plausible array length while leaving headroom against
-            // int64 overflow.
-            let arraySeparation =
-                if arr1 = arr2 then
-                    0L
-                else
-                    let (ManagedHeapAddress.ManagedHeapAddress id1) = arr1
-                    let (ManagedHeapAddress.ManagedHeapAddress id2) = arr2
-                    (int64 (compare id2 id1)) * (1L <<< 40)
+            // Same-array ByteOffset is an honest byte delta and composes
+            // correctly with Unsafe.Add / further arithmetic. Cross-array
+            // ByteOffset has no principled byte distance in our model (we
+            // don't map heap addresses to integers), so we synthesise a
+            // deterministic sentinel large enough to defeat the unsigned
+            // overlap check `(nuint)offset < len` used by Memmove, and mark
+            // it as `SyntheticCrossArrayOffset`. The tag makes any subsequent
+            // `add`/`sub` fail loudly via BinaryArithmetic.execute's
+            // "refusing to operate on non-verbatim native int" branch, rather
+            // than silently composing into a wrong answer.
+            if arr1 = arr2 then
+                let byteOffset = int64 (i2 - i1) * int64 (arrElementSize arr1)
 
-            let sameArrayDelta =
-                if arr1 = arr2 then
-                    int64 (i2 - i1) * int64 (arrElementSize arr1)
-                else
-                    // Pick either array's element size for the intra-array
-                    // delta component; it's dominated by `arraySeparation`
-                    // anyway for overlap-check purposes.
-                    let delta1 = int64 i2 * int64 (arrElementSize arr2)
-                    let delta2 = int64 i1 * int64 (arrElementSize arr1)
-                    delta1 - delta2
+                state
+                |> IlMachineState.pushToEvalStack'
+                    (EvalStackValue.NativeInt (NativeIntSource.Verbatim byteOffset))
+                    currentThread
+                |> IlMachineState.advanceProgramCounter currentThread
+                |> Some
+            else
+                // 2^40 bytes comfortably exceeds any plausible array length
+                // while leaving headroom against int64 overflow. The sign is
+                // keyed off heap-ID ordering so that ByteOffset(a,b) and
+                // ByteOffset(b,a) are exact negatives of each other.
+                let (ManagedHeapAddress.ManagedHeapAddress id1) = arr1
+                let (ManagedHeapAddress.ManagedHeapAddress id2) = arr2
+                let sign = int64 (compare id2 id1)
+                let arraySeparation = sign * (1L <<< 40)
+                // Including a small intra-array delta component makes the
+                // synthetic value vary with (i1, i2), but it's dominated by
+                // `arraySeparation` for overlap-check purposes.
+                let delta1 = int64 i2 * int64 (arrElementSize arr2)
+                let delta2 = int64 i1 * int64 (arrElementSize arr1)
+                let byteOffset = arraySeparation + (delta1 - delta2)
 
-            let byteOffset = sameArrayDelta + arraySeparation
-
-            // Per ECMA-335, `sub` on two byrefs produces a native int, and
-            // the JIT-lowered body of Unsafe.ByteOffset is exactly `sub; ret`.
-            // IntPtr and native int share a stack slot representation, so the
-            // caller treats the returned value uniformly: `beq`/`ceq` against
-            // a native int works, and code that loads `IntPtr.Zero` as a
-            // value-type struct is unwrapped by `ceq` via its single field.
-            state
-            |> IlMachineState.pushToEvalStack'
-                (EvalStackValue.NativeInt (NativeIntSource.Verbatim byteOffset))
-                currentThread
-            |> IlMachineState.advanceProgramCounter currentThread
-            |> Some
+                state
+                |> IlMachineState.pushToEvalStack'
+                    (EvalStackValue.NativeInt (NativeIntSource.SyntheticCrossArrayOffset byteOffset))
+                    currentThread
+                |> IlMachineState.advanceProgramCounter currentThread
+                |> Some
         | "System.Private.CoreLib", "RuntimeHelpers", "CreateSpan" ->
             // https://github.com/dotnet/runtime/blob/9e5e6aa7bc36aeb2a154709a9d1192030c30a2ef/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs#L153
             None

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -792,9 +792,10 @@ module Intrinsics =
         | "System.Private.CoreLib", "Unsafe", "ByteOffset" ->
             // https://github.com/dotnet/runtime/blob/108fa7856efcfd39bc991c2d849eabbf7ba5989c/src/coreclr/tools/Common/TypeSystem/IL/Stubs/UnsafeIntrinsics.cs#L142
             // The source-level IL body throws PlatformNotSupportedException; the JIT replaces it with sub on two byrefs.
-            match Seq.toList methodToCall.Generics with
-            | [ _ ] -> ()
-            | _ -> failwith "bad generics Unsafe.ByteOffset"
+            let t =
+                match Seq.toList methodToCall.Generics with
+                | [ t ] -> t
+                | _ -> failwith "bad generics Unsafe.ByteOffset"
 
             match methodToCall.Signature.ParameterTypes with
             | [ ConcreteByref _ ; ConcreteByref _ ] -> ()
@@ -829,11 +830,21 @@ module Intrinsics =
             let arr1, i1 = extractArrayElement origin
             let arr2, i2 = extractArrayElement target
 
+            // `Array.Empty<T>()` carries no stored element to read a size from,
+            // but the statically-declared `T` on the method gives the same
+            // answer for any byref the caller could legally have obtained: both
+            // parameters are `ref T`, so the natural per-element stride is
+            // `sizeof(T)`. `MemoryMarshal.GetArrayDataReference` and zero-length
+            // span helpers rely on `ByteOffset` working for empty arrays.
+            let tSize, state =
+                let tZero, state = IlMachineState.cliTypeZeroOfHandle state baseClassTypes t
+                CliType.sizeOf tZero, state
+
             let arrElementSize (arr : ManagedHeapAddress) : int =
                 let arrObj = state.ManagedHeap.Arrays.[arr]
 
                 if arrObj.Length = 0 then
-                    failwith "TODO: Unsafe.ByteOffset into an empty array"
+                    tSize
                 else
                     CliType.sizeOf arrObj.Elements.[0]
 

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -733,22 +733,39 @@ module Intrinsics =
                 | [ t ] -> t
                 | _ -> failwith "bad generics Unsafe.Add"
 
+            // Three overloads: `(ref T, int32)`, `(ref T, IntPtr)`, `(ref T, UIntPtr)`.
+            // The IntPtr/UIntPtr overloads exist for native-sized element indices
+            // (e.g. `Unsafe.Add(ref T, (nint)n)`). All three are JIT-lowered to
+            // `sizeof * offset + base`, so we treat them uniformly.
             match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
-            | [ ConcreteByref tFromParam ; ConcreteInt32 state.ConcreteTypes ], ConcreteByref tFromRet when
+            | [ ConcreteByref tFromParam ; ConcreteInt32 state.ConcreteTypes ], ConcreteByref tFromRet
+            | [ ConcreteByref tFromParam ; ConcreteIntPtr state.ConcreteTypes ], ConcreteByref tFromRet
+            | [ ConcreteByref tFromParam ; ConcreteUIntPtr state.ConcreteTypes ], ConcreteByref tFromRet when
                 tFromParam = t && tFromRet = t
                 ->
                 ()
             | _ ->
                 failwith
-                    $"TODO: Unsafe.Add: only the (ref T, int32) overload is implemented; got params %A{methodToCall.Signature.ParameterTypes}"
+                    $"TODO: Unsafe.Add: only the (ref T, int32), (ref T, IntPtr), and (ref T, UIntPtr) overloads are implemented; got params %A{methodToCall.Signature.ParameterTypes}"
 
             let offset, state = IlMachineState.popEvalStack currentThread state
             let src, state = IlMachineState.popEvalStack currentThread state
 
+            // `conv.i` / `conv.u` produce `EvalStackValue.NativeInt (Verbatim ...)`;
+            // the IntPtr/UIntPtr overloads feed us one of those. The int32 overload
+            // produces `EvalStackValue.Int32` directly. Both narrow safely to int
+            // so long as the verbatim value fits; on a 64-bit host the C# compiler
+            // never emits an out-of-range native-int offset for array arithmetic.
             let offset =
                 match offset with
                 | EvalStackValue.Int32 i -> i
-                | _ -> failwith $"TODO: Unsafe.Add: expected Int32 offset, got %O{offset}"
+                | EvalStackValue.NativeInt (NativeIntSource.Verbatim i) ->
+                    if i < int64<int> System.Int32.MinValue || i > int64<int> System.Int32.MaxValue then
+                        failwith
+                            $"TODO: Unsafe.Add: native-int offset %d{i} does not fit in Int32; byte-level arithmetic on array byrefs is not modelled"
+
+                    int32<int64> i
+                | _ -> failwith $"TODO: Unsafe.Add: expected Int32 or Verbatim NativeInt offset, got %O{offset}"
 
             // The input byref may or may not carry an address-preserving
             // `ReinterpretAs` projection (from an `Unsafe.As` or a round-trip).

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -141,6 +141,8 @@ module NullaryIlOp =
                 | NativeIntSource.TypeHandlePtr _
                 | NativeIntSource.AssemblyHandle _
                 | NativeIntSource.ManagedPointer _ -> failwith "Refusing to treat a pointer as an array index"
+                | NativeIntSource.SyntheticCrossArrayOffset _ ->
+                    failwith "Refusing to treat a synthetic cross-array byte offset as an array index"
                 | NativeIntSource.Verbatim i -> i |> int32
             | EvalStackValue.Int32 i -> i
             | _ -> failwith $"Invalid index: {index}"
@@ -171,6 +173,8 @@ module NullaryIlOp =
                 | NativeIntSource.TypeHandlePtr _
                 | NativeIntSource.AssemblyHandle _
                 | NativeIntSource.ManagedPointer _ -> failwith "Refusing to treat a pointer as an array index"
+                | NativeIntSource.SyntheticCrossArrayOffset _ ->
+                    failwith "Refusing to treat a synthetic cross-array byte offset as an array index"
                 | NativeIntSource.Verbatim i -> i |> int32
             | EvalStackValue.Int32 i -> i
             | _ -> failwith $"Invalid index: {index}"

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -755,14 +755,15 @@ module NullaryIlOp =
                 match converted with
                 | None -> failwith "TODO: Conv_U conversion failure unimplemented"
                 | Some conv ->
-                    // > If overflow occurs when converting one integer type to another, the high-order bits are silently truncated.
+                    // NativeIntSource.Verbatim backs the native-int stack slot with
+                    // a signed int64, but the bits are what matter: signed and
+                    // unsigned native-int comparisons reinterpret the slot as
+                    // needed. `int64 (conv : uint64)` is a bit-exact reinterpret
+                    // cast in F#, which is what ECMA-335 requires here (truncate
+                    // high-order bits beyond the native word size).
                     let conv =
                         match conv with
-                        | UnsignedNativeIntSource.Verbatim conv ->
-                            if conv > uint64 System.Int64.MaxValue then
-                                (conv % uint64 System.Int64.MaxValue) |> int64 |> NativeIntSource.Verbatim
-                            else
-                                int64 conv |> NativeIntSource.Verbatim
+                        | UnsignedNativeIntSource.Verbatim conv -> int64 conv |> NativeIntSource.Verbatim
                         | UnsignedNativeIntSource.FromManagedPointer ptr -> NativeIntSource.ManagedPointer ptr
 
                     state

--- a/docs/plans/2026-04-20-memmove.md
+++ b/docs/plans/2026-04-20-memmove.md
@@ -1,0 +1,314 @@
+# Implementing `Buffer.Memmove` / `SpanHelpers.Memmove`
+
+## Context
+
+`GenericEdgeCases.cs` fails with `TODO: implement JIT intrinsic System.Private.CoreLib.SpanHelpers.Memmove`
+during `Number..cctor` when the small-number cache is built. The actual call chain is:
+
+```
+"42".ToString()
+  → Int32.ToString()
+    → Number..cctor
+      → MemoryMarshal.AsBytes(new ReadOnlySpan<char>("\0")).ToArray()
+        → Buffer.Memmove<byte>(ref destArr[0], ref bytesSpan._reference, 2)
+          → Unsafe.As<byte, byte>(...) → ref byte, no-op
+          → SpanHelpers.Memmove(ref byte dest, ref byte src, nuint len)    ← fails here
+```
+
+This chain (or something very like it) is reached by a wide variety of BCL entry points —
+anything that goes through `Number.cctor`, `ReadOnlySpan<T>.ToArray()`, `Span<T>.ToArray()`,
+`MemoryMarshal.AsBytes(...)`, or `string.AsSpan()` will land here. Unblocking this unblocks
+many downstream tests beyond the one that surfaced it.
+
+## Guiding principle (and what we are NOT going to do)
+
+An earlier draft proposed intercepting `Buffer.Memmove<T>` at the managed boundary and
+replacing it with a typed element-wise copy. That's mocking managed code because it's
+inconvenient to implement, and we've explicitly decided not to go that way.
+
+The principle we're applying:
+- **Managed IL we run**: `Buffer.Memmove<T>`, `SpanHelpers.Memmove`, `Unsafe.Add`,
+  `Unsafe.ReadUnaligned`, `Unsafe.WriteUnaligned`, `Unsafe.As`, `Unsafe.AreSame`,
+  `Unsafe.ByteOffset`, `RuntimeHelpers.IsReferenceOrContainsReferences`. Several of these
+  are marked `[Intrinsic]` in the CLR; we ignore the hint and run the managed IL. For
+  methods currently in `safeIntrinsics`, this is already what happens.
+- **Runtime primitives we implement on the PawPrint side**: byref read/write/arithmetic,
+  including byte-level views through a `ReinterpretAs byte` lens.
+- **NativeImpl seam we use**: the P/Invoke `Buffer.MemmoveInternal` (only reached for
+  lengths > ~2 KB on x64/arm64, or for overlapping buffers that don't satisfy the managed
+  fast paths). Stays a future PR — not needed for the current test cluster.
+
+The payoff of doing it this way: every other BCL operation that goes through these IL
+bodies (`BitConverter`, `MemoryMarshal`, `Span<T>` primitives, and much else) inherits the
+machinery for free, and we stay honest about what we're actually simulating.
+
+## What `Memmove` does in the real CLR
+
+Three flavours in `System.Private.CoreLib`:
+
+1. **`Buffer.Memmove<T>(ref T dest, ref T src, nuint elementCount)`** — `[Intrinsic]`.
+   Branches on `RuntimeHelpers.IsReferenceOrContainsReferences<T>()`. Blittable T path
+   calls `SpanHelpers.Memmove(ref byte, ref byte, count * sizeof(T))` after
+   `Unsafe.As<T, byte>`-ing each byref. Reference-containing T path calls
+   `BulkMoveWithWriteBarrier`.
+
+2. **`SpanHelpers.Memmove(ref byte dest, ref byte src, nuint len)`** — `[Intrinsic]`.
+   Hand-unrolled ladder of size-based fast paths using `Unsafe.ReadUnaligned<T>` /
+   `Unsafe.WriteUnaligned<T>` over `ref byte`. Tops out at a P/Invoke
+   (`Buffer.MemmoveInternal`) for len > threshold or for overlapping buffers that fall
+   off the fast path.
+
+3. **`Buffer.BulkMoveWithWriteBarrier(ref byte dest, ref byte src, nuint byteCount)`** —
+   byte-level copy that also fires the GC write barrier. Not reached for blittable T.
+
+The CLR's managed heap is ultimately a byte array, so these all bottom out in a byte copy.
+PawPrint's heap is not bytes — it's typed cells. Making the IL of (1) and (2) run faithfully
+requires PawPrint to expose a byte-level *lens* over the typed heap.
+
+## Why the rich heap makes this nontrivial
+
+A `char[]` in PawPrint is `ImmutableArray<CliType>` with each element
+`CliType.Char (hi, lo)`. An object's fields are a `CliValueType` keyed by name. Byrefs are
+`Byref of ByrefRoot * ByrefProjection list` — roots include `LocalVariable`, `Argument`,
+`HeapValue`, `HeapObjectField`, `ArrayElement`, and projections are `Field name` or
+`ReinterpretAs concreteType`.
+
+There are several places the existing code punts:
+
+- `readManagedByref` / `writeManagedByref` in `IlMachineState.fs:1522` / `:1567`:
+  `ReinterpretAs` is `failwith "TODO: reinterpret as …"` / `failwith "TODO: write through
+  reinterpret"`.
+- `ArithmeticTarget.decompose` in `BinaryArithmetic.fs:29`:
+  `ReinterpretAs` is `failwith "refusing to do pointer arithmetic on reinterpreted
+  pointer"`.
+- `addInt32ManagedPtr` in `BinaryArithmetic.fs:63`:
+  `ArrayTarget` is `failwith "TODO: arrays"`, even for the trivial case of stepping to the
+  next element.
+- `CliType.OfBytesAsType` in `BasicCliType.fs:268`: `failwith "TODO"`. Round-trip with
+  `ToBytes` isn't implemented.
+- String addressing: `_firstChar` carries only the *first* char; the rest live in
+  `ManagedHeap.StringArrayData`. There is no way to pointer-arithmetic past char 0 of a
+  string.
+
+All of these have to change.
+
+## Shape at the failing call
+
+For the specific `GenericEdgeCases` failure:
+- `dest = Byref(ArrayElement(byteArrAddr, 0), [])` — fresh `byte[2]`.
+- `src  = Byref(HeapObjectField(strAddr, "_firstChar"), [ReinterpretAs byte])` — byte view of
+  the first char of the interned `"\0"`.
+- `len = 2` (the string is one char, so AsBytes yields 2 bytes).
+
+`SpanHelpers.Memmove` takes the `len <= 16` branch → `MCPY02` → `MCPY03` → `MCPY04`:
+one `ldind.u1 / stind.i1` byte copy at offset 0, then an `Unsafe.ReadUnaligned<short>` /
+`Unsafe.WriteUnaligned<short>` covering both bytes. No `Block16` / `Block64`, no P/Invoke.
+
+So for this test we specifically need: byte reads/writes of sizes 1 and 2 through a
+`ReinterpretAs byte` lens rooted at either an `ArrayElement` (byte array) or the char data
+of a string.
+
+## Recommended staging
+
+Four PRs to unblock `GenericEdgeCases`, plus two more for the full Memmove story.
+
+### PR A — array-element pointer arithmetic
+
+**Goal**: `Byref(ArrayElement(arr, i), []) + k` should produce `Byref(ArrayElement(arr, i + k), [])`
+for arrays whose element type equals the byref's pointed-to type. Also handle subtraction
+between `ArrayElement` byrefs into different arrays (needed for `Unsafe.ByteOffset`'s
+overlap check).
+
+**Changes**:
+- `BinaryArithmetic.fs:63`: implement `addInt32ManagedPtr` for `ArrayTarget`. Return
+  `Byref(ArrayElement(arr, index + v), [])`. Bounds-check lazily — a byref one past the end
+  is legal (it's how `srcEnd` is expressed).
+- `ManagedPtrInt32` and friends: mirror the same fix.
+- `sub` for `ArrayElement`-to-`ArrayElement` in *different* arrays: return a nativeint
+  large enough (in magnitude) that `Unsafe.ByteOffset`'s `< len` overlap test reliably
+  fails. A sentinel like `int64.MaxValue / 4` works and is deterministic. (Document the
+  choice; if a test later needs true cross-array arithmetic we'll revisit.)
+- Make `ByrefRoot` / `ByrefProjection` / `ManagedPointerSource` derive structural equality
+  (drop the `NoComparison` if it's there only to suppress equality). `Unsafe.AreSame` IL
+  is literally `ceq` on two byrefs, so `ManagedPointerSource` equality must work.
+
+**Tests** (pure C# under `sourcesPure/`):
+- `ref int` arithmetic: `int[] a = {10,20,30,40}; ref int p = ref a[1]; p = ref Unsafe.Add(ref p, 2); return p == 40 ? 0 : 1;`
+- `Unsafe.AreSame`: `int[] a = new int[2]; return Unsafe.AreSame(ref a[0], ref a[0]) && !Unsafe.AreSame(ref a[0], ref a[1]) ? 0 : 1;`
+- `Unsafe.ByteOffset` between different arrays is not directly observable from test code,
+  but `Span.CopyTo` uses it internally — covered in PR B.
+
+**Exit**: `Buffer.Memmove<int>` now fails later, at the byte-view step rather than at
+array-pointer arithmetic.
+
+### PR B — byte view for byrefs
+
+**Goal**: `Byref(_, [..., ReinterpretAs byte])` supports byte-level read/write with
+cumulative byte offset. Underlying storage kinds supported in this PR: primitive-typed
+array elements, single primitive cells (local/argument/heap value).
+
+**Changes**:
+- Extend `ByrefProjection`. Options:
+  - (B1) Add `ByteOffset of int` as a new projection that accumulates under
+    `ReinterpretAs byte` (or under any `ReinterpretAs` for a primitive).
+  - (B2) Change `ReinterpretAs` to `ReinterpretAs of ConcreteType<_> * byteOffset : int`
+    so the two always travel together.
+  - Recommend (B1) — keeps `ReinterpretAs` meaning a single concept. The byte offset is
+    accumulated state, not a type-system fact.
+
+- `ArithmeticTarget.decompose` + `addInt32ManagedPtr` / `ManagedPtrInt32` /
+  `sub`: when the projections end in `ReinterpretAs byte [; ByteOffset n]`, pointer
+  arithmetic touches `n`. Specifically:
+  - `(root, projs + [ReinterpretAs byte]) + k = (root, projs + [ReinterpretAs byte; ByteOffset k])`
+  - `(root, projs + [ReinterpretAs byte; ByteOffset n]) + k = (root, projs + [ReinterpretAs byte; ByteOffset (n + k)])`
+  - Subtract with a same-root-and-prefix pair returns the byte-offset delta; with a
+    different root returns the sentinel from PR A.
+
+- `readManagedByref` for a byref ending in `ReinterpretAs byte` / `ReinterpretAs byte; ByteOffset n`:
+  call a new helper `readBytesAt root prefixProjs n sizeof(T)` that:
+  1. Resolves the underlying "cell stream" — for an `ArrayElement(arr, i)` with prefix
+     `[]`, this is the concatenation of `ToBytes(cell i), ToBytes(cell i+1), …`; for a
+     single-cell root, it's `ToBytes(cellValue)`; for `StringCharAt` (added in PR C) it's
+     the char stream.
+  2. Slices bytes `[n, n + sizeof(T))`.
+  3. Calls `CliType.OfBytesAsType T` on the slice.
+
+  The helper can read across cell boundaries for arrays (each cell has the same size).
+  For single-cell storage, byte offset + size must fit the cell; otherwise fail with a
+  specific message naming the shape.
+
+- `writeManagedByref` (through `applyProjectionsForWrite`): symmetric — read the
+  affected cells to bytes, splice the value's bytes in, write cells back via
+  `OfBytesAsType cellType`.
+
+- `CliType.OfBytesAsType`: implement for `Int8/UInt8/Int16/UInt16/Int32/UInt32/Int64/UInt64/Float32/Float64/Bool/Char`.
+  Property: `∀ primitive T, ∀ v. OfBytesAsType T (ToBytes (valueOfTypeT v)) = valueOfTypeT v`.
+  Choose little-endian explicitly, matching every platform the CLR runs on; document it.
+
+- `Unsafe.As<TFrom, TTo>(ref TFrom)` handling: adds `ReinterpretAs TTo` to the byref's
+  projections. Already present in `Intrinsics.fs`; confirm the behaviour survives the
+  projection-list changes above.
+
+**Tests** (pure C# under `sourcesPure/`):
+- Round-trip a short through `ref byte`:
+  `byte[] b = {0x34, 0x12, 0, 0}; short s = Unsafe.ReadUnaligned<short>(ref b[0]); return s == 0x1234 ? 0 : 1;`
+- Span copy within primitive arrays:
+  `int[] a = {1,2,3}; int[] x = new int[3]; a.AsSpan().CopyTo(x); return (x[0]+x[1]+x[2]==6) ? 0 : 1;`
+- Cross-cell read: read a short straddling two `byte[]` cells.
+- Write test: `Unsafe.WriteUnaligned<int>` into a `byte[]` at offset 0, then verify
+  individual bytes match little-endian.
+
+**Exit**: `Span<T>.CopyTo` works for primitive arrays when total byte count is `<= 16`
+(or actually up to the point where `Block16` would be needed — see PR E). `GenericEdgeCases`
+fails later, at string char addressing.
+
+### PR C — string char addressing
+
+**Goal**: pointer arithmetic past `_firstChar` reaches subsequent chars of a string.
+
+**Changes**:
+- Add `ByrefRoot.StringCharAt of strAddr : ManagedHeapAddress * charIndex : int`.
+- `ManagedHeap`: add a parallel map `StringDataOffsets : Map<ManagedHeapAddress, int>`
+  from string heap address to its starting index in `StringArrayData`. Populate at
+  allocation time (`UnaryStringTokenIlOp.fs` — where `allocateStringData` is called).
+- `Ldflda` on `String._firstChar` (in `UnaryMetadataIlOp.fs`): produce
+  `Byref(StringCharAt(strAddr, 0), [])` instead of `Byref(HeapObjectField(strAddr, "_firstChar"), [])`.
+- `readManagedByref` / `writeManagedByref` / arithmetic learn `StringCharAt`:
+  - Read at `[]` returns the char at `StringArrayData.[StringDataOffsets.[strAddr] + charIndex]`.
+  - Pointer arithmetic `(StringCharAt(s, i), []) + k → (StringCharAt(s, i + k), [])`.
+  - Byte view via PR B: the underlying cell stream is the string's char chunk of
+    `StringArrayData`.
+- Verify `_firstChar` is no longer depended on via `HeapObjectField` anywhere. `grep`
+  for "`_firstChar`" — if JIT intrinsics read it via the field handle (`String.get_Length`
+  is in `safeIntrinsics`, so its IL reads `_stringLength`, not `_firstChar`), we're probably
+  fine, but check.
+
+Note: Strings in PawPrint are allocated null-terminated (`ManagedHeap.fs:89`), matching
+the real CLR layout. `StringCharAt` respects this — reading past `_stringLength` is
+allowed (gets a zero char) and matches what the IL expects.
+
+**Tests**:
+- Read the 2nd char via pointer arithmetic:
+  `string s = "ab"; ref char first = ref MemoryMarshal.GetReference(s.AsSpan()); ref char second = ref Unsafe.Add(ref first, 1); return second == 'b' ? 0 : 1;`
+- `MemoryMarshal.AsBytes(s.AsSpan()).ToArray()` — the `GenericEdgeCases` chain. This test
+  probably already lives in `GenericEdgeCases`; after this PR it should pass.
+
+**Exit**: `GenericEdgeCases.cs` passes end-to-end. Remove its entry from `unimplemented`
+in `WoofWare.PawPrint.Test/TestPureCases.fs`.
+
+### PR D (follow-up) — `Block16` / `Block64` support
+
+Needed once `SpanHelpers.Memmove` is asked for len ≥ 17 bytes; its MCPY00 branch reads a
+`Block16` (16-byte, fieldless struct with `[StructLayout(Sequential, Size=16)]`) via
+`Unsafe.ReadUnaligned<Block16>` and writes it via `Unsafe.WriteUnaligned<Block16>`.
+
+A fieldless struct with a size attribute currently has no way to carry its 16 bytes of
+payload. We'll need one of:
+- A raw-bytes side channel in `CliValueType` for zero-field / size-only types.
+- A first-class `CliType.RawBytes of byte[]` case, constructed by
+  `OfBytesAsType` on such a type.
+
+Out of scope for the current test cluster, but worth noting so the reader knows where the
+story stops.
+
+### PR E (follow-up) — `Buffer.MemmoveInternal` P/Invoke
+
+When len > 2048 (x64) or the overlap path is reached, IL calls `Buffer.MemmoveInternal`
+(or equivalent) via P/Invoke. Implement as a `NativeImpl` that uses the PR B byte-view
+machinery to copy bytes in a simple loop. Two byrefs, one nuint count, byte-level copy
+with correct overlap direction.
+
+Out of scope for the current test cluster.
+
+## Risks and invariants to check
+
+1. **`safeIntrinsics` hygiene**: `Buffer.Memmove` stays listed. Add `SpanHelpers.Memmove`
+   to `safeIntrinsics` so we actually run its IL body rather than hitting the "TODO:
+   implement JIT intrinsic" fallback. Check every `Unsafe.*` method the IL calls —
+   anything not already recognised needs either a safe-intrinsic entry or an explicit
+   intrinsic handler that does the right thing.
+
+2. **`Unsafe.Add` IL shape**: `Unsafe.Add<T>(ref T, int)` expands to
+   `ldarg.0; sizeof !!T; ldarg.1; conv.i; mul; add; ret`. That means our add path has
+   to accept a `nativeint` arithmetic operand (not only `int32`) when adding to a managed
+   pointer. Check `BinaryArithmetic.fs` — the `Int32ManagedPtr` path likely needs a
+   `NativeIntManagedPtr` sibling or a normalisation step. This is a prerequisite for PRs
+   B and C, so land it in PR A or split off a tiny PR A.5.
+
+3. **Endianness**: lock in little-endian in `CliType.ToBytes` / `OfBytesAsType` with a
+   comment. The .NET runtime is LE everywhere that matters (and our tests run on x64 / arm64).
+
+4. **`ToBytes`/`OfBytesAsType` round-trip property**: add a property-based test. Generating
+   `CliNumericType` values and asserting `OfBytesAsType t (ToBytes v) = v` is exactly the
+   kind of oracle the gospel wants.
+
+5. **Determinism**: the byte-view path is a pure function of state. `ImmutableArray<char>`
+   `StringArrayData` stays immutable. No new mutable state.
+
+6. **Overlap detection**: `SpanHelpers.Memmove` decides forward vs. backward based on
+   `Unsafe.ByteOffset(src, dest) < len` and `Unsafe.ByteOffset(dest, src) < len`. With our
+   different-array sentinel, both will be false for distinct containers, so the forward
+   path is taken — correct.
+
+7. **Value types as array elements**: `Byref(ArrayElement(arr, i), [ReinterpretAs byte])`
+   when `arr` is e.g. `Pair[]` for `struct Pair { int A; int B; }` requires PR B's
+   byte-view to walk into the struct, which in turn requires struct-layout-aware byte
+   views. Defer — emit a descriptive failwith when hit, and note in the PR description
+   that struct arrays don't roundtrip through Memmove yet. Likely no current test depends
+   on this.
+
+8. **`BulkMoveWithWriteBarrier`**: not hit by the blittable path; not needed. Leave the
+   failwith in place, ideally with a specific message naming the method.
+
+## Summary
+
+Previous plan: intercept `Buffer.Memmove<T>` and skip running managed IL. Faithful but a
+mock.
+
+This plan: run the managed IL and make the primitives underneath it work. Byref byte-views
+(PRs A-C) are the core of it. A byref with a `ReinterpretAs byte` projection becomes a
+lens over a cell stream, with cumulative byte offset, read/write assembled via
+`CliType.ToBytes` / `OfBytesAsType`. Strings get a dedicated root (PR C) so char-level
+addressing works. Block16/Block64 (PR D) and the P/Invoke fallback (PR E) are follow-ups
+not needed by the current test cluster. The resulting system implements byte-level memory
+semantics faithfully and gains a lot of downstream BCL behaviour for free.


### PR DESCRIPTION
(Claude Opus 4.7.)

These three JIT intrinsics are the pointer-arithmetic prerequisites for running the BCL's Buffer.Memmove / SpanHelpers.Memmove IL faithfully (see docs/plans/2026-04-20-memmove.md, PR A). Each intrinsic's managed body throws PlatformNotSupportedException at runtime; the JIT normally rewrites them. Here we handle them on the PawPrint side:

- Unsafe.AreSame(ref T, ref T): structural equality on ManagedPointerSource.
- Unsafe.Add(ref T, int): shift an ArrayElement byref by the given offset.
- Unsafe.ByteOffset(ref T, ref T): (i2 - i1) * sizeof(T) between two byrefs into the same array, boxed into an IntPtr ValueType.

All three restrict to Byref(ArrayElement arr i, []) shapes for now and fail loudly on anything richer (projections, cross-array ByteOffset, non-int32 Add overloads). That's the minimum needed for the Memmove IL path and keeps the surface easy to extend when richer byrefs show up.

Also extends ceq's NativeInt/NativeInt arm to treat Verbatim 0L as equal to ManagedPointer Null, since arithmetic zero and the IntPtr.Zero literal are both valid representations of zero but used different NativeIntSource variants.