### PR TITLE
Refactor strings as char arrays in the array map

### DIFF
--- a/WoofWare.PawPrint.Test/TestManagedHeap.fs
+++ b/WoofWare.PawPrint.Test/TestManagedHeap.fs
@@ -1,5 +1,6 @@
 namespace WoofWare.PawPrint.Test
 
+open System.Collections.Immutable
 open FsUnitTyped
 open NUnit.Framework
 open WoofWare.PawPrint
@@ -8,29 +9,28 @@ open WoofWare.PawPrint
 [<Parallelizable(ParallelScope.All)>]
 module TestManagedHeap =
 
-    [<Test>]
-    let ``recordStringContents then getStringContents round-trips`` () : unit =
-        let addr = ManagedHeapAddress.ManagedHeapAddress 42
+    /// Register a string at a synthetic String heap address by allocating a null-terminated
+    /// sibling `char[]` in the ordinary `Arrays` map and recording the linkage. Mirrors the
+    /// shape of `IlMachineState.allocateManagedString` without depending on the rest of the
+    /// machine state needed to allocate the String heap object itself.
+    let private registerString (strAddr : ManagedHeapAddress) (contents : string) (heap : ManagedHeap) : ManagedHeap =
+        let payload =
+            let builder = ImmutableArray.CreateBuilder<CliType> (contents.Length + 1)
 
-        ManagedHeap.empty
-        |> ManagedHeap.recordStringContents addr "hello"
-        |> ManagedHeap.getStringContents addr
-        |> shouldEqual (Some "hello")
+            for c in contents do
+                builder.Add (CliType.ofChar c)
 
-    [<Test>]
-    let ``getStringContents returns None when no contents recorded`` () : unit =
-        let addr = ManagedHeapAddress.ManagedHeapAddress 42
-        ManagedHeap.getStringContents addr ManagedHeap.empty |> shouldEqual None
+            builder.Add (CliType.ofChar (char 0))
+            builder.MoveToImmutable ()
 
-    [<Test>]
-    let ``recordStringContents overwrites previous content`` () : unit =
-        let addr = ManagedHeapAddress.ManagedHeapAddress 7
+        let arr : AllocatedArray =
+            {
+                Length = contents.Length + 1
+                Elements = payload
+            }
 
-        ManagedHeap.empty
-        |> ManagedHeap.recordStringContents addr "first"
-        |> ManagedHeap.recordStringContents addr "second"
-        |> ManagedHeap.getStringContents addr
-        |> shouldEqual (Some "second")
+        let charArrAddr, heap = ManagedHeap.allocateArray arr heap
+        heap |> ManagedHeap.recordStringCharArray strAddr charArrAddr
 
     [<Test>]
     let ``stringsEqual: same content at different addresses is equal`` () : unit =
@@ -39,15 +39,15 @@ module TestManagedHeap =
 
         let heap =
             ManagedHeap.empty
-            |> ManagedHeap.recordStringContents addr1 "hello"
-            |> ManagedHeap.recordStringContents addr2 "hello"
+            |> registerString addr1 "hello"
+            |> registerString addr2 "hello"
 
         ManagedHeap.stringsEqual addr1 addr2 heap |> shouldEqual true
 
     [<Test>]
     let ``stringsEqual: same address is equal`` () : unit =
         let addr = ManagedHeapAddress.ManagedHeapAddress 1
-        let heap = ManagedHeap.empty |> ManagedHeap.recordStringContents addr "hello"
+        let heap = ManagedHeap.empty |> registerString addr "hello"
         ManagedHeap.stringsEqual addr addr heap |> shouldEqual true
 
     [<Test>]
@@ -57,8 +57,8 @@ module TestManagedHeap =
 
         let heap =
             ManagedHeap.empty
-            |> ManagedHeap.recordStringContents addr1 "hello"
-            |> ManagedHeap.recordStringContents addr2 "world"
+            |> registerString addr1 "hello"
+            |> registerString addr2 "world"
 
         ManagedHeap.stringsEqual addr1 addr2 heap |> shouldEqual false
 
@@ -68,9 +68,7 @@ module TestManagedHeap =
         let addr2 = ManagedHeapAddress.ManagedHeapAddress 2
 
         let heap =
-            ManagedHeap.empty
-            |> ManagedHeap.recordStringContents addr1 "hello"
-            |> ManagedHeap.recordStringContents addr2 "hell"
+            ManagedHeap.empty |> registerString addr1 "hello" |> registerString addr2 "hell"
 
         ManagedHeap.stringsEqual addr1 addr2 heap |> shouldEqual false
 
@@ -79,10 +77,7 @@ module TestManagedHeap =
         let addr1 = ManagedHeapAddress.ManagedHeapAddress 1
         let addr2 = ManagedHeapAddress.ManagedHeapAddress 2
 
-        let heap =
-            ManagedHeap.empty
-            |> ManagedHeap.recordStringContents addr1 ""
-            |> ManagedHeap.recordStringContents addr2 ""
+        let heap = ManagedHeap.empty |> registerString addr1 "" |> registerString addr2 ""
 
         ManagedHeap.stringsEqual addr1 addr2 heap |> shouldEqual true
 
@@ -93,8 +88,8 @@ module TestManagedHeap =
 
         let heap =
             ManagedHeap.empty
-            |> ManagedHeap.recordStringContents addr1 "hello world"
-            |> ManagedHeap.recordStringContents addr2 "hello"
+            |> registerString addr1 "hello world"
+            |> registerString addr2 "hello"
 
         ManagedHeap.stringsEqual addr1 addr2 heap |> shouldEqual false
 
@@ -105,7 +100,7 @@ module TestManagedHeap =
 
         let heap =
             ManagedHeap.empty
-            |> ManagedHeap.recordStringContents addr1 "abcdef"
-            |> ManagedHeap.recordStringContents addr2 "abcdeg"
+            |> registerString addr1 "abcdef"
+            |> registerString addr2 "abcdeg"
 
         ManagedHeap.stringsEqual addr1 addr2 heap |> shouldEqual false

--- a/WoofWare.PawPrint.Test/TestManagedHeap.fs
+++ b/WoofWare.PawPrint.Test/TestManagedHeap.fs
@@ -1,6 +1,5 @@
 namespace WoofWare.PawPrint.Test
 
-open System.Collections.Immutable
 open FsUnitTyped
 open NUnit.Framework
 open WoofWare.PawPrint
@@ -9,28 +8,14 @@ open WoofWare.PawPrint
 [<Parallelizable(ParallelScope.All)>]
 module TestManagedHeap =
 
-    /// Register a string at a synthetic String heap address by allocating a null-terminated
-    /// sibling `char[]` in the ordinary `Arrays` map and recording the linkage. Mirrors the
-    /// shape of `IlMachineState.allocateManagedString` without depending on the rest of the
-    /// machine state needed to allocate the String heap object itself.
+    /// Register a string at a synthetic String heap address. We can't call
+    /// `IlMachineState.allocateManagedString` directly because it requires a full machine
+    /// state to allocate the `System.String` object with its `_stringLength` field; but
+    /// `stringsEqual` only reads the sibling `char[]`, so invoking just the
+    /// sibling-allocation layer is sufficient. This exercises the real layout builder —
+    /// if the null-termination invariant changes, the production function changes too.
     let private registerString (strAddr : ManagedHeapAddress) (contents : string) (heap : ManagedHeap) : ManagedHeap =
-        let payload =
-            let builder = ImmutableArray.CreateBuilder<CliType> (contents.Length + 1)
-
-            for c in contents do
-                builder.Add (CliType.ofChar c)
-
-            builder.Add (CliType.ofChar (char 0))
-            builder.MoveToImmutable ()
-
-        let arr : AllocatedArray =
-            {
-                Length = contents.Length + 1
-                Elements = payload
-            }
-
-        let charArrAddr, heap = ManagedHeap.allocateArray arr heap
-        heap |> ManagedHeap.recordStringCharArray strAddr charArrAddr
+        ManagedHeap.allocateStringCharSibling strAddr contents heap
 
     [<Test>]
     let ``stringsEqual: same content at different addresses is equal`` () : unit =

--- a/WoofWare.PawPrint.Test/TestManagedHeap.fs
+++ b/WoofWare.PawPrint.Test/TestManagedHeap.fs
@@ -104,3 +104,22 @@ module TestManagedHeap =
             |> registerString addr2 "abcdeg"
 
         ManagedHeap.stringsEqual addr1 addr2 heap |> shouldEqual false
+
+    [<Test>]
+    let ``stringsEqual: ignores a mutated null terminator`` () : unit =
+        // Logical contents match, but one sibling's terminator has been overwritten — e.g.
+        // via a `_firstChar` byref that was advanced past the end. Equality must track the
+        // visible string, not the hidden terminator.
+        let addr1 = ManagedHeapAddress.ManagedHeapAddress 1
+        let addr2 = ManagedHeapAddress.ManagedHeapAddress 2
+
+        let heap =
+            ManagedHeap.empty |> registerString addr1 "abc" |> registerString addr2 "abc"
+
+        let siblingAddr2 = ManagedHeap.resolveStringCharArrayAddr addr2 heap
+        let terminatorIdx = (ManagedHeap.resolveStringChars addr2 heap).Length - 1
+
+        let heap =
+            ManagedHeap.setArrayValue siblingAddr2 terminatorIdx (CliType.ofChar 'Z') heap
+
+        ManagedHeap.stringsEqual addr1 addr2 heap |> shouldEqual true

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -1923,32 +1923,6 @@ module IlMachineState =
         then
             failwith $"unexpectedly don't know how to initialise a string: got fields %O{stringInstanceFields}"
 
-        // Sibling char[] holds the full null-terminated char payload. We allocate it via the
-        // ordinary array allocator: the sibling is an entirely normal entry in `Arrays`, and
-        // its heap address goes into the `StringCharArrays` side-table so consumers can look
-        // it up from the String's address.
-        let charPayload =
-            let builder = ImmutableArray.CreateBuilder<CliType> (contents.Length + 1)
-
-            for c in contents do
-                builder.Add (CliType.ofChar c)
-
-            builder.Add (CliType.ofChar (char 0))
-            builder.MoveToImmutable ()
-
-        let siblingArray : AllocatedArray =
-            {
-                Length = contents.Length + 1
-                Elements = charPayload
-            }
-
-        let siblingAddr, heap = state.ManagedHeap |> ManagedHeap.allocateArray siblingArray
-
-        let state =
-            { state with
-                ManagedHeap = heap
-            }
-
         let state, stringType =
             DumpedAssembly.typeInfoToTypeDefn' baseClassTypes state._LoadedAssemblies baseClassTypes.String
             |> concretizeType
@@ -1974,7 +1948,7 @@ module IlMachineState =
 
         let state =
             { state with
-                ManagedHeap = ManagedHeap.recordStringCharArray addr siblingAddr state.ManagedHeap
+                ManagedHeap = ManagedHeap.allocateStringCharSibling addr contents state.ManagedHeap
             }
 
         addr, state

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -1307,8 +1307,7 @@ module IlMachineState =
                 | ByrefRoot.Argument (t, f, v) -> (getFrame t f state).Arguments.[int<uint16> v]
                 | ByrefRoot.HeapValue addr -> CliType.ValueType (ManagedHeap.get addr state.ManagedHeap).Contents
                 | ByrefRoot.HeapObjectField (addr, fieldName) ->
-                    ManagedHeap.get addr state.ManagedHeap
-                    |> AllocatedNonArrayObject.DereferenceField fieldName
+                    ManagedHeap.dereferenceField addr fieldName state.ManagedHeap
                 | ByrefRoot.ArrayElement (arr, index) -> getArrayValue arr index state
 
             projs
@@ -1424,12 +1423,8 @@ module IlMachineState =
                     ManagedHeap = ManagedHeap.set addr updated state.ManagedHeap
                 }
             | ByrefRoot.HeapObjectField (addr, fieldName) ->
-                let updated =
-                    ManagedHeap.get addr state.ManagedHeap
-                    |> AllocatedNonArrayObject.SetField fieldName newValue
-
                 { state with
-                    ManagedHeap = ManagedHeap.set addr updated state.ManagedHeap
+                    ManagedHeap = ManagedHeap.setField addr fieldName newValue state.ManagedHeap
                 }
             | ByrefRoot.ArrayElement (arr, index) -> state |> setArrayValue arr newValue index
         | ManagedPointerSource.Byref (root, projs) ->
@@ -1460,15 +1455,10 @@ module IlMachineState =
                         | other -> failwith $"cannot write non-value-type {other} through heap value byref"
                     )
                 | ByrefRoot.HeapObjectField (addr, fieldName) ->
-                    (ManagedHeap.get addr state.ManagedHeap
-                     |> AllocatedNonArrayObject.DereferenceField fieldName),
+                    ManagedHeap.dereferenceField addr fieldName state.ManagedHeap,
                     (fun updated ->
-                        let obj =
-                            ManagedHeap.get addr state.ManagedHeap
-                            |> AllocatedNonArrayObject.SetField fieldName updated
-
                         { state with
-                            ManagedHeap = ManagedHeap.set addr obj state.ManagedHeap
+                            ManagedHeap = ManagedHeap.setField addr fieldName updated state.ManagedHeap
                         }
                     )
                 | ByrefRoot.ArrayElement (arr, index) ->

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -902,23 +902,6 @@ module IlMachineState =
 
         alloc, state
 
-    let allocateStringData (len : int) (state : IlMachineState) : int * IlMachineState =
-        let addr, heap = state.ManagedHeap |> ManagedHeap.allocateString len
-
-        let state =
-            { state with
-                ManagedHeap = heap
-            }
-
-        addr, state
-
-    let setStringData (addr : int) (contents : string) (state : IlMachineState) : IlMachineState =
-        let heap = ManagedHeap.setStringData addr contents state.ManagedHeap
-
-        { state with
-            ManagedHeap = heap
-        }
-
     let allocateManagedObject
         (ty : ConcreteTypeHandle)
         (fields : CliValueType)
@@ -1885,6 +1868,14 @@ module IlMachineState =
     /// Does NOT intern the string: every call returns a fresh heap object.  The Ldstr opcode
     /// wraps this with its own interning cache (see UnaryStringTokenIlOp); runtime-generated
     /// strings (stack traces, type names, etc.) call this directly.
+    ///
+    /// The String heap object stores only `_stringLength`; `_firstChar` is not carried as a
+    /// real stored field. The char payload lives in a sibling `char[]` allocated in the
+    /// ordinary `Arrays` map, linked via `ManagedHeap.StringCharArrays`. `Ldfld`/`Ldflda` on
+    /// `System.String._firstChar` is intercepted in `UnaryMetadataIlOp` to read/address the
+    /// sibling's element 0, so the sibling is the single source of truth for char content.
+    /// The sibling is null-terminated (length = text length + 1) to match the real CLR layout
+    /// (https://github.com/dotnet/runtime/blob/ab105b51f8b50ec5567d7cfe9001ca54dd6f64c3/src/libraries/System.Private.CoreLib/src/System/String.cs#L56).
     let allocateManagedString
         (loggerFactory : ILoggerFactory)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
@@ -1913,8 +1904,31 @@ module IlMachineState =
         then
             failwith $"unexpectedly don't know how to initialise a string: got fields %O{stringInstanceFields}"
 
-        let dataAddr, state = allocateStringData contents.Length state
-        let state = setStringData dataAddr contents state
+        // Sibling char[] holds the full null-terminated char payload. We allocate it via the
+        // ordinary array allocator: the sibling is an entirely normal entry in `Arrays`, and
+        // its heap address goes into the `StringCharArrays` side-table so consumers can look
+        // it up from the String's address.
+        let charPayload =
+            let builder = ImmutableArray.CreateBuilder<CliType> (contents.Length + 1)
+
+            for c in contents do
+                builder.Add (CliType.ofChar c)
+
+            builder.Add (CliType.ofChar (char 0))
+            builder.MoveToImmutable ()
+
+        let siblingArray : AllocatedArray =
+            {
+                Length = contents.Length + 1
+                Elements = charPayload
+            }
+
+        let siblingAddr, heap = state.ManagedHeap |> ManagedHeap.allocateArray siblingArray
+
+        let state =
+            { state with
+                ManagedHeap = heap
+            }
 
         let state, stringType =
             DumpedAssembly.typeInfoToTypeDefn' baseClassTypes state._LoadedAssemblies baseClassTypes.String
@@ -1929,12 +1943,6 @@ module IlMachineState =
         let fields =
             [
                 {
-                    Name = "_firstChar"
-                    Contents = CliType.ofChar state.ManagedHeap.StringArrayData.[dataAddr]
-                    Offset = None
-                    Type = AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes baseClassTypes.Char
-                }
-                {
                     Name = "_stringLength"
                     Contents = CliType.Numeric (CliNumericType.Int32 contents.Length)
                     Offset = None
@@ -1947,7 +1955,7 @@ module IlMachineState =
 
         let state =
             { state with
-                ManagedHeap = ManagedHeap.recordStringContents addr contents state.ManagedHeap
+                ManagedHeap = ManagedHeap.recordStringCharArray addr siblingAddr state.ManagedHeap
             }
 
         addr, state

--- a/WoofWare.PawPrint/ManagedHeap.fs
+++ b/WoofWare.PawPrint/ManagedHeap.fs
@@ -234,3 +234,43 @@ module ManagedHeap =
         { heap with
             Arrays = newArrs
         }
+
+    /// Read the named field on the heap object at `addr`. Routes
+    /// `System.String._firstChar` (not a stored field) to element 0 of the sibling
+    /// char array; use this rather than raw `AllocatedNonArrayObject.DereferenceField`
+    /// so the routing lives in one place.
+    let dereferenceField (addr : ManagedHeapAddress) (fieldName : string) (heap : ManagedHeap) : CliType =
+        match heap.StringCharArrays.TryGetValue addr with
+        | true, arrAddr when fieldName = "_firstChar" ->
+            match heap.Arrays.TryGetValue arrAddr with
+            | false, _ ->
+                failwith
+                    $"dereferenceField: String %O{addr} is linked to sibling %O{arrAddr} but that array is missing from the heap"
+            | true, arr -> arr.Elements.[0]
+        | _ ->
+            match heap.NonArrayObjects.TryGetValue addr with
+            | false, _ -> failwith $"todo: array {addr}"
+            | true, obj -> AllocatedNonArrayObject.DereferenceField fieldName obj
+
+    /// Write counterpart to `dereferenceField`; updates the sibling char array for
+    /// a `System.String._firstChar` write.
+    let setField (addr : ManagedHeapAddress) (fieldName : string) (v : CliType) (heap : ManagedHeap) : ManagedHeap =
+        match heap.StringCharArrays.TryGetValue addr with
+        | true, arrAddr when fieldName = "_firstChar" -> setArrayValue arrAddr 0 v heap
+        | _ ->
+            match heap.NonArrayObjects.TryGetValue addr with
+            | false, _ -> failwith $"todo: array {addr}"
+            | true, obj ->
+                let obj = AllocatedNonArrayObject.SetField fieldName v obj
+
+                { heap with
+                    NonArrayObjects = heap.NonArrayObjects |> Map.add addr obj
+                }
+
+    /// The `ByrefRoot` addressing the named field on the heap object at `addr`.
+    /// Routes `System.String._firstChar` to an `ArrayElement` byref into the sibling
+    /// char array, so pointer arithmetic through it reaches the real char storage.
+    let byrefRootForField (addr : ManagedHeapAddress) (fieldName : string) (heap : ManagedHeap) : ByrefRoot =
+        match heap.StringCharArrays.TryGetValue addr with
+        | true, arrAddr when fieldName = "_firstChar" -> ByrefRoot.ArrayElement (arrAddr, 0)
+        | _ -> ByrefRoot.HeapObjectField (addr, fieldName)

--- a/WoofWare.PawPrint/ManagedHeap.fs
+++ b/WoofWare.PawPrint/ManagedHeap.fs
@@ -92,8 +92,8 @@ module ManagedHeap =
         ManagedHeapAddress addr, heap
 
     /// Record the linkage from a String heap address to the heap address of its sibling
-    /// `char[]`. Called by `allocateManagedString` immediately after allocating the String
-    /// object and the char array; consumers read the linkage back via `resolveStringChars`.
+    /// `char[]`. Called by `allocateStringCharSibling` immediately after allocating the
+    /// char array; consumers read the linkage back via `resolveStringChars`.
     let recordStringCharArray
         (strAddr : ManagedHeapAddress)
         (charArrAddr : ManagedHeapAddress)
@@ -103,6 +103,36 @@ module ManagedHeap =
         { heap with
             StringCharArrays = heap.StringCharArrays.SetItem (strAddr, charArrAddr)
         }
+
+    /// Allocate a null-terminated `char[]` sibling for the String object at `strAddr` and
+    /// record the linkage. The sibling is an ordinary entry in `Arrays` with length =
+    /// `contents.Length + 1`; element `contents.Length` is the terminator `\0`, matching the
+    /// real CLR layout. This is the single source of truth for the String char payload
+    /// shape; `allocateManagedString` composes this with String-object allocation, but any
+    /// caller that already holds a String address (e.g. tests) can use this directly.
+    let allocateStringCharSibling
+        (strAddr : ManagedHeapAddress)
+        (contents : string)
+        (heap : ManagedHeap)
+        : ManagedHeap
+        =
+        let payload =
+            let builder = ImmutableArray.CreateBuilder<CliType> (contents.Length + 1)
+
+            for c in contents do
+                builder.Add (CliType.ofChar c)
+
+            builder.Add (CliType.ofChar (char 0))
+            builder.MoveToImmutable ()
+
+        let siblingArray : AllocatedArray =
+            {
+                Length = contents.Length + 1
+                Elements = payload
+            }
+
+        let siblingAddr, heap = allocateArray siblingArray heap
+        recordStringCharArray strAddr siblingAddr heap
 
     /// Resolve a String heap address to its sibling `char[]` allocation. The sibling
     /// stores the null-terminated char data; its length is the string's text length + 1.

--- a/WoofWare.PawPrint/ManagedHeap.fs
+++ b/WoofWare.PawPrint/ManagedHeap.fs
@@ -145,17 +145,17 @@ module ManagedHeap =
             let chars1 = resolveStringChars a1 heap
             let chars2 = resolveStringChars a2 heap
             // Sibling arrays are allocated with length = text length + 1 (null terminator).
-            // The terminator is not part of the comparison, but we compare the whole stored
-            // range anyway: two strings with the same non-terminator contents will also have
-            // matching null terminators at the same index. If the lengths differ, the strings
-            // differ.
+            // Compare only the logical chars: skipping the terminator means code that reaches
+            // past the end via `_firstChar` byref arithmetic can't desynchronise equality from
+            // the visible string value.
             if chars1.Length <> chars2.Length then
                 false
             else
+                let logicalLen = chars1.Length - 1
                 let mutable i = 0
                 let mutable equal = true
 
-                while equal && i < chars1.Length do
+                while equal && i < logicalLen do
                     if chars1.Elements.[i] <> chars2.Elements.[i] then
                         equal <- false
 

--- a/WoofWare.PawPrint/ManagedHeap.fs
+++ b/WoofWare.PawPrint/ManagedHeap.fs
@@ -33,14 +33,12 @@ type ManagedHeap =
         NonArrayObjects : Map<ManagedHeapAddress, AllocatedNonArrayObject>
         Arrays : Map<ManagedHeapAddress, AllocatedArray>
         FirstAvailableAddress : int
-        /// Strings are special-cased in the runtime anyway and have a whole lot of unsafe code in them,
-        /// so we'll have a special pool for their bytes.
-        StringArrayData : ImmutableArray<char>
-        /// Side-table mapping a String object's address to its full character content.
-        /// The managed representation of a String only carries _firstChar and _stringLength,
-        /// which is not enough to reconstruct the full text; we record it here at allocation
-        /// time so operations like String.Equals can compare full contents.
-        StringContents : ImmutableDictionary<ManagedHeapAddress, string>
+        /// Side-table mapping a String heap address to the heap address of its sibling
+        /// `char[]`. The sibling is an ordinary entry in `Arrays`; this map records the
+        /// linkage so `stringsEqual` and the `Ldfld`/`Ldflda` interception for
+        /// `System.String._firstChar` can reach the char storage from the String address.
+        /// Populated at allocation time by `allocateManagedString`.
+        StringCharArrays : ImmutableDictionary<ManagedHeapAddress, ManagedHeapAddress>
     }
 
 [<RequireQualifiedAccess>]
@@ -50,8 +48,7 @@ module ManagedHeap =
             NonArrayObjects = Map.empty
             FirstAvailableAddress = 1
             Arrays = Map.empty
-            StringArrayData = ImmutableArray.Empty
-            StringContents = ImmutableDictionary.Empty
+            StringCharArrays = ImmutableDictionary.Empty
         }
 
     let getSyncBlock (addr : ManagedHeapAddress) (heap : ManagedHeap) : SyncBlock =
@@ -83,30 +80,6 @@ module ManagedHeap =
 
         ManagedHeapAddress addr, heap
 
-    let allocateString (len : int) (heap : ManagedHeap) : int * ManagedHeap =
-        let addr = heap.StringArrayData.Length
-
-        let heap =
-            { heap with
-                // strings are also null-terminated
-                // https://github.com/dotnet/runtime/blob/ab105b51f8b50ec5567d7cfe9001ca54dd6f64c3/src/libraries/System.Private.CoreLib/src/System/String.cs#L56
-                StringArrayData = heap.StringArrayData.AddRange (Seq.replicate (len + 1) (char 0))
-            }
-
-        addr, heap
-
-    let setStringData (addr : int) (contents : string) (heap : ManagedHeap) : ManagedHeap =
-        let newArr =
-            (heap.StringArrayData, seq { 0 .. contents.Length - 1 })
-            ||> Seq.fold (fun data count -> data.SetItem (addr + count, contents.[count]))
-
-        let heap =
-            { heap with
-                StringArrayData = newArr
-            }
-
-        heap
-
     let allocateNonArray (ty : AllocatedNonArrayObject) (heap : ManagedHeap) : ManagedHeapAddress * ManagedHeap =
         let addr = heap.FirstAvailableAddress
 
@@ -118,37 +91,77 @@ module ManagedHeap =
 
         ManagedHeapAddress addr, heap
 
-    /// Record the full character content of a string object located at `addr`, so that
-    /// string-level operations (equality, hashing, etc.) can read it back.
-    let recordStringContents (addr : ManagedHeapAddress) (contents : string) (heap : ManagedHeap) : ManagedHeap =
+    /// Record the linkage from a String heap address to the heap address of its sibling
+    /// `char[]`. Called by `allocateManagedString` immediately after allocating the String
+    /// object and the char array; consumers read the linkage back via `resolveStringChars`.
+    let recordStringCharArray
+        (strAddr : ManagedHeapAddress)
+        (charArrAddr : ManagedHeapAddress)
+        (heap : ManagedHeap)
+        : ManagedHeap
+        =
         { heap with
-            StringContents = heap.StringContents.SetItem (addr, contents)
+            StringCharArrays = heap.StringCharArrays.SetItem (strAddr, charArrAddr)
         }
 
-    /// Retrieve the character content of a string object previously registered via
-    /// `recordStringContents`.  Returns None if no content was recorded (which indicates
-    /// a string that was allocated without using the standard allocation path, or a
-    /// non-string address).
-    let getStringContents (addr : ManagedHeapAddress) (heap : ManagedHeap) : string option =
-        match heap.StringContents.TryGetValue addr with
-        | true, s -> Some s
-        | false, _ -> None
+    /// Resolve a String heap address to its sibling `char[]` allocation. The sibling
+    /// stores the null-terminated char data; its length is the string's text length + 1.
+    /// Fails if the address was not registered via `recordStringCharArray` (i.e. the
+    /// address is not a String, or was allocated via a path that didn't go through
+    /// `allocateManagedString`).
+    let resolveStringChars (strAddr : ManagedHeapAddress) (heap : ManagedHeap) : AllocatedArray =
+        match heap.StringCharArrays.TryGetValue strAddr with
+        | false, _ ->
+            failwith
+                $"resolveStringChars: address %O{strAddr} has no registered sibling char[]; not a String allocated via allocateManagedString"
+        | true, arrAddr ->
+
+        match heap.Arrays.TryGetValue arrAddr with
+        | false, _ ->
+            failwith
+                $"resolveStringChars: String %O{strAddr} is linked to sibling %O{arrAddr} but that array is missing from the heap"
+        | true, arr -> arr
+
+    /// Same as `resolveStringChars`, but returns the sibling's heap address alongside the
+    /// array payload. Used by the `Ldflda` interception to construct an `ArrayElement`
+    /// byref rooted at the sibling.
+    let resolveStringCharArrayAddr (strAddr : ManagedHeapAddress) (heap : ManagedHeap) : ManagedHeapAddress =
+        match heap.StringCharArrays.TryGetValue strAddr with
+        | false, _ ->
+            failwith
+                $"resolveStringCharArrayAddr: address %O{strAddr} has no registered sibling char[]; not a String allocated via allocateManagedString"
+        | true, arrAddr -> arrAddr
 
     /// Value-level equality between two managed string objects addressed by `a1` and `a2`.
     /// Mirrors the semantics of System.String.Equals(string, string): null-aware, reference
-    /// equal implies equal, otherwise compares full character contents.
-    /// Fails if either address is not a known string and the two addresses are distinct
+    /// equal implies equal, otherwise compares full character contents by walking the
+    /// sibling `char[]` of each string.
+    /// Fails if either address is not a registered string and the two addresses are distinct
     /// (i.e., we genuinely need the character content to answer).
     let stringsEqual (a1 : ManagedHeapAddress) (a2 : ManagedHeapAddress) (heap : ManagedHeap) : bool =
         if a1 = a2 then
             true
         else
-            match getStringContents a1 heap, getStringContents a2 heap with
-            | Some s1, Some s2 -> s1 = s2
-            | None, _
-            | _, None ->
-                failwith
-                    $"stringsEqual: one or both addresses %O{a1}, %O{a2} are not registered strings; cannot compare contents"
+            let chars1 = resolveStringChars a1 heap
+            let chars2 = resolveStringChars a2 heap
+            // Sibling arrays are allocated with length = text length + 1 (null terminator).
+            // The terminator is not part of the comparison, but we compare the whole stored
+            // range anyway: two strings with the same non-terminator contents will also have
+            // matching null terminators at the same index. If the lengths differ, the strings
+            // differ.
+            if chars1.Length <> chars2.Length then
+                false
+            else
+                let mutable i = 0
+                let mutable equal = true
+
+                while equal && i < chars1.Length do
+                    if chars1.Elements.[i] <> chars2.Elements.[i] then
+                        equal <- false
+
+                    i <- i + 1
+
+                equal
 
     let getArrayValue (alloc : ManagedHeapAddress) (offset : int) (heap : ManagedHeap) : CliType =
         match heap.Arrays.TryGetValue alloc with

--- a/WoofWare.PawPrint/UnaryMetadataIlOp.fs
+++ b/WoofWare.PawPrint/UnaryMetadataIlOp.fs
@@ -834,6 +834,15 @@ module internal UnaryMetadataIlOp =
                     state
             | _ ->
 
+            // `System.String._firstChar` isn't a stored field; writes go to element 0 of the
+            // sibling `char[]` recorded in `ManagedHeap.StringCharArrays`. Mirrors the
+            // interception in Ldfld/Ldflda; see `IlMachineState.allocateManagedString`.
+            let isStringFirstChar =
+                field.Name = "_firstChar"
+                && field.DeclaringType.Namespace = "System"
+                && field.DeclaringType.Name = "String"
+                && field.DeclaringType.Assembly.FullName = baseClassTypes.Corelib.Name.FullName
+
             let state =
                 match currentObj with
                 | EvalStackValue.Int32 _ -> failwith "unexpectedly setting field on an int"
@@ -842,19 +851,26 @@ module internal UnaryMetadataIlOp =
                 | EvalStackValue.Float _ -> failwith "unexpectedly setting field on a float"
                 | EvalStackValue.NullObjectRef -> failwith "unreachable: NullObjectRef handled above"
                 | EvalStackValue.ObjectRef addr ->
-                    match state.ManagedHeap.NonArrayObjects.TryGetValue addr with
-                    | false, _ -> failwith $"todo: array {addr}"
-                    | true, v ->
-                        let v = AllocatedNonArrayObject.SetField field.Name valueToStore v
-
-                        let heap =
-                            { state.ManagedHeap with
-                                NonArrayObjects = state.ManagedHeap.NonArrayObjects |> Map.add addr v
-                            }
+                    if isStringFirstChar then
+                        let siblingAddr = ManagedHeap.resolveStringCharArrayAddr addr state.ManagedHeap
 
                         { state with
-                            ManagedHeap = heap
+                            ManagedHeap = ManagedHeap.setArrayValue siblingAddr 0 valueToStore state.ManagedHeap
                         }
+                    else
+                        match state.ManagedHeap.NonArrayObjects.TryGetValue addr with
+                        | false, _ -> failwith $"todo: array {addr}"
+                        | true, v ->
+                            let v = AllocatedNonArrayObject.SetField field.Name valueToStore v
+
+                            let heap =
+                                { state.ManagedHeap with
+                                    NonArrayObjects = state.ManagedHeap.NonArrayObjects |> Map.add addr v
+                                }
+
+                            { state with
+                                ManagedHeap = heap
+                            }
                 | EvalStackValue.ManagedPointer src ->
                     IlMachineState.writeManagedByref
                         state

--- a/WoofWare.PawPrint/UnaryMetadataIlOp.fs
+++ b/WoofWare.PawPrint/UnaryMetadataIlOp.fs
@@ -834,15 +834,6 @@ module internal UnaryMetadataIlOp =
                     state
             | _ ->
 
-            // `System.String._firstChar` isn't a stored field; writes go to element 0 of the
-            // sibling `char[]` recorded in `ManagedHeap.StringCharArrays`. Mirrors the
-            // interception in Ldfld/Ldflda; see `IlMachineState.allocateManagedString`.
-            let isStringFirstChar =
-                field.Name = "_firstChar"
-                && field.DeclaringType.Namespace = "System"
-                && field.DeclaringType.Name = "String"
-                && field.DeclaringType.Assembly.FullName = baseClassTypes.Corelib.Name.FullName
-
             let state =
                 match currentObj with
                 | EvalStackValue.Int32 _ -> failwith "unexpectedly setting field on an int"
@@ -851,26 +842,9 @@ module internal UnaryMetadataIlOp =
                 | EvalStackValue.Float _ -> failwith "unexpectedly setting field on a float"
                 | EvalStackValue.NullObjectRef -> failwith "unreachable: NullObjectRef handled above"
                 | EvalStackValue.ObjectRef addr ->
-                    if isStringFirstChar then
-                        let siblingAddr = ManagedHeap.resolveStringCharArrayAddr addr state.ManagedHeap
-
-                        { state with
-                            ManagedHeap = ManagedHeap.setArrayValue siblingAddr 0 valueToStore state.ManagedHeap
-                        }
-                    else
-                        match state.ManagedHeap.NonArrayObjects.TryGetValue addr with
-                        | false, _ -> failwith $"todo: array {addr}"
-                        | true, v ->
-                            let v = AllocatedNonArrayObject.SetField field.Name valueToStore v
-
-                            let heap =
-                                { state.ManagedHeap with
-                                    NonArrayObjects = state.ManagedHeap.NonArrayObjects |> Map.add addr v
-                                }
-
-                            { state with
-                                ManagedHeap = heap
-                            }
+                    { state with
+                        ManagedHeap = ManagedHeap.setField addr field.Name valueToStore state.ManagedHeap
+                    }
                 | EvalStackValue.ManagedPointer src ->
                     IlMachineState.writeManagedByref
                         state
@@ -1042,15 +1016,6 @@ module internal UnaryMetadataIlOp =
                     state
             | _ ->
 
-            // `System.String._firstChar` isn't a stored field; its value lives in element 0
-            // of the sibling `char[]` recorded in `ManagedHeap.StringCharArrays`. See
-            // `IlMachineState.allocateManagedString` for the allocation side.
-            let isStringFirstChar =
-                field.Name = "_firstChar"
-                && field.DeclaringType.Namespace = "System"
-                && field.DeclaringType.Name = "String"
-                && field.DeclaringType.Assembly.FullName = baseClassTypes.Corelib.Name.FullName
-
             let state =
                 match currentObj with
                 | EvalStackValue.Int32 i -> failwith "todo: int32"
@@ -1059,18 +1024,10 @@ module internal UnaryMetadataIlOp =
                 | EvalStackValue.Float f -> failwith "todo: float"
                 | EvalStackValue.NullObjectRef -> failwith "unreachable: NullObjectRef handled above"
                 | EvalStackValue.ObjectRef managedHeapAddress ->
-                    if isStringFirstChar then
-                        let sibling = ManagedHeap.resolveStringChars managedHeapAddress state.ManagedHeap
-
-                        IlMachineState.pushToEvalStack sibling.Elements.[0] thread state
-                    else
-                        match state.ManagedHeap.NonArrayObjects.TryGetValue managedHeapAddress with
-                        | false, _ -> failwith $"todo: array {managedHeapAddress}"
-                        | true, v ->
-                            IlMachineState.pushToEvalStack
-                                (AllocatedNonArrayObject.DereferenceField field.Name v)
-                                thread
-                                state
+                    IlMachineState.pushToEvalStack
+                        (ManagedHeap.dereferenceField managedHeapAddress field.Name state.ManagedHeap)
+                        thread
+                        state
                 | EvalStackValue.ManagedPointer src ->
                     let currentValue =
                         IlMachineState.readManagedByref state src |> CliType.getField field.Name
@@ -1123,16 +1080,6 @@ module internal UnaryMetadataIlOp =
                     state
             | _ ->
 
-            // `System.String._firstChar` isn't a stored field; taking its address yields an
-            // `ArrayElement` byref into element 0 of the sibling `char[]` recorded in
-            // `ManagedHeap.StringCharArrays`. See `IlMachineState.allocateManagedString` for
-            // the allocation side.
-            let isStringFirstChar =
-                field.Name = "_firstChar"
-                && field.DeclaringType.Namespace = "System"
-                && field.DeclaringType.Name = "String"
-                && field.DeclaringType.Assembly.FullName = baseClassTypes.Corelib.Name.FullName
-
             let result =
                 match ptr with
                 | Int32 _
@@ -1142,12 +1089,7 @@ module internal UnaryMetadataIlOp =
                 | ManagedPointer src -> ManagedPointerSource.appendProjection (ByrefProjection.Field field.Name) src
                 | NullObjectRef -> failwith "unreachable: NullObjectRef handled above"
                 | ObjectRef addr ->
-                    if isStringFirstChar then
-                        let siblingAddr = ManagedHeap.resolveStringCharArrayAddr addr state.ManagedHeap
-
-                        ManagedPointerSource.Byref (ByrefRoot.ArrayElement (siblingAddr, 0), [])
-                    else
-                        ManagedPointerSource.Byref (ByrefRoot.HeapObjectField (addr, field.Name), [])
+                    ManagedPointerSource.Byref (ManagedHeap.byrefRootForField addr field.Name state.ManagedHeap, [])
                 | UserDefinedValueType evalStackValueUserType -> failwith "todo"
                 |> EvalStackValue.ManagedPointer
 

--- a/WoofWare.PawPrint/UnaryMetadataIlOp.fs
+++ b/WoofWare.PawPrint/UnaryMetadataIlOp.fs
@@ -1026,6 +1026,15 @@ module internal UnaryMetadataIlOp =
                     state
             | _ ->
 
+            // `System.String._firstChar` isn't a stored field; its value lives in element 0
+            // of the sibling `char[]` recorded in `ManagedHeap.StringCharArrays`. See
+            // `IlMachineState.allocateManagedString` for the allocation side.
+            let isStringFirstChar =
+                field.Name = "_firstChar"
+                && field.DeclaringType.Namespace = "System"
+                && field.DeclaringType.Name = "String"
+                && field.DeclaringType.Assembly.FullName = baseClassTypes.Corelib.Name.FullName
+
             let state =
                 match currentObj with
                 | EvalStackValue.Int32 i -> failwith "todo: int32"
@@ -1034,13 +1043,18 @@ module internal UnaryMetadataIlOp =
                 | EvalStackValue.Float f -> failwith "todo: float"
                 | EvalStackValue.NullObjectRef -> failwith "unreachable: NullObjectRef handled above"
                 | EvalStackValue.ObjectRef managedHeapAddress ->
-                    match state.ManagedHeap.NonArrayObjects.TryGetValue managedHeapAddress with
-                    | false, _ -> failwith $"todo: array {managedHeapAddress}"
-                    | true, v ->
-                        IlMachineState.pushToEvalStack
-                            (AllocatedNonArrayObject.DereferenceField field.Name v)
-                            thread
-                            state
+                    if isStringFirstChar then
+                        let sibling = ManagedHeap.resolveStringChars managedHeapAddress state.ManagedHeap
+
+                        IlMachineState.pushToEvalStack sibling.Elements.[0] thread state
+                    else
+                        match state.ManagedHeap.NonArrayObjects.TryGetValue managedHeapAddress with
+                        | false, _ -> failwith $"todo: array {managedHeapAddress}"
+                        | true, v ->
+                            IlMachineState.pushToEvalStack
+                                (AllocatedNonArrayObject.DereferenceField field.Name v)
+                                thread
+                                state
                 | EvalStackValue.ManagedPointer src ->
                     let currentValue =
                         IlMachineState.readManagedByref state src |> CliType.getField field.Name
@@ -1093,6 +1107,16 @@ module internal UnaryMetadataIlOp =
                     state
             | _ ->
 
+            // `System.String._firstChar` isn't a stored field; taking its address yields an
+            // `ArrayElement` byref into element 0 of the sibling `char[]` recorded in
+            // `ManagedHeap.StringCharArrays`. See `IlMachineState.allocateManagedString` for
+            // the allocation side.
+            let isStringFirstChar =
+                field.Name = "_firstChar"
+                && field.DeclaringType.Namespace = "System"
+                && field.DeclaringType.Name = "String"
+                && field.DeclaringType.Assembly.FullName = baseClassTypes.Corelib.Name.FullName
+
             let result =
                 match ptr with
                 | Int32 _
@@ -1101,7 +1125,13 @@ module internal UnaryMetadataIlOp =
                 | NativeInt nativeIntSource -> failwith "todo"
                 | ManagedPointer src -> ManagedPointerSource.appendProjection (ByrefProjection.Field field.Name) src
                 | NullObjectRef -> failwith "unreachable: NullObjectRef handled above"
-                | ObjectRef addr -> ManagedPointerSource.Byref (ByrefRoot.HeapObjectField (addr, field.Name), [])
+                | ObjectRef addr ->
+                    if isStringFirstChar then
+                        let siblingAddr = ManagedHeap.resolveStringCharArrayAddr addr state.ManagedHeap
+
+                        ManagedPointerSource.Byref (ByrefRoot.ArrayElement (siblingAddr, 0), [])
+                    else
+                        ManagedPointerSource.Byref (ByrefRoot.HeapObjectField (addr, field.Name), [])
                 | UserDefinedValueType evalStackValueUserType -> failwith "todo"
                 |> EvalStackValue.ManagedPointer
 

--- a/docs/plans/2026-04-22-string-sibling-char-array.md
+++ b/docs/plans/2026-04-22-string-sibling-char-array.md
@@ -1,0 +1,291 @@
+# No-op refactor: replace the flat string pool with sibling `char[]` allocations
+
+## Context
+
+`System.String` is modelled on main with two pieces of special-case storage:
+
+- `ManagedHeap.StringArrayData : ImmutableArray<char>` — a flat bump-allocated pool
+  containing *every* string's chars back-to-back, with null terminators.
+- `ManagedHeap.StringContents : ImmutableDictionary<ManagedHeapAddress, string>` — a
+  side-table from a String heap address to its managed `string` contents, consulted by
+  `ManagedHeap.stringsEqual` (the only consumer; used by the `string.Equals(string, string)`
+  intrinsic).
+
+The String heap object itself carries two real CLR-shaped fields: `_firstChar` (a
+`Char`) and `_stringLength` (an `Int32`). `_firstChar` is populated with
+`StringArrayData.[dataAddr]` at allocation time, but the remaining chars live only in
+`StringArrayData`.
+
+This layout is load-bearing for the current runtime, but it blocks the `memmove`
+programme (`docs/plans/2026-04-20-memmove.md`). PR C in that stack ("string char
+addressing") ended up growing a parallel `ByrefRoot.StringCharAt` constructor and
+threading it through byref read/write, byref arithmetic, byte-view intrinsics, and
+four `SetField "_firstChar"` sync sites — nearly all of which are structurally
+identical to the existing `ByrefRoot.ArrayElement` machinery. The reason `ArrayElement`
+couldn't be reused was simply that the chars weren't in an array; they were in
+`StringArrayData`.
+
+If the chars sat in a sibling `char[]` in the ordinary `Arrays` map, PR C collapses
+into ~two IL-dispatch cases and inherits the entirety of the array-byref machinery
+from PRs A and B for free.
+
+The user's specific concern about PR C's shape — "is there some structural reason the
+CLR requires these as special cases?" — is answered by this refactor: there isn't,
+the specialness is an artefact of our pool, and removing the pool removes the
+specialness.
+
+## Guiding principle
+
+This is a pure representational refactor. No observable behaviour changes, no IL
+semantics change, no currently-failing test starts passing, no currently-passing test
+changes its output. The only visible difference is internal data-structure shape.
+
+## Current state on main
+
+### Allocation (`IlMachineState.allocateManagedString`)
+
+```
+allocateStringData contents.Length    // grows StringArrayData by len+1
+setStringData dataAddr contents       // writes contents into the pool
+_firstChar = CliType.ofChar StringArrayData.[dataAddr]
+_stringLength = Int32 contents.Length
+allocateManagedObject with these two fields
+ManagedHeap.recordStringContents addr contents    // populates StringContents
+```
+
+Two entry points: `UnaryStringTokenIlOp` (Ldstr, with the `InternedStrings`
+cache keyed by StringToken) and `IlMachineStateExecution` (TypeInitializationException
+constructing its `_typeName`). Both go through `allocateManagedString`, so there is
+one allocation seam.
+
+### `_firstChar` / `_stringLength` consumers
+
+A subagent search on the pre-refactor branch confirmed that `_firstChar` is only
+observed through named access; nothing iterates string fields generically and expects
+`_firstChar` to be present. The producers of `ByrefRoot.HeapObjectField(_, "_firstChar")`
+on main are exactly one: `UnaryMetadataIlOp.fs` line 1104 (the `Ldflda` handler). The
+value is read via `AllocatedNonArrayObject.DereferenceField "_firstChar"` (Ldfld on an
+ObjectRef) or via the generic Ldfld-through-ManagedPointer path; both take the field
+name by string match inside `CliValueType.DereferenceField`.
+
+### `StringArrayData` / `StringContents` consumers
+
+- `StringArrayData`: read once in `allocateManagedString` for the `_firstChar` seed;
+  indexed nowhere else on main.
+- `StringContents`: read only through `ManagedHeap.getStringContents`, which is called
+  only from `ManagedHeap.stringsEqual`, which is called only from the
+  `string.Equals(string, string)` intrinsic handler (`Intrinsics.fs:503` on main).
+
+No cross-string aliasing: the pool is a bump allocator, no two strings share char
+storage, and interning lives at the IL level (`InternedStrings` keyed by
+`StringToken`), completely orthogonal to the pool.
+
+## Goal
+
+Replace the pool and the cache with a sibling `char[]` allocation per string, stored
+in the normal `Arrays` map, with a side-table recording the String-to-sibling link.
+Intercept `Ldfld`/`Ldflda` on `System.String._firstChar` to read/address the sibling's
+element 0, so that the String heap object no longer needs to carry `_firstChar` as a
+stored field.
+
+Observable behaviour is identical before and after. Nothing on main moves from
+"passing" to "failing" or vice versa. The test suite runs unchanged.
+
+### Why this sets up the memmove rebase
+
+After this refactor lands:
+
+- PR C of the memmove stack collapses to: "`Ldflda System.String._firstChar` returns a
+  byref rooted at `ArrayElement(siblingAddr, 0)`, [] instead of the HeapObjectField
+  root." Exactly one IL-dispatch site changes.
+- `ByrefRoot.StringCharAt`, `StringDataOffsets`, `resolveStringCharAt`, `writeStringChar`,
+  `recordStringDataOffset`, and all the `StringCharAt` branches in
+  `BasicCliType.normaliseArrayByteOffset` / `Intrinsics` / `readManagedByref` /
+  `writeManagedByref` / `BinaryArithmetic` disappear — they were emulating
+  `ArrayElement` byref semantics, and now they *are* `ArrayElement` byrefs.
+- The four `SetField "_firstChar"` sync sites in `Intrinsics`/`IlMachineState` go away:
+  the sibling array is the single source of truth; there is no `_firstChar` field to
+  keep in sync.
+
+## Changes
+
+### `ManagedHeap.fs`
+
+**Remove:**
+
+- `StringArrayData : ImmutableArray<char>`
+- `StringContents : ImmutableDictionary<ManagedHeapAddress, string>`
+- `allocateString : int -> ManagedHeap -> int * ManagedHeap`
+- `setStringData : int -> string -> ManagedHeap -> ManagedHeap`
+- `recordStringContents : ManagedHeapAddress -> string -> ManagedHeap -> ManagedHeap`
+- `getStringContents : ManagedHeapAddress -> ManagedHeap -> string option`
+
+**Add:**
+
+- `StringCharArrays : Map<ManagedHeapAddress, ManagedHeapAddress>` — maps the String
+  heap address to the heap address of its sibling `char[]`. Populated at allocation
+  time. The sibling array lives in the ordinary `Arrays` map; nothing else special.
+- `resolveStringChars : ManagedHeapAddress -> ManagedHeap -> AllocatedArray` — returns
+  the sibling array for a given String address. Internal helper for `stringsEqual`
+  and the Ldfld interception.
+
+**Change `stringsEqual`:** instead of comparing `StringContents[a1]` against
+`StringContents[a2]`, read the two sibling arrays, take the first `_stringLength`
+chars of each (the terminator is not part of the comparison), and compare element-wise.
+`_stringLength` is read from the String heap object's stored field. If either address
+is not a registered string (no entry in `StringCharArrays`), fail loudly with the same
+message shape as before.
+
+### `IlMachineState.fs`
+
+**Remove:**
+
+- `allocateStringData : int -> IlMachineState -> int * IlMachineState`
+- `setStringData : int -> string -> IlMachineState -> IlMachineState`
+
+**Change `allocateManagedString`:**
+
+```
+let allocateManagedString loggerFactory baseClassTypes contents state =
+    // validate String.Fields shape exactly as today (unchanged)
+    //
+    // 1. Allocate a char[] of length (contents.Length + 1) with null terminator,
+    //    populated with contents + '\0'.
+    let siblingAddr, state = <existing char[] allocation machinery> state
+    //    This uses AllocatedArray with ElementType = Char and Length = len + 1,
+    //    exactly as a normal `new char[n]` would.
+    //
+    // 2. Build the String heap object with _stringLength only (no _firstChar).
+    //    Fields list = [ _stringLength ] (one element, Int32 contents.Length).
+    //
+    // 3. Allocate the String object; record the linkage.
+    let addr, state = allocateManagedObject stringType fields state
+    let state =
+        { state with
+            ManagedHeap =
+                { state.ManagedHeap with
+                    StringCharArrays = state.ManagedHeap.StringCharArrays.Add (addr, siblingAddr)
+                }
+        }
+    addr, state
+```
+
+The metadata-shape check stays as today (asserts `[_firstChar; _stringLength]`), but
+construction only stores `_stringLength`. Document inline: "String's `_firstChar` field
+is synthesised via Ldfld/Ldflda interception in UnaryMetadataIlOp — see the sibling
+char[] at `state.ManagedHeap.StringCharArrays.[addr]`." Failure mode if the BCL's
+`String` shape ever changes is unchanged (same `failwith`).
+
+### `UnaryMetadataIlOp.fs`
+
+**Add two interception cases**, symmetric, each guarded on "the field is
+`System.String._firstChar`":
+
+- `Ldfld`: when `field.DeclaringType` is `System.String` and `field.Name` is
+  `_firstChar`, read `resolveStringChars addr heap`'s element 0 and push that char;
+  skip the default `AllocatedNonArrayObject.DereferenceField` / `CliType.getField`
+  path.
+- `Ldflda`: in the same guard, produce
+  `ManagedPointerSource.Byref (ByrefRoot.ArrayElement (siblingAddr, 0), [])` instead
+  of `Byref (ByrefRoot.HeapObjectField (strAddr, "_firstChar"), [])`.
+
+The guard lives at the top of the per-variant `ObjectRef` branch (and the
+`ManagedPointer` branch for Ldfld), before the generic field dispatch. The check is a
+structural match on the field's declaring type — not a pattern on the field name in
+isolation, and not a blanket name match like on the earlier branch. "Is this a String
+and is the requested field `_firstChar`?" If yes, route to the sibling; if no, fall
+through unchanged.
+
+(If later we grow more sibling-backed types, we can generalise the check by routing it
+through a tiny predicate. For now, one type has this treatment, so a direct check is
+clearest.)
+
+### `UnaryStringTokenIlOp.fs`
+
+No change. `InternedStrings`-keyed `ldstr` path continues to call
+`IlMachineState.allocateManagedString`; the implementation behind the seam changes but
+the signature doesn't.
+
+### `Intrinsics.fs`
+
+No change in the `string.Equals(string, string)` handler — it still calls
+`ManagedHeap.stringsEqual`, which is still the one function that understands how to
+compare two string addresses. The implementation behind `stringsEqual` changes; the
+call site doesn't.
+
+### `tui-design.md`
+
+Update the one prose reference: "shows the string content from `StringArrayData`"
+→ "shows the string content from the sibling char array recorded in
+`StringCharArrays`."
+
+## Validation
+
+No new tests. This refactor must pass the existing test suite unchanged. The suite
+already exercises:
+
+- Ldstr with interning (many tests).
+- `String.Equals(string, string)` over interned and runtime-constructed strings.
+- `TypeInitializationException` allocation paths (exception tests).
+- `Ldfld _firstChar` through the various paths (implicitly, via any BCL code that
+  walks String internally — most BCL string code reads `_firstChar` through
+  `Unsafe.Add`/`RuntimeHelpers.GetRawData`, which routes through our intrinsics, but
+  the plain-field read path is exercised by anything that emits a naked
+  `ldfld _firstChar`, e.g. `string.get_Chars(0)` fallbacks).
+
+Run:
+
+```
+nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --verbosity normal
+```
+
+and confirm the same pass/fail set as before the refactor. No entries added to or
+removed from `unimplemented`.
+
+## Risks and invariants
+
+1. **Metadata shape check stays.** The `_firstChar; _stringLength` assertion in
+   `allocateManagedString` is the one place we hard-check the BCL's String layout;
+   keep it. If .NET ever reshapes `System.String`, we want a loud failure with a clear
+   name, not a silent drift.
+
+2. **`DereferenceField "_firstChar"` on a String.** After the refactor, the String
+   heap object does not store `_firstChar`. Any generic path that calls
+   `CliValueType.DereferenceField "_firstChar"` on a String's `CliValueType` will
+   throw "Field '_firstChar' not found". The existing dispatch paths that do this
+   (two in `UnaryMetadataIlOp.Ldfld`) are covered by the interception. If a new path
+   ever reaches `DereferenceField "_firstChar"` on a String without going through
+   `Ldfld`, it will fail loudly — which is the correct outcome.
+
+3. **`_stringLength` byref stability.** `Ldflda` on `_stringLength` continues to
+   produce `Byref(HeapObjectField(strAddr, "_stringLength"), [])` — unchanged. The
+   field is still a real stored field.
+
+4. **`StringCharArrays` side-table lifetime.** Keyed by the String's heap address.
+   Strings are immutable and never collected (we have no GC), so entries are
+   permanent. No invalidation concern.
+
+5. **Sibling allocation ordering.** Allocate the sibling `char[]` first, then the
+   String object, then record the linkage. This means `FirstAvailableAddress`
+   increments twice per string. Fine — all tests exercising allocation patterns take
+   this as opaque.
+
+6. **Interning still works.** `InternedStrings` is keyed by `StringToken`, not by
+   content, and lives in `IlMachineState`, not the heap. Completely unaffected.
+
+7. **Determinism.** No new mutable state; side-table is immutable like the rest of the
+   heap. Allocation order is deterministic.
+
+8. **`stringsEqual` complexity.** Goes from O(1) dictionary lookup to O(min len)
+   element-wise comparison. Fine — it was only used by `string.Equals`, which is O(n)
+   anyway in the real BCL; nothing depends on the dictionary-lookup shortcut.
+
+## After this lands
+
+Rebase `memmove-pr-c-string-char-addressing` on the new main. The existing diff
+largely evaporates — no new ByrefRoot constructor, no parallel data table, no
+`SetField "_firstChar"` sync sites, no StringCharAt branches anywhere. PR C becomes
+a change to the `Ldflda System.String._firstChar` interception: instead of returning
+`Byref(ArrayElement(siblingAddr, 0), [])`, it returns the same but exposes the full
+char range for pointer arithmetic. In practice this is already the case — so PR C
+may collapse to zero lines of runtime change plus its tests.

--- a/docs/tui-design.md
+++ b/docs/tui-design.md
@@ -129,7 +129,7 @@ Note: `WhatWeDid.SuspendedForClassInit` indicates "this thread's requested instr
 Three sub-views selectable with the filter dropdown:
 - **Objects**: `ManagedHeap.NonArrayObjects` -- shows `ConcreteType` name, sync block state, and a compact field summary
 - **Arrays**: `ManagedHeap.Arrays` -- shows element type, length, and first few elements
-- **Strings**: Objects whose type resolves to `System.String` -- shows the string content from `StringArrayData`
+- **Strings**: Objects whose type resolves to `System.String` -- shows the string content from the sibling `char[]` recorded in `StringCharArrays`
 
 Pressing Enter on an object opens a **detail view**:
 


### PR DESCRIPTION
Opus 4.7[1m] ultrareview:

🟡 WoofWare.PawPrint/UnaryMetadataIlOp.fs:1141
> The isStringFirstChar interception is missing from the ManagedPointer branches in the Ldflda, Ldfld, and Stfld handlers. If a ManagedPointer to a String somehow reached these paths, the code would attempt to project through _firstChar as a regular field, which no longer exists on the String heap object after this refactor. In practice this is unreachable because String is a reference type (so this is always an ObjectRef), but adding the guard to the ManagedPointer branches would make the interception consistent and robust against future changes.