### PR TITLE
Implement Thread.GetCurrentThreadNative (stage 1 threading)

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/ThreadCurrentThread.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/ThreadCurrentThread.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+
+namespace HelloWorldApp
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            Thread t1 = Thread.CurrentThread;
+            if (t1 == null) return 1;
+
+            Thread t2 = Thread.CurrentThread;
+            if (!object.ReferenceEquals(t1, t2)) return 2;
+
+            return 0;
+        }
+    }
+}

--- a/WoofWare.PawPrint/AbstractMachine.fs
+++ b/WoofWare.PawPrint/AbstractMachine.fs
@@ -350,6 +350,22 @@ module AbstractMachine =
 
                     (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
                 | "System.Private.CoreLib",
+                  "System.Threading",
+                  "Thread",
+                  "GetCurrentThreadNative",
+                  [],
+                  ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                                    "System.Threading",
+                                                    "Thread",
+                                                    threadGenerics) when threadGenerics.IsEmpty ->
+                    let addr, state =
+                        IlMachineState.getOrAllocateManagedThreadObject loggerFactory baseClassTypes thread state
+
+                    let state =
+                        IlMachineState.pushToEvalStack (CliType.ObjectRef (Some addr)) thread state
+
+                    (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+                | "System.Private.CoreLib",
                   "System",
                   "Type",
                   "GetField",

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -2338,7 +2338,7 @@ module IlMachineState =
         let state, allFields =
             collectAllInstanceFields loggerFactory baseClassTypes state threadTypeHandle
 
-        let fields = CliValueType.OfFields threadTypeInfo.Layout allFields
+        let fields = CliValueType.OfFields threadTypeHandle threadTypeInfo.Layout allFields
 
         let addr, state = allocateManagedObject threadTypeHandle fields state
 

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -2299,9 +2299,11 @@ module IlMachineState =
 
     /// Return the managed `System.Threading.Thread` heap object corresponding to the given guest
     /// thread, allocating it on first request and caching the address thereafter so that repeated
-    /// calls yield reference-identical objects. Only `_managedThreadId` is populated (from the
-    /// `ThreadId` integer); other Thread fields remain zero-initialised and the Thread constructor
-    /// is NOT run.
+    /// calls yield reference-identical objects. Populates only the fields whose zero-initialised
+    /// defaults would observably diverge from the CLR: `_managedThreadId` (0 is the CLR's
+    /// "no managed thread" sentinel, so we offset the interpreter's `ThreadId` by 1) and
+    /// `_priority` (CLR exposes `ThreadPriority.Normal = 2`, not zero-valued `Lowest`). The Thread
+    /// constructor is NOT run; other fields remain zero-initialised.
     let getOrAllocateManagedThreadObject
         (loggerFactory : ILoggerFactory)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
@@ -2341,10 +2343,17 @@ module IlMachineState =
         let addr, state = allocateManagedObject threadTypeHandle fields state
 
         let (ThreadId idx) = threadId
+        let managedThreadId = idx + 1
+        let threadPriorityNormal = 2
 
         let updatedObj =
             ManagedHeap.get addr state.ManagedHeap
-            |> AllocatedNonArrayObject.SetField "_managedThreadId" (CliType.Numeric (CliNumericType.Int32 idx))
+            |> AllocatedNonArrayObject.SetField
+                "_managedThreadId"
+                (CliType.Numeric (CliNumericType.Int32 managedThreadId))
+            |> AllocatedNonArrayObject.SetField
+                "_priority"
+                (CliType.Numeric (CliNumericType.Int32 threadPriorityNormal))
 
         let state =
             { state with

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -33,6 +33,10 @@ type IlMachineState =
         /// Cache of RuntimeAssembly heap objects keyed by assembly full name, so that
         /// two types from the same assembly return the same Assembly object (reference identity).
         RuntimeAssemblyObjects : ImmutableDictionary<string, ManagedHeapAddress>
+        /// Cache of managed `System.Threading.Thread` heap objects, one per ThreadId, so that
+        /// `Thread.CurrentThread` returns a reference-identical object on repeated access from
+        /// the same guest thread.
+        ManagedThreadObjects : Map<ThreadId, ManagedHeapAddress>
     }
 
     member this.WithTypeBeginInit (thread : ThreadId) (ty : ConcreteTypeHandle) =
@@ -1299,6 +1303,7 @@ module IlMachineState =
                 TypeHandles = TypeHandleRegistry.empty ()
                 FieldHandles = FieldHandleRegistry.empty ()
                 RuntimeAssemblyObjects = ImmutableDictionary.Empty
+                ManagedThreadObjects = Map.empty
             }
 
         state.WithLoadedAssembly assyName entryAssembly
@@ -2288,6 +2293,63 @@ module IlMachineState =
         let state =
             { state with
                 ManagedHeap = ManagedHeap.recordStringContents addr contents state.ManagedHeap
+            }
+
+        addr, state
+
+    /// Return the managed `System.Threading.Thread` heap object corresponding to the given guest
+    /// thread, allocating it on first request and caching the address thereafter so that repeated
+    /// calls yield reference-identical objects. Only `_managedThreadId` is populated (from the
+    /// `ThreadId` integer); other Thread fields remain zero-initialised and the Thread constructor
+    /// is NOT run.
+    let getOrAllocateManagedThreadObject
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (threadId : ThreadId)
+        (state : IlMachineState)
+        : ManagedHeapAddress * IlMachineState
+        =
+        match state.ManagedThreadObjects.TryFind threadId with
+        | Some addr -> addr, state
+        | None ->
+
+        let threadTypeInfo =
+            baseClassTypes.Corelib.TypeDefs
+            |> Seq.choose (fun (KeyValue (_, v)) ->
+                if v.Namespace = "System.Threading" && v.Name = "Thread" then
+                    Some v
+                else
+                    None
+            )
+            |> Seq.exactlyOne
+
+        let state, threadTypeHandle =
+            DumpedAssembly.typeInfoToTypeDefn' baseClassTypes state._LoadedAssemblies threadTypeInfo
+            |> concretizeType
+                loggerFactory
+                baseClassTypes
+                state
+                baseClassTypes.Corelib.Name
+                ImmutableArray.Empty
+                ImmutableArray.Empty
+
+        let state, allFields =
+            collectAllInstanceFields loggerFactory baseClassTypes state threadTypeHandle
+
+        let fields = CliValueType.OfFields threadTypeInfo.Layout allFields
+
+        let addr, state = allocateManagedObject threadTypeHandle fields state
+
+        let (ThreadId idx) = threadId
+
+        let updatedObj =
+            ManagedHeap.get addr state.ManagedHeap
+            |> AllocatedNonArrayObject.SetField "_managedThreadId" (CliType.Numeric (CliNumericType.Int32 idx))
+
+        let state =
+            { state with
+                ManagedHeap = ManagedHeap.set addr updatedObj state.ManagedHeap
+                ManagedThreadObjects = state.ManagedThreadObjects |> Map.add threadId addr
             }
 
         addr, state


### PR DESCRIPTION
## Summary
- Adds `System.Threading.Thread.GetCurrentThreadNative` InternalCall, making `Thread.CurrentThread` return a real managed `Thread` object.
- New `IlMachineState.ManagedThreadObjects` cache guarantees reference identity across calls from the same guest thread.
- Only `_managedThreadId` (CLR reserves 0, so exposed IDs are `ThreadId + 1`) and `_priority` (set to `Normal = 2` to avoid defaulting to `Lowest`) are populated; the Thread constructor is not run.

This is the first step toward the project's deterministic-concurrency goal. The scheduler itself (per-instruction interleaving, observable-side-effect yield heuristic, eventually Antithesis-style constrained search) is not touched here.

### Out of scope (left for follow-ups)
- `_DONT_USE_InternalThread` is zero, so `ThreadState` / `IsBackground` / `IsAlive` still throw — they need the native-thread emulation layer plus their own InternalCall/QCall wiring.
- `ManagedThreadId` getter is `[Intrinsic]`-marked and still hits the "unimplemented JIT intrinsic" failwith in `Intrinsics.call`.

## Test plan
- [x] New `ThreadCurrentThread.cs` test verifies non-null + reference identity across two `Thread.CurrentThread` calls.
- [x] Full suite (`dotnet test`) still green — 195/195.
- [x] `codex review --base main` — findings on CLR-reserved id 0 and default priority addressed; remaining `_DONT_USE_InternalThread` finding deferred to the next stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)