### PR TITLE
Accept nativeint offsets in managed-pointer arithmetic (PR A.5)

### DIFF
--- a/WoofWare.PawPrint/BinaryArithmetic.fs
+++ b/WoofWare.PawPrint/BinaryArithmetic.fs
@@ -341,6 +341,7 @@ module BinaryArithmetic =
                             $"managed pointer arithmetic (%s{op.Name}): nativeint offset does not fit in int32: %d{n}"
 
                     int32<int64> n
+                | NativeIntSource.ManagedPointer ManagedPointerSource.Null -> 0
                 | v ->
                     failwith
                         $"managed pointer arithmetic (%s{op.Name}): refusing to use non-verbatim native int %O{v} as pointer offset"
@@ -360,6 +361,7 @@ module BinaryArithmetic =
                             $"managed pointer arithmetic (%s{op.Name}): nativeint offset does not fit in int32: %d{n}"
 
                     int32<int64> n
+                | NativeIntSource.ManagedPointer ManagedPointerSource.Null -> 0
                 | v ->
                     failwith
                         $"managed pointer arithmetic (%s{op.Name}): refusing to use non-verbatim native int %O{v} as pointer offset"

--- a/WoofWare.PawPrint/BinaryArithmetic.fs
+++ b/WoofWare.PawPrint/BinaryArithmetic.fs
@@ -333,12 +333,40 @@ module BinaryArithmetic =
             |> NativeIntSource.Verbatim
             |> EvalStackValue.NativeInt
         | EvalStackValue.NativeInt val1, EvalStackValue.ManagedPointer val2 ->
-            failwith "" |> EvalStackValue.ManagedPointer
+            let val1 =
+                match val1 with
+                | NativeIntSource.Verbatim n ->
+                    if n > int64<int32> System.Int32.MaxValue || n < int64<int32> System.Int32.MinValue then
+                        failwith
+                            $"managed pointer arithmetic (%s{op.Name}): nativeint offset does not fit in int32: %d{n}"
+
+                    int32<int64> n
+                | v ->
+                    failwith
+                        $"managed pointer arithmetic (%s{op.Name}): refusing to use non-verbatim native int %O{v} as pointer offset"
+
+            match op.Int32ManagedPtr state val1 val2 with
+            | Choice1Of2 v -> EvalStackValue.ManagedPointer v
+            | Choice2Of2 i -> EvalStackValue.NativeInt (NativeIntSource.Verbatim (int64<int32> i))
         | EvalStackValue.NativeInt val1, EvalStackValue.ObjectRef val2 -> failwith "" |> EvalStackValue.ObjectRef
         | EvalStackValue.NativeInt _, EvalStackValue.NullObjectRef -> failwith ""
         | EvalStackValue.Float val1, EvalStackValue.Float val2 -> op.FloatFloat val1 val2 |> EvalStackValue.Float
         | EvalStackValue.ManagedPointer val1, EvalStackValue.NativeInt val2 ->
-            failwith "" |> EvalStackValue.ManagedPointer
+            let val2 =
+                match val2 with
+                | NativeIntSource.Verbatim n ->
+                    if n > int64<int32> System.Int32.MaxValue || n < int64<int32> System.Int32.MinValue then
+                        failwith
+                            $"managed pointer arithmetic (%s{op.Name}): nativeint offset does not fit in int32: %d{n}"
+
+                    int32<int64> n
+                | v ->
+                    failwith
+                        $"managed pointer arithmetic (%s{op.Name}): refusing to use non-verbatim native int %O{v} as pointer offset"
+
+            match op.ManagedPtrInt32 state val1 val2 with
+            | Choice1Of2 result -> EvalStackValue.ManagedPointer result
+            | Choice2Of2 result -> EvalStackValue.NativeInt (NativeIntSource.Verbatim (int64<int32> result))
         | EvalStackValue.ObjectRef val1, EvalStackValue.NativeInt val2 -> failwith "" |> EvalStackValue.ObjectRef
         | EvalStackValue.NullObjectRef, EvalStackValue.NativeInt _ -> failwith ""
         | EvalStackValue.ManagedPointer val1, EvalStackValue.Int32 val2 ->


### PR DESCRIPTION
## Summary

- `Unsafe.Add<T>(ref T, int)` IL expands to `sizeof * conv.i * mul * add`, producing a managed-pointer `add` against a `nativeint` operand. The `execute` dispatch previously threw `failwith \"\"` for `NativeInt + ManagedPointer` and `ManagedPointer + NativeInt`; now it narrows the nativeint to int32 (with an explicit range check) and routes through the existing `Int32ManagedPtr` / `ManagedPtrInt32` ops.
- Treats `NativeIntSource.ManagedPointer ManagedPointerSource.Null` as a zero offset, since that is the interpreter's representation of a default-initialized `IntPtr`/`UIntPtr` slot (per codex review feedback).
- No `IArithmeticOperation` interface change.

Part of the Memmove plan in `docs/plans/2026-04-20-memmove.md` (PR A.5 prerequisite for PRs B / C). Per instructions, correctness is argued rather than tested — `Unsafe.Add` is still intercepted as an intrinsic today (PR #200), so this path is exercised only once the rest of the byte-view machinery starts running real IL.

## Test plan

- [x] `dotnet build` — clean
- [x] `codex review --base main` — clean after addressing its P2 on `ManagedPointer Null`