### PR TITLE
Add nominal primitive-like struct registry

### DIFF
--- a/WoofWare.PawPrint.Domain/TypeInfo.fs
+++ b/WoofWare.PawPrint.Domain/TypeInfo.fs
@@ -192,6 +192,9 @@ type BaseClassTypes<'corelib> =
         TypedReference : TypeInfo<GenericParamFromMetadata, TypeDefn>
         IntPtr : TypeInfo<GenericParamFromMetadata, TypeDefn>
         UIntPtr : TypeInfo<GenericParamFromMetadata, TypeDefn>
+        /// `System.ByReference` (non-generic in modern corelibs) or `System.ByReference<T>` (older).
+        /// Optional because not every supported corelib exposes it.
+        ByReference : TypeInfo<GenericParamFromMetadata, TypeDefn> option
         Exception : TypeInfo<GenericParamFromMetadata, TypeDefn>
         ArithmeticException : TypeInfo<GenericParamFromMetadata, TypeDefn>
         DivideByZeroException : TypeInfo<GenericParamFromMetadata, TypeDefn>

--- a/WoofWare.PawPrint.Test/TestPrimitiveLikeStructRegistry.fs
+++ b/WoofWare.PawPrint.Test/TestPrimitiveLikeStructRegistry.fs
@@ -1,0 +1,124 @@
+namespace WoofWare.PawPrint.Test
+
+open System.Collections.Immutable
+open System.IO
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+[<TestFixture>]
+module TestPrimitiveLikeStructRegistry =
+
+    let private corelib : DumpedAssembly =
+        let corelibPath = typeof<obj>.Assembly.Location
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use stream = File.OpenRead corelibPath
+        Assembly.read loggerFactory (Some corelibPath) stream
+
+    let private bct : BaseClassTypes<DumpedAssembly> = Corelib.getBaseTypes corelib
+
+    let private mkCt (ti : TypeInfo<GenericParamFromMetadata, TypeDefn>) : ConcreteType<int> =
+        ConcreteType.makeFromIdentity ti.Identity ti.Namespace ti.Name ImmutableArray<int>.Empty
+
+    let private mkCtWithGenerics
+        (ti : TypeInfo<GenericParamFromMetadata, TypeDefn>)
+        (generics : int ImmutableArray)
+        : ConcreteType<int>
+        =
+        ConcreteType.makeFromIdentity ti.Identity ti.Namespace ti.Name generics
+
+    [<Test>]
+    let ``IntPtr flattens to native int`` () : unit =
+        PrimitiveLikeStruct.kind bct (mkCt bct.IntPtr)
+        |> shouldEqual (Some PrimitiveLikeKind.FlattenToNativeInt)
+
+    [<Test>]
+    let ``UIntPtr flattens to native int`` () : unit =
+        PrimitiveLikeStruct.kind bct (mkCt bct.UIntPtr)
+        |> shouldEqual (Some PrimitiveLikeKind.FlattenToNativeInt)
+
+    [<Test>]
+    let ``RuntimeTypeHandle flattens to object ref`` () : unit =
+        PrimitiveLikeStruct.kind bct (mkCt bct.RuntimeTypeHandle)
+        |> shouldEqual (Some PrimitiveLikeKind.FlattenToObjectRef)
+
+    [<Test>]
+    let ``RuntimeMethodHandle flattens to runtime pointer`` () : unit =
+        PrimitiveLikeStruct.kind bct (mkCt bct.RuntimeMethodHandle)
+        |> shouldEqual (Some PrimitiveLikeKind.FlattenToRuntimePointer)
+
+    [<Test>]
+    let ``RuntimeFieldHandle flattens to runtime pointer`` () : unit =
+        PrimitiveLikeStruct.kind bct (mkCt bct.RuntimeFieldHandle)
+        |> shouldEqual (Some PrimitiveLikeKind.FlattenToRuntimePointer)
+
+    [<Test>]
+    let ``RuntimeFieldHandleInternal flattens to runtime pointer`` () : unit =
+        PrimitiveLikeStruct.kind bct (mkCt bct.RuntimeFieldHandleInternal)
+        |> shouldEqual (Some PrimitiveLikeKind.FlattenToRuntimePointer)
+
+    [<Test>]
+    let ``ByReference (if present on this corelib) flattens to managed pointer`` () : unit =
+        match bct.ByReference with
+        | None -> Assert.Inconclusive "corelib under test does not expose System.ByReference"
+        | Some br ->
+            PrimitiveLikeStruct.kind bct (mkCt br)
+            |> shouldEqual (Some PrimitiveLikeKind.FlattenToManagedPointer)
+
+    [<Test>]
+    let ``ByReference matches on definition identity, ignoring generic instantiation`` () : unit =
+        match bct.ByReference with
+        | None -> Assert.Inconclusive "corelib under test does not expose System.ByReference"
+        | Some br ->
+            let generics = ImmutableArray.Create<int> (42)
+
+            PrimitiveLikeStruct.kind bct (mkCtWithGenerics br generics)
+            |> shouldEqual (Some PrimitiveLikeKind.FlattenToManagedPointer)
+
+    [<Test>]
+    let ``String is not primitive-like`` () : unit =
+        PrimitiveLikeStruct.kind bct (mkCt bct.String) |> shouldEqual None
+
+    [<Test>]
+    let ``Int32 is not primitive-like`` () : unit =
+        PrimitiveLikeStruct.kind bct (mkCt bct.Int32) |> shouldEqual None
+
+    [<Test>]
+    let ``Object is not primitive-like`` () : unit =
+        PrimitiveLikeStruct.kind bct (mkCt bct.Object) |> shouldEqual None
+
+    [<Test>]
+    let ``Exception is not primitive-like`` () : unit =
+        PrimitiveLikeStruct.kind bct (mkCt bct.Exception) |> shouldEqual None
+
+    [<Test>]
+    let ``RuntimeType is not primitive-like`` () : unit =
+        PrimitiveLikeStruct.kind bct (mkCt bct.RuntimeType) |> shouldEqual None
+
+    [<Test>]
+    let ``TypedReference is not primitive-like`` () : unit =
+        PrimitiveLikeStruct.kind bct (mkCt bct.TypedReference) |> shouldEqual None
+
+    [<Test>]
+    let ``isPrimitiveLike agrees with kind`` () : unit =
+        let candidates : TypeInfo<GenericParamFromMetadata, TypeDefn> list =
+            [
+                bct.IntPtr
+                bct.UIntPtr
+                bct.RuntimeTypeHandle
+                bct.RuntimeMethodHandle
+                bct.RuntimeFieldHandle
+                bct.RuntimeFieldHandleInternal
+                bct.String
+                bct.Int32
+                bct.Object
+                bct.Exception
+                bct.RuntimeType
+                bct.TypedReference
+            ]
+
+        for ti in candidates do
+            let ct = mkCt ti
+
+            PrimitiveLikeStruct.isPrimitiveLike bct ct
+            |> shouldEqual (PrimitiveLikeStruct.kind bct ct |> Option.isSome)

--- a/WoofWare.PawPrint.Test/TestPrimitiveLikeStructRegistry.fs
+++ b/WoofWare.PawPrint.Test/TestPrimitiveLikeStructRegistry.fs
@@ -43,14 +43,14 @@ module TestPrimitiveLikeStructRegistry =
         |> shouldEqual (Some PrimitiveLikeKind.FlattenToObjectRef)
 
     [<Test>]
-    let ``RuntimeMethodHandle flattens to runtime pointer`` () : unit =
+    let ``RuntimeMethodHandle flattens to object ref`` () : unit =
         PrimitiveLikeStruct.kind bct (mkCt bct.RuntimeMethodHandle)
-        |> shouldEqual (Some PrimitiveLikeKind.FlattenToRuntimePointer)
+        |> shouldEqual (Some PrimitiveLikeKind.FlattenToObjectRef)
 
     [<Test>]
-    let ``RuntimeFieldHandle flattens to runtime pointer`` () : unit =
+    let ``RuntimeFieldHandle flattens to object ref`` () : unit =
         PrimitiveLikeStruct.kind bct (mkCt bct.RuntimeFieldHandle)
-        |> shouldEqual (Some PrimitiveLikeKind.FlattenToRuntimePointer)
+        |> shouldEqual (Some PrimitiveLikeKind.FlattenToObjectRef)
 
     [<Test>]
     let ``RuntimeFieldHandleInternal flattens to runtime pointer`` () : unit =

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -23,6 +23,7 @@
     <Compile Include="TestCrossAssemblyTypeInitialisation.fs" />
     <Compile Include="TestCrossAssemblyCastclass.fs" />
     <Compile Include="TestNativeMethodDetection.fs" />
+    <Compile Include="TestPrimitiveLikeStructRegistry.fs" />
     <Compile Include="TestExceptionHResults.fs" />
     <Compile Include="TestPureCases.fs" />
     <Compile Include="TestImpureCases.fs" />

--- a/WoofWare.PawPrint/Corelib.fs
+++ b/WoofWare.PawPrint/Corelib.fs
@@ -228,9 +228,13 @@ module Corelib =
 type PrimitiveLikeKind =
     /// `System.IntPtr`, `System.UIntPtr` — flattens to `EvalStackValue.NativeInt`.
     | FlattenToNativeInt
-    /// `System.RuntimeTypeHandle` (field `m_type : RuntimeType`) — flattens to `EvalStackValue.ObjectRef`.
+    /// `System.RuntimeTypeHandle` (field `m_type : RuntimeType`),
+    /// `System.RuntimeMethodHandle` (field `m_value : IRuntimeMethodInfo`),
+    /// `System.RuntimeFieldHandle` (field `m_ptr : IRuntimeFieldInfo`) —
+    /// flattens to `EvalStackValue.ObjectRef`. On CoreCLR these handles are ref-backed:
+    /// `ldtoken` imports a managed reference, not a raw pointer.
     | FlattenToObjectRef
-    /// `System.RuntimeMethodHandle`, `System.RuntimeFieldHandle`, `System.RuntimeFieldHandleInternal` —
+    /// `System.RuntimeFieldHandleInternal` (field `m_handle : IntPtr`) —
     /// flattens to a runtime-pointer-valued `EvalStackValue.NativeInt`.
     | FlattenToRuntimePointer
     /// `System.ByReference`/`System.ByReference<T>` — flattens to `EvalStackValue.ManagedPointer`.
@@ -257,9 +261,9 @@ module PrimitiveLikeStruct =
             elif identity = bct.RuntimeTypeHandle.Identity then
                 Some PrimitiveLikeKind.FlattenToObjectRef
             elif identity = bct.RuntimeMethodHandle.Identity then
-                Some PrimitiveLikeKind.FlattenToRuntimePointer
+                Some PrimitiveLikeKind.FlattenToObjectRef
             elif identity = bct.RuntimeFieldHandle.Identity then
-                Some PrimitiveLikeKind.FlattenToRuntimePointer
+                Some PrimitiveLikeKind.FlattenToObjectRef
             elif identity = bct.RuntimeFieldHandleInternal.Identity then
                 Some PrimitiveLikeKind.FlattenToRuntimePointer
             else

--- a/WoofWare.PawPrint/Corelib.fs
+++ b/WoofWare.PawPrint/Corelib.fs
@@ -21,6 +21,20 @@ module Corelib =
         )
         |> Seq.exactlyOne
 
+    let private tryFindCorelibType
+        (corelib : DumpedAssembly)
+        (``namespace`` : string)
+        (names : string list)
+        : TypeInfo<GenericParamFromMetadata, TypeDefn> option
+        =
+        corelib.TypeDefs
+        |> Seq.tryPick (fun (KeyValue (_, v)) ->
+            if v.Namespace = ``namespace`` && List.contains v.Name names then
+                Some v
+            else
+                None
+        )
+
     let getBaseTypes (corelib : DumpedAssembly) : BaseClassTypes<DumpedAssembly> =
         let stringType = findCorelibType corelib "System" "String"
         let arrayType = findCorelibType corelib "System" "Array"
@@ -48,6 +62,9 @@ module Corelib =
         let typedReferenceType = findCorelibType corelib "System" "TypedReference"
         let intPtrType = findCorelibType corelib "System" "IntPtr"
         let uintPtrType = findCorelibType corelib "System" "UIntPtr"
+
+        let byReferenceType =
+            tryFindCorelibType corelib "System" [ "ByReference" ; "ByReference`1" ]
 
         let runtimeFieldInfoStubType =
             findCorelibType corelib "System" "RuntimeFieldInfoStub"
@@ -114,6 +131,7 @@ module Corelib =
             TypedReference = typedReferenceType
             IntPtr = intPtrType
             UIntPtr = uintPtrType
+            ByReference = byReferenceType
             Exception = exceptionType
             ArithmeticException = arithmeticException
             DivideByZeroException = divideByZeroException
@@ -198,3 +216,56 @@ module Corelib =
             ctx
         )
         |> _.ConcreteTypes
+
+/// How a primitive-like BCL struct flattens onto the eval stack.
+///
+/// Several BCL types are nominally `struct { single_field }` at metadata level (so `ldfld`,
+/// reflection, and heap layout see a one-field struct), but the real CLR's JIT treats them
+/// as if they were just the underlying primitive/reference. At the interpreter's eval-stack
+/// boundary we mirror that: storage keeps the wrapped struct form; the stack sees the
+/// flattened primitive form via the kind below.
+[<RequireQualifiedAccess>]
+type PrimitiveLikeKind =
+    /// `System.IntPtr`, `System.UIntPtr` — flattens to `EvalStackValue.NativeInt`.
+    | FlattenToNativeInt
+    /// `System.RuntimeTypeHandle` (field `m_type : RuntimeType`) — flattens to `EvalStackValue.ObjectRef`.
+    | FlattenToObjectRef
+    /// `System.RuntimeMethodHandle`, `System.RuntimeFieldHandle`, `System.RuntimeFieldHandleInternal` —
+    /// flattens to a runtime-pointer-valued `EvalStackValue.NativeInt`.
+    | FlattenToRuntimePointer
+    /// `System.ByReference`/`System.ByReference<T>` — flattens to `EvalStackValue.ManagedPointer`.
+    | FlattenToManagedPointer
+
+[<RequireQualifiedAccess>]
+module PrimitiveLikeStruct =
+    /// Returns `Some kind` if the concrete type is one of the BCL structs whose storage form is a
+    /// single-field wrapper but whose eval-stack form should be the underlying primitive/reference.
+    /// Returns `None` for everything else, including user-defined single-field structs.
+    let kind (bct : BaseClassTypes<DumpedAssembly>) (ct : ConcreteType<'a>) : PrimitiveLikeKind option =
+        if not ct.Generics.IsEmpty then
+            // Only ByReference<T> is generic; match it structurally below if present.
+            match bct.ByReference with
+            | Some br when ct.Identity = br.Identity -> Some PrimitiveLikeKind.FlattenToManagedPointer
+            | _ -> None
+        else
+            let identity = ct.Identity
+
+            if identity = bct.IntPtr.Identity then
+                Some PrimitiveLikeKind.FlattenToNativeInt
+            elif identity = bct.UIntPtr.Identity then
+                Some PrimitiveLikeKind.FlattenToNativeInt
+            elif identity = bct.RuntimeTypeHandle.Identity then
+                Some PrimitiveLikeKind.FlattenToObjectRef
+            elif identity = bct.RuntimeMethodHandle.Identity then
+                Some PrimitiveLikeKind.FlattenToRuntimePointer
+            elif identity = bct.RuntimeFieldHandle.Identity then
+                Some PrimitiveLikeKind.FlattenToRuntimePointer
+            elif identity = bct.RuntimeFieldHandleInternal.Identity then
+                Some PrimitiveLikeKind.FlattenToRuntimePointer
+            else
+                match bct.ByReference with
+                | Some br when identity = br.Identity -> Some PrimitiveLikeKind.FlattenToManagedPointer
+                | _ -> None
+
+    let isPrimitiveLike (bct : BaseClassTypes<DumpedAssembly>) (ct : ConcreteType<'a>) : bool =
+        kind bct ct |> Option.isSome


### PR DESCRIPTION
We've got a couple of functions that interpret "struct with one field" interchangeably with "the field", and this is really nasty. Add a registry so we can distinguish them when the CLR treats them interchangeably.