### PR TITLE
Remove CastClassCrossAssembly from unimplemented tests

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -24,7 +24,6 @@ module TestPureCases =
             "LdtokenField.cs" // Unimplemented RuntimeTypeHandle::GetModule
             "GenericEdgeCases.cs" // TODO: Unsafe.ByteOffset on unsupported byref: Pointer(<<RVA data...>>)
             "UnsafeAs.cs" // TODO: read through `ReinterpretAs` as non-primitive type .FourBytes
-            "CastClassCrossAssembly.cs" // apparent infinite loop in test
             "CrossAssemblyTypes.cs" // TODO: byref element offset on non-array byref without a trailing byte-view ReinterpretAs projection
             "InitializeArrayBoxedFieldHandle.cs" // BUG: reached extern dispatch for System.Numerics.IMinMaxValue::getMaxValue
             "ConstrainedCallvirtStructOverload.cs" // blocked downstream of ValueType.ToString


### PR DESCRIPTION
It passes now.