### PR TITLE
Mark Thread.get_ManagedThreadId as safe intrinsic

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/ThreadManagedThreadId.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/ThreadManagedThreadId.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+
+namespace HelloWorldApp
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            int id1 = Thread.CurrentThread.ManagedThreadId;
+            if (id1 <= 0) return 1;
+
+            int id2 = Thread.CurrentThread.ManagedThreadId;
+            if (id1 != id2) return 2;
+
+            return 0;
+        }
+    }
+}

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -29,6 +29,8 @@ module Intrinsics =
             "System.Private.CoreLib", "Buffer", "Memmove"
             // https://github.com/dotnet/runtime/blob/1c3221b63340d7f81dfd829f3bcd822e582324f6/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs#L799
             "System.Private.CoreLib", "Thread", "get_CurrentThread"
+            // IL body is `ldarg.0; ldfld _managedThreadId; ret` — pure field access.
+            "System.Private.CoreLib", "Thread", "get_ManagedThreadId"
         ]
         |> Set.ofList
 


### PR DESCRIPTION
## Summary
- Adds `Thread.get_ManagedThreadId` to `safeIntrinsics` in `Intrinsics.fs`, allowing the IL body (`ldarg.0; ldfld _managedThreadId; ret`) to execute rather than hitting the "unimplemented JIT intrinsic" failwith.
- New `ThreadManagedThreadId.cs` test verifies the ID is positive and stable across repeated access.

Stage 2 follow-up to #215 (Thread.GetCurrentThreadNative).

## Test plan
- [x] `ThreadManagedThreadId.cs` passes — ID > 0 and consistent across calls.
- [x] Full suite 197/197 green.
- [x] `codex review --base main` — no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)