### PR TITLE
Implement full String.Equals intrinsic

### DIFF
--- a/WoofWare.PawPrint.Test/TestManagedHeap.fs
+++ b/WoofWare.PawPrint.Test/TestManagedHeap.fs
@@ -1,0 +1,111 @@
+namespace WoofWare.PawPrint.Test
+
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestManagedHeap =
+
+    [<Test>]
+    let ``recordStringContents then getStringContents round-trips`` () : unit =
+        let addr = ManagedHeapAddress.ManagedHeapAddress 42
+
+        ManagedHeap.empty
+        |> ManagedHeap.recordStringContents addr "hello"
+        |> ManagedHeap.getStringContents addr
+        |> shouldEqual (Some "hello")
+
+    [<Test>]
+    let ``getStringContents returns None when no contents recorded`` () : unit =
+        let addr = ManagedHeapAddress.ManagedHeapAddress 42
+        ManagedHeap.getStringContents addr ManagedHeap.empty |> shouldEqual None
+
+    [<Test>]
+    let ``recordStringContents overwrites previous content`` () : unit =
+        let addr = ManagedHeapAddress.ManagedHeapAddress 7
+
+        ManagedHeap.empty
+        |> ManagedHeap.recordStringContents addr "first"
+        |> ManagedHeap.recordStringContents addr "second"
+        |> ManagedHeap.getStringContents addr
+        |> shouldEqual (Some "second")
+
+    [<Test>]
+    let ``stringsEqual: same content at different addresses is equal`` () : unit =
+        let addr1 = ManagedHeapAddress.ManagedHeapAddress 1
+        let addr2 = ManagedHeapAddress.ManagedHeapAddress 2
+
+        let heap =
+            ManagedHeap.empty
+            |> ManagedHeap.recordStringContents addr1 "hello"
+            |> ManagedHeap.recordStringContents addr2 "hello"
+
+        ManagedHeap.stringsEqual addr1 addr2 heap |> shouldEqual true
+
+    [<Test>]
+    let ``stringsEqual: same address is equal`` () : unit =
+        let addr = ManagedHeapAddress.ManagedHeapAddress 1
+        let heap = ManagedHeap.empty |> ManagedHeap.recordStringContents addr "hello"
+        ManagedHeap.stringsEqual addr addr heap |> shouldEqual true
+
+    [<Test>]
+    let ``stringsEqual: different content of same length is not equal`` () : unit =
+        let addr1 = ManagedHeapAddress.ManagedHeapAddress 1
+        let addr2 = ManagedHeapAddress.ManagedHeapAddress 2
+
+        let heap =
+            ManagedHeap.empty
+            |> ManagedHeap.recordStringContents addr1 "hello"
+            |> ManagedHeap.recordStringContents addr2 "world"
+
+        ManagedHeap.stringsEqual addr1 addr2 heap |> shouldEqual false
+
+    [<Test>]
+    let ``stringsEqual: different length is not equal`` () : unit =
+        let addr1 = ManagedHeapAddress.ManagedHeapAddress 1
+        let addr2 = ManagedHeapAddress.ManagedHeapAddress 2
+
+        let heap =
+            ManagedHeap.empty
+            |> ManagedHeap.recordStringContents addr1 "hello"
+            |> ManagedHeap.recordStringContents addr2 "hell"
+
+        ManagedHeap.stringsEqual addr1 addr2 heap |> shouldEqual false
+
+    [<Test>]
+    let ``stringsEqual: empty strings are equal`` () : unit =
+        let addr1 = ManagedHeapAddress.ManagedHeapAddress 1
+        let addr2 = ManagedHeapAddress.ManagedHeapAddress 2
+
+        let heap =
+            ManagedHeap.empty
+            |> ManagedHeap.recordStringContents addr1 ""
+            |> ManagedHeap.recordStringContents addr2 ""
+
+        ManagedHeap.stringsEqual addr1 addr2 heap |> shouldEqual true
+
+    [<Test>]
+    let ``stringsEqual: shared prefix but one is longer is not equal`` () : unit =
+        let addr1 = ManagedHeapAddress.ManagedHeapAddress 1
+        let addr2 = ManagedHeapAddress.ManagedHeapAddress 2
+
+        let heap =
+            ManagedHeap.empty
+            |> ManagedHeap.recordStringContents addr1 "hello world"
+            |> ManagedHeap.recordStringContents addr2 "hello"
+
+        ManagedHeap.stringsEqual addr1 addr2 heap |> shouldEqual false
+
+    [<Test>]
+    let ``stringsEqual: differ only in last char is not equal`` () : unit =
+        let addr1 = ManagedHeapAddress.ManagedHeapAddress 1
+        let addr2 = ManagedHeapAddress.ManagedHeapAddress 2
+
+        let heap =
+            ManagedHeap.empty
+            |> ManagedHeap.recordStringContents addr1 "abcdef"
+            |> ManagedHeap.recordStringContents addr2 "abcdeg"
+
+        ManagedHeap.stringsEqual addr1 addr2 heap |> shouldEqual false

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -19,6 +19,7 @@
     <Compile Include="TestTypeResolution.fs" />
     <Compile Include="TestTypeIdentityProperties.fs" />
     <Compile Include="TestEvalStack.fs" />
+    <Compile Include="TestManagedHeap.fs" />
     <Compile Include="TestCrossAssemblyTypeInitialisation.fs" />
     <Compile Include="TestCrossAssemblyCastclass.fs" />
     <Compile Include="TestNativeMethodDetection.fs" />

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -408,21 +408,7 @@ module Intrinsics =
                     | None, None -> true
                     | Some _, None
                     | None, Some _ -> false
-                    | Some arg1, Some arg2 ->
-                        if arg1 = arg2 then
-                            true
-                        else
-
-                        let arg1 = ManagedHeap.get arg1 state.ManagedHeap
-                        let arg2 = ManagedHeap.get arg2 state.ManagedHeap
-
-                        if
-                            AllocatedNonArrayObject.DereferenceField "_firstChar" arg1
-                            <> AllocatedNonArrayObject.DereferenceField "_firstChar" arg2
-                        then
-                            false
-                        else
-                            failwith "TODO"
+                    | Some arg1, Some arg2 -> ManagedHeap.stringsEqual arg1 arg2 state.ManagedHeap
 
                 state
                 |> IlMachineState.pushToEvalStack (CliType.ofBool areEqual) currentThread

--- a/WoofWare.PawPrint/ManagedHeap.fs
+++ b/WoofWare.PawPrint/ManagedHeap.fs
@@ -36,6 +36,11 @@ type ManagedHeap =
         /// Strings are special-cased in the runtime anyway and have a whole lot of unsafe code in them,
         /// so we'll have a special pool for their bytes.
         StringArrayData : ImmutableArray<char>
+        /// Side-table mapping a String object's address to its full character content.
+        /// The managed representation of a String only carries _firstChar and _stringLength,
+        /// which is not enough to reconstruct the full text; we record it here at allocation
+        /// time so operations like String.Equals can compare full contents.
+        StringContents : ImmutableDictionary<ManagedHeapAddress, string>
     }
 
 [<RequireQualifiedAccess>]
@@ -46,6 +51,7 @@ module ManagedHeap =
             FirstAvailableAddress = 1
             Arrays = Map.empty
             StringArrayData = ImmutableArray.Empty
+            StringContents = ImmutableDictionary.Empty
         }
 
     let getSyncBlock (addr : ManagedHeapAddress) (heap : ManagedHeap) : SyncBlock =
@@ -70,11 +76,9 @@ module ManagedHeap =
         let addr = heap.FirstAvailableAddress
 
         let heap =
-            {
+            { heap with
                 FirstAvailableAddress = heap.FirstAvailableAddress + 1
-                NonArrayObjects = heap.NonArrayObjects
                 Arrays = heap.Arrays |> Map.add (ManagedHeapAddress addr) ty
-                StringArrayData = heap.StringArrayData
             }
 
         ManagedHeapAddress addr, heap
@@ -107,14 +111,44 @@ module ManagedHeap =
         let addr = heap.FirstAvailableAddress
 
         let heap =
-            {
+            { heap with
                 FirstAvailableAddress = addr + 1
                 NonArrayObjects = heap.NonArrayObjects |> Map.add (ManagedHeapAddress addr) ty
-                Arrays = heap.Arrays
-                StringArrayData = heap.StringArrayData
             }
 
         ManagedHeapAddress addr, heap
+
+    /// Record the full character content of a string object located at `addr`, so that
+    /// string-level operations (equality, hashing, etc.) can read it back.
+    let recordStringContents (addr : ManagedHeapAddress) (contents : string) (heap : ManagedHeap) : ManagedHeap =
+        { heap with
+            StringContents = heap.StringContents.SetItem (addr, contents)
+        }
+
+    /// Retrieve the character content of a string object previously registered via
+    /// `recordStringContents`.  Returns None if no content was recorded (which indicates
+    /// a string that was allocated without using the standard allocation path, or a
+    /// non-string address).
+    let getStringContents (addr : ManagedHeapAddress) (heap : ManagedHeap) : string option =
+        match heap.StringContents.TryGetValue addr with
+        | true, s -> Some s
+        | false, _ -> None
+
+    /// Value-level equality between two managed string objects addressed by `a1` and `a2`.
+    /// Mirrors the semantics of System.String.Equals(string, string): null-aware, reference
+    /// equal implies equal, otherwise compares full character contents.
+    /// Fails if either address is not a known string and the two addresses are distinct
+    /// (i.e., we genuinely need the character content to answer).
+    let stringsEqual (a1 : ManagedHeapAddress) (a2 : ManagedHeapAddress) (heap : ManagedHeap) : bool =
+        if a1 = a2 then
+            true
+        else
+            match getStringContents a1 heap, getStringContents a2 heap with
+            | Some s1, Some s2 -> s1 = s2
+            | None, _
+            | _, None ->
+                failwith
+                    $"stringsEqual: one or both addresses %O{a1}, %O{a2} are not registered strings; cannot compare contents"
 
     let getArrayValue (alloc : ManagedHeapAddress) (offset : int) (heap : ManagedHeap) : CliType =
         match heap.Arrays.TryGetValue alloc with

--- a/WoofWare.PawPrint/UnaryStringTokenIlOp.fs
+++ b/WoofWare.PawPrint/UnaryStringTokenIlOp.fs
@@ -83,6 +83,11 @@ module internal UnaryStringTokenIlOp =
 
                     let addr, state = IlMachineState.allocateManagedObject stringType fields state
 
+                    let state =
+                        { state with
+                            ManagedHeap = ManagedHeap.recordStringContents addr stringToAllocate state.ManagedHeap
+                        }
+
                     addr,
                     { state with
                         InternedStrings = state.InternedStrings.Add (sh, addr)


### PR DESCRIPTION
The String.Equals intrinsic previously gave up with failwith "TODO" whenever two distinct string objects shared their first character but were not reference-equal, so it only worked for interned literals and for strings that differed in their first char.

Record each allocated string's full character content in a new ManagedHeap.StringContents side table at allocation time (Ldstr), and have the intrinsic compare those contents directly via ManagedHeap .stringsEqual.  The `_firstChar`/`_stringLength` fields on the managed object were not enough on their own: managed strings store no back- pointer into StringArrayData, and the BCL's unsafe implementation of char comparison relies on layout guarantees we don't provide.