### PR TITLE
Replace TryExactlyOneField with nominal PrimitiveLikeField

### DIFF
--- a/WoofWare.PawPrint.Test/TestEvalStackPrimitiveLikeBoundary.fs
+++ b/WoofWare.PawPrint.Test/TestEvalStackPrimitiveLikeBoundary.fs
@@ -153,12 +153,9 @@ module TestEvalStackPrimitiveLikeBoundary =
         | CliType.ValueType vt ->
             vt.PrimitiveLikeKind |> shouldEqual (Some PrimitiveLikeKind.FlattenToNativeInt)
 
-            match CliValueType.TryExactlyOneField vt with
-            | Some field ->
-                match field.Contents with
-                | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim 1234L)) -> ()
-                | other -> failwithf "Expected wrapped NativeInt 1234, got %A" other
-            | None -> failwith "rewrapped IntPtr had no single field"
+            match (CliValueType.PrimitiveLikeField vt).Contents with
+            | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim 1234L)) -> ()
+            | other -> failwithf "Expected wrapped NativeInt 1234, got %A" other
         | other -> failwithf "Expected CliType.ValueType after rewrap, got %A" other
 
     // -- RuntimeTypeHandle (flattens to ObjectRef) ------------------------------------------
@@ -196,12 +193,9 @@ module TestEvalStackPrimitiveLikeBoundary =
         | CliType.ValueType vt ->
             vt.PrimitiveLikeKind |> shouldEqual (Some PrimitiveLikeKind.FlattenToObjectRef)
 
-            match CliValueType.TryExactlyOneField vt with
-            | Some field ->
-                match field.Contents with
-                | CliType.ObjectRef (Some a) -> a |> shouldEqual addr
-                | other -> failwithf "Expected wrapped ObjectRef %O, got %A" addr other
-            | None -> failwith "rewrapped RuntimeTypeHandle had no single field"
+            match (CliValueType.PrimitiveLikeField vt).Contents with
+            | CliType.ObjectRef (Some a) -> a |> shouldEqual addr
+            | other -> failwithf "Expected wrapped ObjectRef %O, got %A" addr other
         | other -> failwithf "Expected CliType.ValueType after rewrap, got %A" other
 
     [<Test>]

--- a/WoofWare.PawPrint/BasicCliType.fs
+++ b/WoofWare.PawPrint/BasicCliType.fs
@@ -500,20 +500,14 @@ and CliValueType =
             /// `System.RuntimeTypeHandle`, or a user struct). Used at the eval-stack boundary to
             /// decide primitive-like flattening via `PrimitiveLikeStruct.kind`.
             _Declared : ConcreteTypeHandle
-            /// Cached primitive-like classification for `_Declared`. `Some kind` for the closed set
-            /// of BCL wrapper structs (IntPtr, RuntimeTypeHandle, etc.); `None` for everything else
-            /// (user-defined structs, non-primitive BCL structs). Populated at construction time so
-            /// the context-free `EvalStackValue.ofCliType` can flatten without threading
+            /// Cached primitive-like classification for `_Declared`. `Some kind` for any value type
+            /// whose storage form is a single-field wrapper that the eval stack flattens: the
+            /// closed set of BCL wrapper structs (IntPtr, RuntimeTypeHandle, ...) plus every CLR
+            /// enum (detected structurally by the reserved `value__` field at offset 0). `None`
+            /// for user-defined structs and non-primitive BCL structs. Populated at construction
+            /// time so the context-free `EvalStackValue.ofCliType` can flatten without threading
             /// `BaseClassTypes`/`AllConcreteTypes` through every push site.
             _PrimitiveLikeKind : PrimitiveLikeKind option
-            /// Cached enum classification: `true` iff this value type is the storage shape of a CLR
-            /// enum (exactly one instance field at offset 0 named `value__` with an integral
-            /// underlying type). Unlike primitive-likes, enums stay as `UserDefinedValueType` on
-            /// the eval stack; they only need a nominal handle on the pop-side rewrap and on `ceq`.
-            /// The `value__` name is CLR-reserved for enums, so this structural test is equivalent
-            /// to the nominal "has base type `System.Enum`" check without threading assembly
-            /// lookup through every `CliValueType` construction site.
-            _IsEnumLike : bool
             _Fields : CliConcreteField list
             Layout : Layout
             /// We track dependency orderings between updates to overlapping fields with a monotonically increasing
@@ -523,9 +517,12 @@ and CliValueType =
 
     member this.Declared : ConcreteTypeHandle = this._Declared
     member this.PrimitiveLikeKind : PrimitiveLikeKind option = this._PrimitiveLikeKind
-    member this.IsEnumLike : bool = this._IsEnumLike
 
-    static member private ComputeIsEnumLike (fields : CliConcreteField list) : bool =
+    /// Structural detection of CLR enums: exactly one instance field at offset 0 named `value__`
+    /// with an integral underlying type. The `value__` name is CLR-reserved for enums, so this
+    /// matches the nominal "has base type `System.Enum`" check without threading assembly lookup
+    /// through every construction site.
+    static member private IsEnumStructural (fields : CliConcreteField list) : bool =
         match fields with
         | [ f ] when f.Name = "value__" && f.Offset = 0 ->
             match f.Contents with
@@ -547,6 +544,24 @@ and CliValueType =
             | CliType.RuntimePointer _
             | CliType.ValueType _ -> false
         | _ -> false
+
+    /// Combine the nominal BCL-wrapper classification with the structural enum detection.
+    /// Returns the BCL kind if `declared` is one of the wrapper structs; otherwise returns
+    /// `Some EnumLike` if `fields` has the structural shape of a CLR enum; otherwise `None`.
+    static member private ClassifyPrimitiveLike
+        (bct : BaseClassTypes<DumpedAssembly>)
+        (allCt : AllConcreteTypes)
+        (declared : ConcreteTypeHandle)
+        (fields : CliConcreteField list)
+        : PrimitiveLikeKind option
+        =
+        match PrimitiveLikeStruct.kindFromHandle bct allCt declared with
+        | Some k -> Some k
+        | None ->
+            if CliValueType.IsEnumStructural fields then
+                Some PrimitiveLikeKind.EnumLike
+            else
+                None
 
     static member private ComputeConcreteFields (layout : Layout) (fields : CliField list) : CliConcreteField list =
         // Minimum size only matters for `sizeof` computation
@@ -639,8 +654,7 @@ and CliValueType =
 
         {
             _Declared = declared
-            _PrimitiveLikeKind = PrimitiveLikeStruct.kindFromHandle bct allCt declared
-            _IsEnumLike = CliValueType.ComputeIsEnumLike fields
+            _PrimitiveLikeKind = CliValueType.ClassifyPrimitiveLike bct allCt declared fields
             _Fields = fields
             Layout = layout
             NextTimestamp = 1UL
@@ -655,7 +669,6 @@ and CliValueType =
         {
             _Declared = source._Declared
             _PrimitiveLikeKind = source._PrimitiveLikeKind
-            _IsEnumLike = source._IsEnumLike
             _Fields = fields
             Layout = layout
             NextTimestamp = 1UL
@@ -700,7 +713,6 @@ and CliValueType =
         {
             _Declared = vt._Declared
             _PrimitiveLikeKind = vt._PrimitiveLikeKind
-            _IsEnumLike = vt._IsEnumLike
             _Fields = newFields
             Layout = vt.Layout
             NextTimestamp = vt.NextTimestamp + 1UL
@@ -806,7 +818,6 @@ and CliValueType =
         {
             _Declared = cvt._Declared
             _PrimitiveLikeKind = cvt._PrimitiveLikeKind
-            _IsEnumLike = cvt._IsEnumLike
             Layout = cvt.Layout
             _Fields =
                 cvt._Fields
@@ -823,20 +834,20 @@ and CliValueType =
             NextTimestamp = cvt.NextTimestamp + 1UL
         }
 
-    /// Projects the single instance field at offset 0 of a primitive-like or enum-like struct.
+    /// Projects the single instance field at offset 0 of a primitive-like struct.
     /// These structs are guaranteed by construction to have exactly one instance field at offset 0
     /// (e.g. `IntPtr._value`, `RuntimeTypeHandle.m_type`, every enum's `value__`); any failure here
-    /// indicates a violated invariant, not a caller error. Gated on the nominal predicate so it
+    /// indicates a violated invariant, not a caller error. Gated on the classification so it
     /// cannot misfire on user-defined single-field structs.
     static member PrimitiveLikeField (cvt : CliValueType) : CliField =
-        if not (cvt._PrimitiveLikeKind.IsSome || cvt._IsEnumLike) then
-            failwith $"CliValueType.PrimitiveLikeField: %O{cvt._Declared} is not primitive-like or enum-like"
+        if cvt._PrimitiveLikeKind.IsNone then
+            failwith $"CliValueType.PrimitiveLikeField: %O{cvt._Declared} is not primitive-like"
 
         match cvt._Fields with
         | [ x ] when x.Offset = 0 -> CliConcreteField.ToCliField x
         | _ ->
             failwith
-                $"invariant: primitive-like or enum-like struct %O{cvt._Declared} must have exactly one instance field at offset 0"
+                $"invariant: primitive-like struct %O{cvt._Declared} must have exactly one instance field at offset 0"
 
     /// To facilitate bodges. This function absolutely should not exist.
     static member TrySequentialFields (cvt : CliValueType) : CliField list option =
@@ -854,7 +865,7 @@ type CliTypeResolutionResult =
 
 [<RequireQualifiedAccess>]
 module CliType =
-    /// If `ty` is a primitive-like wrapper struct (IntPtr, RuntimeTypeHandle, etc.) at rest,
+    /// If `ty` is a primitive-like wrapper (IntPtr, RuntimeTypeHandle, an enum, ...) at rest,
     /// return the contents of its single underlying field; otherwise return `ty` unchanged.
     /// Used by consumers that read stored primitive-like fields and need to see the flattened
     /// primitive form (e.g. `RuntimeType.m_handle` as a `NativeInt (TypeHandlePtr ...)`).

--- a/WoofWare.PawPrint/BasicCliType.fs
+++ b/WoofWare.PawPrint/BasicCliType.fs
@@ -823,16 +823,20 @@ and CliValueType =
             NextTimestamp = cvt.NextTimestamp + 1UL
         }
 
-    /// To facilitate bodges. This function absolutely should not exist.
-    static member TryExactlyOneField (cvt : CliValueType) : CliField option =
+    /// Projects the single instance field at offset 0 of a primitive-like or enum-like struct.
+    /// These structs are guaranteed by construction to have exactly one instance field at offset 0
+    /// (e.g. `IntPtr._value`, `RuntimeTypeHandle.m_type`, every enum's `value__`); any failure here
+    /// indicates a violated invariant, not a caller error. Gated on the nominal predicate so it
+    /// cannot misfire on user-defined single-field structs.
+    static member PrimitiveLikeField (cvt : CliValueType) : CliField =
+        if not (cvt._PrimitiveLikeKind.IsSome || cvt._IsEnumLike) then
+            failwith $"CliValueType.PrimitiveLikeField: %O{cvt._Declared} is not primitive-like or enum-like"
+
         match cvt._Fields with
-        | [] -> None
-        | [ x ] ->
-            if x.Offset = 0 then
-                Some (CliConcreteField.ToCliField x)
-            else
-                None
-        | _ -> None
+        | [ x ] when x.Offset = 0 -> CliConcreteField.ToCliField x
+        | _ ->
+            failwith
+                $"invariant: primitive-like or enum-like struct %O{cvt._Declared} must have exactly one instance field at offset 0"
 
     /// To facilitate bodges. This function absolutely should not exist.
     static member TrySequentialFields (cvt : CliValueType) : CliField list option =
@@ -856,10 +860,7 @@ module CliType =
     /// primitive form (e.g. `RuntimeType.m_handle` as a `NativeInt (TypeHandlePtr ...)`).
     let unwrapPrimitiveLike (ty : CliType) : CliType =
         match ty with
-        | CliType.ValueType vt when vt.PrimitiveLikeKind.IsSome ->
-            match CliValueType.TryExactlyOneField vt with
-            | Some field -> field.Contents
-            | None -> ty
+        | CliType.ValueType vt when vt.PrimitiveLikeKind.IsSome -> (CliValueType.PrimitiveLikeField vt).Contents
         | _ -> ty
 
     /// In fact any non-zero value will do for True, but we'll use 1

--- a/WoofWare.PawPrint/Corelib.fs
+++ b/WoofWare.PawPrint/Corelib.fs
@@ -217,13 +217,14 @@ module Corelib =
         )
         |> _.ConcreteTypes
 
-/// How a primitive-like BCL struct flattens onto the eval stack.
+/// How a single-field wrapper value type flattens onto the eval stack.
 ///
 /// Several BCL types are nominally `struct { single_field }` at metadata level (so `ldfld`,
 /// reflection, and heap layout see a one-field struct), but the real CLR's JIT treats them
-/// as if they were just the underlying primitive/reference. At the interpreter's eval-stack
-/// boundary we mirror that: storage keeps the wrapped struct form; the stack sees the
-/// flattened primitive form via the kind below.
+/// as if they were just the underlying primitive/reference. CLR enums share the same shape:
+/// a single instance field `value__` at offset 0 whose stack form is its integer underlying
+/// type. At the interpreter's eval-stack boundary we mirror that: storage keeps the wrapped
+/// struct form; the stack sees the flattened primitive form via the kind below.
 [<RequireQualifiedAccess>]
 type PrimitiveLikeKind =
     /// `System.IntPtr`, `System.UIntPtr` — flattens to `EvalStackValue.NativeInt`.
@@ -239,6 +240,11 @@ type PrimitiveLikeKind =
     | FlattenToRuntimePointer
     /// `System.ByReference`/`System.ByReference<T>` — flattens to `EvalStackValue.ManagedPointer`.
     | FlattenToManagedPointer
+    /// Any CLR enum — structurally `struct { value__ : <integral> }` — flattens to the
+    /// `EvalStackValue` of its underlying integer. ECMA III.1.8 treats enums as their
+    /// underlying integer for every numeric/comparison opcode; the rewrap on pop reconstructs
+    /// the enum slot around the coerced integer.
+    | EnumLike
 
 [<RequireQualifiedAccess>]
 module PrimitiveLikeStruct =

--- a/WoofWare.PawPrint/EvalStack.fs
+++ b/WoofWare.PawPrint/EvalStack.fs
@@ -154,13 +154,12 @@ module EvalStackValue =
                 NativeIntSource.FieldHandlePtr ptrInt |> EvalStackValue.NativeInt
             | CliRuntimePointer.Managed ptr -> ptr |> EvalStackValue.ManagedPointer
         | CliType.ValueType vt ->
-            // Primitive-like BCL wrappers (IntPtr, RuntimeTypeHandle, ...) and enums both get
-            // flattened to their underlying primitive on the stack. ECMA III.1.8 treats enums
-            // as their underlying integer for every numeric/comparison opcode; flattening here
-            // means cgt.un/clt.un/add/etc. don't need enum-specific arms. Storage stays wrapped;
-            // `toCliTypeCoerced` re-wraps on the pop side when the target slot is enum- or
-            // primitive-like.
-            if vt.PrimitiveLikeKind.IsSome || vt.IsEnumLike then
+            // Primitive-like single-field wrappers (IntPtr, RuntimeTypeHandle, enums, ...) all get
+            // flattened to their underlying primitive on the stack. ECMA III.1.8 treats enums as
+            // their underlying integer for every numeric/comparison opcode; flattening here means
+            // cgt.un/clt.un/add/etc. don't need enum-specific arms. Storage stays wrapped;
+            // `toCliTypeCoerced` re-wraps on the pop side when the target slot is primitive-like.
+            if vt.PrimitiveLikeKind.IsSome then
                 ofCliType (CliValueType.PrimitiveLikeField vt).Contents
             else
                 EvalStackValue.UserDefinedValueType vt
@@ -340,15 +339,14 @@ module EvalStackValue =
                     |> CliType.ValueType
                 | _, _ -> failwith "TODO: overlapping fields going onto eval stack"
             | popped ->
-                // A bare primitive popped into a ValueType slot is only legal for (a) the
-                // primitive-like BCL wrappers (IntPtr, RuntimeTypeHandle, ...), which are
-                // flattened on push and rewrapped here, and (b) enums, where CIL freely
-                // coerces between the underlying integer on the stack and the enum slot.
-                // Both cases share the same rewrap: clone the target's single-field skeleton
-                // and store the coerced primitive into `value__`/`_value`. A single-field
-                // user-defined struct receiving a bare primitive is invalid IL; fail loud
-                // so the misfire surfaces instead of silently degrading the storage shape.
-                if vt.PrimitiveLikeKind.IsSome || vt.IsEnumLike then
+                // A bare primitive popped into a ValueType slot is only legal for primitive-like
+                // wrappers: the BCL handles (IntPtr, RuntimeTypeHandle, ...) flattened on push,
+                // and enums, where CIL freely coerces between the underlying integer on the stack
+                // and the enum slot. Both cases share the same rewrap: clone the target's single-
+                // field skeleton and store the coerced primitive into `value__`/`_value`. A
+                // single-field user-defined struct receiving a bare primitive is invalid IL; fail
+                // loud so the misfire surfaces instead of silently degrading the storage shape.
+                if vt.PrimitiveLikeKind.IsSome then
                     let field = CliValueType.PrimitiveLikeField vt
                     let newContents = toCliTypeCoerced field.Contents popped
 
@@ -385,15 +383,13 @@ type EvalStack =
     static member Peek (stack : EvalStack) : EvalStackValue option = stack.Values |> List.tryHead
 
     static member Push' (v : EvalStackValue) (stack : EvalStack) : EvalStack =
-        // Invariant: primitive-like wrapper structs (IntPtr, RuntimeTypeHandle, ...) and enums
-        // must never appear on the eval stack as UserDefinedValueType; EvalStackValue.ofCliType
-        // flattens them on push. A caller using Push' directly must respect this too.
+        // Invariant: primitive-like wrapper structs (IntPtr, RuntimeTypeHandle, enums, ...) must
+        // never appear on the eval stack as UserDefinedValueType; EvalStackValue.ofCliType flattens
+        // them on push. A caller using Push' directly must respect this too.
         match v with
         | EvalStackValue.UserDefinedValueType vt when vt.PrimitiveLikeKind.IsSome ->
             failwith
                 $"eval-stack invariant violated: primitive-like struct %O{vt.Declared} pushed as UserDefinedValueType (kind = %O{vt.PrimitiveLikeKind})"
-        | EvalStackValue.UserDefinedValueType vt when vt.IsEnumLike ->
-            failwith $"eval-stack invariant violated: enum-like struct %O{vt.Declared} pushed as UserDefinedValueType"
         | _ -> ()
 
         {

--- a/WoofWare.PawPrint/EvalStack.fs
+++ b/WoofWare.PawPrint/EvalStack.fs
@@ -161,11 +161,7 @@ module EvalStackValue =
             // `toCliTypeCoerced` re-wraps on the pop side when the target slot is enum- or
             // primitive-like.
             if vt.PrimitiveLikeKind.IsSome || vt.IsEnumLike then
-                match CliValueType.TryExactlyOneField vt with
-                | Some field -> ofCliType field.Contents
-                | None ->
-                    failwith
-                        $"primitive-like or enum-like struct %O{vt.Declared} did not have a single field at offset 0 during eval-stack flatten"
+                ofCliType (CliValueType.PrimitiveLikeField vt).Contents
             else
                 EvalStackValue.UserDefinedValueType vt
 
@@ -353,19 +349,15 @@ module EvalStackValue =
                 // user-defined struct receiving a bare primitive is invalid IL; fail loud
                 // so the misfire surfaces instead of silently degrading the storage shape.
                 if vt.PrimitiveLikeKind.IsSome || vt.IsEnumLike then
-                    match CliValueType.TryExactlyOneField vt with
-                    | Some field ->
-                        let newContents = toCliTypeCoerced field.Contents popped
+                    let field = CliValueType.PrimitiveLikeField vt
+                    let newContents = toCliTypeCoerced field.Contents popped
 
-                        let newField =
-                            { field with
-                                Contents = newContents
-                            }
+                    let newField =
+                        { field with
+                            Contents = newContents
+                        }
 
-                        [ newField ] |> CliValueType.OfFieldsLike vt vt.Layout |> CliType.ValueType
-                    | None ->
-                        failwith
-                            $"invariant: primitive-like or enum-like struct {vt.Declared} must have exactly one field at offset 0"
+                    [ newField ] |> CliValueType.OfFieldsLike vt vt.Layout |> CliType.ValueType
                 else
                     failwith $"TODO: {popped} into value type {target}"
 

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -262,20 +262,16 @@ module Intrinsics =
                         failwith
                             $"Interlocked.CompareExchange(ref IntPtr,...): expected ManagedPointer byref, got %O{other}"
 
-                let rec toNativeIntSource (v : EvalStackValue) : NativeIntSource =
+                // Eval-stack IntPtr arguments are flattened to the primitive by the push
+                // boundary (see EvalStackValue.ofCliType), so a UserDefinedValueType IntPtr
+                // is unreachable here by invariant.
+                let toNativeIntSource (v : EvalStackValue) : NativeIntSource =
                     match v with
                     | EvalStackValue.NativeInt src -> src
                     | EvalStackValue.Int64 i -> NativeIntSource.Verbatim i
                     | EvalStackValue.Int32 i -> NativeIntSource.Verbatim (int64<int> i)
                     | EvalStackValue.ManagedPointer src -> NativeIntSource.ManagedPointer src
                     | EvalStackValue.NullObjectRef -> NativeIntSource.ManagedPointer ManagedPointerSource.Null
-                    | EvalStackValue.UserDefinedValueType vt ->
-                        // An IntPtr struct wrapping a single native-int field.
-                        match CliValueType.TryExactlyOneField vt with
-                        | Some field -> toNativeIntSource (EvalStackValue.ofCliType field.Contents)
-                        | None ->
-                            failwith
-                                $"Interlocked.CompareExchange(ref IntPtr,...): expected IntPtr struct with one field, got %O{vt}"
                     | other ->
                         failwith
                             $"Interlocked.CompareExchange(ref IntPtr,...): unexpected IntPtr-shaped eval stack value %O{other}"
@@ -285,43 +281,18 @@ module Intrinsics =
 
                 let currentValue = IlMachineState.readManagedByref state byrefSrc
 
-                // `ref IntPtr` derefs to the IntPtr struct. Dig through to the underlying
-                // NativeInt field for CAS, then rewrap on write.
-                let rec extractNativeInt (v : CliType) : NativeIntSource =
-                    match v with
-                    | CliType.Numeric (CliNumericType.NativeInt src) -> src
-                    | CliType.Numeric (CliNumericType.Int64 i) -> NativeIntSource.Verbatim i
-                    | CliType.ValueType vt ->
-                        match CliValueType.TryExactlyOneField vt with
-                        | Some field -> extractNativeInt field.Contents
-                        | None ->
-                            failwith
-                                $"Interlocked.CompareExchange(ref IntPtr,...): expected IntPtr struct with one field at byref target, got %O{vt}"
+                // `ref IntPtr` derefs to the IntPtr wrapper struct. Route the read/write through
+                // the eval-stack flatten/rewrap boundary: `ofCliType` peels the primitive-like
+                // wrapper to `NativeInt`, and `toCliTypeCoerced` reconstructs the wrapper shape
+                // on write. The primitive-like registry is the single source of truth for shape.
+                let currentSrc =
+                    match EvalStackValue.ofCliType currentValue with
+                    | EvalStackValue.NativeInt src -> src
+                    | EvalStackValue.Int64 i -> NativeIntSource.Verbatim i
+                    | EvalStackValue.Int32 i -> NativeIntSource.Verbatim (int64<int> i)
                     | other ->
                         failwith
                             $"Interlocked.CompareExchange(ref IntPtr,...): expected NativeInt at byref target, got %O{other}"
-
-                let rec rewrapNativeInt (shape : CliType) (newSrc : NativeIntSource) : CliType =
-                    match shape with
-                    | CliType.Numeric (CliNumericType.NativeInt _) -> CliType.Numeric (CliNumericType.NativeInt newSrc)
-                    | CliType.Numeric (CliNumericType.Int64 _) ->
-                        match newSrc with
-                        | NativeIntSource.Verbatim i -> CliType.Numeric (CliNumericType.Int64 i)
-                        | _ ->
-                            failwith
-                                "Interlocked.CompareExchange(ref IntPtr,...): refusing to downcast non-verbatim NativeIntSource to Int64"
-                    | CliType.ValueType vt ->
-                        match CliValueType.TryExactlyOneField vt with
-                        | Some field ->
-                            let updated = rewrapNativeInt field.Contents newSrc
-
-                            CliType.ValueType (CliValueType.WithFieldSet field.Name updated vt)
-                        | None ->
-                            failwith
-                                $"Interlocked.CompareExchange(ref IntPtr,...): cannot rewrap into non-single-field struct %O{vt}"
-                    | other -> failwith $"Interlocked.CompareExchange(ref IntPtr,...): cannot rewrap into %O{other}"
-
-                let currentSrc = extractNativeInt currentValue
 
                 // Two representations of zero exist (`Verbatim 0L` for `new IntPtr(0)` and
                 // `ManagedPointer Null` for default-initialised IntPtr / `IntPtr.Zero`); treat
@@ -331,7 +302,9 @@ module Intrinsics =
 
                 let state =
                     if nativeIntEq currentSrc comparandSrc then
-                        let newValue = rewrapNativeInt currentValue valueSrc
+                        let newValue =
+                            EvalStackValue.toCliTypeCoerced currentValue (EvalStackValue.NativeInt valueSrc)
+
                         IlMachineState.writeManagedByref state byrefSrc newValue
                     else
                         state

--- a/WoofWare.PawPrint/UnaryMetadataIlOp.fs
+++ b/WoofWare.PawPrint/UnaryMetadataIlOp.fs
@@ -1346,12 +1346,13 @@ module internal UnaryMetadataIlOp =
                                     // Genuine user-defined value type (incl. enums): keep wrapped.
                                     CliType.ValueType boxed.Contents, state
                                 | _ ->
-                                    // Primitive target: extract the single field's contents.
-                                    match CliValueType.TryExactlyOneField boxed.Contents with
-                                    | Some field -> field.Contents, state
-                                    | None ->
-                                        failwith
-                                            $"Unbox_Any: primitive target {targetZero} but boxed struct has != 1 field: {boxed.Contents}"
+                                    // Primitive target: Box stored the value in a single instance
+                                    // field at offset 0 whose Size matches the primitive. Read it
+                                    // back by offset/size — the Box path guarantees the shape, so
+                                    // this is a nominal dereference, not a structural guess.
+                                    let size = (CliType.SizeOf targetZero).Size
+
+                                    CliValueType.DereferenceFieldAt 0 size boxed.Contents, state
 
                         state
                         |> IlMachineState.pushToEvalStack toPush thread

--- a/WoofWare.PawPrint/UnaryMetadataIlOp.fs
+++ b/WoofWare.PawPrint/UnaryMetadataIlOp.fs
@@ -1325,9 +1325,9 @@ module internal UnaryMetadataIlOp =
                     // test to exercise; not in scope for this PR.
                     if boxed.ConcreteType = targetConcreteTypeHandle then
                         // Push the boxed value back onto the eval stack. The push path
-                        // (EvalStackValue.ofCliType) handles primitive-like types (IntPtr,
-                        // RuntimeTypeHandle, etc.) via the flatten invariant, and leaves
-                        // user-defined value types (including enums) as UserDefinedValueType.
+                        // (EvalStackValue.ofCliType) handles primitive-like value types
+                        // (IntPtr, RuntimeTypeHandle, enums, ...) via the flatten invariant,
+                        // and leaves genuine user-defined value types as UserDefinedValueType.
                         //
                         // For primitive targets (Int32, Float64, etc.) the Box path stored
                         // the value in a single-field struct (e.g. { value__ = Int32 42 }).
@@ -1335,7 +1335,7 @@ module internal UnaryMetadataIlOp =
                         // them here and extract the inner field before pushing.
                         let toPush, state =
                             if boxed.Contents.PrimitiveLikeKind.IsSome then
-                                // Primitive-like: ofCliType will flatten on push.
+                                // Primitive-like (incl. enum): ofCliType will flatten on push.
                                 CliType.ValueType boxed.Contents, state
                             else
                                 let targetZero, state =
@@ -1343,7 +1343,7 @@ module internal UnaryMetadataIlOp =
 
                                 match targetZero with
                                 | CliType.ValueType _ ->
-                                    // Genuine user-defined value type (incl. enums): keep wrapped.
+                                    // Genuine user-defined value type: keep wrapped.
                                     CliType.ValueType boxed.Contents, state
                                 | _ ->
                                     // Primitive target: Box stored the value in a single instance


### PR DESCRIPTION
The structural `TryExactlyOneField` bodge was the last residue of the competing representational discipline for primitive-like BCL wrappers (IntPtr, RuntimeTypeHandle, etc.). Its remaining callers either sat on the eval-stack flatten/rewrap boundary (where the nominal registry already gates usage) or reimplemented the same unwrap recursively for `Interlocked.CompareExchange(ref IntPtr, ...)` (a post-plan regression).

Introduce `CliValueType.PrimitiveLikeField`, a nominally gated projector that asserts the primitive-like-or-enum-like invariant and cannot misfire on user-defined single-field structs. Migrate the eval-stack boundary and `CliType.unwrapPrimitiveLike` to it; rewrite the `Interlocked.CompareExchange` intrinsic to route reads/writes through the eval-stack boundary itself (`EvalStackValue.ofCliType` / `toCliTypeCoerced`); fix the `Unbox_Any` primitive-target residue with a size-indexed `DereferenceFieldAt 0` dereference.