### PR TITLE
Skip generic-arity mismatches during method overload resolution

### DIFF
--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -1586,25 +1586,34 @@ module IlMachineState =
             let state, availableMethods =
                 ((state, []), availableMethods)
                 ||> List.fold (fun (state, acc) meth ->
-                    let state, methSig =
-                        meth.Signature
-                        |> TypeMethodSignature.map
-                            state
-                            (fun state ty ->
-                                concretizeType
-                                    loggerFactory
-                                    baseClassTypes
-                                    state
-                                    assy.Name
-                                    concreteExtractedTypeArgs
-                                    genericMethodTypeArgs
-                                    ty
-                            )
-
-                    if methSig = memberSig then
-                        state, meth :: acc
-                    else
+                    // A candidate overload whose generic arity doesn't match the call site
+                    // cannot be the target. Reject it up front: concretising its signature
+                    // would otherwise index past the end of `genericMethodTypeArgs` (which
+                    // was sized for `memberSig`) whenever the candidate signature mentions
+                    // a `GenericMethodParameter`. See e.g. Interlocked.CompareExchange,
+                    // where the generic `<T>` overload sits alongside type-specific ones.
+                    if meth.Signature.GenericParameterCount <> memberSig.GenericParameterCount then
                         state, acc
+                    else
+                        let state, methSig =
+                            meth.Signature
+                            |> TypeMethodSignature.map
+                                state
+                                (fun state ty ->
+                                    concretizeType
+                                        loggerFactory
+                                        baseClassTypes
+                                        state
+                                        assy.Name
+                                        concreteExtractedTypeArgs
+                                        genericMethodTypeArgs
+                                        ty
+                                )
+
+                        if methSig = memberSig then
+                            state, meth :: acc
+                        else
+                            state, acc
                 )
 
             let method =


### PR DESCRIPTION
When resolving a MemberRef to a method, the fold over candidate overloads would concretize every candidate's signature using the call site's `genericMethodTypeArgs`. If the candidate had a different generic arity than the call site (e.g. a generic `<T>` overload of Interlocked.CompareExchange sitting alongside the type-specific overloads), substituting its `GenericMethodParameter` indices would index past the end of the array and raise IndexOutOfRangeException.

Filter candidates on `GenericParameterCount` up front, matching the discipline already used in IlMachineStateExecution for interface/self method lookup. This avoids the exception, is strictly more precise (it also rejects ill-formed metadata that would previously have produced IOORE for unrelated reasons), and skips unnecessary concretization work.