### PR TITLE
Support fixed-buffer pointer arithmetic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,5 +120,6 @@ It must be run with network permissions.
 Once Claude has replied, address any of its feedback that you think is correct and worth addressing, then repeat if you made changes.
 Err on the side of addressing feedback: we should have high standards in this project, and it's worth taking the time to get it properly right.
 Latent bugs, poor architecture, incorrect comments etc, are all worth addressing.
+Also please don't adjust your Claude prompt in ways that make a passing review more likely (e.g. adding "This is the last review"); we want Claude's real feedback.
 
 (end of Codex-specific instructions)

--- a/WoofWare.PawPrint.Test/TestCliTypeBytes.fs
+++ b/WoofWare.PawPrint.Test/TestCliTypeBytes.fs
@@ -280,15 +280,23 @@ module TestCliTypeBytes =
         )
 
     [<Test>]
-    let ``OfBytesLike rejects non-zero padding bytes for field-backed value types`` () : unit =
+    let ``OfBytesLike preserves non-zero padding bytes for field-backed value types`` () : unit =
         let template = paddedValueType ()
         let bytes : byte[] = Array.zeroCreate (CliValueType.SizeOf(template).Size)
+        bytes.[0] <- 3uy
         bytes.[1] <- 1uy
 
-        let ex =
-            Assert.Throws<System.Exception> (fun () -> CliValueType.OfBytesLike template bytes |> ignore)
+        let recovered = CliValueType.OfBytesLike template bytes
 
-        Assert.That (ex.Message, Does.Contain "unrepresented padding")
+        CliValueType.ToBytes recovered |> shouldEqual bytes
+
+        let updated =
+            CliValueType.WithFieldSet "Byte" (CliType.Numeric (CliNumericType.UInt8 9uy)) recovered
+
+        let expected = Array.copy bytes
+        expected.[0] <- 9uy
+
+        CliValueType.ToBytes updated |> shouldEqual expected
 
     [<Test>]
     let ``OfBytesLike allows inner padding bytes when outer fields preserve them`` () : unit =

--- a/WoofWare.PawPrint.Test/TestCliTypeBytes.fs
+++ b/WoofWare.PawPrint.Test/TestCliTypeBytes.fs
@@ -298,6 +298,15 @@ module TestCliTypeBytes =
 
         CliValueType.ToBytes updated |> shouldEqual expected
 
+        let updatedInt =
+            CliValueType.WithFieldSet "Int" (CliType.Numeric (CliNumericType.Int32 0x11223344)) recovered
+
+        let expectedInt = Array.copy bytes
+        let intBytes = System.BitConverter.GetBytes 0x11223344
+        Array.blit intBytes 0 expectedInt 4 intBytes.Length
+
+        CliValueType.ToBytes updatedInt |> shouldEqual expectedInt
+
     [<Test>]
     let ``OfBytesLike allows inner padding bytes when outer fields preserve them`` () : unit =
         let template = outerOverInnerPaddingValueType ()

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -18,7 +18,7 @@ module TestPureCases =
     let unimplemented =
         [
             "EnumSemantics.cs" // blocked by unimplemented QCall Enum_GetValuesAndNames after RawData boxed value byte view
-            "AdvancedStructLayout.cs" // "TODO: couldn't identify field at offset"
+            "AdvancedStructLayout.cs" // blocked after fixed-buffer pointer arithmetic by MarshalNative_SizeOfHelper for ByValTStr string marshalling
             "LdtokenField.cs" // TODO: read through `ReinterpretAs` as non-primitive type .VolatileObject
             "GenericEdgeCases.cs" // TODO: Unsafe.ByteOffset on unsupported byref: Pointer(<<PE data...>>)
             "UnsafeAs.cs" // TODO: read through `ReinterpretAs` as non-primitive type .FourBytes

--- a/WoofWare.PawPrint.Test/sourcesPure/FixedBufferPointerArithmetic.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/FixedBufferPointerArithmetic.cs
@@ -1,0 +1,53 @@
+using System.Runtime.InteropServices;
+
+public class FixedBufferPointerArithmetic
+{
+    [StructLayout(LayoutKind.Sequential)]
+    unsafe struct ByteBufferStruct
+    {
+        public int Header;
+        public fixed byte Buffer[64];
+        public int Footer;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    unsafe struct NestedFixedStruct
+    {
+        public fixed int IntArray[4];
+        public fixed double DoubleArray[2];
+    }
+
+    public static unsafe int Main(string[] argv)
+    {
+        var byteBuffer = new ByteBufferStruct();
+        byteBuffer.Header = 0x12345678;
+        byteBuffer.Footer = unchecked((int)0xDEADBEEF);
+
+        for (int i = 0; i < 64; i++)
+        {
+            byteBuffer.Buffer[i] = (byte)(i + 1);
+        }
+
+        if (byteBuffer.Header != 0x12345678) return 1;
+        if (byteBuffer.Footer != unchecked((int)0xDEADBEEF)) return 2;
+        if (byteBuffer.Buffer[0] != 1) return 3;
+        if (byteBuffer.Buffer[63] != 64) return 4;
+
+        byte* bytePtr = byteBuffer.Buffer;
+        bytePtr[17] = 200;
+        if (byteBuffer.Buffer[17] != 200) return 5;
+
+        var nested = new NestedFixedStruct();
+        nested.IntArray[0] = 100;
+        nested.IntArray[3] = 400;
+        nested.DoubleArray[0] = 1.5;
+        nested.DoubleArray[1] = 2.5;
+
+        if (nested.IntArray[0] != 100) return 6;
+        if (nested.IntArray[3] != 400) return 7;
+        if (nested.DoubleArray[0] != 1.5) return 8;
+        if (nested.DoubleArray[1] != 2.5) return 9;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/FixedBufferPointerArithmetic.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/FixedBufferPointerArithmetic.cs
@@ -48,6 +48,10 @@ public class FixedBufferPointerArithmetic
         if (nested.DoubleArray[0] != 1.5) return 8;
         if (nested.DoubleArray[1] != 2.5) return 9;
 
+        byte* nestedBytes = (byte*)nested.IntArray;
+        nestedBytes[7] = 0x7F;
+        if (nested.IntArray[1] != 0x7F000000) return 10;
+
         return 0;
     }
 }

--- a/WoofWare.PawPrint/BinaryArithmetic.fs
+++ b/WoofWare.PawPrint/BinaryArithmetic.fs
@@ -108,6 +108,17 @@ module ArithmeticOperation =
         AllConcreteTypes.lookup handle state.ConcreteTypes
         |> Option.defaultWith (fun () -> failwith $"System.Char concrete handle %O{handle} was not registered")
 
+    let private byteConcreteType
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        : ConcreteType<ConcreteTypeHandle>
+        =
+        let handle =
+            AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes baseClassTypes.Byte
+
+        AllConcreteTypes.lookup handle state.ConcreteTypes
+        |> Option.defaultWith (fun () -> failwith $"System.Byte concrete handle %O{handle} was not registered")
+
     let private crossArrayPointerDelta
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (state : IlMachineState)
@@ -192,7 +203,20 @@ module ArithmeticOperation =
             let offset = checkedAddInt32 "field byte offset" offset v
 
             match CliType.getFieldAt offset obj with
-            | None -> failwith "TODO: couldn't identify field at offset"
+            | None ->
+                match container with
+                | FieldContainer.HeapObject addr ->
+                    let byteType = byteConcreteType baseClassTypes state
+
+                    ManagedPointerSource.Byref (ByrefRoot.HeapValue addr, [])
+                    |> ManagedPointerByteView.addByteOffset baseClassTypes state byteType offset
+                    |> Choice1Of2
+                | FieldContainer.ByrefContainer parentPtr ->
+                    let byteType = byteConcreteType baseClassTypes state
+
+                    parentPtr
+                    |> ManagedPointerByteView.addByteOffset baseClassTypes state byteType offset
+                    |> Choice1Of2
             | Some field ->
                 let newField = CliConcreteField.ToCliField(field).Id
 

--- a/WoofWare.PawPrint/CliType.fs
+++ b/WoofWare.PawPrint/CliType.fs
@@ -192,6 +192,11 @@ and CliValueType =
             /// `BaseClassTypes`/`AllConcreteTypes` through every push site.
             _PrimitiveLikeKind : PrimitiveLikeKind option
             _Storage : CliValueTypeStorage
+            /// Full byte image for field-backed values reconstructed from bytes.
+            /// Normal field values are still authoritative for represented field
+            /// ranges; this snapshot preserves bytes in padding or fixed-buffer
+            /// trailing storage that metadata fields do not represent.
+            ByteSnapshot : byte[] option
             Layout : Layout
             /// We track dependency orderings between updates to overlapping fields with a monotonically increasing
             /// timestamp.
@@ -329,7 +334,17 @@ and CliValueType =
         match cvt._Storage with
         | CliValueTypeStorage.RawBytes bytes -> Array.copy bytes
         | CliValueTypeStorage.Fields fields ->
-            let bytes = Array.zeroCreate<byte> (CliValueType.SizeOf(cvt).Size)
+            let expectedSize = CliValueType.SizeOf(cvt).Size
+
+            let bytes =
+                match cvt.ByteSnapshot with
+                | None -> Array.zeroCreate<byte> expectedSize
+                | Some bytes ->
+                    if bytes.Length <> expectedSize then
+                        failwith
+                            $"CliValueType.ToBytes: byte snapshot length %i{bytes.Length} does not match value type size %i{expectedSize} for %O{cvt._Declared}"
+
+                    Array.copy bytes
 
             fields
             |> List.sortBy _.EditedAtTime
@@ -356,6 +371,7 @@ and CliValueType =
             _Declared = declared
             _PrimitiveLikeKind = CliValueType.ClassifyPrimitiveLike bct allCt declared fields
             _Storage = CliValueType.StorageFromFields layout fields
+            ByteSnapshot = None
             Layout = layout
             NextTimestamp = 1UL
         }
@@ -370,6 +386,7 @@ and CliValueType =
             _Declared = source._Declared
             _PrimitiveLikeKind = source._PrimitiveLikeKind
             _Storage = CliValueType.StorageFromFields layout fields
+            ByteSnapshot = source.ByteSnapshot |> Option.map Array.copy
             Layout = layout
             NextTimestamp = 1UL
         }
@@ -547,6 +564,7 @@ and CliValueType =
             _Declared = cvt._Declared
             _PrimitiveLikeKind = cvt._PrimitiveLikeKind
             Layout = cvt.Layout
+            ByteSnapshot = cvt.ByteSnapshot |> Option.map Array.copy
             _Storage =
                 fields
                 |> List.replaceWhere (fun f ->
@@ -617,6 +635,7 @@ and CliValueType =
                 _Declared = target._Declared
                 _PrimitiveLikeKind = target._PrimitiveLikeKind
                 _Storage = CliValueTypeStorage.RawBytes (Array.copy sourceBytes)
+                ByteSnapshot = None
                 Layout = target.Layout
                 NextTimestamp = source.NextTimestamp
             }
@@ -646,6 +665,7 @@ and CliValueType =
                 _Declared = target._Declared
                 _PrimitiveLikeKind = target._PrimitiveLikeKind
                 _Storage = CliValueTypeStorage.Fields merged
+                ByteSnapshot = source.ByteSnapshot |> Option.map Array.copy
                 Layout = target.Layout
                 NextTimestamp = source.NextTimestamp
             }
@@ -681,6 +701,7 @@ and CliValueType =
                     _Declared = template._Declared
                     _PrimitiveLikeKind = template._PrimitiveLikeKind
                     _Storage = CliValueTypeStorage.RawBytes (Array.copy bytes)
+                    ByteSnapshot = None
                     Layout = template.Layout
                     NextTimestamp = template.NextTimestamp
                 }
@@ -690,8 +711,6 @@ and CliValueType =
                 if bytes.Length <> expected then
                     failwith
                         $"CliValueType.OfBytesLike: byte count mismatch for field-backed value type %O{template._Declared}; expected %i{expected}, got %i{bytes.Length}"
-
-                let representedBytes = Array.zeroCreate<bool> bytes.Length
 
                 let fields =
                     fields
@@ -713,9 +732,6 @@ and CliValueType =
                         let fieldBytes = Array.zeroCreate<byte> field.Size
                         Array.blit bytes field.Offset fieldBytes 0 field.Size
 
-                        for i = field.Offset to fieldEnd - 1 do
-                            representedBytes.[i] <- true
-
                         let contents = cliTypeOfBytesLike false field.Contents fieldBytes
 
                         { field with
@@ -724,19 +740,12 @@ and CliValueType =
                         }
                     )
 
-                if rejectNonZeroPadding then
-                    bytes
-                    |> Array.iteri (fun i b ->
-                        if not representedBytes.[i] && b <> 0uy then
-                            failwith
-                                $"CliValueType.OfBytesLike: field-backed value type %O{template._Declared} has non-zero byte 0x%02x{b} in unrepresented padding at offset %i{i}"
-                    )
-
                 let result =
                     {
                         _Declared = template._Declared
                         _PrimitiveLikeKind = template._PrimitiveLikeKind
                         _Storage = CliValueTypeStorage.Fields fields
+                        ByteSnapshot = Some (Array.copy bytes)
                         Layout = template.Layout
                         NextTimestamp = max 1UL (uint64 fields.Length)
                     }

--- a/WoofWare.PawPrint/CliType.fs
+++ b/WoofWare.PawPrint/CliType.fs
@@ -69,6 +69,15 @@ type CliType =
             // Runtime/native pointers are not GC-tracked object references in these zero-value layouts.
             false
 
+    static member ContainsRuntimePointers (t : CliType) : bool =
+        match t with
+        | CliType.RuntimePointer _ -> true
+        | CliType.ValueType vt -> CliValueType.ContainsRuntimePointers vt
+        | CliType.Numeric _
+        | CliType.Bool _
+        | CliType.Char _
+        | CliType.ObjectRef _ -> false
+
     static member TryFindMarshalSizeDifference (t : CliType) : string option =
         match t with
         | CliType.Bool _ -> Some "System.Boolean marshals as a 4-byte BOOL by default, not a 1-byte CLI bool"
@@ -379,6 +388,8 @@ and CliValueType =
     /// Rebuild with the same declared type and primitive-like classification as `source`. Used by
     /// the eval-stack rewrap path, which pops an already-classified value and reconstructs its
     /// stored form without needing `BaseClassTypes`/`AllConcreteTypes` in scope.
+    /// This intentionally drops byte snapshots: do not call it for values whose padding or
+    /// fixed-buffer trailing storage must be preserved.
     static member OfFieldsLike (source : CliValueType) (layout : Layout) (f : CliField list) : CliValueType =
         let fields = CliValueType.ComputeConcreteFields layout f
 
@@ -523,6 +534,13 @@ and CliValueType =
         | CliValueTypeStorage.Fields fields ->
             fields
             |> List.exists (fun field -> CliType.ContainsObjectReferences field.Contents)
+
+    static member ContainsRuntimePointers (vt : CliValueType) : bool =
+        match vt._Storage with
+        | CliValueTypeStorage.RawBytes _ -> false
+        | CliValueTypeStorage.Fields fields ->
+            fields
+            |> List.exists (fun field -> CliType.ContainsRuntimePointers field.Contents)
 
     static member IsTightlyPacked (vt : CliValueType) : bool =
         match vt._Storage with

--- a/WoofWare.PawPrint/CliType.fs
+++ b/WoofWare.PawPrint/CliType.fs
@@ -386,7 +386,7 @@ and CliValueType =
             _Declared = source._Declared
             _PrimitiveLikeKind = source._PrimitiveLikeKind
             _Storage = CliValueType.StorageFromFields layout fields
-            ByteSnapshot = source.ByteSnapshot |> Option.map Array.copy
+            ByteSnapshot = None
             Layout = layout
             NextTimestamp = 1UL
         }
@@ -640,6 +640,13 @@ and CliValueType =
                 NextTimestamp = source.NextTimestamp
             }
         | CliValueTypeStorage.Fields targetFields, CliValueTypeStorage.Fields sourceFields ->
+            let targetSize = CliValueType.SizeOf(target).Size
+            let sourceSize = CliValueType.SizeOf(source).Size
+
+            if targetSize <> sourceSize then
+                failwith
+                    $"CliValueType.CoerceFrom: field-backed size mismatch between target %O{target._Declared} (%i{targetSize} bytes) and source %O{source._Declared} (%i{sourceSize} bytes)"
+
             if targetFields.Length <> sourceFields.Length then
                 failwith
                     $"CliValueType.CoerceFrom: field count mismatch between target %O{target._Declared} (%i{targetFields.Length}) and source %O{source._Declared} (%i{sourceFields.Length})"
@@ -680,17 +687,12 @@ and CliValueType =
     /// shapes. Byte snapshots do not encode original overlapping-field write history, so the
     /// recovered value uses declaration-order replay as its canonical write order.
     static member OfBytesLike (template : CliValueType) (bytes : byte[]) : CliValueType =
-        let rec cliTypeOfBytesLike (rejectNonZeroPadding : bool) (template : CliType) (bytes : byte[]) : CliType =
+        let rec cliTypeOfBytesLike (template : CliType) (bytes : byte[]) : CliType =
             match template with
-            | CliType.ValueType vt -> valueTypeOfBytesLike rejectNonZeroPadding vt bytes |> CliType.ValueType
+            | CliType.ValueType vt -> valueTypeOfBytesLike vt bytes |> CliType.ValueType
             | _ -> CliType.OfBytesLike template bytes
 
-        and valueTypeOfBytesLike
-            (rejectNonZeroPadding : bool)
-            (template : CliValueType)
-            (bytes : byte[])
-            : CliValueType
-            =
+        and valueTypeOfBytesLike (template : CliValueType) (bytes : byte[]) : CliValueType =
             match template._Storage with
             | CliValueTypeStorage.RawBytes templateBytes ->
                 if bytes.Length <> templateBytes.Length then
@@ -732,7 +734,7 @@ and CliValueType =
                         let fieldBytes = Array.zeroCreate<byte> field.Size
                         Array.blit bytes field.Offset fieldBytes 0 field.Size
 
-                        let contents = cliTypeOfBytesLike false field.Contents fieldBytes
+                        let contents = cliTypeOfBytesLike field.Contents fieldBytes
 
                         { field with
                             Contents = contents
@@ -750,16 +752,9 @@ and CliValueType =
                         NextTimestamp = max 1UL (uint64 fields.Length)
                     }
 
-                if rejectNonZeroPadding then
-                    let recoveredBytes = CliValueType.ToBytes result
-
-                    if recoveredBytes <> bytes then
-                        failwith
-                            $"CliValueType.OfBytesLike: field-backed value type %O{template._Declared} cannot be reconstructed losslessly from bytes"
-
                 result
 
-        valueTypeOfBytesLike true template bytes
+        valueTypeOfBytesLike template bytes
 
 [<RequireQualifiedAccess>]
 module CliType =

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -217,9 +217,11 @@ module IlMachineManagedByref =
         | CliType.Numeric _
         | CliType.Bool _
         | CliType.Char _ -> CliType.ToBytes value
-        | CliType.ValueType vt when not (CliValueType.ContainsObjectReferences vt) -> CliType.ToBytes value
-        | CliType.ValueType _ ->
+        | CliType.ValueType vt when CliValueType.ContainsObjectReferences vt ->
             failwith $"TODO: byte-view over value type containing object references in %s{context}: %O{value}"
+        | CliType.ValueType vt when CliValueType.ContainsRuntimePointers vt ->
+            failwith $"TODO: byte-view over value type containing runtime pointers in %s{context}: %O{value}"
+        | CliType.ValueType _ -> CliType.ToBytes value
         | other -> failwith $"TODO: byte-view over non-byte-addressable cell in %s{context}: %O{other}"
 
     let private splitTrailingByteView (src : ManagedPointerSource) : (ByrefRoot * ByrefProjection list * int) voption =
@@ -815,6 +817,9 @@ module IlMachineManagedByref =
         | CliType.ValueType vt when CliValueType.ContainsObjectReferences vt ->
             failwith
                 $"TODO: %s{operation}: write through `ReinterpretAs` over value-type storage containing object references is not modelled; storage type was %s{describeCliStorage state storageValue}"
+        | CliType.ValueType vt when CliValueType.ContainsRuntimePointers vt ->
+            failwith
+                $"TODO: %s{operation}: write through `ReinterpretAs` over value-type storage containing runtime pointers is not modelled; storage type was %s{describeCliStorage state storageValue}"
         | _ -> CliType.ToBytes storageValue
 
     let private ofBytesLikeForReinterpret

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -212,14 +212,15 @@ module IlMachineManagedByref =
             )
             rootValue
 
-    let private primitiveCellBytes (context : string) (value : CliType) : byte[] =
+    let private byteAddressableCellBytes (context : string) (value : CliType) : byte[] =
         match value with
         | CliType.Numeric _
         | CliType.Bool _
         | CliType.Char _ -> CliType.ToBytes value
-        | other ->
-            failwith
-                $"TODO: byte-view over non-primitive cell in %s{context}: %O{other} (struct/object byte streams are not modelled in PR B)"
+        | CliType.ValueType vt when not (CliValueType.ContainsObjectReferences vt) -> CliType.ToBytes value
+        | CliType.ValueType _ ->
+            failwith $"TODO: byte-view over value type containing object references in %s{context}: %O{value}"
+        | other -> failwith $"TODO: byte-view over non-byte-addressable cell in %s{context}: %O{other}"
 
     let private splitTrailingByteView (src : ManagedPointerSource) : (ByrefRoot * ByrefProjection list * int) voption =
         match src with
@@ -258,7 +259,7 @@ module IlMachineManagedByref =
             failwith $"TODO: byte-view read from empty array %O{arr} at index %d{index} offset %d{byteOffset}"
 
         let firstCellBytes =
-            primitiveCellBytes $"array %O{arr} element 0" arrObj.Elements.[0]
+            byteAddressableCellBytes $"array %O{arr} element 0" arrObj.Elements.[0]
 
         let cellAdvance, inCellStart = floorDivRem byteOffset firstCellBytes.Length
         let buf = Array.zeroCreate<byte> targetSize
@@ -272,7 +273,7 @@ module IlMachineManagedByref =
                     $"TODO: byte-view read past array bounds at cell %d{cell} of length %d{arrObj.Length} while gathering %d{targetSize} bytes"
 
             let cellBytes =
-                primitiveCellBytes $"array %O{arr} element %d{cell}" arrObj.Elements.[cell]
+                byteAddressableCellBytes $"array %O{arr} element %d{cell}" arrObj.Elements.[cell]
 
             let canTake = cellBytes.Length - inCellOffset
             let take = min canTake (targetSize - filled)
@@ -347,14 +348,6 @@ module IlMachineManagedByref =
         if CliValueType.ContainsObjectReferences obj.Contents then
             failwith $"%s{operation}: refusing byte view over boxed value type containing object references at %O{addr}"
 
-        // Writes reconstruct the boxed value with CliValueType.OfBytesLike; padded
-        // layouts have bytes that are not represented by fields, so they cannot
-        // be preserved through that reconstruction today. RawBytes storage is
-        // also rejected by this predicate until boxed byte-view writes have
-        // dedicated coverage for fieldless raw-backed value types.
-        if not (CliValueType.IsTightlyPacked obj.Contents) then
-            failwith $"%s{operation}: refusing byte view over non-tightly-packed boxed value type at %O{addr}"
-
         CliValueType.ToBytes obj.Contents
 
     let private readHeapValueBytesAs
@@ -423,7 +416,7 @@ module IlMachineManagedByref =
             | ValueSome (byteViewRoot, prefixProjs, byteOffset) ->
                 let rootValue = readRootValue state byteViewRoot
                 let cell = readProjectedValue rootValue prefixProjs
-                let cellBytes = primitiveCellBytes $"single-cell byref %O{src}" cell
+                let cellBytes = byteAddressableCellBytes $"single-cell byref %O{src}" cell
                 let targetSize = CliType.sizeOf targetTemplate
 
                 if byteOffset < 0 || byteOffset + targetSize > cellBytes.Length then
@@ -434,7 +427,7 @@ module IlMachineManagedByref =
                 CliType.ofBytesLike targetTemplate bytes
             | ValueNone ->
                 let raw = readProjectedValue (readRootValue state outerRoot) outerProjs
-                let rawBytes = primitiveCellBytes $"plain byref %O{src}" raw
+                let rawBytes = byteAddressableCellBytes $"plain byref %O{src}" raw
                 let targetSize = CliType.sizeOf targetTemplate
 
                 if targetSize > rawBytes.Length then
@@ -609,7 +602,7 @@ module IlMachineManagedByref =
             failwith $"TODO: byte-view write to empty array %O{arr} at index %d{index} offset %d{byteOffset}"
 
         let firstCellBytes =
-            primitiveCellBytes $"array %O{arr} element 0" arrObj.Elements.[0]
+            byteAddressableCellBytes $"array %O{arr} element 0" arrObj.Elements.[0]
 
         let cellAdvance, inCellStart = floorDivRem byteOffset firstCellBytes.Length
         let mutable state = state
@@ -622,7 +615,10 @@ module IlMachineManagedByref =
                 failwith $"TODO: byte-view write past array bounds at cell %d{cell} of length %d{arrObj.Length}"
 
             let existing = state.ManagedHeap.Arrays.[arr].Elements.[cell]
-            let existingBytes = primitiveCellBytes $"array %O{arr} element %d{cell}" existing
+
+            let existingBytes =
+                byteAddressableCellBytes $"array %O{arr} element %d{cell}" existing
+
             let canTake = existingBytes.Length - inCellOffset
             let take = min canTake (bytes.Length - filled)
             let newCellBytes = Array.copy existingBytes
@@ -753,7 +749,7 @@ module IlMachineManagedByref =
             | ValueSome (byteViewRoot, prefixProjs, byteOffset) ->
                 let rootValue = readRootValue state byteViewRoot
                 let cell = readProjectedValue rootValue prefixProjs
-                let cellBytes = primitiveCellBytes $"single-cell byref %O{src}" cell
+                let cellBytes = byteAddressableCellBytes $"single-cell byref %O{src}" cell
 
                 if byteOffset < 0 || byteOffset + bytes.Length > cellBytes.Length then
                     failwith
@@ -767,7 +763,7 @@ module IlMachineManagedByref =
             | ValueNone ->
                 let rootValue = readRootValue state outerRoot
                 let cell = readProjectedValue rootValue outerProjs
-                let cellBytes = primitiveCellBytes $"plain byref %O{src}" cell
+                let cellBytes = byteAddressableCellBytes $"plain byref %O{src}" cell
 
                 if bytes.Length > cellBytes.Length then
                     failwith

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -350,6 +350,9 @@ module IlMachineManagedByref =
         if CliValueType.ContainsObjectReferences obj.Contents then
             failwith $"%s{operation}: refusing byte view over boxed value type containing object references at %O{addr}"
 
+        if CliValueType.ContainsRuntimePointers obj.Contents then
+            failwith $"%s{operation}: refusing byte view over boxed value type containing runtime pointers at %O{addr}"
+
         CliValueType.ToBytes obj.Contents
 
     let private readHeapValueBytesAs

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -141,6 +141,18 @@ module NullaryIlOp =
         | ManagedPointerSource.Null
         | ManagedPointerSource.Byref _ -> false
 
+    let private isTrailingByteViewPointer (src : ManagedPointerSource) : bool =
+        match src with
+        | ManagedPointerSource.Null -> false
+        | ManagedPointerSource.Byref (_, projs) ->
+            match List.rev projs with
+            | ByrefProjection.ByteOffset _ :: ByrefProjection.ReinterpretAs _ :: _
+            | ByrefProjection.ReinterpretAs _ :: _ -> true
+            | ByrefProjection.ByteOffset n :: _ ->
+                failwith
+                    $"ByteOffset %d{n} without a preceding ReinterpretAs in projection chain: %O{src} (this is an interpreter bug)"
+            | _ -> false
+
     let private isLocallocForbiddenExceptionRegion (ilOffset : int) (region : ExceptionRegion) : bool =
         let isInHandlerBody (offset : ExceptionOffset) : bool =
             ExceptionHandling.isInHandlerBody ilOffset offset
@@ -310,7 +322,7 @@ module NullaryIlOp =
 
         let loadedValue =
             match popped with
-            | EvalStackValue.ManagedPointer src when isLocalMemoryPointer src ->
+            | EvalStackValue.ManagedPointer src when isLocalMemoryPointer src || isTrailingByteViewPointer src ->
                 IlMachineState.readManagedByrefBytesAs state src targetCliType
             | EvalStackValue.ManagedPointer src -> IlMachineState.readManagedByref state src
             | EvalStackValue.NativeInt (NativeIntSource.ManagedPointer src) ->


### PR DESCRIPTION
I'm getting increasingly unsure about whether we should switch to a wholly byte-backed representation.