### PR TITLE
Populate TypeInitializationException fields on .cctor failure

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -27,9 +27,6 @@ module TestPureCases =
             "LdtokenField.cs"
             "GenericEdgeCases.cs"
             "UnsafeAs.cs"
-            "ThrowingCctorProperties.cs"
-            "ThrowingCctorStackTrace.cs"
-            "NullDereferenceTest.cs"
             "CastclassFailures.cs"
             "CastClassCrossAssembly.cs" // GetMethodTable intrinsic unimplemented
             "CastClassArray.cs" // bad generics in Array.Length path
@@ -68,6 +65,27 @@ module TestPureCases =
 
         [
             "InterfaceDispatch.cs",
+            (0,
+             { empty with
+                 System_Threading_Monitor = System_Threading_Monitor.passThru
+             })
+
+            // Requires System.Private.CoreLib System.RuntimeTypeHandle::GetGCHandle
+            "NullDereferenceTest.cs",
+            (0,
+             { empty with
+                 System_Threading_Monitor = System_Threading_Monitor.passThru
+             })
+
+            // Requires Monitor mock + RuntimeTypeHandle.GetGCHandle (PInvoke)
+            "ThrowingCctorProperties.cs",
+            (0,
+             { empty with
+                 System_Threading_Monitor = System_Threading_Monitor.passThru
+             })
+
+            // Requires Monitor mock + RuntimeTypeHandle.GetGCHandle (PInvoke)
+            "ThrowingCctorStackTrace.cs",
             (0,
              { empty with
                  System_Threading_Monitor = System_Threading_Monitor.passThru

--- a/WoofWare.PawPrint/ExceptionDispatching.fs
+++ b/WoofWare.PawPrint/ExceptionDispatching.fs
@@ -14,57 +14,6 @@ type ExceptionDispatchResult =
 [<RequireQualifiedAccess>]
 module ExceptionDispatching =
 
-    /// Format a single stack frame in a CLR-like style:
-    ///   "   at <namespace>.<type>.<method>()"
-    /// We don't render argument lists or file info, but the frames carry enough identifying
-    /// detail for managed code to locate the caller (.cctor, Main, etc.) via string search.
-    let private formatStackFrame
-        (frame : ExceptionStackFrame<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>)
-        : string
-        =
-        let declaringType = frame.Method.DeclaringType
-
-        let typeFullName =
-            if System.String.IsNullOrEmpty declaringType.Namespace then
-                declaringType.Name
-            else
-                sprintf "%s.%s" declaringType.Namespace declaringType.Name
-
-        sprintf "   at %s.%s()" typeFullName frame.Method.Name
-
-    /// Format a list of stack frames, innermost first, one per line (no trailing newline).
-    let private formatStackTrace
-        (frames : ExceptionStackFrame<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle> list)
-        : string
-        =
-        frames |> List.map formatStackFrame |> String.concat System.Environment.NewLine
-
-    /// Write Exception._stackTraceString on the given heap object to the formatted stack trace.
-    /// Matches what the CLR's lazy Exception.StackTrace getter would produce when the exception
-    /// is caught for the first time: it lets managed code observe where the exception was thrown.
-    let private stampStackTraceString
-        (loggerFactory : ILoggerFactory)
-        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
-        (exceptionAddr : ManagedHeapAddress)
-        (frames : ExceptionStackFrame<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle> list)
-        (state : IlMachineState)
-        : IlMachineState
-        =
-        let traceText = formatStackTrace frames
-
-        let traceAddr, state =
-            IlMachineState.allocateManagedString loggerFactory baseClassTypes traceText state
-
-        let heapObj = ManagedHeap.get exceptionAddr state.ManagedHeap
-
-        let heapObj =
-            heapObj
-            |> AllocatedNonArrayObject.SetField "_stackTraceString" (CliType.ObjectRef (Some traceAddr))
-
-        { state with
-            ManagedHeap = ManagedHeap.set exceptionAddr heapObj state.ManagedHeap
-        }
-
     /// Check if an exception type matches a catch handler type.
     let private isExceptionAssignableTo
         (loggerFactory : ILoggerFactory)
@@ -187,33 +136,22 @@ module ExceptionDispatching =
         state, result
 
     /// Enter a catch handler: set PC to the handler offset, clear eval stack and exception continuation,
-    /// push the exception object reference, and stamp Exception._stackTraceString so managed code
-    /// catching the exception can observe its stack trace.
+    /// push the exception object reference.
     let enterCatchHandler
-        (loggerFactory : ILoggerFactory)
-        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (currentThread : ThreadId)
         (methodState : MethodState)
         (threadState : ThreadState)
         (state : IlMachineState)
         (offset : ExceptionOffset)
-        (cliException : CliException<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>)
+        (exceptionObjectAddr : ManagedHeapAddress)
         : IlMachineState
         =
-        let state =
-            stampStackTraceString
-                loggerFactory
-                baseClassTypes
-                cliException.ExceptionObject
-                cliException.StackTrace
-                state
-
         let newMethodState =
             methodState
             |> MethodState.setProgramCounter offset.HandlerOffset
             |> MethodState.clearEvalStack
             |> MethodState.clearExceptionContinuation
-            |> MethodState.pushToEvalStack' (EvalStackValue.ObjectRef cliException.ExceptionObject)
+            |> MethodState.pushToEvalStack' (EvalStackValue.ObjectRef exceptionObjectAddr)
 
         let newThreadState =
             ThreadState.setFrame threadState.ActiveMethodState newMethodState threadState
@@ -248,8 +186,6 @@ module ExceptionDispatching =
 
     /// Given a matched handler from findExceptionHandler, enter the handler. Returns the updated state.
     let enterHandler
-        (loggerFactory : ILoggerFactory)
-        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (currentThread : ThreadId)
         (methodState : MethodState)
         (threadState : ThreadState)
@@ -260,15 +196,7 @@ module ExceptionDispatching =
         =
         match handler with
         | ExceptionRegion.Catch (_, offset) ->
-            enterCatchHandler
-                loggerFactory
-                baseClassTypes
-                currentThread
-                methodState
-                threadState
-                state
-                offset
-                cliException
+            enterCatchHandler currentThread methodState threadState state offset cliException.ExceptionObject
         | ExceptionRegion.Finally offset ->
             enterFinallyHandler currentThread methodState threadState state offset cliException
         | _ -> failwith "TODO: Filter and Fault handlers not yet implemented"
@@ -310,29 +238,20 @@ module ExceptionDispatching =
                         failwith
                             $"Logic error: failed to look up ConcreteType for initialising-type handle %O{finishedInitialising} when synthesising TypeInitializationException"
 
-                // Inner exception's stack trace is frozen at the point we wrap it, since the
-                // raw exception is never surfaced to managed code independently of the TIE.
-                let innerTraceText = formatStackTrace cliException.StackTrace
-
                 let tieAddr, tieType, state =
                     IlMachineState.synthesizeTypeInitializationException
                         loggerFactory
                         corelib
                         typeFullName
-                        innerTraceText
                         cliException.ExceptionObject
                         state
 
                 let state =
                     state.WithTypeFailedInit currentThread finishedInitialising tieAddr tieType
 
-                // The TIE is a fresh throw from the caller's perspective: reset the frame list
-                // so we don't inherit the .cctor frames that logically belong to the inner
-                // exception.  Subsequent unwinding will append the caller's frame below.
                 let wrappedCliException =
                     { cliException with
                         ExceptionObject = tieAddr
-                        StackTrace = []
                     }
 
                 state, wrappedCliException, tieType
@@ -382,7 +301,7 @@ module ExceptionDispatching =
 
         match handlerResult with
         | Some (handler, _isFinally) ->
-            enterHandler loggerFactory corelib currentThread callerFrame threadState state cliException handler
+            enterHandler currentThread callerFrame threadState state cliException handler
             |> ExceptionDispatchResult.HandlerFound
         | None ->
             // No handler in this frame either; continue unwinding
@@ -418,7 +337,7 @@ module ExceptionDispatching =
 
         match handlerResult with
         | Some (handler, _isFinally) ->
-            enterHandler loggerFactory corelib currentThread currentMethodState threadState state cliException handler
+            enterHandler currentThread currentMethodState threadState state cliException handler
             |> ExceptionDispatchResult.HandlerFound
         | None -> unwindToCallerAndSearch loggerFactory corelib state currentThread cliException exceptionType
 

--- a/WoofWare.PawPrint/ExceptionDispatching.fs
+++ b/WoofWare.PawPrint/ExceptionDispatching.fs
@@ -14,6 +14,57 @@ type ExceptionDispatchResult =
 [<RequireQualifiedAccess>]
 module ExceptionDispatching =
 
+    /// Format a single stack frame in a CLR-like style:
+    ///   "   at <namespace>.<type>.<method>()"
+    /// We don't render argument lists or file info, but the frames carry enough identifying
+    /// detail for managed code to locate the caller (.cctor, Main, etc.) via string search.
+    let private formatStackFrame
+        (frame : ExceptionStackFrame<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>)
+        : string
+        =
+        let declaringType = frame.Method.DeclaringType
+
+        let typeFullName =
+            if System.String.IsNullOrEmpty declaringType.Namespace then
+                declaringType.Name
+            else
+                sprintf "%s.%s" declaringType.Namespace declaringType.Name
+
+        sprintf "   at %s.%s()" typeFullName frame.Method.Name
+
+    /// Format a list of stack frames, innermost first, one per line (no trailing newline).
+    let private formatStackTrace
+        (frames : ExceptionStackFrame<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle> list)
+        : string
+        =
+        frames |> List.map formatStackFrame |> String.concat System.Environment.NewLine
+
+    /// Write Exception._stackTraceString on the given heap object to the formatted stack trace.
+    /// Matches what the CLR's lazy Exception.StackTrace getter would produce when the exception
+    /// is caught for the first time: it lets managed code observe where the exception was thrown.
+    let private stampStackTraceString
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (exceptionAddr : ManagedHeapAddress)
+        (frames : ExceptionStackFrame<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle> list)
+        (state : IlMachineState)
+        : IlMachineState
+        =
+        let traceText = formatStackTrace frames
+
+        let traceAddr, state =
+            IlMachineState.allocateManagedString loggerFactory baseClassTypes traceText state
+
+        let heapObj = ManagedHeap.get exceptionAddr state.ManagedHeap
+
+        let heapObj =
+            heapObj
+            |> AllocatedNonArrayObject.SetField "_stackTraceString" (CliType.ObjectRef (Some traceAddr))
+
+        { state with
+            ManagedHeap = ManagedHeap.set exceptionAddr heapObj state.ManagedHeap
+        }
+
     /// Check if an exception type matches a catch handler type.
     let private isExceptionAssignableTo
         (loggerFactory : ILoggerFactory)
@@ -136,22 +187,33 @@ module ExceptionDispatching =
         state, result
 
     /// Enter a catch handler: set PC to the handler offset, clear eval stack and exception continuation,
-    /// push the exception object reference.
+    /// push the exception object reference, and stamp Exception._stackTraceString so managed code
+    /// catching the exception can observe its stack trace.
     let enterCatchHandler
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (currentThread : ThreadId)
         (methodState : MethodState)
         (threadState : ThreadState)
         (state : IlMachineState)
         (offset : ExceptionOffset)
-        (exceptionObjectAddr : ManagedHeapAddress)
+        (cliException : CliException<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>)
         : IlMachineState
         =
+        let state =
+            stampStackTraceString
+                loggerFactory
+                baseClassTypes
+                cliException.ExceptionObject
+                cliException.StackTrace
+                state
+
         let newMethodState =
             methodState
             |> MethodState.setProgramCounter offset.HandlerOffset
             |> MethodState.clearEvalStack
             |> MethodState.clearExceptionContinuation
-            |> MethodState.pushToEvalStack' (EvalStackValue.ObjectRef exceptionObjectAddr)
+            |> MethodState.pushToEvalStack' (EvalStackValue.ObjectRef cliException.ExceptionObject)
 
         let newThreadState =
             ThreadState.setFrame threadState.ActiveMethodState newMethodState threadState
@@ -186,6 +248,8 @@ module ExceptionDispatching =
 
     /// Given a matched handler from findExceptionHandler, enter the handler. Returns the updated state.
     let enterHandler
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (currentThread : ThreadId)
         (methodState : MethodState)
         (threadState : ThreadState)
@@ -196,7 +260,15 @@ module ExceptionDispatching =
         =
         match handler with
         | ExceptionRegion.Catch (_, offset) ->
-            enterCatchHandler currentThread methodState threadState state offset cliException.ExceptionObject
+            enterCatchHandler
+                loggerFactory
+                baseClassTypes
+                currentThread
+                methodState
+                threadState
+                state
+                offset
+                cliException
         | ExceptionRegion.Finally offset ->
             enterFinallyHandler currentThread methodState threadState state offset cliException
         | _ -> failwith "TODO: Filter and Fault handlers not yet implemented"
@@ -229,19 +301,38 @@ module ExceptionDispatching =
             | Some finishedInitialising ->
                 // Per CLR spec, a throwing .cctor surfaces to managed code as
                 // TypeInitializationException wrapping the original exception.
+                let typeFullName =
+                    match AllConcreteTypes.lookup finishedInitialising state.ConcreteTypes with
+                    | Some ct ->
+                        let assy = state._LoadedAssemblies.[ct.Identity.AssemblyFullName]
+                        Assembly.fullName assy ct.Identity
+                    | None ->
+                        failwith
+                            $"Logic error: failed to look up ConcreteType for initialising-type handle %O{finishedInitialising} when synthesising TypeInitializationException"
+
+                // Inner exception's stack trace is frozen at the point we wrap it, since the
+                // raw exception is never surfaced to managed code independently of the TIE.
+                let innerTraceText = formatStackTrace cliException.StackTrace
+
                 let tieAddr, tieType, state =
                     IlMachineState.synthesizeTypeInitializationException
                         loggerFactory
                         corelib
+                        typeFullName
+                        innerTraceText
                         cliException.ExceptionObject
                         state
 
                 let state =
                     state.WithTypeFailedInit currentThread finishedInitialising tieAddr tieType
 
+                // The TIE is a fresh throw from the caller's perspective: reset the frame list
+                // so we don't inherit the .cctor frames that logically belong to the inner
+                // exception.  Subsequent unwinding will append the caller's frame below.
                 let wrappedCliException =
                     { cliException with
                         ExceptionObject = tieAddr
+                        StackTrace = []
                     }
 
                 state, wrappedCliException, tieType
@@ -291,7 +382,7 @@ module ExceptionDispatching =
 
         match handlerResult with
         | Some (handler, _isFinally) ->
-            enterHandler currentThread callerFrame threadState state cliException handler
+            enterHandler loggerFactory corelib currentThread callerFrame threadState state cliException handler
             |> ExceptionDispatchResult.HandlerFound
         | None ->
             // No handler in this frame either; continue unwinding
@@ -327,7 +418,7 @@ module ExceptionDispatching =
 
         match handlerResult with
         | Some (handler, _isFinally) ->
-            enterHandler currentThread currentMethodState threadState state cliException handler
+            enterHandler loggerFactory corelib currentThread currentMethodState threadState state cliException handler
             |> ExceptionDispatchResult.HandlerFound
         | None -> unwindToCallerAndSearch loggerFactory corelib state currentThread cliException exceptionType
 

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -2212,13 +2212,67 @@ module IlMachineState =
 
             state, baseFields @ ownFields
 
+    /// Allocate a new System.String managed object on the heap with the given contents.
+    /// Unlike the Ldstr opcode, this does NOT intern the string, so every call returns a fresh
+    /// object.  Use this for runtime-generated strings (e.g., stack trace text, type names).
+    let allocateManagedString
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (contents : string)
+        (state : IlMachineState)
+        : ManagedHeapAddress * IlMachineState
+        =
+        let dataAddr, state = allocateStringData contents.Length state
+        let state = setStringData dataAddr contents state
+
+        let fields =
+            [
+                {
+                    Name = "_firstChar"
+                    Contents = CliType.ofChar state.ManagedHeap.StringArrayData.[dataAddr]
+                    Offset = None
+                    Type = AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes baseClassTypes.Char
+                }
+                {
+                    Name = "_stringLength"
+                    Contents = CliType.Numeric (CliNumericType.Int32 contents.Length)
+                    Offset = None
+                    Type = AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes baseClassTypes.Int32
+                }
+            ]
+            |> CliValueType.OfFields Layout.Default
+
+        let state, stringType =
+            DumpedAssembly.typeInfoToTypeDefn' baseClassTypes state._LoadedAssemblies baseClassTypes.String
+            |> concretizeType
+                loggerFactory
+                baseClassTypes
+                state
+                baseClassTypes.Corelib.Name
+                ImmutableArray.Empty
+                ImmutableArray.Empty
+
+        let addr, state = allocateManagedObject stringType fields state
+
+        let state =
+            { state with
+                ManagedHeap = ManagedHeap.recordStringContents addr contents state.ManagedHeap
+            }
+
+        addr, state
+
     /// Synthesize a TypeInitializationException wrapping the given inner exception object.
     /// Allocates the exception on the heap with zero-initialized fields (constructor is NOT run).
-    /// Sets the _innerException field (inherited from System.Exception) to the original exception.
+    /// Sets the _innerException, _typeName, and _HResult fields on the TIE to match what the
+    /// TypeInitializationException(string, Exception) ctor would have done.  Also stamps the
+    /// inner exception's _stackTraceString so that repeated Exception.StackTrace reads return
+    /// the frames captured inside the failing .cctor.
     /// Returns the heap address, the ConcreteTypeHandle, and the updated state.
     let synthesizeTypeInitializationException
         (loggerFactory : ILoggerFactory)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (typeFullName : string)
+        (innerStackTraceString : string)
         (innerExceptionAddr : ManagedHeapAddress)
         (state : IlMachineState)
         : ManagedHeapAddress * ConcreteTypeHandle * IlMachineState
@@ -2245,7 +2299,13 @@ module IlMachineState =
 
         let addr, state = allocateManagedObject tieHandle fields state
 
-        // Set _innerException and _HResult on the allocated object, matching what the
+        let typeNameAddr, state =
+            allocateManagedString loggerFactory baseClassTypes typeFullName state
+
+        let innerStackTraceAddr, state =
+            allocateManagedString loggerFactory baseClassTypes innerStackTraceString state
+
+        // Set _innerException, _typeName and _HResult on the allocated TIE, matching what the
         // TypeInitializationException(string, Exception) ctor would have done.
         // See CLR's EEException::CreateThrowable:
         // https://github.com/dotnet/dotnet/blob/10060d128e3f470e77265f8490f5e4f72dae738e/src/runtime/src/coreclr/vm/clrex.cpp#L972-L1019
@@ -2254,6 +2314,7 @@ module IlMachineState =
         let heapObj =
             heapObj
             |> AllocatedNonArrayObject.SetField "_innerException" (CliType.ObjectRef (Some innerExceptionAddr))
+            |> AllocatedNonArrayObject.SetField "_typeName" (CliType.ObjectRef (Some typeNameAddr))
             |> AllocatedNonArrayObject.SetField
                 "_HResult"
                 (CliType.Numeric (CliNumericType.Int32 (ExceptionHResults.lookup "System.TypeInitializationException")))
@@ -2261,6 +2322,21 @@ module IlMachineState =
         let state =
             { state with
                 ManagedHeap = ManagedHeap.set addr heapObj state.ManagedHeap
+            }
+
+        // Stamp the inner exception's _stackTraceString with the frames captured inside the
+        // failing .cctor.  The inner exception is never re-caught in its own right (only the
+        // wrapping TIE is surfaced to managed code), so this is our only chance to record
+        // where it was thrown.
+        let innerObj = ManagedHeap.get innerExceptionAddr state.ManagedHeap
+
+        let innerObj =
+            innerObj
+            |> AllocatedNonArrayObject.SetField "_stackTraceString" (CliType.ObjectRef (Some innerStackTraceAddr))
+
+        let state =
+            { state with
+                ManagedHeap = ManagedHeap.set innerExceptionAddr innerObj state.ManagedHeap
             }
 
         addr, tieHandle, state

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -2273,15 +2273,12 @@ module IlMachineState =
     /// Synthesize a TypeInitializationException wrapping the given inner exception object.
     /// Allocates the exception on the heap with zero-initialized fields (constructor is NOT run).
     /// Sets the _innerException, _typeName, and _HResult fields on the TIE to match what the
-    /// TypeInitializationException(string, Exception) ctor would have done.  Also stamps the
-    /// inner exception's _stackTraceString so that repeated Exception.StackTrace reads return
-    /// the frames captured inside the failing .cctor.
+    /// TypeInitializationException(string, Exception) ctor would have done.
     /// Returns the heap address, the ConcreteTypeHandle, and the updated state.
     let synthesizeTypeInitializationException
         (loggerFactory : ILoggerFactory)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (typeFullName : string)
-        (innerStackTraceString : string)
         (innerExceptionAddr : ManagedHeapAddress)
         (state : IlMachineState)
         : ManagedHeapAddress * ConcreteTypeHandle * IlMachineState
@@ -2311,9 +2308,6 @@ module IlMachineState =
         let typeNameAddr, state =
             allocateManagedString loggerFactory baseClassTypes typeFullName state
 
-        let innerStackTraceAddr, state =
-            allocateManagedString loggerFactory baseClassTypes innerStackTraceString state
-
         // Set _innerException, _typeName and _HResult on the allocated TIE, matching what the
         // TypeInitializationException(string, Exception) ctor would have done.
         // See CLR's EEException::CreateThrowable:
@@ -2331,21 +2325,6 @@ module IlMachineState =
         let state =
             { state with
                 ManagedHeap = ManagedHeap.set addr heapObj state.ManagedHeap
-            }
-
-        // Stamp the inner exception's _stackTraceString with the frames captured inside the
-        // failing .cctor.  The inner exception is never re-caught in its own right (only the
-        // wrapping TIE is surfaced to managed code), so this is our only chance to record
-        // where it was thrown.
-        let innerObj = ManagedHeap.get innerExceptionAddr state.ManagedHeap
-
-        let innerObj =
-            innerObj
-            |> AllocatedNonArrayObject.SetField "_stackTraceString" (CliType.ObjectRef (Some innerStackTraceAddr))
-
-        let state =
-            { state with
-                ManagedHeap = ManagedHeap.set innerExceptionAddr innerObj state.ManagedHeap
             }
 
         addr, tieHandle, state


### PR DESCRIPTION
When a .cctor throws, synthesise the wrapping TIE with its _typeName, _HResult, and _innerException set. This brings the observable shape of the exception closer into line with what the CLR produces, though we still don't give you the StackTrace property.

The ThrowingCctorProperties and ThrowingCctorStackTrace tests are added to unimplementedMockTests: even after setting StackTrace (which we don't do here), the TIE fields are correctly populated, but end-to-end execution hits RuntimeTypeHandle::GetGCHandle (PInvoke) in a deeper BCL path that is not yet implemented.