### PR TITLE
Thread declared ConcreteTypeHandle through CliValueType

### DIFF
--- a/WoofWare.PawPrint/AbstractMachine.fs
+++ b/WoofWare.PawPrint/AbstractMachine.fs
@@ -323,7 +323,8 @@ module AbstractMachine =
                             state
                             runtimeAssemblyTypeHandle
 
-                    let fields = CliValueType.OfFields runtimeAssemblyTypeInfo.Layout allFields
+                    let fields =
+                        CliValueType.OfFields runtimeAssemblyTypeHandle runtimeAssemblyTypeInfo.Layout allFields
 
                     let addr, state =
                         IlMachineState.allocateManagedObject runtimeAssemblyTypeHandle fields state

--- a/WoofWare.PawPrint/BasicCliType.fs
+++ b/WoofWare.PawPrint/BasicCliType.fs
@@ -305,12 +305,19 @@ and CliConcreteField =
 and CliValueType =
     private
         {
+            /// Do not use directly; use the `.Declared` accessor.
+            /// Identifies the declared CLR type of this value (e.g. `System.IntPtr`,
+            /// `System.RuntimeTypeHandle`, or a user struct). Used at the eval-stack boundary to
+            /// decide primitive-like flattening via `PrimitiveLikeStruct.kind`.
+            _Declared : ConcreteTypeHandle
             _Fields : CliConcreteField list
             Layout : Layout
             /// We track dependency orderings between updates to overlapping fields with a monotonically increasing
             /// timestamp.
             NextTimestamp : uint64
         }
+
+    member this.Declared : ConcreteTypeHandle = this._Declared
 
     static member private ComputeConcreteFields (layout : Layout) (fields : CliField list) : CliConcreteField list =
         // Minimum size only matters for `sizeof` computation
@@ -391,10 +398,11 @@ and CliValueType =
 
         bytes
 
-    static member OfFields (layout : Layout) (f : CliField list) : CliValueType =
+    static member OfFields (declared : ConcreteTypeHandle) (layout : Layout) (f : CliField list) : CliValueType =
         let fields = CliValueType.ComputeConcreteFields layout f
 
         {
+            _Declared = declared
             _Fields = fields
             Layout = layout
             NextTimestamp = 1UL
@@ -437,6 +445,7 @@ and CliValueType =
             )
 
         {
+            _Declared = vt._Declared
             _Fields = newFields
             Layout = vt.Layout
             NextTimestamp = vt.NextTimestamp + 1UL
@@ -536,6 +545,7 @@ and CliValueType =
     /// `DereferenceField` handles resolving conflicts between overlapping fields.
     static member WithFieldSet (field : string) (value : CliType) (cvt : CliValueType) : CliValueType =
         {
+            _Declared = cvt._Declared
             Layout = cvt.Layout
             _Fields =
                 cvt._Fields
@@ -615,6 +625,10 @@ module CliType =
         | PrimitiveType.String -> CliType.ObjectRef None
         | PrimitiveType.TypedReference -> failwith "todo"
         | PrimitiveType.IntPtr ->
+            let intPtrHandle =
+                AllConcreteTypes.findExistingNonGenericConcreteType concreteTypes corelib.IntPtr.Identity
+                |> Option.get
+
             {
                 Name = "_value"
                 Contents =
@@ -622,14 +636,16 @@ module CliType =
                         CliNumericType.NativeInt (NativeIntSource.ManagedPointer ManagedPointerSource.Null)
                     )
                 Offset = None
-                Type =
-                    AllConcreteTypes.findExistingNonGenericConcreteType concreteTypes corelib.IntPtr.Identity
-                    |> Option.get
+                Type = intPtrHandle
             }
             |> List.singleton
-            |> CliValueType.OfFields Layout.Default
+            |> CliValueType.OfFields intPtrHandle Layout.Default
             |> CliType.ValueType
         | PrimitiveType.UIntPtr ->
+            let uintPtrHandle =
+                AllConcreteTypes.findExistingNonGenericConcreteType concreteTypes corelib.UIntPtr.Identity
+                |> Option.get
+
             {
                 Name = "_value"
                 Contents =
@@ -637,12 +653,10 @@ module CliType =
                         CliNumericType.NativeInt (NativeIntSource.ManagedPointer ManagedPointerSource.Null)
                     )
                 Offset = None
-                Type =
-                    AllConcreteTypes.findExistingNonGenericConcreteType concreteTypes corelib.UIntPtr.Identity
-                    |> Option.get
+                Type = uintPtrHandle
             }
             |> List.singleton
-            |> CliValueType.OfFields Layout.Default
+            |> CliValueType.OfFields uintPtrHandle Layout.Default
             |> CliType.ValueType
         | PrimitiveType.Object -> CliType.ObjectRef None
 
@@ -814,7 +828,7 @@ module CliType =
                         Type = fieldHandle
                     }
                 )
-                |> CliValueType.OfFields typeDef.Layout
+                |> CliValueType.OfFields handle typeDef.Layout
 
             CliType.ValueType vt, currentConcreteTypes
         else

--- a/WoofWare.PawPrint/Corelib.fs
+++ b/WoofWare.PawPrint/Corelib.fs
@@ -273,3 +273,15 @@ module PrimitiveLikeStruct =
 
     let isPrimitiveLike (bct : BaseClassTypes<DumpedAssembly>) (ct : ConcreteType<'a>) : bool =
         kind bct ct |> Option.isSome
+
+    /// Resolve a `ConcreteTypeHandle` through `AllConcreteTypes` and classify it via `kind`.
+    /// Returns `None` if the handle does not resolve or the type is not primitive-like.
+    let kindFromHandle
+        (bct : BaseClassTypes<DumpedAssembly>)
+        (allCt : AllConcreteTypes)
+        (h : ConcreteTypeHandle)
+        : PrimitiveLikeKind option
+        =
+        match AllConcreteTypes.lookup h allCt with
+        | None -> None
+        | Some ct -> kind bct ct

--- a/WoofWare.PawPrint/EvalStack.fs
+++ b/WoofWare.PawPrint/EvalStack.fs
@@ -290,12 +290,12 @@ module EvalStackValue =
             match popped with
             | EvalStackValue.UserDefinedValueType popped' ->
                 match CliValueType.TrySequentialFields vt, CliValueType.TrySequentialFields popped' with
-                | Some vt, Some popped ->
-                    if vt.Length <> popped.Length then
+                | Some vtFields, Some popped ->
+                    if vtFields.Length <> popped.Length then
                         failwith
-                            $"mismatch: popped value type {popped} (length %i{popped.Length}) into {vt} (length %i{vt.Length})"
+                            $"mismatch: popped value type {popped} (length %i{popped.Length}) into {vtFields} (length %i{vtFields.Length})"
 
-                    (vt, popped)
+                    (vtFields, popped)
                     ||> List.map2 (fun field1 popped ->
                         if field1.Name <> popped.Name then
                             failwith $"TODO: name mismatch, {field1.Name} vs {popped.Name}"
@@ -312,7 +312,7 @@ module EvalStackValue =
                             Type = field1.Type
                         }
                     )
-                    |> CliValueType.OfFields popped'.Layout
+                    |> CliValueType.OfFields vt.Declared popped'.Layout
                     |> CliType.ValueType
                 | _, _ -> failwith "TODO: overlapping fields going onto eval stack"
             | popped ->

--- a/WoofWare.PawPrint/ExceptionDispatching.fs
+++ b/WoofWare.PawPrint/ExceptionDispatching.fs
@@ -445,7 +445,7 @@ module ExceptionDispatching =
         let state, allFields =
             IlMachineState.collectAllInstanceFields loggerFactory baseClassTypes state exnHandle
 
-        let fields = CliValueType.OfFields exceptionTypeInfo.Layout allFields
+        let fields = CliValueType.OfFields exnHandle exceptionTypeInfo.Layout allFields
 
         let addr, state = IlMachineState.allocateManagedObject exnHandle fields state
 

--- a/WoofWare.PawPrint/FieldHandleRegistry.fs
+++ b/WoofWare.PawPrint/FieldHandleRegistry.fs
@@ -65,7 +65,9 @@ module FieldHandleRegistry =
                 Type = AllConcreteTypes.getRequiredNonGenericHandle allConcreteTypes baseClassTypes.RuntimeFieldInfoStub
             }
             |> List.singleton
-            |> CliValueType.OfFields Layout.Default
+            |> CliValueType.OfFields
+                (AllConcreteTypes.getRequiredNonGenericHandle allConcreteTypes baseClassTypes.RuntimeFieldHandle)
+                Layout.Default
             |> CliType.ValueType
 
         let handle =
@@ -99,7 +101,9 @@ module FieldHandleRegistry =
                 Type = AllConcreteTypes.getRequiredNonGenericHandle allConcreteTypes baseClassTypes.IntPtr
             }
             |> List.singleton
-            |> CliValueType.OfFields Layout.Default
+            |> CliValueType.OfFields
+                (AllConcreteTypes.getRequiredNonGenericHandle allConcreteTypes baseClassTypes.RuntimeFieldHandleInternal)
+                Layout.Default
             |> CliType.ValueType
 
         // https://github.com/dotnet/runtime/blob/1d1bf92fcf43aa6981804dc53c5174445069c9e4/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs#L1074
@@ -154,7 +158,9 @@ module FieldHandleRegistry =
                             baseClassTypes.RuntimeFieldHandleInternal
                 }
             ]
-            |> CliValueType.OfFields Layout.Default // explicitly sequential but no custom packing size
+            |> CliValueType.OfFields
+                (AllConcreteTypes.getRequiredNonGenericHandle allConcreteTypes baseClassTypes.RuntimeFieldInfoStub)
+                Layout.Default // explicitly sequential but no custom packing size
 
         let alloc, state = allocate runtimeFieldInfoStub allocState
 

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -2256,6 +2256,16 @@ module IlMachineState =
         let dataAddr, state = allocateStringData contents.Length state
         let state = setStringData dataAddr contents state
 
+        let state, stringType =
+            DumpedAssembly.typeInfoToTypeDefn' baseClassTypes state._LoadedAssemblies baseClassTypes.String
+            |> concretizeType
+                loggerFactory
+                baseClassTypes
+                state
+                baseClassTypes.Corelib.Name
+                ImmutableArray.Empty
+                ImmutableArray.Empty
+
         let fields =
             [
                 {
@@ -2271,17 +2281,7 @@ module IlMachineState =
                     Type = AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes baseClassTypes.Int32
                 }
             ]
-            |> CliValueType.OfFields Layout.Default
-
-        let state, stringType =
-            DumpedAssembly.typeInfoToTypeDefn' baseClassTypes state._LoadedAssemblies baseClassTypes.String
-            |> concretizeType
-                loggerFactory
-                baseClassTypes
-                state
-                baseClassTypes.Corelib.Name
-                ImmutableArray.Empty
-                ImmutableArray.Empty
+            |> CliValueType.OfFields stringType Layout.Default
 
         let addr, state = allocateManagedObject stringType fields state
 
@@ -2323,7 +2323,7 @@ module IlMachineState =
         let state, allFields =
             collectAllInstanceFields loggerFactory baseClassTypes state tieHandle
 
-        let fields = CliValueType.OfFields tieTypeInfo.Layout allFields
+        let fields = CliValueType.OfFields tieHandle tieTypeInfo.Layout allFields
 
         let addr, state = allocateManagedObject tieHandle fields state
 

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -162,6 +162,19 @@ module Intrinsics =
                 go arg
 
             let state =
+                let state, runtimeTypeHandleHandle =
+                    DumpedAssembly.typeInfoToTypeDefn'
+                        baseClassTypes
+                        state._LoadedAssemblies
+                        baseClassTypes.RuntimeTypeHandle
+                    |> IlMachineState.concretizeType
+                        loggerFactory
+                        baseClassTypes
+                        state
+                        baseClassTypes.Corelib.Name
+                        ImmutableArray.Empty
+                        ImmutableArray.Empty
+
                 let vt =
                     // https://github.com/dotnet/runtime/blob/2b21c73fa2c32fa0195e4a411a435dda185efd08/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs#L92
                     {
@@ -175,12 +188,7 @@ module Intrinsics =
                             |> Option.get
                     }
                     |> List.singleton
-                    |> CliValueType.OfFields
-                        (AllConcreteTypes.findExistingNonGenericConcreteType
-                            state.ConcreteTypes
-                            baseClassTypes.RuntimeTypeHandle.Identity
-                         |> Option.get)
-                        Layout.Default
+                    |> CliValueType.OfFields runtimeTypeHandleHandle Layout.Default
 
                 IlMachineState.pushToEvalStack (CliType.ValueType vt) currentThread state
                 |> IlMachineState.advanceProgramCounter currentThread

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -175,7 +175,12 @@ module Intrinsics =
                             |> Option.get
                     }
                     |> List.singleton
-                    |> CliValueType.OfFields Layout.Default
+                    |> CliValueType.OfFields
+                        (AllConcreteTypes.findExistingNonGenericConcreteType
+                            state.ConcreteTypes
+                            baseClassTypes.RuntimeTypeHandle.Identity
+                         |> Option.get)
+                        Layout.Default
 
                 IlMachineState.pushToEvalStack (CliType.ValueType vt) currentThread state
                 |> IlMachineState.advanceProgramCounter currentThread

--- a/WoofWare.PawPrint/TypeHandleRegistry.fs
+++ b/WoofWare.PawPrint/TypeHandleRegistry.fs
@@ -65,7 +65,9 @@ module TypeHandleRegistry =
                     Type = AllConcreteTypes.getRequiredNonGenericHandle allConcreteTypes corelib.Int32
                 }
             ]
-            |> CliValueType.OfFields Layout.Default
+            |> CliValueType.OfFields
+                (AllConcreteTypes.getRequiredNonGenericHandle allConcreteTypes corelib.RuntimeType)
+                Layout.Default
 
         let alloc, state = allocate fields allocState
 

--- a/WoofWare.PawPrint/UnaryMetadataIlOp.fs
+++ b/WoofWare.PawPrint/UnaryMetadataIlOp.fs
@@ -387,7 +387,7 @@ module internal UnaryMetadataIlOp =
             let state, allFields =
                 IlMachineState.collectAllInstanceFields loggerFactory baseClassTypes state declaringTypeHandle
 
-            let fields = CliValueType.OfFields ctorType.Layout allFields
+            let fields = CliValueType.OfFields declaringTypeHandle ctorType.Layout allFields
 
             // Note: this is a bit unorthodox for value types, which *aren't* heap-allocated.
             // We'll perform their construction on the heap, though, to keep the interface
@@ -584,7 +584,9 @@ module internal UnaryMetadataIlOp =
                                             state, cliField :: acc
                                         )
 
-                                    List.rev fieldValues |> CliValueType.OfFields underlyingDefn.Layout, state
+                                    List.rev fieldValues
+                                    |> CliValueType.OfFields underlyingTypeHandle underlyingDefn.Layout,
+                                    state
 
                             let addr, state =
                                 IlMachineState.allocateManagedObject underlyingTypeHandle cvt state
@@ -634,7 +636,8 @@ module internal UnaryMetadataIlOp =
                                     state, cliField :: acc
                                 )
 
-                            let cvt = List.rev fieldValues |> CliValueType.OfFields defn.Layout
+                            let cvt = List.rev fieldValues |> CliValueType.OfFields typeHandle defn.Layout
+
                             cvt, state
 
                     let addr, state = IlMachineState.allocateManagedObject typeHandle cvt state
@@ -1661,7 +1664,11 @@ module internal UnaryMetadataIlOp =
                             AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes baseClassTypes.RuntimeType
                     }
                     |> List.singleton
-                    |> CliValueType.OfFields Layout.Default
+                    |> CliValueType.OfFields
+                        (AllConcreteTypes.getRequiredNonGenericHandle
+                            state.ConcreteTypes
+                            baseClassTypes.RuntimeTypeHandle)
+                        Layout.Default
 
                 IlMachineState.pushToEvalStack (CliType.ValueType vt) thread state
 
@@ -1722,7 +1729,11 @@ module internal UnaryMetadataIlOp =
                                     baseClassTypes.RuntimeType
                         }
                         |> List.singleton
-                        |> CliValueType.OfFields Layout.Default
+                        |> CliValueType.OfFields
+                            (AllConcreteTypes.getRequiredNonGenericHandle
+                                state.ConcreteTypes
+                                baseClassTypes.RuntimeTypeHandle)
+                            Layout.Default
 
                     IlMachineState.pushToEvalStack (CliType.ValueType vt) thread state
                 | MetadataToken.TypeDefinition h ->

--- a/WoofWare.PawPrint/UnaryMetadataIlOp.fs
+++ b/WoofWare.PawPrint/UnaryMetadataIlOp.fs
@@ -1654,6 +1654,19 @@ module internal UnaryMetadataIlOp =
                 let alloc, state =
                     IlMachineState.getOrAllocateType loggerFactory baseClassTypes handle state
 
+                let state, runtimeTypeHandleHandle =
+                    DumpedAssembly.typeInfoToTypeDefn'
+                        baseClassTypes
+                        state._LoadedAssemblies
+                        baseClassTypes.RuntimeTypeHandle
+                    |> IlMachineState.concretizeType
+                        loggerFactory
+                        baseClassTypes
+                        state
+                        baseClassTypes.Corelib.Name
+                        ImmutableArray.Empty
+                        ImmutableArray.Empty
+
                 let vt =
                     // https://github.com/dotnet/runtime/blob/2b21c73fa2c32fa0195e4a411a435dda185efd08/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs#L92
                     {
@@ -1664,11 +1677,7 @@ module internal UnaryMetadataIlOp =
                             AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes baseClassTypes.RuntimeType
                     }
                     |> List.singleton
-                    |> CliValueType.OfFields
-                        (AllConcreteTypes.getRequiredNonGenericHandle
-                            state.ConcreteTypes
-                            baseClassTypes.RuntimeTypeHandle)
-                        Layout.Default
+                    |> CliValueType.OfFields runtimeTypeHandleHandle Layout.Default
 
                 IlMachineState.pushToEvalStack (CliType.ValueType vt) thread state
 
@@ -1718,6 +1727,19 @@ module internal UnaryMetadataIlOp =
                     let alloc, state =
                         IlMachineState.getOrAllocateType loggerFactory baseClassTypes handle state
 
+                    let state, runtimeTypeHandleHandle =
+                        DumpedAssembly.typeInfoToTypeDefn'
+                            baseClassTypes
+                            state._LoadedAssemblies
+                            baseClassTypes.RuntimeTypeHandle
+                        |> IlMachineState.concretizeType
+                            loggerFactory
+                            baseClassTypes
+                            state
+                            baseClassTypes.Corelib.Name
+                            ImmutableArray.Empty
+                            ImmutableArray.Empty
+
                     let vt =
                         {
                             Name = "m_type"
@@ -1729,11 +1751,7 @@ module internal UnaryMetadataIlOp =
                                     baseClassTypes.RuntimeType
                         }
                         |> List.singleton
-                        |> CliValueType.OfFields
-                            (AllConcreteTypes.getRequiredNonGenericHandle
-                                state.ConcreteTypes
-                                baseClassTypes.RuntimeTypeHandle)
-                            Layout.Default
+                        |> CliValueType.OfFields runtimeTypeHandleHandle Layout.Default
 
                     IlMachineState.pushToEvalStack (CliType.ValueType vt) thread state
                 | MetadataToken.TypeDefinition h ->


### PR DESCRIPTION
## Summary

Scaffolding for PR 2 of the phased plan to eliminate `CliValueType.TryExactlyOneField` in favour of a nominal primitive-like struct registry.

- Adds a required `_Declared : ConcreteTypeHandle` field to `CliValueType` so primitive-likeness can be detected locally from a value, without threading `(BaseClassTypes, AllConcreteTypes)` through every consumer.
- Updates all 18 `CliValueType.OfFields` call sites to pass the declared handle.
- Adds `PrimitiveLikeStruct.kindFromHandle` — a small helper that resolves a `ConcreteTypeHandle` through `AllConcreteTypes` and delegates to `kind`.

Zero behaviour change. This PR lands the prerequisites so the follow-up flatten/rewrap migration (teach `ofCliType` to flatten primitive-like structs onto the eval stack, `toCliTypeCoerced` to rewrap) stays small and reviewable.

## Test plan

- [x] `nix develop -c dotnet build` clean (warnings-as-errors)
- [x] `nix develop -c dotnet test` — 194 tests pass
- [x] `nix develop -c dotnet fantomas .` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)