### PR TITLE
Stop running cctor for internal CLR exceptions

### DIFF
--- a/.claude/commands/raise-guest-exception.md
+++ b/.claude/commands/raise-guest-exception.md
@@ -37,10 +37,12 @@ with
 
 ## Tier 2: Constructing and throwing a new exception object
 
-Use `IlMachineStateExecution.raiseManagedException`. It takes a `TypeInfo`, e.g. as from `BaseClassTypes` (such as `baseClassTypes.NullReferenceException`) and returns `IlMachineState * WhatWeDid`. Do NOT advance the program counter after calling it — exception dispatch uses the faulting instruction's PC to determine which exception handler regions are active and to build the stack trace.
+Use `IlMachineStateExecution.raiseRuntimeException`. It takes a `TypeInfo`, e.g. as from `BaseClassTypes` (such as `baseClassTypes.NullReferenceException`) and returns `IlMachineState * WhatWeDid`. Do NOT advance the program counter after calling it — exception dispatch uses the faulting instruction's PC to determine which exception handler regions are active and to build the stack trace.
+
+This entry point is intended for exceptions the runtime itself synthesises (e.g. `NullReferenceException` from a null deref, `InvalidCastException` from a failed `castclass`). It deliberately skips the exception type's `.cctor`, which is safe for the BCL exception types but not for arbitrary guest-defined types — so don't use it to dispatch guest-thrown exceptions. Those go through Tier 1 (`throwExceptionObject`) after the guest's own `newobj` has already run the cctor.
 
 ```fsharp
-IlMachineStateExecution.raiseManagedException
+IlMachineStateExecution.raiseRuntimeException
     loggerFactory
     baseClassTypes
     baseClassTypes.NullReferenceException

--- a/WoofWare.PawPrint/ExceptionDispatching.fs
+++ b/WoofWare.PawPrint/ExceptionDispatching.fs
@@ -734,7 +734,7 @@ module ExceptionDispatching =
 
     /// Allocate a zero-initialised exception of the given type on the managed heap and set its
     /// _HResult field to the correct value.  The constructor is NOT run; the caller is
-    /// responsible for pushing a ctor frame (see IlMachineStateExecution.raiseManagedException).
+    /// responsible for pushing a ctor frame (see IlMachineStateExecution.raiseRuntimeException).
     ///
     /// This is the allocation half of the CLR's EEException::CreateThrowable.
     /// See the corresponding CLR source:

--- a/WoofWare.PawPrint/IlMachineStateExecution.fs
+++ b/WoofWare.PawPrint/IlMachineStateExecution.fs
@@ -774,16 +774,28 @@ module IlMachineStateExecution =
             else
                 state, WhatWeDid.BlockedOnClassInit threadId
 
-    /// Allocate a runtime-synthesised exception without running the exception type's .cctor,
-    /// push its default instance constructor frame, and return to the dispatch loop.  When
-    /// the ctor completes (Ret), returnStackFrame will signal DispatchException so the Ret
-    /// handler can dispatch the exception.
+    /// Synthesise an exception from inside the runtime itself (the host emulating the CLR),
+    /// as opposed to a `throw` opcode executed by guest IL. Allocates the exception without
+    /// running the exception type's .cctor, pushes its default instance constructor frame,
+    /// and returns to the dispatch loop. When the ctor completes (Ret), returnStackFrame
+    /// will signal DispatchException so the Ret handler can dispatch the exception.
+    ///
+    /// Use this for opcode-manufactured exceptions like `NullReferenceException` from a null
+    /// dereference or `InvalidCastException` from a failed `castclass`. Do NOT use it for
+    /// dispatching exceptions that the guest itself constructs and throws via `newobj` + `throw`
+    /// — those go through `ExceptionDispatching.throwExceptionObject` and the cctor will already
+    /// have run during the guest's `newobj`.
+    ///
+    /// All current call sites pass a non-generic BCL exception type from `BaseClassTypes`. The
+    /// cctor-skip is safe for those (their cctors are trivial or empty); it would not be safe
+    /// for an arbitrary guest-defined exception type, which is why this entry point is
+    /// reserved for runtime use.
     ///
     /// This is a runtime boundary, not guest `newobj` semantics. It mirrors the CLR's
     /// EEException::CreateThrowable path: allocate the object directly, call the default
     /// instance ctor, then overwrite HResult.
     /// See: https://github.com/dotnet/dotnet/blob/10060d128e3f470e77265f8490f5e4f72dae738e/src/runtime/src/coreclr/vm/clrex.cpp#L972-L1019
-    let raiseManagedException
+    let raiseRuntimeException
         (loggerFactory : ILoggerFactory)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (exceptionTypeInfo : TypeInfo<GenericParamFromMetadata, TypeDefn>)
@@ -803,20 +815,20 @@ module IlMachineStateExecution =
 
         if not typeDef.Generics.IsEmpty then
             failwith
-                $"raiseManagedException: expected non-generic exception type, but %s{exceptionTypeInfo.Namespace}.%s{exceptionTypeInfo.Name} has %i{typeDef.Generics.Length} generic parameter(s)"
+                $"raiseRuntimeException: expected non-generic exception type, but %s{exceptionTypeInfo.Namespace}.%s{exceptionTypeInfo.Name} has %i{typeDef.Generics.Length} generic parameter(s)"
 
         let ctor =
             typeDef.Methods
             |> List.tryFind (fun method -> method.Name = ".ctor" && not method.IsStatic && method.Parameters.IsEmpty)
             |> Option.defaultWith (fun () ->
                 failwith
-                    $"raiseManagedException: no parameterless .ctor found on %s{exceptionTypeInfo.Namespace}.%s{exceptionTypeInfo.Name}"
+                    $"raiseRuntimeException: no parameterless .ctor found on %s{exceptionTypeInfo.Namespace}.%s{exceptionTypeInfo.Name}"
             )
             // The type has no generic parameters (guarded above), so any GenericParamFromMetadata
             // in the ctor's type-generic positions is unreachable. Map them to TypeDefn to satisfy
             // concretizeMethodForExecution's signature.
             |> MethodInfo.mapTypeGenerics (fun _ ->
-                failwith<TypeDefn> "raiseManagedException: exception type was unexpectedly generic"
+                failwith<TypeDefn> "raiseRuntimeException: exception type was unexpectedly generic"
             )
 
         // 3. Push the allocated object ref as `this` for the ctor.

--- a/WoofWare.PawPrint/IlMachineStateExecution.fs
+++ b/WoofWare.PawPrint/IlMachineStateExecution.fs
@@ -774,12 +774,14 @@ module IlMachineStateExecution =
             else
                 state, WhatWeDid.BlockedOnClassInit threadId
 
-    /// Allocate a runtime-synthesised exception, push its default constructor frame, and
-    /// return to the dispatch loop.  When the ctor completes (Ret), returnStackFrame will
-    /// signal DispatchException so the Ret handler can dispatch the exception.
+    /// Allocate a runtime-synthesised exception without running the exception type's .cctor,
+    /// push its default instance constructor frame, and return to the dispatch loop.  When
+    /// the ctor completes (Ret), returnStackFrame will signal DispatchException so the Ret
+    /// handler can dispatch the exception.
     ///
-    /// This mirrors the CLR's EEException::CreateThrowable which allocates, calls the
-    /// default ctor, then overwrites HResult.
+    /// This is a runtime boundary, not guest `newobj` semantics. It mirrors the CLR's
+    /// EEException::CreateThrowable path: allocate the object directly, call the default
+    /// instance ctor, then overwrite HResult.
     /// See: https://github.com/dotnet/dotnet/blob/10060d128e3f470e77265f8490f5e4f72dae738e/src/runtime/src/coreclr/vm/clrex.cpp#L972-L1019
     let raiseManagedException
         (loggerFactory : ILoggerFactory)
@@ -789,96 +791,72 @@ module IlMachineStateExecution =
         (state : IlMachineState)
         : IlMachineState * WhatWeDid
         =
-        // 0. Concretize the exception type and ensure it is initialized before allocating.
-        //    This mirrors the Newobj pattern: type init must precede allocation so that if
-        //    the .cctor needs to run (or has previously failed), we return early without
-        //    leaking an allocation or corrupting the eval stack.
-        let stk : SignatureTypeKind =
-            DumpedAssembly.signatureTypeKind baseClassTypes state._LoadedAssemblies exceptionTypeInfo
+        // 1. Allocate the zero-initialised exception with _HResult pre-set.  This deliberately
+        //    bypasses ensureTypeInitialised: opcode-manufactured exceptions are produced by the
+        //    runtime rather than by guest `newobj` class-initialisation semantics.
+        let addr, _exnHandle, state =
+            ExceptionDispatching.allocateRuntimeException loggerFactory baseClassTypes exceptionTypeInfo state
 
-        let state, exnTypeHandle =
-            IlMachineState.concretizeType
-                loggerFactory
-                baseClassTypes
-                state
-                exceptionTypeInfo.Assembly
-                ImmutableArray.Empty
-                ImmutableArray.Empty
-                (TypeDefn.FromDefinition (exceptionTypeInfo.Identity, stk))
+        // 2. Find the parameterless .ctor on the exception type.
+        let assy = state._LoadedAssemblies.[exceptionTypeInfo.Assembly.FullName]
+        let typeDef = assy.TypeDefs.[exceptionTypeInfo.Identity.TypeDefinition.Get]
 
-        let state, typeInit =
-            ensureTypeInitialised loggerFactory baseClassTypes currentThread exnTypeHandle state
+        if not typeDef.Generics.IsEmpty then
+            failwith
+                $"raiseManagedException: expected non-generic exception type, but %s{exceptionTypeInfo.Namespace}.%s{exceptionTypeInfo.Name} has %i{typeDef.Generics.Length} generic parameter(s)"
 
-        match typeInit with
-        | WhatWeDid.Executed ->
-
-            // 1. Allocate the zero-initialised exception with _HResult pre-set.
-            let addr, _exnHandle, state =
-                ExceptionDispatching.allocateRuntimeException loggerFactory baseClassTypes exceptionTypeInfo state
-
-            // 2. Find the parameterless .ctor on the exception type.
-            let assy = state._LoadedAssemblies.[exceptionTypeInfo.Assembly.FullName]
-            let typeDef = assy.TypeDefs.[exceptionTypeInfo.Identity.TypeDefinition.Get]
-
-            if not typeDef.Generics.IsEmpty then
+        let ctor =
+            typeDef.Methods
+            |> List.tryFind (fun method -> method.Name = ".ctor" && not method.IsStatic && method.Parameters.IsEmpty)
+            |> Option.defaultWith (fun () ->
                 failwith
-                    $"raiseManagedException: expected non-generic exception type, but %s{exceptionTypeInfo.Namespace}.%s{exceptionTypeInfo.Name} has %i{typeDef.Generics.Length} generic parameter(s)"
+                    $"raiseManagedException: no parameterless .ctor found on %s{exceptionTypeInfo.Namespace}.%s{exceptionTypeInfo.Name}"
+            )
+            // The type has no generic parameters (guarded above), so any GenericParamFromMetadata
+            // in the ctor's type-generic positions is unreachable. Map them to TypeDefn to satisfy
+            // concretizeMethodForExecution's signature.
+            |> MethodInfo.mapTypeGenerics (fun _ ->
+                failwith<TypeDefn> "raiseManagedException: exception type was unexpectedly generic"
+            )
 
-            let ctor =
-                typeDef.Methods
-                |> List.tryFind (fun method ->
-                    method.Name = ".ctor" && not method.IsStatic && method.Parameters.IsEmpty
-                )
-                |> Option.defaultWith (fun () ->
-                    failwith
-                        $"raiseManagedException: no parameterless .ctor found on %s{exceptionTypeInfo.Namespace}.%s{exceptionTypeInfo.Name}"
-                )
-                // The type has no generic parameters (guarded above), so any GenericParamFromMetadata
-                // in the ctor's type-generic positions is unreachable. Map them to TypeDefn to satisfy
-                // concretizeMethodForExecution's signature.
-                |> MethodInfo.mapTypeGenerics (fun _ ->
-                    failwith<TypeDefn> "raiseManagedException: exception type was unexpectedly generic"
-                )
+        // 3. Push the allocated object ref as `this` for the ctor.
+        let state =
+            IlMachineState.pushToEvalStack (CliType.ObjectRef (Some addr)) currentThread state
 
-            // 3. Push the allocated object ref as `this` for the ctor.
-            let state =
-                IlMachineState.pushToEvalStack (CliType.ObjectRef (Some addr)) currentThread state
+        // 4. Call the ctor, marking the return state so that returnStackFrame dispatches
+        //    the exception instead of pushing the object onto the caller's eval stack.
+        //    Do NOT advance the caller's PC: when the ctor returns and exception dispatch
+        //    begins, handler lookup and the stack-trace frame must see the faulting
+        //    instruction's PC, not the next instruction.  (Same class of bug as call-site
+        //    vs resumed-PC for cross-frame unwinding, which CallSiteIlOpIndex solves.)
+        let state, _ =
+            state.WithThreadSwitchedToAssembly exceptionTypeInfo.Assembly currentThread
 
-            // 4. Call the ctor, marking the return state so that returnStackFrame dispatches
-            //    the exception instead of pushing the object onto the caller's eval stack.
-            //    Do NOT advance the caller's PC: when the ctor returns and exception dispatch
-            //    begins, handler lookup and the stack-trace frame must see the faulting
-            //    instruction's PC, not the next instruction.  (Same class of bug as call-site
-            //    vs resumed-PC for cross-frame unwinding, which CallSiteIlOpIndex solves.)
-            let state, _ =
-                state.WithThreadSwitchedToAssembly exceptionTypeInfo.Assembly currentThread
-
-            let state, concretizedCtor, _declaringTypeHandle =
-                ExecutionConcretization.concretizeMethodForExecution
-                    loggerFactory
-                    baseClassTypes
-                    currentThread
-                    ctor
-                    None
-                    None
-                    state
-
-            let threadState = state.ThreadState.[currentThread]
-
-            callMethod
+        let state, concretizedCtor, _declaringTypeHandle =
+            ExecutionConcretization.concretizeMethodForExecution
                 loggerFactory
                 baseClassTypes
-                None
-                (Some addr) // weAreConstructingObj
-                false // no interface resolution
-                false // wasClassConstructor
-                false // do NOT advance caller PC — dispatch needs the faulting instruction's offset
-                concretizedCtor.Generics
-                concretizedCtor
                 currentThread
-                threadState
+                ctor
                 None
-                true // dispatchAsExceptionOnReturn
-                state,
-            WhatWeDid.Executed
-        | other -> state, other
+                None
+                state
+
+        let threadState = state.ThreadState.[currentThread]
+
+        callMethod
+            loggerFactory
+            baseClassTypes
+            None
+            (Some addr) // weAreConstructingObj
+            false // no interface resolution
+            false // wasClassConstructor
+            false // do NOT advance caller PC — dispatch needs the faulting instruction's offset
+            concretizedCtor.Generics
+            concretizedCtor
+            currentThread
+            threadState
+            None
+            true // dispatchAsExceptionOnReturn
+            state,
+        WhatWeDid.Executed

--- a/WoofWare.PawPrint/MethodState.fs
+++ b/WoofWare.PawPrint/MethodState.fs
@@ -48,7 +48,7 @@ type MethodReturnState =
         CallSiteIlOpIndex : int
         /// When true, the constructed object (WasConstructingObj) should be dispatched as a
         /// managed exception on return instead of being pushed onto the caller's eval stack.
-        /// Used by raiseManagedException to run exception ctors via the dispatch loop.
+        /// Used by raiseRuntimeException to run exception ctors via the dispatch loop.
         DispatchAsExceptionOnReturn : bool
     }
 

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -167,7 +167,7 @@ module NullaryIlOp =
         match popped with
         | EvalStackValue.NullObjectRef
         | EvalStackValue.ManagedPointer ManagedPointerSource.Null ->
-            IlMachineStateExecution.raiseManagedException
+            IlMachineStateExecution.raiseRuntimeException
                 loggerFactory
                 corelib
                 corelib.NullReferenceException
@@ -212,7 +212,7 @@ module NullaryIlOp =
         match addr with
         | EvalStackValue.NullObjectRef
         | EvalStackValue.ManagedPointer ManagedPointerSource.Null ->
-            IlMachineStateExecution.raiseManagedException
+            IlMachineStateExecution.raiseRuntimeException
                 loggerFactory
                 corelib
                 corelib.NullReferenceException
@@ -1213,7 +1213,7 @@ module NullaryIlOp =
             match exceptionObject with
             | EvalStackValue.NullObjectRef ->
                 // Per ECMA-335 III.4.31: if the object is null, throw NullReferenceException instead.
-                IlMachineStateExecution.raiseManagedException
+                IlMachineStateExecution.raiseRuntimeException
                     loggerFactory
                     corelib
                     corelib.NullReferenceException
@@ -1342,7 +1342,7 @@ module NullaryIlOp =
             match addr with
             | EvalStackValue.NullObjectRef
             | EvalStackValue.ManagedPointer ManagedPointerSource.Null ->
-                IlMachineStateExecution.raiseManagedException
+                IlMachineStateExecution.raiseRuntimeException
                     loggerFactory
                     corelib
                     corelib.NullReferenceException
@@ -1374,7 +1374,7 @@ module NullaryIlOp =
             match addr with
             | EvalStackValue.NullObjectRef
             | EvalStackValue.ManagedPointer ManagedPointerSource.Null ->
-                IlMachineStateExecution.raiseManagedException
+                IlMachineStateExecution.raiseRuntimeException
                     loggerFactory
                     corelib
                     corelib.NullReferenceException

--- a/WoofWare.PawPrint/UnaryMetadataIlOp.fs
+++ b/WoofWare.PawPrint/UnaryMetadataIlOp.fs
@@ -458,7 +458,7 @@ module internal UnaryMetadataIlOp =
                     | _ -> false
                 )
             then
-                IlMachineStateExecution.raiseManagedException
+                IlMachineStateExecution.raiseRuntimeException
                     loggerFactory
                     baseClassTypes
                     baseClassTypes.NullReferenceException
@@ -539,7 +539,7 @@ module internal UnaryMetadataIlOp =
 
                     state, WhatWeDid.Executed
                 else
-                    IlMachineStateExecution.raiseManagedException
+                    IlMachineStateExecution.raiseRuntimeException
                         loggerFactory
                         baseClassTypes
                         baseClassTypes.InvalidCastException
@@ -1046,7 +1046,7 @@ module internal UnaryMetadataIlOp =
 
             match currentObj with
             | EvalStackValue.NullObjectRef ->
-                IlMachineStateExecution.raiseManagedException
+                IlMachineStateExecution.raiseRuntimeException
                     loggerFactory
                     baseClassTypes
                     baseClassTypes.NullReferenceException
@@ -1240,7 +1240,7 @@ module internal UnaryMetadataIlOp =
 
             match currentObj with
             | EvalStackValue.NullObjectRef ->
-                IlMachineStateExecution.raiseManagedException
+                IlMachineStateExecution.raiseRuntimeException
                     loggerFactory
                     baseClassTypes
                     baseClassTypes.NullReferenceException
@@ -1325,7 +1325,7 @@ module internal UnaryMetadataIlOp =
 
             match ptr with
             | NullObjectRef ->
-                IlMachineStateExecution.raiseManagedException
+                IlMachineStateExecution.raiseRuntimeException
                     loggerFactory
                     baseClassTypes
                     baseClassTypes.NullReferenceException
@@ -1523,7 +1523,7 @@ module internal UnaryMetadataIlOp =
                         |> IlMachineState.advanceProgramCounter thread
                         |> Tuple.withRight WhatWeDid.Executed
                     else
-                        IlMachineStateExecution.raiseManagedException
+                        IlMachineStateExecution.raiseRuntimeException
                             loggerFactory
                             baseClassTypes
                             baseClassTypes.InvalidCastException
@@ -1534,7 +1534,7 @@ module internal UnaryMetadataIlOp =
                 // Value-type target, non-Nullable.
                 match actualObj with
                 | EvalStackValue.NullObjectRef ->
-                    IlMachineStateExecution.raiseManagedException
+                    IlMachineStateExecution.raiseRuntimeException
                         loggerFactory
                         baseClassTypes
                         baseClassTypes.NullReferenceException
@@ -1554,7 +1554,7 @@ module internal UnaryMetadataIlOp =
 
                     match boxedOpt with
                     | None ->
-                        IlMachineStateExecution.raiseManagedException
+                        IlMachineStateExecution.raiseRuntimeException
                             loggerFactory
                             baseClassTypes
                             baseClassTypes.InvalidCastException
@@ -1602,7 +1602,7 @@ module internal UnaryMetadataIlOp =
                         |> IlMachineState.advanceProgramCounter thread
                         |> Tuple.withRight WhatWeDid.Executed
                     else
-                        IlMachineStateExecution.raiseManagedException
+                        IlMachineStateExecution.raiseRuntimeException
                             loggerFactory
                             baseClassTypes
                             baseClassTypes.InvalidCastException


### PR DESCRIPTION
Looks like the CLR doesn't actually run the cctor for internally raised exceptions.