### PR TITLE
Add QCall dispatch point

### DIFF
--- a/WoofWare.PawPrint.Domain/MethodInfo.fs
+++ b/WoofWare.PawPrint.Domain/MethodInfo.fs
@@ -52,6 +52,13 @@ module Parameter =
 
         result.ToImmutable ()
 
+type NativeMethodImport =
+    {
+        ModuleName : string
+        EntryPointName : string
+        Attributes : MethodImportAttributes
+    }
+
 type ExceptionOffset =
     {
         TryLength : int
@@ -185,6 +192,8 @@ type MethodInfo<'typeGenerics, 'methodGenerics, 'methodVars> =
 
         ImplAttributes : MethodImplAttributes
 
+        NativeImport : NativeMethodImport option
+
         /// <summary>
         /// Whether this method is static (true) or an instance method (false).
         /// </summary>
@@ -258,6 +267,7 @@ module MethodInfo =
             CustomAttributes = m.CustomAttributes
             MethodAttributes = m.MethodAttributes
             ImplAttributes = m.ImplAttributes
+            NativeImport = m.NativeImport
             IsStatic = m.IsStatic
         }
 
@@ -280,6 +290,7 @@ module MethodInfo =
             CustomAttributes = m.CustomAttributes
             MethodAttributes = m.MethodAttributes
             ImplAttributes = m.ImplAttributes
+            NativeImport = m.NativeImport
             IsStatic = m.IsStatic
         }
 
@@ -301,6 +312,7 @@ module MethodInfo =
             CustomAttributes = m.CustomAttributes
             MethodAttributes = m.MethodAttributes
             ImplAttributes = m.ImplAttributes
+            NativeImport = m.NativeImport
             IsStatic = m.IsStatic
         }
 
@@ -713,6 +725,20 @@ module MethodInfo =
         let methodGenericParams =
             GenericParameter.readAll metadataReader (methodDef.GetGenericParameters ())
 
+        let nativeImport =
+            if methodDef.Attributes.HasFlag MethodAttributes.PinvokeImpl then
+                let import = methodDef.GetImport ()
+                let moduleRef = metadataReader.GetModuleReference import.Module
+
+                Some
+                    {
+                        ModuleName = metadataReader.GetString moduleRef.Name
+                        EntryPointName = metadataReader.GetString import.Name
+                        Attributes = import.Attributes
+                    }
+            else
+                None
+
         let declaringType =
             ConcreteType.make
                 assemblyName
@@ -734,6 +760,7 @@ module MethodInfo =
             CustomAttributes = attrs
             IsStatic = not methodSig.Header.IsInstance
             ImplAttributes = implAttrs
+            NativeImport = nativeImport
         }
         |> Some
 

--- a/WoofWare.PawPrint.Domain/TypeConcretisation.fs
+++ b/WoofWare.PawPrint.Domain/TypeConcretisation.fs
@@ -1088,6 +1088,7 @@ module Concretization =
                 CustomAttributes = method.CustomAttributes
                 MethodAttributes = method.MethodAttributes
                 ImplAttributes = method.ImplAttributes
+                NativeImport = method.NativeImport
                 IsStatic = method.IsStatic
             }
 

--- a/WoofWare.PawPrint.Test/TestCliTypeBytes.fs
+++ b/WoofWare.PawPrint.Test/TestCliTypeBytes.fs
@@ -38,6 +38,9 @@ module TestCliTypeBytes =
     let private int32Handle : ConcreteTypeHandle =
         AllConcreteTypes.getRequiredNonGenericHandle allCt bct.Int32
 
+    let private boolHandle : ConcreteTypeHandle =
+        AllConcreteTypes.getRequiredNonGenericHandle allCt bct.Boolean
+
     let private genPrimitiveNumeric : Gen<CliNumericType> =
         Gen.oneof
             [
@@ -102,6 +105,19 @@ module TestCliTypeBytes =
         CliValueType.OfFields bct allCt declaredHandle Layout.Default [ field ]
         |> CliType.ValueType
 
+    let private fieldBackedBoolValueType () : CliType =
+        let field : CliField =
+            {
+                Id = FieldId.named "Flag"
+                Name = "Flag"
+                Contents = CliType.Bool 0uy
+                Offset = None
+                Type = boolHandle
+            }
+
+        CliValueType.OfFields bct allCt declaredHandle Layout.Default [ field ]
+        |> CliType.ValueType
+
     [<Test>]
     let ``ToBytes output size matches SizeOf for primitive CliType values`` () : unit =
         Check.One (config, Prop.forAll (Arb.fromGen genPrimitiveCliType) toBytesSizeAgreesWithSizeOf)
@@ -134,3 +150,24 @@ module TestCliTypeBytes =
 
         Assert.Throws<System.Exception> (fun () -> CliType.OfBytesLike template [| 1uy ; 2uy ; 3uy ; 4uy |] |> ignore)
         |> ignore
+
+    [<Test>]
+    let ``Marshal size guard detects shapes whose unmanaged size may differ`` () : unit =
+        CliType.TryFindMarshalSizeDifference (CliType.Numeric (CliNumericType.Int32 0))
+        |> shouldEqual None
+
+        CliType.TryFindMarshalSizeDifference (CliType.Bool 0uy)
+        |> Option.isSome
+        |> shouldEqual true
+
+        CliType.TryFindMarshalSizeDifference (CliType.Char (0uy, 0uy))
+        |> Option.isSome
+        |> shouldEqual true
+
+        CliType.TryFindMarshalSizeDifference (CliType.ObjectRef None)
+        |> Option.isSome
+        |> shouldEqual true
+
+        CliType.TryFindMarshalSizeDifference (fieldBackedBoolValueType ())
+        |> Option.isSome
+        |> shouldEqual true

--- a/WoofWare.PawPrint.Test/TestNativeMethodDetection.fs
+++ b/WoofWare.PawPrint.Test/TestNativeMethodDetection.fs
@@ -25,6 +25,23 @@ module TestNativeMethodDetection =
         | [ m ] -> m
         | many -> failwith $"Ambiguous: found {List.length many} overloads of {ns}.{typeName}.{methodName}"
 
+    let private findPInvokeByEntryPoint (ns : string) (typeName : string) (entryPoint : string) =
+        match corelib.TryGetTopLevelTypeDef ns typeName with
+        | None -> failwith $"Type {ns}.{typeName} not found in CoreLib"
+        | Some typeInfo ->
+
+        match
+            typeInfo.Methods
+            |> List.filter (fun m ->
+                match m.NativeImport with
+                | Some import -> import.ModuleName = "QCall" && import.EntryPointName = entryPoint
+                | None -> false
+            )
+        with
+        | [] -> failwith $"QCall entry point {entryPoint} not found on {ns}.{typeName}"
+        | [ m ] -> m
+        | many -> failwith $"Ambiguous: found {List.length many} QCall entry points {entryPoint} on {ns}.{typeName}"
+
     [<Test>]
     let ``Environment.GetProcessorCount is a native method`` () : unit =
         let m = findMethod "System" "Environment" "GetProcessorCount"
@@ -37,6 +54,20 @@ module TestNativeMethodDetection =
         m.IsNativeMethod |> shouldEqual true
         m.IsCliInternal |> shouldEqual true
         m.Instructions |> shouldEqual None
+
+    [<Test>]
+    let ``generated QCall stubs expose native entry point metadata`` () : unit =
+        let rva =
+            findPInvokeByEntryPoint "System" "RuntimeFieldHandle" "RuntimeFieldHandle_GetRVAFieldInfo"
+
+        rva.IsPinvokeImpl |> shouldEqual true
+        rva.Instructions |> shouldEqual None
+
+        let sizeOf =
+            findPInvokeByEntryPoint "System.Runtime.InteropServices" "Marshal" "MarshalNative_SizeOfHelper"
+
+        sizeOf.IsPinvokeImpl |> shouldEqual true
+        sizeOf.Instructions |> shouldEqual None
 
     [<Test>]
     let ``Object.ToString is not a native method`` () : unit =

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -18,7 +18,7 @@ module TestPureCases =
     let unimplemented =
         [
             "EnumSemantics.cs" // blocked on Object.GetType intrinsic reached from ValueType.ToString
-            "OverlappingStructs.cs" // blocked on Marshal.SizeOfHelper PInvoke boundary
+            "OverlappingStructs.cs" // blocked after Marshal.SizeOfHelper on field-backed struct reconstruction from raw bytes
             "AdvancedStructLayout.cs" // "TODO: couldn't identify field at offset"
             "Threads.cs" // infinite loop, apparently? test doesn't terminate
             "LdtokenField.cs" // Unimplemented RuntimeTypeHandle::GetModule

--- a/WoofWare.PawPrint.Test/sourcesPure/MarshalSizeOf.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/MarshalSizeOf.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Runtime.InteropServices;
+
+public class Program
+{
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    struct Packed
+    {
+        public byte B;
+        public int I;
+        public byte B2;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 10)]
+    struct ExplicitWithSize
+    {
+        [FieldOffset(0)]
+        public int I;
+
+        [FieldOffset(2)]
+        public short S;
+    }
+
+    public static int Main(string[] args)
+    {
+        if (Marshal.SizeOf(typeof(Packed)) != 6) return 1;
+        if (Marshal.SizeOf(typeof(ExplicitWithSize)) != 10) return 2;
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/BasicCliType.fs
+++ b/WoofWare.PawPrint/BasicCliType.fs
@@ -576,6 +576,15 @@ type CliType =
             // Runtime/native pointers are not GC-tracked object references in these zero-value layouts.
             false
 
+    static member TryFindMarshalSizeDifference (t : CliType) : string option =
+        match t with
+        | CliType.Bool _ -> Some "System.Boolean marshals as a 4-byte BOOL by default, not a 1-byte CLI bool"
+        | CliType.Char _ -> Some "System.Char marshalling depends on CharSet and does not always match 2-byte CLI char"
+        | CliType.ObjectRef _ -> Some "object references require managed-to-unmanaged marshalling"
+        | CliType.ValueType vt -> CliValueType.TryFindMarshalSizeDifference vt
+        | CliType.Numeric _
+        | CliType.RuntimePointer _ -> None
+
     static member ToBytes (t : CliType) : byte[] =
         match t with
         | CliType.Numeric n -> CliNumericType.ToBytes n
@@ -1046,6 +1055,16 @@ and CliValueType =
         | CliValueTypeStorage.Fields fields ->
             fields
             |> List.exists (fun field -> CliType.ContainsObjectReferences field.Contents)
+
+    static member TryFindMarshalSizeDifference (vt : CliValueType) : string option =
+        match vt._Storage with
+        | CliValueTypeStorage.RawBytes _ -> None
+        | CliValueTypeStorage.Fields fields ->
+            fields
+            |> List.tryPick (fun field ->
+                CliType.TryFindMarshalSizeDifference field.Contents
+                |> Option.map (fun reason -> $"field %s{field.Name}: %s{reason}")
+            )
 
     /// Sets the value of the specified field, *without* touching any overlapping fields.
     /// `DereferenceField` handles resolving conflicts between overlapping fields.

--- a/WoofWare.PawPrint/Native/NativeCall.fs
+++ b/WoofWare.PawPrint/Native/NativeCall.fs
@@ -17,6 +17,11 @@ type NativeCallContext =
 
 [<RequireQualifiedAccess>]
 module NativeCall =
+    let tryQCallEntryPoint (ctx : NativeCallContext) : string option =
+        match ctx.Instruction.ExecutingMethod.NativeImport with
+        | Some import when import.ModuleName = "QCall" -> Some import.EntryPointName
+        | _ -> None
+
     let qCallTypeHandleToConcreteTypeHandle (operation : string) (arg : EvalStackValue) : ConcreteTypeHandle =
         match arg with
         | EvalStackValue.UserDefinedValueType vt ->
@@ -157,7 +162,9 @@ module NativeCall =
             if instruction.ExecutingMethod.IsCliInternal then
                 "InternalCall"
             elif instruction.ExecutingMethod.IsPinvokeImpl then
-                "PInvokeImpl"
+                match instruction.ExecutingMethod.NativeImport with
+                | Some import -> $"PInvokeImpl %s{import.ModuleName}!%s{import.EntryPointName}"
+                | None -> "PInvokeImpl"
             elif instruction.ExecutingMethod.ImplAttributes.HasFlag System.Reflection.MethodImplAttributes.Runtime then
                 "Runtime"
             else

--- a/WoofWare.PawPrint/Native/NativeCall.fs
+++ b/WoofWare.PawPrint/Native/NativeCall.fs
@@ -22,18 +22,20 @@ module NativeCall =
         | Some import when import.ModuleName = "QCall" -> Some import.EntryPointName
         | _ -> None
 
-    let qCallTypeHandleToConcreteTypeHandle (operation : string) (arg : EvalStackValue) : ConcreteTypeHandle =
+    let qCallTypeHandleToRuntimeTypeHandleTarget (operation : string) (arg : EvalStackValue) : RuntimeTypeHandleTarget =
         match arg with
         | EvalStackValue.UserDefinedValueType vt ->
             match CliValueType.DereferenceField "_handle" vt |> CliType.unwrapPrimitiveLike with
-            | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.TypeHandlePtr cth)) ->
-                match cth with
-                | RuntimeTypeHandleTarget.Closed cth -> cth
-                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
-                    failwith
-                        $"%s{operation}: expected closed RuntimeTypeHandleTarget in QCallTypeHandle._handle, but got open generic"
+            | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.TypeHandlePtr target)) -> target
             | other -> failwith $"%s{operation}: expected TypeHandlePtr in QCallTypeHandle._handle, got %O{other}"
         | other -> failwith $"%s{operation}: expected QCallTypeHandle value type, got %O{other}"
+
+    let qCallTypeHandleToConcreteTypeHandle (operation : string) (arg : EvalStackValue) : ConcreteTypeHandle =
+        match qCallTypeHandleToRuntimeTypeHandleTarget operation arg with
+        | RuntimeTypeHandleTarget.Closed cth -> cth
+        | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
+            failwith
+                $"%s{operation}: expected closed RuntimeTypeHandleTarget in QCallTypeHandle._handle, but got open generic"
 
     let gcHandleKindOfEvalStackValue (operation : string) (arg : EvalStackValue) : GcHandleKind =
         let value =

--- a/WoofWare.PawPrint/Native/NativeDispatch.fs
+++ b/WoofWare.PawPrint/Native/NativeDispatch.fs
@@ -12,6 +12,9 @@ module NativeDispatch =
                 match NativeQCall.tryExecute ctx with
                 | Some result -> Some result
                 | None ->
+                    // QCall migration note: some name-based native handlers below still model
+                    // CoreCLR QCalls on newer runtimes. Move each to NativeQCall as its import
+                    // metadata is needed, then delete the corresponding name-based fallback.
                     match NativeMetadataImport.tryExecute ctx with
                     | Some result -> Some result
                     | None ->

--- a/WoofWare.PawPrint/Native/NativeDispatch.fs
+++ b/WoofWare.PawPrint/Native/NativeDispatch.fs
@@ -9,23 +9,20 @@ module NativeDispatch =
             match NativeMonitor.tryExecute ctx with
             | Some result -> Some result
             | None ->
-                match NativeMetadataImport.tryExecute ctx with
+                match NativeQCall.tryExecute ctx with
                 | Some result -> Some result
                 | None ->
-                    match NativeRuntimeFieldHandle.tryExecute ctx with
+                    match NativeMetadataImport.tryExecute ctx with
                     | Some result -> Some result
                     | None ->
-                        match NativeRuntimeHelpers.tryExecute ctx with
+                        match NativeGcHandle.tryExecute ctx with
                         | Some result -> Some result
                         | None ->
-                            match NativeGcHandle.tryExecute ctx with
+                            match NativeRuntimeType.tryExecute ctx with
                             | Some result -> Some result
                             | None ->
-                                match NativeRuntimeType.tryExecute ctx with
+                                match NativeThreading.tryExecute ctx with
                                 | Some result -> Some result
-                                | None ->
-                                    match NativeThreading.tryExecute ctx with
-                                    | Some result -> Some result
-                                    | None -> NativeType.tryExecute ctx
+                                | None -> NativeType.tryExecute ctx
 
     let failUnimplemented (ctx : NativeCallContext) : ExecutionResult = NativeCall.failUnimplemented ctx

--- a/WoofWare.PawPrint/Native/NativeGcHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeGcHandle.fs
@@ -2,22 +2,22 @@ namespace WoofWare.PawPrint
 
 [<RequireQualifiedAccess>]
 module NativeGcHandle =
-    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
         match
+            entryPoint,
             ctx.TargetAssembly.Name.Name,
             ctx.TargetType.Namespace,
             ctx.TargetType.Name,
-            instruction.ExecutingMethod.Name,
             instruction.ExecutingMethod.Signature.ParameterTypes,
             instruction.ExecutingMethod.Signature.ReturnType
         with
-        | "System.Private.CoreLib",
+        | "QCall_GetGCHandleForTypeHandle",
+          "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
-          "GetGCHandle",
           [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
                                               "System.Runtime.CompilerServices",
                                               "QCallTypeHandle",
@@ -33,10 +33,10 @@ module NativeGcHandle =
             let gcHandleType = instruction.Arguments.[1] |> EvalStackValue.ofCliType
 
             let typeHandle =
-                NativeCall.qCallTypeHandleToConcreteTypeHandle "RuntimeTypeHandle.GetGCHandle" qCallHandle
+                NativeCall.qCallTypeHandleToConcreteTypeHandle "QCall_GetGCHandleForTypeHandle" qCallHandle
 
             let kind =
-                NativeCall.gcHandleKindOfEvalStackValue "RuntimeTypeHandle.GetGCHandle" gcHandleType
+                NativeCall.gcHandleKindOfEvalStackValue "QCall_GetGCHandleForTypeHandle" gcHandleType
 
             let handle, gcHandles =
                 state.GcHandles
@@ -50,10 +50,10 @@ module NativeGcHandle =
             let state = NativeCall.pushGcHandleAddress handle ctx.Thread state
 
             (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
-        | "System.Private.CoreLib",
+        | "QCall_FreeGCHandleForTypeHandle",
+          "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
-          "FreeGCHandle",
           [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
                                               "System.Runtime.CompilerServices",
                                               "QCallTypeHandle",
@@ -67,11 +67,11 @@ module NativeGcHandle =
             // unregister the handle before destroying it; PawPrint has one process-wide
             // handle registry, but keeping the type association visible makes a future
             // collector/loader model easier to add.
-            NativeCall.qCallTypeHandleToConcreteTypeHandle "RuntimeTypeHandle.FreeGCHandle" qCallHandle
+            NativeCall.qCallTypeHandleToConcreteTypeHandle "QCall_FreeGCHandleForTypeHandle" qCallHandle
             |> ignore
 
             let handle =
-                NativeCall.gcHandleAddressOfEvalStackValue "RuntimeTypeHandle.FreeGCHandle" objHandle
+                NativeCall.gcHandleAddressOfEvalStackValue "QCall_FreeGCHandleForTypeHandle" objHandle
 
             let state =
                 { state with
@@ -86,7 +86,21 @@ module NativeGcHandle =
                 |> Tuple.withRight WhatWeDid.Executed
                 |> ExecutionResult.Stepped
                 |> Some
-            | other -> failwith $"RuntimeTypeHandle.FreeGCHandle: unexpected return type %O{other}"
+            | other -> failwith $"QCall_FreeGCHandleForTypeHandle: unexpected return type %O{other}"
+        | _ -> None
+
+    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+        let state = ctx.State
+        let instruction = ctx.Instruction
+
+        match
+            ctx.TargetAssembly.Name.Name,
+            ctx.TargetType.Namespace,
+            ctx.TargetType.Name,
+            instruction.ExecutingMethod.Name,
+            instruction.ExecutingMethod.Signature.ParameterTypes,
+            instruction.ExecutingMethod.Signature.ReturnType
+        with
         | "System.Private.CoreLib",
           "System.Runtime.InteropServices",
           "GCHandle",

--- a/WoofWare.PawPrint/Native/NativeGcHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeGcHandle.fs
@@ -29,14 +29,14 @@ module NativeGcHandle =
           ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr when
             qCallGenerics.IsEmpty && gcHandleTypeGenerics.IsEmpty
             ->
+            let operation = "RuntimeTypeHandle.GetGCHandle (QCall_GetGCHandleForTypeHandle)"
             let qCallHandle = instruction.Arguments.[0] |> EvalStackValue.ofCliType
             let gcHandleType = instruction.Arguments.[1] |> EvalStackValue.ofCliType
 
             let typeHandle =
-                NativeCall.qCallTypeHandleToConcreteTypeHandle "QCall_GetGCHandleForTypeHandle" qCallHandle
+                NativeCall.qCallTypeHandleToConcreteTypeHandle operation qCallHandle
 
-            let kind =
-                NativeCall.gcHandleKindOfEvalStackValue "QCall_GetGCHandleForTypeHandle" gcHandleType
+            let kind = NativeCall.gcHandleKindOfEvalStackValue operation gcHandleType
 
             let handle, gcHandles =
                 state.GcHandles
@@ -60,6 +60,7 @@ module NativeGcHandle =
                                               qCallGenerics)
             ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr ],
           returnType when qCallGenerics.IsEmpty ->
+            let operation = "RuntimeTypeHandle.FreeGCHandle (QCall_FreeGCHandleForTypeHandle)"
             let qCallHandle = instruction.Arguments.[0] |> EvalStackValue.ofCliType
             let objHandle = instruction.Arguments.[1] |> EvalStackValue.ofCliType
 
@@ -67,11 +68,9 @@ module NativeGcHandle =
             // unregister the handle before destroying it; PawPrint has one process-wide
             // handle registry, but keeping the type association visible makes a future
             // collector/loader model easier to add.
-            NativeCall.qCallTypeHandleToConcreteTypeHandle "QCall_FreeGCHandleForTypeHandle" qCallHandle
-            |> ignore
+            NativeCall.qCallTypeHandleToConcreteTypeHandle operation qCallHandle |> ignore
 
-            let handle =
-                NativeCall.gcHandleAddressOfEvalStackValue "QCall_FreeGCHandleForTypeHandle" objHandle
+            let handle = NativeCall.gcHandleAddressOfEvalStackValue operation objHandle
 
             let state =
                 { state with
@@ -86,7 +85,7 @@ module NativeGcHandle =
                 |> Tuple.withRight WhatWeDid.Executed
                 |> ExecutionResult.Stepped
                 |> Some
-            | other -> failwith $"QCall_FreeGCHandleForTypeHandle: unexpected return type %O{other}"
+            | other -> failwith $"%s{operation}: unexpected return type %O{other}"
         | _ -> None
 
     let tryExecute (ctx : NativeCallContext) : ExecutionResult option =

--- a/WoofWare.PawPrint/Native/NativeMarshal.fs
+++ b/WoofWare.PawPrint/Native/NativeMarshal.fs
@@ -33,6 +33,18 @@ module NativeMarshal =
             let zero, state =
                 IlMachineState.cliTypeZeroOfHandle state ctx.BaseClassTypes typeHandle
 
+            let throwIfNotMarshalable =
+                match instruction.Arguments.[1] |> EvalStackValue.ofCliType with
+                | EvalStackValue.Int32 0 -> false
+                | EvalStackValue.Int32 _ -> true
+                | other -> failwith $"%s{operation}: expected throwIfNotMarshalable as Int32, got %O{other}"
+
+            match CliType.TryFindMarshalSizeDifference zero with
+            | Some reason ->
+                failwith
+                    $"%s{operation}: refusing to approximate unmanaged marshalled size with managed layout size because %s{reason} (throwIfNotMarshalable=%b{throwIfNotMarshalable})"
+            | None -> ()
+
             let size = CliType.sizeOf zero
 
             let state =

--- a/WoofWare.PawPrint/Native/NativeMarshal.fs
+++ b/WoofWare.PawPrint/Native/NativeMarshal.fs
@@ -1,0 +1,42 @@
+namespace WoofWare.PawPrint
+
+[<RequireQualifiedAccess>]
+module NativeMarshal =
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
+        let state = ctx.State
+        let instruction = ctx.Instruction
+
+        match
+            entryPoint,
+            ctx.TargetAssembly.Name.Name,
+            ctx.TargetType.Namespace,
+            ctx.TargetType.Name,
+            instruction.ExecutingMethod.Signature.ParameterTypes,
+            instruction.ExecutingMethod.Signature.ReturnType
+        with
+        | "MarshalNative_SizeOfHelper",
+          "System.Private.CoreLib",
+          "System.Runtime.InteropServices",
+          "Marshal",
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "QCallTypeHandle",
+                                              qCallGenerics)
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32 ],
+          ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32 when qCallGenerics.IsEmpty ->
+            let operation = "MarshalNative_SizeOfHelper"
+            let qCallHandle = instruction.Arguments.[0] |> EvalStackValue.ofCliType
+
+            let typeHandle =
+                NativeCall.qCallTypeHandleToConcreteTypeHandle operation qCallHandle
+
+            let zero, state =
+                IlMachineState.cliTypeZeroOfHandle state ctx.BaseClassTypes typeHandle
+
+            let size = CliType.sizeOf zero
+
+            let state =
+                IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 size)) ctx.Thread state
+
+            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+        | _ -> None

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -1,0 +1,17 @@
+namespace WoofWare.PawPrint
+
+[<RequireQualifiedAccess>]
+module NativeQCall =
+    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+        match NativeCall.tryQCallEntryPoint ctx with
+        | None -> None
+        | Some entryPoint ->
+            match NativeRuntimeHelpers.tryExecuteQCall entryPoint ctx with
+            | Some result -> Some result
+            | None ->
+                match NativeRuntimeFieldHandle.tryExecuteQCall entryPoint ctx with
+                | Some result -> Some result
+                | None ->
+                    match NativeGcHandle.tryExecuteQCall entryPoint ctx with
+                    | Some result -> Some result
+                    | None -> NativeMarshal.tryExecuteQCall entryPoint ctx

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -2,16 +2,19 @@ namespace WoofWare.PawPrint
 
 [<RequireQualifiedAccess>]
 module NativeQCall =
+    let private handlers : Map<string, NativeCallContext -> ExecutionResult option> =
+        [
+            "ReflectionInvocation_RunClassConstructor",
+            NativeRuntimeHelpers.tryExecuteQCall "ReflectionInvocation_RunClassConstructor"
+            "RuntimeFieldHandle_GetRVAFieldInfo",
+            NativeRuntimeFieldHandle.tryExecuteQCall "RuntimeFieldHandle_GetRVAFieldInfo"
+            "QCall_GetGCHandleForTypeHandle", NativeGcHandle.tryExecuteQCall "QCall_GetGCHandleForTypeHandle"
+            "QCall_FreeGCHandleForTypeHandle", NativeGcHandle.tryExecuteQCall "QCall_FreeGCHandleForTypeHandle"
+            "MarshalNative_SizeOfHelper", NativeMarshal.tryExecuteQCall "MarshalNative_SizeOfHelper"
+        ]
+        |> Map.ofList
+
     let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
         match NativeCall.tryQCallEntryPoint ctx with
         | None -> None
-        | Some entryPoint ->
-            match NativeRuntimeHelpers.tryExecuteQCall entryPoint ctx with
-            | Some result -> Some result
-            | None ->
-                match NativeRuntimeFieldHandle.tryExecuteQCall entryPoint ctx with
-                | Some result -> Some result
-                | None ->
-                    match NativeGcHandle.tryExecuteQCall entryPoint ctx with
-                    | Some result -> Some result
-                    | None -> NativeMarshal.tryExecuteQCall entryPoint ctx
+        | Some entryPoint -> handlers |> Map.tryFind entryPoint |> Option.bind (fun handler -> handler ctx)

--- a/WoofWare.PawPrint/Native/NativeRuntimeFieldHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeFieldHandle.fs
@@ -36,27 +36,27 @@ module NativeRuntimeFieldHandle =
 
         IlMachineState.rvaDataForField loggerFactory baseClassTypes assembly fieldInfo typeGenerics state
 
-    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
         match
+            entryPoint,
             ctx.TargetAssembly.Name.Name,
             ctx.TargetType.Namespace,
             ctx.TargetType.Name,
-            instruction.ExecutingMethod.Name,
             instruction.ExecutingMethod.Signature.ParameterTypes,
             instruction.ExecutingMethod.Signature.ReturnType
         with
-        | "System.Private.CoreLib",
+        | "RuntimeFieldHandle_GetRVAFieldInfo",
+          "System.Private.CoreLib",
           "System",
           "RuntimeFieldHandle",
-          "<GetRVAFieldInfo>g____PInvoke|23_0",
           [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib", "System", "RuntimeFieldHandleInternal", generics)
             ConcretePointer (ConcretePointer (ConcreteVoid state.ConcreteTypes))
             ConcretePointer (ConcreteUInt32 state.ConcreteTypes) ],
           ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32 when generics.IsEmpty ->
-            let operation = "RuntimeFieldHandle.GetRVAFieldInfo"
+            let operation = "RuntimeFieldHandle_GetRVAFieldInfo"
 
             let addressOut =
                 NativeCall.managedPointerOfPointerArgument operation "address out pointer" instruction.Arguments.[1]

--- a/WoofWare.PawPrint/Native/NativeRuntimeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeHelpers.fs
@@ -25,45 +25,50 @@ module NativeRuntimeHelpers =
                                               "QCallTypeHandle",
                                               generics) ],
           ConcreteVoid state.ConcreteTypes when generics.IsEmpty ->
-            let operation = "ReflectionInvocation_RunClassConstructor"
+            let operation = "RuntimeHelpers.RunClassConstructor"
             let qCallHandle = instruction.Arguments.[0] |> EvalStackValue.ofCliType
 
-            let typeHandle =
-                NativeCall.qCallTypeHandleToConcreteTypeHandle operation qCallHandle
+            let typeHandleTarget =
+                NativeCall.qCallTypeHandleToRuntimeTypeHandleTarget operation qCallHandle
 
-            match typeHandle with
-            | ConcreteTypeHandle.Byref _
-            | ConcreteTypeHandle.Pointer _
-            | ConcreteTypeHandle.OneDimArrayZero _
-            | ConcreteTypeHandle.Array _ ->
-                // Pointer, byref, and array type descriptors have no .cctor; CoreCLR treats this
-                // as a no-op. Return immediately.
-                (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
-            | ConcreteTypeHandle.Concrete _ ->
-                let state, typeInit =
-                    IlMachineStateExecution.ensureTypeInitialised
-                        ctx.LoggerFactory
-                        ctx.BaseClassTypes
-                        ctx.Thread
-                        typeHandle
-                        state
+            match typeHandleTarget with
+            | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
+                failwith
+                    $"TODO: RuntimeHelpers.RunClassConstructor for open generic type definition %O{typeHandleTarget}"
+            | RuntimeTypeHandleTarget.Closed typeHandle ->
+                match typeHandle with
+                | ConcreteTypeHandle.Byref _
+                | ConcreteTypeHandle.Pointer _
+                | ConcreteTypeHandle.OneDimArrayZero _
+                | ConcreteTypeHandle.Array _ ->
+                    // Pointer, byref, and array type descriptors have no .cctor; CoreCLR treats this
+                    // as a no-op. Return immediately.
+                    (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+                | ConcreteTypeHandle.Concrete _ ->
+                    let state, typeInit =
+                        IlMachineStateExecution.ensureTypeInitialised
+                            ctx.LoggerFactory
+                            ctx.BaseClassTypes
+                            ctx.Thread
+                            typeHandle
+                            state
 
-                match typeInit with
-                | WhatWeDid.Executed -> (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
-                | WhatWeDid.SuspendedForClassInit ->
-                    // The cctor was pushed as a new frame. We must NOT go through the normal
-                    // returnStackFrame path (which would pop the cctor frame we just pushed).
-                    // Instead, return Stepped directly so the dispatch loop runs the cctor.
-                    // When the cctor finishes, returnStackFrame pops it, bringing us back to
-                    // this native method frame. executeOneStep re-enters here and
-                    // ensureTypeInitialised will return Executed.
-                    ExecutionResult.Stepped (state, WhatWeDid.SuspendedForClassInit) |> Some
-                | WhatWeDid.ThrowingTypeInitializationException ->
-                    (state, WhatWeDid.ThrowingTypeInitializationException)
-                    |> ExecutionResult.Stepped
-                    |> Some
-                | WhatWeDid.BlockedOnClassInit blockedBy ->
-                    // Another thread owns this type's .cctor lock. Yield so the scheduler
-                    // can run that thread to completion before re-entering.
-                    ExecutionResult.Stepped (state, WhatWeDid.BlockedOnClassInit blockedBy) |> Some
+                    match typeInit with
+                    | WhatWeDid.Executed -> (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+                    | WhatWeDid.SuspendedForClassInit ->
+                        // The cctor was pushed as a new frame. We must NOT go through the normal
+                        // returnStackFrame path (which would pop the cctor frame we just pushed).
+                        // Instead, return Stepped directly so the dispatch loop runs the cctor.
+                        // When the cctor finishes, returnStackFrame pops it, bringing us back to
+                        // this native method frame. executeOneStep re-enters here and
+                        // ensureTypeInitialised will return Executed.
+                        ExecutionResult.Stepped (state, WhatWeDid.SuspendedForClassInit) |> Some
+                    | WhatWeDid.ThrowingTypeInitializationException ->
+                        (state, WhatWeDid.ThrowingTypeInitializationException)
+                        |> ExecutionResult.Stepped
+                        |> Some
+                    | WhatWeDid.BlockedOnClassInit blockedBy ->
+                        // Another thread owns this type's .cctor lock. Yield so the scheduler
+                        // can run that thread to completion before re-entering.
+                        ExecutionResult.Stepped (state, WhatWeDid.BlockedOnClassInit blockedBy) |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeRuntimeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeHelpers.fs
@@ -2,11 +2,12 @@ namespace WoofWare.PawPrint
 
 [<RequireQualifiedAccess>]
 module NativeRuntimeHelpers =
-    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
         match
+            entryPoint,
             ctx.TargetAssembly.Name.Name,
             ctx.TargetType.Namespace,
             ctx.TargetType.Name,
@@ -14,7 +15,8 @@ module NativeRuntimeHelpers =
             instruction.ExecutingMethod.Signature.ParameterTypes,
             instruction.ExecutingMethod.Signature.ReturnType
         with
-        | "System.Private.CoreLib",
+        | "ReflectionInvocation_RunClassConstructor",
+          "System.Private.CoreLib",
           "System.Runtime.CompilerServices",
           "RuntimeHelpers",
           "RunClassConstructor",
@@ -23,60 +25,45 @@ module NativeRuntimeHelpers =
                                               "QCallTypeHandle",
                                               generics) ],
           ConcreteVoid state.ConcreteTypes when generics.IsEmpty ->
-            // QCall: triggers the .cctor for the type identified by the QCallTypeHandle argument.
-            // Extract the ConcreteTypeHandle from the QCallTypeHandle's _handle field, then
-            // ensure the type is initialised.
-            let state = IlMachineState.loadArgument ctx.Thread 0 state
-            let arg, state = IlMachineState.popEvalStack ctx.Thread state
+            let operation = "ReflectionInvocation_RunClassConstructor"
+            let qCallHandle = instruction.Arguments.[0] |> EvalStackValue.ofCliType
 
-            let typeHandleTarget =
-                match arg with
-                | EvalStackValue.UserDefinedValueType vt ->
-                    // QCallTypeHandle._handle is typed as IntPtr (a primitive-like wrapper),
-                    // so the dereferenced field contents are wrapped; unwrap to the inner NativeInt.
-                    match CliValueType.DereferenceField "_handle" vt |> CliType.unwrapPrimitiveLike with
-                    | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.TypeHandlePtr target)) -> target
-                    | other -> failwith $"RunClassConstructor: expected TypeHandlePtr in _handle field, got %O{other}"
-                | other -> failwith $"RunClassConstructor: expected QCallTypeHandle value type, got %O{other}"
+            let typeHandle =
+                NativeCall.qCallTypeHandleToConcreteTypeHandle operation qCallHandle
 
-            match typeHandleTarget with
-            | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
-                failwith
-                    $"TODO: RuntimeHelpers.RunClassConstructor for open generic type definition %O{typeHandleTarget}"
-            | RuntimeTypeHandleTarget.Closed concreteTypeHandle ->
-                match concreteTypeHandle with
-                | ConcreteTypeHandle.Byref _
-                | ConcreteTypeHandle.Pointer _
-                | ConcreteTypeHandle.OneDimArrayZero _
-                | ConcreteTypeHandle.Array _ ->
-                    // Pointer, byref, and array type descriptors have no .cctor; CoreCLR treats this
-                    // as a no-op. Return immediately.
-                    (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
-                | ConcreteTypeHandle.Concrete _ ->
-                    let state, typeInit =
-                        IlMachineStateExecution.ensureTypeInitialised
-                            ctx.LoggerFactory
-                            ctx.BaseClassTypes
-                            ctx.Thread
-                            concreteTypeHandle
-                            state
+            match typeHandle with
+            | ConcreteTypeHandle.Byref _
+            | ConcreteTypeHandle.Pointer _
+            | ConcreteTypeHandle.OneDimArrayZero _
+            | ConcreteTypeHandle.Array _ ->
+                // Pointer, byref, and array type descriptors have no .cctor; CoreCLR treats this
+                // as a no-op. Return immediately.
+                (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            | ConcreteTypeHandle.Concrete _ ->
+                let state, typeInit =
+                    IlMachineStateExecution.ensureTypeInitialised
+                        ctx.LoggerFactory
+                        ctx.BaseClassTypes
+                        ctx.Thread
+                        typeHandle
+                        state
 
-                    match typeInit with
-                    | WhatWeDid.Executed -> (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
-                    | WhatWeDid.SuspendedForClassInit ->
-                        // The cctor was pushed as a new frame. We must NOT go through the normal
-                        // returnStackFrame path (which would pop the cctor frame we just pushed).
-                        // Instead, return Stepped directly so the dispatch loop runs the cctor.
-                        // When the cctor finishes, returnStackFrame pops it, bringing us back to
-                        // this native method frame. executeOneStep re-enters here and
-                        // ensureTypeInitialised will return Executed.
-                        ExecutionResult.Stepped (state, WhatWeDid.SuspendedForClassInit) |> Some
-                    | WhatWeDid.ThrowingTypeInitializationException ->
-                        (state, WhatWeDid.ThrowingTypeInitializationException)
-                        |> ExecutionResult.Stepped
-                        |> Some
-                    | WhatWeDid.BlockedOnClassInit blockedBy ->
-                        // Another thread owns this type's .cctor lock. Yield so the scheduler
-                        // can run that thread to completion before re-entering.
-                        ExecutionResult.Stepped (state, WhatWeDid.BlockedOnClassInit blockedBy) |> Some
+                match typeInit with
+                | WhatWeDid.Executed -> (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+                | WhatWeDid.SuspendedForClassInit ->
+                    // The cctor was pushed as a new frame. We must NOT go through the normal
+                    // returnStackFrame path (which would pop the cctor frame we just pushed).
+                    // Instead, return Stepped directly so the dispatch loop runs the cctor.
+                    // When the cctor finishes, returnStackFrame pops it, bringing us back to
+                    // this native method frame. executeOneStep re-enters here and
+                    // ensureTypeInitialised will return Executed.
+                    ExecutionResult.Stepped (state, WhatWeDid.SuspendedForClassInit) |> Some
+                | WhatWeDid.ThrowingTypeInitializationException ->
+                    (state, WhatWeDid.ThrowingTypeInitializationException)
+                    |> ExecutionResult.Stepped
+                    |> Some
+                | WhatWeDid.BlockedOnClassInit blockedBy ->
+                    // Another thread owns this type's .cctor lock. Yield so the scheduler
+                    // can run that thread to completion before re-entering.
+                    ExecutionResult.Stepped (state, WhatWeDid.BlockedOnClassInit blockedBy) |> Some
         | _ -> None

--- a/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
+++ b/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
@@ -56,7 +56,9 @@
     <Compile Include="Native\NativeMetadataImport.fs" />
     <Compile Include="Native\NativeRuntimeFieldHandle.fs" />
     <Compile Include="Native\NativeRuntimeHelpers.fs" />
+    <Compile Include="Native\NativeMarshal.fs" />
     <Compile Include="Native\NativeGcHandle.fs" />
+    <Compile Include="Native\NativeQCall.fs" />
     <Compile Include="Native\NativeRuntimeType.fs" />
     <Compile Include="Native\NativeThreading.fs" />
     <Compile Include="Native\NativeType.fs" />


### PR DESCRIPTION
This should avoid fragile string matching against C#-compiler-generated names.