### PR TITLE
Plumb pointer provenance through Conv.U8 / Conv.I8

### DIFF
--- a/WoofWare.PawPrint.Test/TestBinaryArithmetic.fs
+++ b/WoofWare.PawPrint.Test/TestBinaryArithmetic.fs
@@ -738,3 +738,178 @@ module TestBinaryArithmetic =
         then
             failwith
                 $"generator missed required storage identities: array=%d{arrayCases}, string=%d{stringCases}, local-memory=%d{localMemoryCases}, stack-local=%d{stackLocalCases}, stack-argument=%d{stackArgumentCases}"
+
+    // The following tests cover the BCL's portable wraparound idiom from
+    // UnmanagedMemoryStream.Initialize: `((byte*)((long)pointer + capacity)) < pointer`
+    // expressed as `Conv.U8 → ldc.i8 capacity → Add → Conv.U → ldarg pointer → Bge.un`.
+    // On a 64-bit interpreter the wraparound is statically vacuous; we have to keep
+    // pointer provenance flowing through the int64 widening so that the eventual
+    // `Conv.U` recovers the byref and the comparison behaves correctly.
+
+    let private convU8AndAdd (state : IlMachineState) (ptr : EvalStackValue) (capacity : int64) : EvalStackValue =
+        let widened : EvalStackValue =
+            match EvalStackValue.convToUInt64 ptr with
+            | Some src -> EvalStackValue.Int64 src
+            | None -> failwith $"convToUInt64 returned None for %O{ptr}"
+
+        execute ArithmeticOperation.add state widened (EvalStackValue.Int64 (Int64Source.Verbatim capacity))
+
+    [<Test>]
+    let ``Conv.U8 then Conv.U on a byte-view byref recovers the original pointer`` () : unit =
+        let state, arr = stateWithIntArray [ 10 ; 20 ; 30 ; 40 ]
+        let ptr = byteViewPointer arr 1 3
+
+        let widened : EvalStackValue =
+            match EvalStackValue.convToUInt64 ptr with
+            | Some src -> EvalStackValue.Int64 src
+            | None -> failwith "convToUInt64 returned None"
+
+        let recovered : NativeIntSource =
+            match EvalStackValue.toUnsignedNativeInt widened with
+            | Some (UnsignedNativeIntSource.FromManagedPointer mp) -> NativeIntSource.ManagedPointer mp
+            | other -> failwith $"expected FromManagedPointer, got %O{other}"
+
+        let asNativeInt = EvalStackValue.NativeInt recovered
+
+        if not (EvalStackValueComparisons.ceq ptr asNativeInt) then
+            failwith $"expected Conv.U8 → Conv.U to round-trip the byref, got %O{recovered} from %O{ptr}"
+
+    [<Test>]
+    let ``Conv.I8 then Conv.I on a byte-view byref recovers the original pointer`` () : unit =
+        let state, arr = stateWithIntArray [ 10 ; 20 ; 30 ; 40 ]
+        let ptr = byteViewPointer arr 2 1
+
+        let widened : EvalStackValue =
+            match EvalStackValue.convToInt64 ptr with
+            | Some src -> EvalStackValue.Int64 src
+            | None -> failwith "convToInt64 returned None"
+
+        let recovered : NativeIntSource =
+            match EvalStackValue.toNativeInt widened with
+            | Some src -> src
+            | None -> failwith "toNativeInt returned None"
+
+        if not (EvalStackValueComparisons.ceq ptr (EvalStackValue.NativeInt recovered)) then
+            failwith $"expected Conv.I8 → Conv.I to round-trip the byref, got %O{recovered}"
+
+    [<Test>]
+    let ``Conv.U8 of a null managed pointer normalises to verbatim zero`` () : unit =
+        // Null is the zero pointer, so widening it must reduce to a plain Int64 0.
+        // This keeps later arithmetic on the result usable without dragging the
+        // null-pointer special case through every arm.
+        match EvalStackValue.convToUInt64 (EvalStackValue.ManagedPointer ManagedPointerSource.Null) with
+        | Some (Int64Source.Verbatim 0L) -> ()
+        | other -> failwith $"expected null → verbatim 0, got %O{other}"
+
+    [<Test>]
+    let ``Conv.U8 then Add then Conv.U advances a byte-view byref`` () : unit =
+        let state, arr = stateWithIntArray [ 10 ; 20 ; 30 ; 40 ; 50 ]
+        let ptr = byteViewPointer arr 1 0
+
+        let advanced = convU8AndAdd state ptr 5L
+
+        let recovered : NativeIntSource =
+            match EvalStackValue.toUnsignedNativeInt advanced with
+            | Some (UnsignedNativeIntSource.FromManagedPointer mp) -> NativeIntSource.ManagedPointer mp
+            | other -> failwith $"expected FromManagedPointer after Conv.U, got %O{other}"
+
+        // Original byref was at array index 1 with byte cursor 0; advancing 5 bytes
+        // through the int64 round-trip must place the cursor 5 bytes ahead under
+        // the same root and prefix. With element size 4 (int32), 5 bytes lands in
+        // index 2 with a 1-byte residual cursor.
+        match recovered with
+        | NativeIntSource.ManagedPointer (ManagedPointerSource.Byref (ByrefRoot.ArrayElement (resultArr, idx),
+                                                                      [ ByrefProjection.ReinterpretAs _
+                                                                        ByrefProjection.ByteOffset off ])) when
+            resultArr = arr
+            ->
+            idx |> shouldEqual 2
+            off |> shouldEqual 1
+        | other -> failwith $"unexpected advanced byref shape: %O{other}"
+
+    [<Test>]
+    let ``UnmanagedMemoryStream wraparound check is statically not taken on 64-bit`` () : unit =
+        // ECMA-335 III.3.4: bge.un is `not clt.un`. On 64-bit the BCL's wraparound
+        // detection (advanced < pointer) is structurally false, so the branch over
+        // the throw is always taken. We model this by checking cgeUn on the same
+        // operands the BCL idiom produces.
+        let state, arr = stateWithIntArray [ 10 ; 20 ; 30 ; 40 ; 50 ; 60 ; 70 ; 80 ]
+        let ptr = byteViewPointer arr 0 0
+
+        let advanced = convU8AndAdd state ptr 12L
+
+        // Bge.un compares value1 (deeper, advanced) with value2 (top, original).
+        // Per the C# `if (advanced < ptr) throw`, the IL skips the throw via
+        // bge.un.s when advanced >= ptr; that condition must hold for any
+        // non-negative capacity.
+        if not (EvalStackValueComparisons.cgeUn advanced ptr) then
+            failwith "expected the wraparound check to detect no wraparound for a non-negative capacity"
+
+        if EvalStackValueComparisons.cltUn advanced ptr then
+            failwith "expected clt.un to be false for advanced vs original byref"
+
+    [<Test>]
+    let ``cgt.un between byrefs of the same root reflects byte-cursor ordering`` () : unit =
+        let state, arr = stateWithIntArray [ 10 ; 20 ; 30 ; 40 ]
+        let earlier = byteViewPointer arr 1 0
+        let later = byteViewPointer arr 1 3
+
+        if not (EvalStackValueComparisons.cgtUn later earlier) then
+            failwith "expected later byte-view byref to compare strictly greater unsigned"
+
+        if EvalStackValueComparisons.cgtUn earlier later then
+            failwith "expected earlier byte-view byref not to compare greater unsigned"
+
+        if EvalStackValueComparisons.cgtUn earlier earlier then
+            failwith "expected cgt.un on identical byrefs to be false"
+
+    [<Test>]
+    let ``cgt.un refuses to compare byrefs across distinct roots`` () : unit =
+        // Cross-root pointer comparison has no defensible answer in our model;
+        // this test pins the strict same-root requirement so the next loose use
+        // of pointer-bit comparisons surfaces a clear diagnostic.
+        let state, arr1, arr2 = stateWithTwoIntArrays [ 10 ; 20 ] [ 100 ; 200 ]
+
+        let p1 = byteViewPointer arr1 0 0
+        let p2 = byteViewPointer arr2 0 0
+
+        let outcome =
+            try
+                EvalStackValueComparisons.cgtUn p1 p2 |> ignore
+                Choice1Of2 ()
+            with e ->
+                Choice2Of2 e
+
+        match outcome with
+        | Choice1Of2 () -> failwith "expected cgt.un to refuse cross-root byref comparison"
+        | Choice2Of2 e when e.Message.Contains "common root" -> ()
+        | Choice2Of2 e -> failwith $"unexpected exception from cgt.un: %s{e.Message}"
+
+    [<Test>]
+    let ``Conv.U8 round-trip via Add preserves provenance under arithmetic identity`` () : unit =
+        // Property: for every non-negative offset that fits in int32, the round-trip
+        // through Conv.U8 + Add + Conv.U must equal a direct pointer advance via
+        // Add at the byref level. This pins the 64-bit assumption: the widened-int64
+        // arithmetic and the native-int arithmetic agree.
+        let state, arr = stateWithIntArray (List.init 32 id)
+
+        let property (capacity : int) : bool =
+            if capacity < 0 then
+                true
+            else
+                let ptr = byteViewPointer arr 0 0
+
+                let viaInt64 =
+                    let advanced = convU8AndAdd state ptr (int64 capacity)
+
+                    match EvalStackValue.toUnsignedNativeInt advanced with
+                    | Some (UnsignedNativeIntSource.FromManagedPointer mp) ->
+                        EvalStackValue.NativeInt (NativeIntSource.ManagedPointer mp)
+                    | other -> failwith $"unexpected: %O{other}"
+
+                let viaNativeInt =
+                    execute ArithmeticOperation.add state ptr (EvalStackValue.Int32 capacity)
+
+                EvalStackValueComparisons.ceq viaInt64 viaNativeInt
+
+        Check.One (propertyConfig, Prop.forAll (Arb.fromGen (Gen.choose (0, System.Int32.MaxValue / 2))) property)

--- a/WoofWare.PawPrint.Test/TestBinaryArithmetic.fs
+++ b/WoofWare.PawPrint.Test/TestBinaryArithmetic.fs
@@ -913,3 +913,109 @@ module TestBinaryArithmetic =
                 EvalStackValueComparisons.ceq viaInt64 viaNativeInt
 
         Check.One (propertyConfig, Prop.forAll (Arb.fromGen (Gen.choose (0, System.Int32.MaxValue / 2))) property)
+
+    [<Test>]
+    let ``tryByteAddressDeltaSign accepts canonical byrefs at distinct array indices`` () : unit =
+        let _, arr = stateWithIntArray (List.init 8 id)
+
+        let extractByref (esv : EvalStackValue) : ManagedPointerSource =
+            match esv with
+            | EvalStackValue.ManagedPointer mp -> mp
+            | other -> failwith $"expected managed pointer, got %O{other}"
+
+        let p0 = extractByref (byteViewPointer arr 0 0)
+        let p1Plus3 = extractByref (byteViewPointer arr 1 3)
+
+        match ManagedPointerSource.tryByteAddressDeltaSign p0 p1Plus3 with
+        | Some sign when sign > 0 -> ()
+        | other -> failwith $"expected positive sign for arr[0] -> arr[1]+3, got %O{other}"
+
+        match ManagedPointerSource.tryByteAddressDeltaSign p1Plus3 p0 with
+        | Some sign when sign < 0 -> ()
+        | other -> failwith $"expected negative sign for arr[1]+3 -> arr[0], got %O{other}"
+
+    [<Test>]
+    let ``tryByteAddressDeltaSign throws on a non-canonical negative trailing byte cursor`` () : unit =
+        let _, arr = stateWithIntArray (List.init 4 id)
+
+        let canonical = ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, 0), [])
+
+        // Manually construct a malformed pointer: the trailing ByteOffset
+        // bypasses normaliseTrailingByteOffset's floor-division and is negative.
+        // tryByteAddressDeltaSign's array fallback's correctness depends on each
+        // residual sitting in [0, cellSize); a negative residual indicates a
+        // construction-site bug and must not silently degrade to a wrong sign.
+        let malformed =
+            ManagedPointerSource.Byref (
+                ByrefRoot.ArrayElement (arr, 1),
+                [ ByrefProjection.ReinterpretAs byteType ; ByrefProjection.ByteOffset -1 ]
+            )
+
+        let outcome =
+            try
+                ManagedPointerSource.tryByteAddressDeltaSign canonical malformed |> ignore
+                Choice1Of2 ()
+            with e ->
+                Choice2Of2 e
+
+        match outcome with
+        | Choice1Of2 () -> failwith "expected tryByteAddressDeltaSign to throw on negative trailing byte cursor"
+        | Choice2Of2 e when e.Message.Contains "non-negative" -> ()
+        | Choice2Of2 e -> failwith $"unexpected exception: %s{e.Message}"
+
+    [<Test>]
+    let ``tryByteAddressDeltaSign throws on a ByteOffset at a non-trailing position`` () : unit =
+        let _, arr = stateWithIntArray (List.init 4 id)
+
+        let canonical = ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, 0), [])
+
+        // ByrefProjection.ByteOffset is documented to only appear as the final
+        // element preceded by ReinterpretAs. A non-trailing ByteOffset is an
+        // invariant violation; the helper must throw rather than silently
+        // returning a wrong sign.
+        let malformed =
+            ManagedPointerSource.Byref (
+                ByrefRoot.ArrayElement (arr, 1),
+                [
+                    ByrefProjection.ReinterpretAs byteType
+                    ByrefProjection.ByteOffset 1
+                    ByrefProjection.ReinterpretAs byteType
+                ]
+            )
+
+        let outcome =
+            try
+                ManagedPointerSource.tryByteAddressDeltaSign canonical malformed |> ignore
+                Choice1Of2 ()
+            with e ->
+                Choice2Of2 e
+
+        match outcome with
+        | Choice1Of2 () -> failwith "expected tryByteAddressDeltaSign to throw on non-trailing ByteOffset"
+        | Choice2Of2 e when e.Message.Contains "non-trailing" -> ()
+        | Choice2Of2 e -> failwith $"unexpected exception: %s{e.Message}"
+
+    [<Test>]
+    let ``tryByteAddressDeltaSign throws on a trailing ByteOffset without ReinterpretAs`` () : unit =
+        let _, arr = stateWithIntArray (List.init 4 id)
+
+        let canonical = ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, 0), [])
+
+        // A trailing ByteOffset must be preceded by ReinterpretAs (the byte
+        // cursor is on top of a byte view of the cell). Without that pairing
+        // the projection list is malformed.
+        let malformed =
+            ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, 1), [ ByrefProjection.ByteOffset 1 ])
+
+        let outcome =
+            try
+                ManagedPointerSource.tryByteAddressDeltaSign canonical malformed |> ignore
+                Choice1Of2 ()
+            with e ->
+                Choice2Of2 e
+
+        match outcome with
+        | Choice1Of2 () ->
+            failwith "expected tryByteAddressDeltaSign to throw on trailing ByteOffset without ReinterpretAs"
+        | Choice2Of2 e when e.Message.Contains "preceded by ReinterpretAs" -> ()
+        | Choice2Of2 e -> failwith $"unexpected exception: %s{e.Message}"

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -24,7 +24,7 @@ module TestPureCases =
             "UnsafeAs.cs" // TODO: read through `ReinterpretAs` as non-primitive type .FourBytes
             "CrossAssemblyTypes.cs" // TODO: byref element offset on non-array byref without a trailing byte-view ReinterpretAs projection
             "InitializeArrayBoxedFieldHandle.cs" // blocked on constrained static interface dispatch for INumber<T>.Min on System.Char while parsing <PrivateImplementationDetails>
-            "InterfaceDispatch.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
+            "InterfaceDispatch.cs" // past the UnmanagedMemoryStream wraparound check; now blocked on Unsafe.ByteOffset over a PeByteRange byref
             "NullDereferenceTest.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
             "CastClassInvalid.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
             "CastclassFailures.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource

--- a/WoofWare.PawPrint/BinaryArithmetic.fs
+++ b/WoofWare.PawPrint/BinaryArithmetic.fs
@@ -688,6 +688,27 @@ module BinaryArithmetic =
                 failwith
                     $"managed pointer arithmetic (%s{op.Name}): refusing to use non-verbatim native int %O{v} as pointer offset"
 
+        // 64-bit assumption: an int64 offset that does not fit in int32 cannot
+        // be applied to a managed pointer in our model. On 32-bit, the BCL's
+        // wraparound idiom intentionally produces oversize int64s and relies
+        // on the subsequent Conv.U truncating mod 2^32; we don't model that.
+        let widenedInt64OffsetForPointerArithmetic (n : int64) : int32 =
+            if n > int64<int32> System.Int32.MaxValue || n < int64<int32> System.Int32.MinValue then
+                failwith
+                    $"managed pointer arithmetic (%s{op.Name}): int64 offset does not fit in int32: %d{n} (the WidenedNativeInt arms are 64-bit-only — on 32-bit, oversize offsets would truncate mod 2^32)"
+
+            int32<int64> n
+
+        let widenedManagedPtrChoiceAsInt64
+            (signed : bool)
+            (result : Choice<ManagedPointerSource, int>)
+            : EvalStackValue
+            =
+            match result with
+            | Choice1Of2 ptr ->
+                EvalStackValue.Int64 (Int64Source.widenedNativeInt (NativeIntSource.ManagedPointer ptr) signed)
+            | Choice2Of2 i -> EvalStackValue.Int64 (Int64Source.Verbatim (int64<int32> i))
+
         // see table at https://learn.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.add?view=net-9.0
         match val1, val2 with
         | EvalStackValue.Int32 val1, EvalStackValue.Int32 val2 -> op.Int32Int32 val1 val2 |> EvalStackValue.Int32
@@ -714,6 +735,18 @@ module BinaryArithmetic =
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset val1),
           EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset val2) ->
             op.CrossArrayOffsets val1 val2 |> Int64Source.Verbatim |> EvalStackValue.Int64
+        | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (NativeIntSource.ManagedPointer val1, signed)),
+          EvalStackValue.Int64 (Int64Source.Verbatim val2) ->
+            let val2 = widenedInt64OffsetForPointerArithmetic val2
+
+            op.ManagedPtrInt32 baseClassTypes state val1 val2
+            |> widenedManagedPtrChoiceAsInt64 signed
+        | EvalStackValue.Int64 (Int64Source.Verbatim val1),
+          EvalStackValue.Int64 (Int64Source.WidenedNativeInt (NativeIntSource.ManagedPointer val2, signed)) ->
+            let val1 = widenedInt64OffsetForPointerArithmetic val1
+
+            op.Int32ManagedPtr baseClassTypes state val1 val2
+            |> widenedManagedPtrChoiceAsInt64 signed
         | EvalStackValue.NativeInt (NativeIntSource.ManagedPointer val1), EvalStackValue.Int32 val2 ->
             op.ManagedPtrInt32 baseClassTypes state val1 val2 |> managedPtrChoiceAsNativeInt
         | EvalStackValue.NativeInt val1, EvalStackValue.Int32 val2 ->

--- a/WoofWare.PawPrint/CliNumericType.fs
+++ b/WoofWare.PawPrint/CliNumericType.fs
@@ -131,14 +131,16 @@ module Int64Source =
         | Int64Source.WidenedNativeInt (src, _) -> Some (NativeIntSource.isNonnegative src)
         | _ -> failwith "TODO: SyntheticCrossArrayOffset"
 
-    /// Numerically compare two `Int64Source` values, treating them as their
-    /// underlying int64 bits. `Int64Source` no longer supports structural
+    /// Signed comparison of two `Int64Source` values, treating each as the
+    /// signed int64 it represents. Returns negative / zero / positive in the
+    /// `compare` convention. `Int64Source` no longer supports structural
     /// comparison (it now contains a `NativeIntSource`, which is
     /// `[<NoComparison>]`), so callers must funnel through this helper.
     /// Non-`Verbatim` variants don't have a meaningful numeric ordering and
     /// fail loudly — provenance-tracked offsets and widened pointer bits
-    /// shouldn't be compared as plain integers.
-    let compareBits (i1 : Int64Source) (i2 : Int64Source) : int =
+    /// shouldn't be compared as plain integers. For unsigned comparison see
+    /// the `cgt.un` / `clt.un` paths in `EvalStackValueComparisons`.
+    let compareSigned (i1 : Int64Source) (i2 : Int64Source) : int =
         match i1, i2 with
         | Int64Source.Verbatim a, Int64Source.Verbatim b -> compare a b
         | _, _ -> failwith $"TODO: refusing to compare Int64Source values numerically: %O{i1} vs %O{i2}"

--- a/WoofWare.PawPrint/CliNumericType.fs
+++ b/WoofWare.PawPrint/CliNumericType.fs
@@ -7,19 +7,52 @@ open Checked
 type Int64Source =
     | Verbatim of int64
     | SyntheticCrossArrayOffset of SyntheticCrossArrayOffset
+    /// The result of `conv.i8` / `conv.u8` applied to a NativeInt (managed
+    /// pointer, function pointer, type handle, …). On a 64-bit interpreter
+    /// this widening is bit-preserving; on a 32-bit interpreter it would
+    /// zero/sign-extend 32→64. PawPrint is a 64-bit interpreter
+    /// (`NATIVE_INT_SIZE = 8`), so the int64 obtained this way carries the
+    /// same provenance as the underlying NativeIntSource. Operations on this
+    /// variant must respect that an int64 obtained this way could in
+    /// principle outgrow the native word — but on 64-bit we never observe
+    /// this, so most numeric ops fail loudly to keep the round-trip
+    /// inversion contract honest.
+    ///
+    /// Always construct via `Int64Source.widenedNativeInt`, which normalises
+    /// `Verbatim` and `SyntheticCrossArrayOffset` cases to the corresponding
+    /// `Int64Source` variants. Unnormalised forms violate invariants of
+    /// pattern matches that assume `Verbatim` / `SyntheticCrossArrayOffset`
+    /// cover all "purely numeric" int64 values.
+    | WidenedNativeInt of source : NativeIntSource * signed : bool
 
     override this.ToString () =
         match this with
         | Int64Source.Verbatim i -> $"%i{i}"
         | Int64Source.SyntheticCrossArrayOffset _ -> "<synthetic cross-array offset>"
+        | Int64Source.WidenedNativeInt (src, signed) ->
+            let conv = if signed then "conv.i8" else "conv.u8"
+            $"<%s{conv} %O{src}>"
 
 [<RequireQualifiedAccess>]
 module Int64Source =
+
+    /// Smart constructor for `Int64Source.WidenedNativeInt`. Normalises the
+    /// `Verbatim` and `SyntheticCrossArrayOffset` cases of the underlying
+    /// `NativeIntSource` so they round-trip back into the canonical
+    /// `Int64Source` shapes; non-numeric sources are wrapped to preserve
+    /// provenance through `conv.i8` / `conv.u8`.
+    let widenedNativeInt (src : NativeIntSource) (signed : bool) : Int64Source =
+        match src with
+        | NativeIntSource.Verbatim n -> Int64Source.Verbatim n
+        | NativeIntSource.SyntheticCrossArrayOffset s -> Int64Source.SyntheticCrossArrayOffset s
+        | NativeIntSource.ManagedPointer ManagedPointerSource.Null -> Int64Source.Verbatim 0L
+        | _ -> Int64Source.WidenedNativeInt (src, signed)
 
     let isZero (i : Int64Source) : bool =
         match i with
         | Int64Source.Verbatim i -> i = 0L
         | Int64Source.SyntheticCrossArrayOffset _ -> failwith "TODO: is SyntheticCrossArrayOffset zero?"
+        | Int64Source.WidenedNativeInt (src, _) -> NativeIntSource.isZero src
 
     /// Returns None if the input was Int64.MinValue.
     let negate (i : Int64Source) : Int64Source option =
@@ -33,47 +66,82 @@ module Int64Source =
             SyntheticCrossArrayOffset.negate i
             |> Int64Source.SyntheticCrossArrayOffset
             |> Some
+        | Int64Source.WidenedNativeInt (src, _) ->
+            failwith $"TODO: refusing to negate widened native int %O{src} (would lose provenance)"
 
     let shr (i : Int64Source) (shift : int) : Int64Source =
         match i with
         | Int64Source.Verbatim i -> i >>> shift |> Int64Source.Verbatim
         | Int64Source.SyntheticCrossArrayOffset _ -> failwith "TODO: SyntheticCrossArrayOffset"
+        | Int64Source.WidenedNativeInt (src, _) ->
+            failwith $"TODO: refusing to shr widened native int %O{src} (bit-twiddling on pointer bits)"
 
     let shl (i : Int64Source) (shift : int) : Int64Source =
         match i with
         | Int64Source.Verbatim i -> i <<< shift |> Int64Source.Verbatim
         | Int64Source.SyntheticCrossArrayOffset _ -> failwith "TODO: SyntheticCrossArrayOffset"
+        | Int64Source.WidenedNativeInt (src, _) ->
+            failwith $"TODO: refusing to shl widened native int %O{src} (bit-twiddling on pointer bits)"
 
     let add (i1 : Int64Source) (i2 : Int64Source) : Int64Source =
         match i1, i2 with
         | Int64Source.Verbatim i1, Int64Source.Verbatim i2 -> i1 + i2 |> Int64Source.Verbatim
+        | Int64Source.WidenedNativeInt (src, _), _
+        | _, Int64Source.WidenedNativeInt (src, _) ->
+            // Pointer-shaped int64 arithmetic is handled by BinaryArithmetic.execute
+            // (which dispatches on EvalStackValue pairs), not via this generic helper.
+            failwith $"TODO: Int64Source.add on widened native int %O{src} should be routed through BinaryArithmetic"
         | _, _ -> failwith "TODO: SyntheticCrossArrayOffset"
 
     let bitNot (i : Int64Source) : Int64Source =
         match i with
         | Int64Source.Verbatim i -> Int64Source.Verbatim ~~~i
+        | Int64Source.WidenedNativeInt (src, _) ->
+            failwith $"TODO: refusing to bitNot widened native int %O{src} (bit-twiddling on pointer bits)"
         | _ -> failwith "TODO: SyntheticCrossArrayOffset"
 
     let bitAnd (i1 : Int64Source) (i2 : Int64Source) : Int64Source =
         match i1, i2 with
         | Int64Source.Verbatim i1, Int64Source.Verbatim i2 -> i1 &&& i2 |> Int64Source.Verbatim
+        | Int64Source.WidenedNativeInt (src, _), _
+        | _, Int64Source.WidenedNativeInt (src, _) ->
+            failwith $"TODO: refusing to bitAnd widened native int %O{src} (bit-twiddling on pointer bits)"
         | _, _ -> failwith "TODO: SyntheticCrossArrayOffset"
 
     let bitOr (i1 : Int64Source) (i2 : Int64Source) : Int64Source =
         match i1, i2 with
         | Int64Source.Verbatim i1, Int64Source.Verbatim i2 -> i1 ||| i2 |> Int64Source.Verbatim
+        | Int64Source.WidenedNativeInt (src, _), _
+        | _, Int64Source.WidenedNativeInt (src, _) ->
+            failwith $"TODO: refusing to bitOr widened native int %O{src} (bit-twiddling on pointer bits)"
         | _, _ -> failwith "TODO: SyntheticCrossArrayOffset"
 
     let bitXor (i1 : Int64Source) (i2 : Int64Source) : Int64Source =
         match i1, i2 with
         | Int64Source.Verbatim i1, Int64Source.Verbatim i2 -> i1 ^^^ i2 |> Int64Source.Verbatim
+        | Int64Source.WidenedNativeInt (src, _), _
+        | _, Int64Source.WidenedNativeInt (src, _) ->
+            failwith $"TODO: refusing to bitXor widened native int %O{src} (bit-twiddling on pointer bits)"
         | _, _ -> failwith "TODO: SyntheticCrossArrayOffset"
 
     /// Returns None if we can't decide whether this number is nonnegative.
     let isNonnegative (i : Int64Source) : bool option =
         match i with
         | Int64Source.Verbatim i -> Some (i >= 0L)
+        | Int64Source.WidenedNativeInt (src, _) -> Some (NativeIntSource.isNonnegative src)
         | _ -> failwith "TODO: SyntheticCrossArrayOffset"
+
+    /// Numerically compare two `Int64Source` values, treating them as their
+    /// underlying int64 bits. `Int64Source` no longer supports structural
+    /// comparison (it now contains a `NativeIntSource`, which is
+    /// `[<NoComparison>]`), so callers must funnel through this helper.
+    /// Non-`Verbatim` variants don't have a meaningful numeric ordering and
+    /// fail loudly — provenance-tracked offsets and widened pointer bits
+    /// shouldn't be compared as plain integers.
+    let compareBits (i1 : Int64Source) (i2 : Int64Source) : int =
+        match i1, i2 with
+        | Int64Source.Verbatim a, Int64Source.Verbatim b -> compare a b
+        | _, _ -> failwith $"TODO: refusing to compare Int64Source values numerically: %O{i1} vs %O{i2}"
 
 /// Defined in III.1.1.1
 type CliNumericType =
@@ -108,6 +176,8 @@ type CliNumericType =
         | CliNumericType.Int64 (Int64Source.Verbatim i) -> BitConverter.GetBytes i
         | CliNumericType.Int64 (Int64Source.SyntheticCrossArrayOffset _) ->
             failwith "refusing to convert cross-array offset to bytes"
+        | CliNumericType.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
+            failwith $"refusing to convert widened native int %O{src} to bytes"
         | CliNumericType.NativeInt src ->
             match src with
             | NativeIntSource.Verbatim i -> BitConverter.GetBytes i

--- a/WoofWare.PawPrint/EvalStack.fs
+++ b/WoofWare.PawPrint/EvalStack.fs
@@ -183,6 +183,20 @@ module EvalStackValue =
         | EvalStackValue.Int64 (Int64Source.Verbatim i) -> Some (uint64 i |> UnsignedNativeIntSource.Verbatim)
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset i) ->
             Some (UnsignedNativeIntSource.FromSyntheticCrossArrayStorage i)
+        | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
+            // Inversion of `Conv.U8` / `Conv.I8` followed by `Conv.U`. On a
+            // 64-bit interpreter the widening is bit-preserving, so the
+            // truncation back to native int recovers the original
+            // NativeIntSource. On a 32-bit interpreter this would lose the
+            // high 32 bits, which is exactly the wraparound that the
+            // `UnmanagedMemoryStream.Initialize` idiom checks for; modelling
+            // that would require revisiting `NATIVE_INT_SIZE`.
+            match src with
+            | NativeIntSource.ManagedPointer ptr -> Some (UnsignedNativeIntSource.FromManagedPointer ptr)
+            | NativeIntSource.SyntheticCrossArrayOffset s ->
+                Some (UnsignedNativeIntSource.FromSyntheticCrossArrayStorage s)
+            | NativeIntSource.Verbatim n -> Some (UnsignedNativeIntSource.Verbatim (uint64 n))
+            | _ -> failwith $"TODO: Conv_U from widened native int with non-pointer source %O{src}"
         | EvalStackValue.NativeInt i ->
             match i with
             | NativeIntSource.Verbatim i -> uint64 i |> UnsignedNativeIntSource.Verbatim |> Some
@@ -224,6 +238,11 @@ module EvalStackValue =
         | EvalStackValue.Int64 (Int64Source.Verbatim i) -> i |> convIFromInt64 |> NativeIntSource.Verbatim |> Some
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset i) ->
             NativeIntSource.SyntheticCrossArrayOffset i |> Some
+        | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
+            // Inversion of `Conv.U8` / `Conv.I8` followed by `Conv.I`. See
+            // the matching arm in `toUnsignedNativeInt` for the architecture
+            // assumption.
+            Some src
         | EvalStackValue.Int32 i -> i |> convIFromInt32 |> NativeIntSource.Verbatim |> Some
         | EvalStackValue.NativeInt src -> Some src
         | EvalStackValue.Float f -> f |> convIFromFloat |> NativeIntSource.Verbatim |> Some
@@ -237,6 +256,8 @@ module EvalStackValue =
         | EvalStackValue.Int32 i -> convI1FromInt32 i |> Some
         | EvalStackValue.Int64 (Int64Source.Verbatim i) -> convI1FromInt64 i |> Some
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _) -> failwith "TODO: SyntheticCrossArrayOffset"
+        | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
+            failwith $"TODO: Conv_I1 from widened native int %O{src} (truncating pointer-shaped int64 to int8)"
         | EvalStackValue.NativeInt src -> nativeIntBitsForIntegerConversion "Conv_I1" src |> convI1FromInt64 |> Some
         | EvalStackValue.Float f -> convI1FromFloat f |> Some
         | EvalStackValue.ManagedPointer _
@@ -249,6 +270,8 @@ module EvalStackValue =
         | EvalStackValue.Int32 i -> convI2FromInt32 i |> Some
         | EvalStackValue.Int64 (Int64Source.Verbatim i) -> convI2FromInt64 i |> Some
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _) -> failwith "TODO: SyntheticCrossArrayOffset"
+        | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
+            failwith $"TODO: Conv_I2 from widened native int %O{src} (truncating pointer-shaped int64 to int16)"
         | EvalStackValue.NativeInt src -> nativeIntBitsForIntegerConversion "Conv_I2" src |> convI2FromInt64 |> Some
         | EvalStackValue.Float f -> convI2FromFloat f |> Some
         | EvalStackValue.ManagedPointer _
@@ -261,6 +284,8 @@ module EvalStackValue =
         | EvalStackValue.Int32 i -> Some i
         | EvalStackValue.Int64 (Int64Source.Verbatim i) -> convI4FromInt64 i |> Some
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _) -> failwith "TODO: SyntheticCrossArrayOffset"
+        | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
+            failwith $"TODO: Conv_I4 from widened native int %O{src} (truncating pointer-shaped int64 to int32)"
         | EvalStackValue.NativeInt src -> nativeIntBitsForIntegerConversion "Conv_I4" src |> convI4FromInt64 |> Some
         | EvalStackValue.Float f -> convI4FromFloat f |> Some
         | EvalStackValue.ManagedPointer _
@@ -273,26 +298,20 @@ module EvalStackValue =
         | EvalStackValue.Int32 i -> Some (int64<int> i |> Int64Source.Verbatim)
         | EvalStackValue.Int64 i -> Some i
         | EvalStackValue.NativeInt src ->
-            match src with
-            | NativeIntSource.Verbatim int64 -> Some (Int64Source.Verbatim int64)
-            | NativeIntSource.SyntheticCrossArrayOffset i -> Some (Int64Source.SyntheticCrossArrayOffset i)
-            | NativeIntSource.ManagedPointer ManagedPointerSource.Null ->
-                // I think it's fine for us to treat 0 and the null pointer interchangeably throughout.
-                Some (Int64Source.Verbatim 0L)
-            | NativeIntSource.ManagedPointer _
-            | NativeIntSource.FunctionPointer _
-            | NativeIntSource.TypeHandlePtr _
-            | NativeIntSource.MethodTablePtr _
-            | NativeIntSource.MethodTableAuxiliaryDataPtr _
-            | NativeIntSource.MethodHandlePtr _
-            | NativeIntSource.FieldHandlePtr _
-            | NativeIntSource.GcHandlePtr _
-            | NativeIntSource.AssemblyHandle _
-            | NativeIntSource.ModuleHandle _
-            | NativeIntSource.MetadataImportHandle _ -> failwith "refusing to convert pointer to int64"
+            // `widenedNativeInt` normalises the Verbatim/SyntheticCrossArrayOffset/Null
+            // cases back to canonical Int64Source variants. Non-numeric
+            // sources (managed pointers, function pointers, type handles)
+            // get wrapped so their provenance survives the
+            // `Conv.I8 → … → Conv.I` round-trip.
+            Some (Int64Source.widenedNativeInt src true)
         | EvalStackValue.Float f -> convI8FromFloat f |> Int64Source.Verbatim |> Some
-        | EvalStackValue.ManagedPointer _
-        | EvalStackValue.NullObjectRef
+        | EvalStackValue.ManagedPointer ptr ->
+            // Same rationale as the NativeInt arm: keep the pointer's provenance
+            // as a widened-native-int so a subsequent `Conv.U` / `Conv.I`
+            // recovers the original ManagedPointer.
+            Some (Int64Source.widenedNativeInt (NativeIntSource.ManagedPointer ptr) true)
+        | EvalStackValue.NullObjectRef ->
+            Some (Int64Source.widenedNativeInt (NativeIntSource.ManagedPointer ManagedPointerSource.Null) true)
         | EvalStackValue.ObjectRef _
         | EvalStackValue.UserDefinedValueType _ -> failReferenceConversion "Conv_I8" value
 
@@ -301,11 +320,12 @@ module EvalStackValue =
         match value with
         | EvalStackValue.Int32 i -> Some (int64 (uint32 i) |> Int64Source.Verbatim)
         | EvalStackValue.Int64 i -> Some i
-        | EvalStackValue.NativeInt src ->
-            nativeIntBitsForIntegerConversion "Conv_U8" src |> Int64Source.Verbatim |> Some
+        | EvalStackValue.NativeInt src -> Some (Int64Source.widenedNativeInt src false)
         | EvalStackValue.Float f -> convU8FromFloat f |> Int64Source.Verbatim |> Some
-        | EvalStackValue.ManagedPointer _
-        | EvalStackValue.NullObjectRef
+        | EvalStackValue.ManagedPointer ptr ->
+            Some (Int64Source.widenedNativeInt (NativeIntSource.ManagedPointer ptr) false)
+        | EvalStackValue.NullObjectRef ->
+            Some (Int64Source.widenedNativeInt (NativeIntSource.ManagedPointer ManagedPointerSource.Null) false)
         | EvalStackValue.ObjectRef _
         | EvalStackValue.UserDefinedValueType _ -> failReferenceConversion "Conv_U8" value
 
@@ -315,6 +335,8 @@ module EvalStackValue =
         | EvalStackValue.Int32 i -> convU1FromInt32 i |> Some
         | EvalStackValue.Int64 (Int64Source.Verbatim i) -> convU1FromInt64 i |> Some
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _) -> failwith "TODO: SyntheticCrossArrayOffset"
+        | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
+            failwith $"TODO: Conv_U1 from widened native int %O{src} (truncating pointer-shaped int64 to uint8)"
         | EvalStackValue.NativeInt src -> nativeIntBitsForIntegerConversion "Conv_U1" src |> convU1FromInt64 |> Some
         | EvalStackValue.Float f -> convU1FromFloat f |> Some
         | EvalStackValue.ManagedPointer _
@@ -328,6 +350,8 @@ module EvalStackValue =
         | EvalStackValue.Int32 i -> convU2FromInt32 i |> Some
         | EvalStackValue.Int64 (Int64Source.Verbatim i) -> convU2FromInt64 i |> Some
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _) -> failwith "TODO: SyntheticCrossArrayOffset"
+        | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
+            failwith $"TODO: Conv_U2 from widened native int %O{src} (truncating pointer-shaped int64 to uint16)"
         | EvalStackValue.NativeInt src -> nativeIntBitsForIntegerConversion "Conv_U2" src |> convU2FromInt64 |> Some
         | EvalStackValue.Float f -> convU2FromFloat f |> Some
         | EvalStackValue.ManagedPointer _
@@ -341,6 +365,8 @@ module EvalStackValue =
         | EvalStackValue.Int32 i -> convU4FromInt32 i |> Some
         | EvalStackValue.Int64 (Int64Source.Verbatim i) -> convU4FromInt64 i |> Some
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _) -> failwith "TODO: SyntheticCrossArrayOffset"
+        | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
+            failwith $"TODO: Conv_U4 from widened native int %O{src} (truncating pointer-shaped int64 to uint32)"
         | EvalStackValue.NativeInt src -> nativeIntBitsForIntegerConversion "Conv_U4" src |> convU4FromInt64 |> Some
         | EvalStackValue.Float f -> convU4FromFloat f |> Some
         | EvalStackValue.ManagedPointer _
@@ -354,6 +380,8 @@ module EvalStackValue =
         | EvalStackValue.Int64 (Int64Source.Verbatim i) -> convR4FromInt64 i |> Some
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _) ->
             failwith "Refusing to convert byte offset to float"
+        | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
+            failwith $"Refusing to convert widened native int %O{src} to float"
         | EvalStackValue.NativeInt src -> nativeIntBitsForIntegerConversion "Conv_R4" src |> convR4FromInt64 |> Some
         | EvalStackValue.Float f -> convR4FromFloat f |> Some
         | EvalStackValue.ManagedPointer _
@@ -367,6 +395,8 @@ module EvalStackValue =
         | EvalStackValue.Int64 (Int64Source.Verbatim i) -> convR8FromInt64 i |> Some
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _) ->
             failwith "Refusing to convert byte offset to float"
+        | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
+            failwith $"Refusing to convert widened native int %O{src} to float"
         | EvalStackValue.NativeInt src -> nativeIntBitsForIntegerConversion "Conv_R8" src |> convR8FromInt64 |> Some
         | EvalStackValue.Float f -> convR8FromFloat f |> Some
         | EvalStackValue.ManagedPointer _
@@ -380,6 +410,8 @@ module EvalStackValue =
         | EvalStackValue.Int64 (Int64Source.Verbatim i) -> convRUnFromInt64 i |> Some
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _) ->
             failwith "Refusing to convert byte offset to float"
+        | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
+            failwith $"Refusing to convert widened native int %O{src} to float"
         | EvalStackValue.NativeInt src -> nativeIntBitsForIntegerConversion "Conv_R_Un" src |> convRUnFromInt64 |> Some
         | EvalStackValue.Float _ -> failwith "Conv_R_Un: refusing to convert an existing float as unsigned integer"
         | EvalStackValue.ManagedPointer _
@@ -489,6 +521,11 @@ module EvalStackValue =
                             CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim i))
                         | Int64Source.SyntheticCrossArrayOffset i ->
                             CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.SyntheticCrossArrayOffset i))
+                        | Int64Source.WidenedNativeInt (src, _) ->
+                            // The int64 carries a widened NativeIntSource; truncating
+                            // back to native int recovers the original source on
+                            // 64-bit (the widening is bit-preserving).
+                            CliType.Numeric (CliNumericType.NativeInt src)
                     | CliType.RuntimePointer ptr ->
                         match ptr with
                         | CliRuntimePointer.Verbatim i ->

--- a/WoofWare.PawPrint/EvalStackValueComparisons.fs
+++ b/WoofWare.PawPrint/EvalStackValueComparisons.fs
@@ -5,7 +5,7 @@ module EvalStackValueComparisons =
 
     let clt (var1 : EvalStackValue) (var2 : EvalStackValue) : bool =
         match var1, var2 with
-        | EvalStackValue.Int64 var1, EvalStackValue.Int64 var2 -> Int64Source.compareBits var1 var2 < 0
+        | EvalStackValue.Int64 var1, EvalStackValue.Int64 var2 -> Int64Source.compareSigned var1 var2 < 0
         | EvalStackValue.Float var1, EvalStackValue.Float var2 -> var1 < var2
         | EvalStackValue.NullObjectRef, _
         | _, EvalStackValue.NullObjectRef ->
@@ -42,7 +42,7 @@ module EvalStackValueComparisons =
 
     let cgt (var1 : EvalStackValue) (var2 : EvalStackValue) : bool =
         match var1, var2 with
-        | EvalStackValue.Int64 var1, EvalStackValue.Int64 var2 -> Int64Source.compareBits var1 var2 > 0
+        | EvalStackValue.Int64 var1, EvalStackValue.Int64 var2 -> Int64Source.compareSigned var1 var2 > 0
         | EvalStackValue.Float var1, EvalStackValue.Float var2 -> var1 > var2
         | EvalStackValue.NullObjectRef, _
         | _, EvalStackValue.NullObjectRef ->

--- a/WoofWare.PawPrint/EvalStackValueComparisons.fs
+++ b/WoofWare.PawPrint/EvalStackValueComparisons.fs
@@ -5,7 +5,7 @@ module EvalStackValueComparisons =
 
     let clt (var1 : EvalStackValue) (var2 : EvalStackValue) : bool =
         match var1, var2 with
-        | EvalStackValue.Int64 var1, EvalStackValue.Int64 var2 -> var1 < var2
+        | EvalStackValue.Int64 var1, EvalStackValue.Int64 var2 -> Int64Source.compareBits var1 var2 < 0
         | EvalStackValue.Float var1, EvalStackValue.Float var2 -> var1 < var2
         | EvalStackValue.NullObjectRef, _
         | _, EvalStackValue.NullObjectRef ->
@@ -42,7 +42,7 @@ module EvalStackValueComparisons =
 
     let cgt (var1 : EvalStackValue) (var2 : EvalStackValue) : bool =
         match var1, var2 with
-        | EvalStackValue.Int64 var1, EvalStackValue.Int64 var2 -> var1 > var2
+        | EvalStackValue.Int64 var1, EvalStackValue.Int64 var2 -> Int64Source.compareBits var1 var2 > 0
         | EvalStackValue.Float var1, EvalStackValue.Float var2 -> var1 > var2
         | EvalStackValue.NullObjectRef, _
         | _, EvalStackValue.NullObjectRef ->
@@ -77,8 +77,15 @@ module EvalStackValueComparisons =
         | EvalStackValue.UserDefinedValueType _, UserDefinedValueType _ ->
             failwith "TODO: Cgt UserDefinedValueType vs UserDefinedValueType comparison unimplemented"
 
-    let cgtUn (var1 : EvalStackValue) (var2 : EvalStackValue) : bool =
+    let rec cgtUn (var1 : EvalStackValue) (var2 : EvalStackValue) : bool =
         match var1, var2 with
+        // A WidenedNativeInt is the int64 bit pattern of a NativeInt under our
+        // 64-bit assumption, so unsigned comparison agrees with comparing the
+        // underlying NativeInt directly. Rewriting here lets the NativeInt
+        // arms (including the byref-vs-byref same-root case) handle every
+        // mixed combination uniformly.
+        | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)), _ -> cgtUn (EvalStackValue.NativeInt src) var2
+        | _, EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) -> cgtUn var1 (EvalStackValue.NativeInt src)
         | EvalStackValue.Int32 var1, EvalStackValue.Int32 var2 -> uint32 var1 > uint32 var2
         | EvalStackValue.Int32 var1, EvalStackValue.NativeInt var2 ->
             failwith "TODO: comparison of unsigned int32 with nativeint"
@@ -99,19 +106,34 @@ module EvalStackValueComparisons =
                     SyntheticCrossArrayOffset.cgtVerbatim var1 var2
                 else
                     failwith "TODO: didn't want to think about negative ints yet"
+            | NativeIntSource.ManagedPointer ManagedPointerSource.Null,
+              NativeIntSource.ManagedPointer ManagedPointerSource.Null -> false
+            | NativeIntSource.ManagedPointer ManagedPointerSource.Null, NativeIntSource.ManagedPointer _ -> false
+            | NativeIntSource.ManagedPointer _, NativeIntSource.ManagedPointer ManagedPointerSource.Null -> true
+            | NativeIntSource.ManagedPointer p1, NativeIntSource.ManagedPointer p2 ->
+                // Spec III.3.4: cgt.un on managed pointers is unsigned address
+                // comparison. We strengthen this to "must share a storage
+                // container": within the same storage the address ordering is
+                // well-defined; across distinct containers there is no
+                // defensible answer in our model. The helper returns the
+                // sign of `addr(p2) - addr(p1)`, so `var1 > var2` corresponds
+                // to a negative delta.
+                match ManagedPointerSource.tryByteAddressDeltaSign p1 p2 with
+                | Some sign -> sign < 0
+                | None -> failwith $"refusing to cgt.un byrefs without a common root: %O{p1} vs %O{p2}"
             | _ -> failwith $"TODO: cgt.un on non-Verbatim nativeints: %O{var1} vs %O{var2}"
+        | EvalStackValue.NativeInt _, EvalStackValue.ManagedPointer var2 ->
+            cgtUn var1 (EvalStackValue.NativeInt (NativeIntSource.ManagedPointer var2))
         | EvalStackValue.NativeInt var1, EvalStackValue.Int32 var2 ->
             failwith "TODO: comparison of unsigned nativeint with int32"
         | EvalStackValue.Float var1, EvalStackValue.Float var2 -> not (var1 <= var2)
         | EvalStackValue.Float _, _ -> failwith $"Cgt.un invalid for comparing %O{var1} with %O{var2}"
+        | EvalStackValue.ManagedPointer var1, EvalStackValue.NativeInt _ ->
+            cgtUn (EvalStackValue.NativeInt (NativeIntSource.ManagedPointer var1)) var2
         | EvalStackValue.ManagedPointer var1, EvalStackValue.ManagedPointer var2 ->
-            // I'm going to be stricter than the spec and simply ban every pointer comparison except those with null,
-            // pending a strong argument to fully support this.
-            match var1, var2 with
-            | ManagedPointerSource.Null, ManagedPointerSource.Null -> false
-            | ManagedPointerSource.Null, _ -> false
-            | _, ManagedPointerSource.Null -> true
-            | _, _ -> failwith $"I've banned this case: {var1} vs {var2}"
+            cgtUn
+                (EvalStackValue.NativeInt (NativeIntSource.ManagedPointer var1))
+                (EvalStackValue.NativeInt (NativeIntSource.ManagedPointer var2))
         | EvalStackValue.NullObjectRef, EvalStackValue.NullObjectRef -> false
         | EvalStackValue.NullObjectRef, EvalStackValue.ObjectRef _ -> false
         | EvalStackValue.ObjectRef _, EvalStackValue.NullObjectRef -> true
@@ -123,8 +145,12 @@ module EvalStackValueComparisons =
         | EvalStackValue.ObjectRef _, other -> failwith $"Cgt.un invalid for comparing ObjectRef with {other}"
         | other1, other2 -> failwith $"Cgt.un instruction invalid for comparing {other1} vs {other2}"
 
-    let cltUn (var1 : EvalStackValue) (var2 : EvalStackValue) : bool =
+    let rec cltUn (var1 : EvalStackValue) (var2 : EvalStackValue) : bool =
         match var1, var2 with
+        // See cgtUn: WidenedNativeInt collapses to NativeInt for unsigned
+        // comparison under the 64-bit assumption.
+        | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)), _ -> cltUn (EvalStackValue.NativeInt src) var2
+        | _, EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) -> cltUn var1 (EvalStackValue.NativeInt src)
         | EvalStackValue.Int32 var1, EvalStackValue.Int32 var2 -> uint32 var1 < uint32 var2
         | EvalStackValue.Int32 var1, EvalStackValue.NativeInt var2 ->
             failwith "TODO: comparison of unsigned int32 with nativeint"
@@ -145,12 +171,30 @@ module EvalStackValueComparisons =
                     SyntheticCrossArrayOffset.cltVerbatim var1 var2
                 else
                     failwith "TODO: didn't want to think about negative ints yet"
+            | NativeIntSource.ManagedPointer ManagedPointerSource.Null,
+              NativeIntSource.ManagedPointer ManagedPointerSource.Null -> false
+            | NativeIntSource.ManagedPointer ManagedPointerSource.Null, NativeIntSource.ManagedPointer _ -> true
+            | NativeIntSource.ManagedPointer _, NativeIntSource.ManagedPointer ManagedPointerSource.Null -> false
+            | NativeIntSource.ManagedPointer p1, NativeIntSource.ManagedPointer p2 ->
+                // See cgt.un for rationale; this is the symmetric case.
+                // Helper returns sign of `addr(p2) - addr(p1)`; `var1 < var2`
+                // corresponds to a positive delta.
+                match ManagedPointerSource.tryByteAddressDeltaSign p1 p2 with
+                | Some sign -> sign > 0
+                | None -> failwith $"refusing to clt.un byrefs without a common root: %O{p1} vs %O{p2}"
             | _, _ -> failwith $"TODO: clt.un on non-Verbatim nativeints: %O{var1} vs %O{var2}"
+        | EvalStackValue.NativeInt _, EvalStackValue.ManagedPointer var2 ->
+            cltUn var1 (EvalStackValue.NativeInt (NativeIntSource.ManagedPointer var2))
         | EvalStackValue.NativeInt var1, EvalStackValue.Int32 var2 ->
             failwith "TODO: comparison of unsigned nativeint with int32"
         | EvalStackValue.Float var1, EvalStackValue.Float var2 -> not (var1 >= var2)
         | EvalStackValue.Float _, _ -> failwith $"Cgt.un invalid for comparing %O{var1} with %O{var2}"
-        | EvalStackValue.ManagedPointer var1, EvalStackValue.ManagedPointer var2 -> failwith "TODO"
+        | EvalStackValue.ManagedPointer var1, EvalStackValue.NativeInt _ ->
+            cltUn (EvalStackValue.NativeInt (NativeIntSource.ManagedPointer var1)) var2
+        | EvalStackValue.ManagedPointer var1, EvalStackValue.ManagedPointer var2 ->
+            cltUn
+                (EvalStackValue.NativeInt (NativeIntSource.ManagedPointer var1))
+                (EvalStackValue.NativeInt (NativeIntSource.ManagedPointer var2))
         | EvalStackValue.NullObjectRef, EvalStackValue.NullObjectRef -> false
         | EvalStackValue.NullObjectRef, EvalStackValue.ObjectRef _ -> true
         | EvalStackValue.ObjectRef _, EvalStackValue.NullObjectRef -> false

--- a/WoofWare.PawPrint/IntrinsicHelpers.fs
+++ b/WoofWare.PawPrint/IntrinsicHelpers.fs
@@ -424,6 +424,9 @@ module internal IntrinsicHelpers =
                 match count with
                 | Int64Source.SyntheticCrossArrayOffset _ ->
                     failwith "refusing to interpret memory address difference as byte count"
+                | Int64Source.WidenedNativeInt (src, _) ->
+                    failwith
+                        $"%s{operation}: byte count came from a widened native int %O{src}; refusing to interpret pointer-shaped int64 as byte count"
                 | Int64Source.Verbatim count -> checkedByteCount operation count
             | _ -> failwith "unexpectedly got negative byte count"
         | EvalStackValue.Int32 count -> checkedByteCount operation (int64 count)

--- a/WoofWare.PawPrint/ManagedPointerSource.fs
+++ b/WoofWare.PawPrint/ManagedPointerSource.fs
@@ -212,6 +212,59 @@ module ManagedPointerSource =
         | ManagedPointerSource.Byref (ByrefRoot.ArrayElement (array, _), _) -> Some array
         | _ -> None
 
+    /// If both byrefs reach the same storage modulo a byte cursor — i.e. they
+    /// share a root and identical prefix projections, differing only in the
+    /// trailing byte cursor under a final `ReinterpretAs` — return how far
+    /// `src2` is past `src1` in bytes (negative if behind). Returns `None`
+    /// for distinct roots, projections that aren't pure byte cursors, or any
+    /// shape we can't unambiguously decompose. The result is a relative byte
+    /// delta only; callers must not interpret it as an absolute address.
+    let tryByteOffsetWithinSameRoot (src1 : ManagedPointerSource) (src2 : ManagedPointerSource) : int64 option =
+        let splitTrailingByteCursor (projs : ByrefProjection list) : (ByrefProjection list * int64) option =
+            // Returns (prefix, trailing byte offset). The prefix excludes the
+            // final ReinterpretAs and any ByteOffset attached to it. A bare
+            // empty list (no trailing reinterpret) counts as offset 0; a
+            // trailing Field is not a pure byte cursor and yields None.
+            match List.rev projs with
+            | ByrefProjection.ByteOffset n :: ByrefProjection.ReinterpretAs _ :: revRest ->
+                Some (List.rev revRest, int64 n)
+            | ByrefProjection.ReinterpretAs _ :: revRest -> Some (List.rev revRest, 0L)
+            | [] -> Some ([], 0L)
+            | _ -> None
+
+        match src1, src2 with
+        | ManagedPointerSource.Null, ManagedPointerSource.Null -> Some 0L
+        | ManagedPointerSource.Byref (root1, projs1), ManagedPointerSource.Byref (root2, projs2) when root1 = root2 ->
+            match splitTrailingByteCursor projs1, splitTrailingByteCursor projs2 with
+            | Some (prefix1, offset1), Some (prefix2, offset2) when prefix1 = prefix2 -> Some (offset2 - offset1)
+            | _ -> None
+        | _ -> None
+
+    /// Returns the sign of `addr(src2) - addr(src1)` — i.e. negative when
+    /// src2 sits at a lower byte address than src1, positive when higher,
+    /// zero when equal. The convention matches `tryByteOffsetWithinSameRoot`,
+    /// which returns the same delta byte-accurately.
+    ///
+    /// Strictly weaker than `tryByteOffsetWithinSameRoot`: the magnitude is
+    /// not meaningful, only the sign. Use this for pointer comparisons
+    /// (`cgt.un`, `clt.un`) where only order matters; use
+    /// `tryByteOffsetWithinSameRoot` whenever the actual byte delta is
+    /// required.
+    let tryByteAddressDeltaSign (src1 : ManagedPointerSource) (src2 : ManagedPointerSource) : int option =
+        match tryByteOffsetWithinSameRoot src1 src2 with
+        | Some n -> Some (compare n 0L)
+        | None ->
+            // Same array, possibly different element index: element size is
+            // strictly positive, so `compare idx1 idx2` agrees with the sign
+            // of the byte address delta `addr(src2) - addr(src1)` whenever
+            // the indices differ. When the indices match the strict helper
+            // would already have answered.
+            match src1, src2 with
+            | ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr1, idx1), _),
+              ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr2, idx2), _) when arr1 = arr2 && idx1 <> idx2 ->
+                Some (compare idx2 idx1)
+            | _ -> None
+
     /// Returns deterministic low address bits for byrefs that have a stable
     /// synthetic address model. For PE byte ranges this is `RVA + byteOffset`,
     /// not a real loaded module address; callers may use it only for low-bit

--- a/WoofWare.PawPrint/ManagedPointerSource.fs
+++ b/WoofWare.PawPrint/ManagedPointerSource.fs
@@ -240,6 +240,36 @@ module ManagedPointerSource =
             | _ -> None
         | _ -> None
 
+    /// Validate the byref-projection list invariant for a byref reaching
+    /// `tryByteAddressDeltaSign`'s array fallback: `ByteOffset` only appears
+    /// as the final element preceded by `ReinterpretAs`, and is non-negative
+    /// (the construction-site canonicaliser establishes this via
+    /// floor-division in `normaliseTrailingByteOffset`). Throws on violation —
+    /// a malformed projection list signals a construction-site bug, and
+    /// silently returning a possibly-wrong delta sign would mask it.
+    let private validateByrefProjectionsAreCanonical
+        (src : ManagedPointerSource)
+        (projs : ByrefProjection list)
+        : unit
+        =
+        let rec walk (preceding : ByrefProjection option) (rest : ByrefProjection list) : unit =
+            match rest with
+            | [] -> ()
+            | [ ByrefProjection.ByteOffset n ] ->
+                match preceding with
+                | Some (ByrefProjection.ReinterpretAs _) ->
+                    if n < 0 then
+                        failwith
+                            $"ManagedPointerSource: trailing byte cursor must be non-negative under canonical form, got %d{n} in %O{src}"
+                | _ ->
+                    failwith
+                        $"ManagedPointerSource: trailing ByteOffset %d{n} must be preceded by ReinterpretAs in %O{src}"
+            | ByrefProjection.ByteOffset n :: _ ->
+                failwith $"ManagedPointerSource: ByteOffset %d{n} appears at a non-trailing position in %O{src}"
+            | proj :: tail -> walk (Some proj) tail
+
+        walk None projs
+
     /// Returns the sign of `addr(src2) - addr(src1)` — i.e. negative when
     /// src2 sits at a lower byte address than src1, positive when higher,
     /// zero when equal. The convention matches `tryByteOffsetWithinSameRoot`,
@@ -250,18 +280,31 @@ module ManagedPointerSource =
     /// (`cgt.un`, `clt.un`) where only order matters; use
     /// `tryByteOffsetWithinSameRoot` whenever the actual byte delta is
     /// required.
+    ///
+    /// Precondition: byrefs reaching the array-index fallback path must be
+    /// in canonical projection-list form — `ByteOffset` only as the trailing
+    /// element under `ReinterpretAs`, and non-negative. Throws on violation
+    /// rather than silently returning a wrong sign. The `< cellSize` half of
+    /// the canonical bound (which we cannot verify here without heap access)
+    /// is established at construction by floor-division in
+    /// `normaliseTrailingByteOffset`.
     let tryByteAddressDeltaSign (src1 : ManagedPointerSource) (src2 : ManagedPointerSource) : int option =
         match tryByteOffsetWithinSameRoot src1 src2 with
         | Some n -> Some (compare n 0L)
         | None ->
             // Same array, possibly different element index: element size is
-            // strictly positive, so `compare idx1 idx2` agrees with the sign
-            // of the byte address delta `addr(src2) - addr(src1)` whenever
-            // the indices differ. When the indices match the strict helper
-            // would already have answered.
+            // strictly positive and each pointer's byte effect relative to
+            // its cell start lies in `[0, cellSize)` (residuals via
+            // floor-division; field offsets by layout). Hence
+            // `compare idx2 idx1` agrees with the sign of the byte address
+            // delta `addr(src2) - addr(src1)` whenever the indices differ.
+            // When the indices match, `tryByteOffsetWithinSameRoot` would
+            // already have answered.
             match src1, src2 with
-            | ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr1, idx1), _),
-              ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr2, idx2), _) when arr1 = arr2 && idx1 <> idx2 ->
+            | ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr1, idx1), projs1),
+              ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr2, idx2), projs2) when arr1 = arr2 && idx1 <> idx2 ->
+                validateByrefProjectionsAreCanonical src1 projs1
+                validateByrefProjectionsAreCanonical src2 projs2
                 Some (compare idx2 idx1)
             | _ -> None
 

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -108,6 +108,8 @@ module NullaryIlOp =
             | EvalStackValue.Int64 (Int64Source.Verbatim i) -> i
             | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _) ->
                 failwith "Localloc: refusing to use synthetic pointer delta as a byte count"
+            | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
+                failwith $"Localloc: refusing to use widened native int %O{src} as a byte count"
             | EvalStackValue.NativeInt (NativeIntSource.Verbatim i) -> i
             | EvalStackValue.NativeInt (NativeIntSource.SyntheticCrossArrayOffset _) ->
                 failwith "Localloc: refusing to use synthetic pointer delta as a byte count"
@@ -277,6 +279,8 @@ module NullaryIlOp =
         | EvalStackValue.Int64 (Int64Source.Verbatim i) -> fromUnsignedInt64 "unsigned int64" i
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset i) ->
             failwith "TODO: synthetic cross-array offset"
+        | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
+            failwith $"TODO: Conv_ovf_i4_un from widened native int %O{src}"
         | EvalStackValue.NativeInt (NativeIntSource.Verbatim i) -> fromUnsignedInt64 "unsigned native int" i
         | EvalStackValue.NativeInt (NativeIntSource.SyntheticCrossArrayOffset i) ->
             failwith "TODO: synthetic cross-array offset"

--- a/WoofWare.PawPrint/UnaryConstIlOp.fs
+++ b/WoofWare.PawPrint/UnaryConstIlOp.fs
@@ -221,7 +221,7 @@ module internal UnaryConstIlOp =
                 | EvalStackValue.Int32 v1, EvalStackValue.Int32 v2 -> v1 < v2
                 | EvalStackValue.Int32 i, EvalStackValue.NativeInt nativeIntSource -> failwith "todo"
                 | EvalStackValue.Int32 i, _ -> failwith $"invalid comparison, {i} with {value2}"
-                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.compareBits v1 v2 < 0
+                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.compareSigned v1 v2 < 0
                 | EvalStackValue.Int64 i, _ -> failwith $"invalid comparison, {i} with {value2}"
                 | EvalStackValue.NativeInt nativeIntSource, _ -> failwith "todo"
                 | EvalStackValue.Float v1, EvalStackValue.Float v2 -> failwith "todo"
@@ -250,7 +250,7 @@ module internal UnaryConstIlOp =
                 | EvalStackValue.Int32 v1, EvalStackValue.Int32 v2 -> v1 <= v2
                 | EvalStackValue.Int32 i, EvalStackValue.NativeInt nativeIntSource -> failwith "todo"
                 | EvalStackValue.Int32 i, _ -> failwith $"invalid comparison, {i} with {value2}"
-                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.compareBits v1 v2 <= 0
+                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.compareSigned v1 v2 <= 0
                 | EvalStackValue.Int64 i, _ -> failwith $"invalid comparison, {i} with {value2}"
                 | EvalStackValue.NativeInt nativeIntSource, _ -> failwith "todo"
                 | EvalStackValue.Float v1, EvalStackValue.Float v2 -> failwith "todo"
@@ -279,7 +279,7 @@ module internal UnaryConstIlOp =
                 | EvalStackValue.Int32 v1, EvalStackValue.Int32 v2 -> v1 > v2
                 | EvalStackValue.Int32 i, EvalStackValue.NativeInt nativeIntSource -> failwith "todo"
                 | EvalStackValue.Int32 i, _ -> failwith $"invalid comparison, {i} with {value2}"
-                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.compareBits v1 v2 > 0
+                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.compareSigned v1 v2 > 0
                 | EvalStackValue.Int64 i, _ -> failwith $"invalid comparison, {i} with {value2}"
                 | EvalStackValue.NativeInt nativeIntSource, _ -> failwith "todo"
                 | EvalStackValue.Float v1, EvalStackValue.Float v2 -> failwith "todo"
@@ -308,7 +308,7 @@ module internal UnaryConstIlOp =
                 | EvalStackValue.Int32 v1, EvalStackValue.Int32 v2 -> v1 >= v2
                 | EvalStackValue.Int32 i, EvalStackValue.NativeInt nativeIntSource -> failwith "todo"
                 | EvalStackValue.Int32 i, _ -> failwith $"invalid comparison, {i} with {value2}"
-                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.compareBits v1 v2 >= 0
+                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.compareSigned v1 v2 >= 0
                 | EvalStackValue.Int64 i, _ -> failwith $"invalid comparison, {i} with {value2}"
                 | EvalStackValue.NativeInt nativeIntSource, _ -> failwith "todo"
                 | EvalStackValue.Float v1, EvalStackValue.Float v2 -> failwith "todo"
@@ -363,7 +363,7 @@ module internal UnaryConstIlOp =
                 | EvalStackValue.Int32 v1, EvalStackValue.Int32 v2 -> v1 <= v2
                 | EvalStackValue.Int32 i, EvalStackValue.NativeInt nativeIntSource -> failwith "todo"
                 | EvalStackValue.Int32 i, _ -> failwith $"invalid comparison, {i} with {value2}"
-                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.compareBits v1 v2 <= 0
+                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.compareSigned v1 v2 <= 0
                 | EvalStackValue.Int64 i, _ -> failwith $"invalid comparison, {i} with {value2}"
                 | EvalStackValue.NativeInt nativeIntSource, _ -> failwith "todo"
                 | EvalStackValue.Float v1, EvalStackValue.Float v2 -> failwith "todo"
@@ -405,7 +405,7 @@ module internal UnaryConstIlOp =
                 | EvalStackValue.Int32 v1, EvalStackValue.Int32 v2 -> v1 >= v2
                 | EvalStackValue.Int32 i, EvalStackValue.NativeInt nativeIntSource -> failwith "todo"
                 | EvalStackValue.Int32 i, _ -> failwith $"invalid comparison, {i} with {value2}"
-                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.compareBits v1 v2 >= 0
+                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.compareSigned v1 v2 >= 0
                 | EvalStackValue.Int64 i, _ -> failwith $"invalid comparison, {i} with {value2}"
                 | EvalStackValue.NativeInt nativeIntSource, _ -> failwith "todo"
                 | EvalStackValue.Float v1, EvalStackValue.Float v2 -> failwith "todo"

--- a/WoofWare.PawPrint/UnaryConstIlOp.fs
+++ b/WoofWare.PawPrint/UnaryConstIlOp.fs
@@ -221,7 +221,7 @@ module internal UnaryConstIlOp =
                 | EvalStackValue.Int32 v1, EvalStackValue.Int32 v2 -> v1 < v2
                 | EvalStackValue.Int32 i, EvalStackValue.NativeInt nativeIntSource -> failwith "todo"
                 | EvalStackValue.Int32 i, _ -> failwith $"invalid comparison, {i} with {value2}"
-                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> v1 < v2
+                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.compareBits v1 v2 < 0
                 | EvalStackValue.Int64 i, _ -> failwith $"invalid comparison, {i} with {value2}"
                 | EvalStackValue.NativeInt nativeIntSource, _ -> failwith "todo"
                 | EvalStackValue.Float v1, EvalStackValue.Float v2 -> failwith "todo"
@@ -250,7 +250,7 @@ module internal UnaryConstIlOp =
                 | EvalStackValue.Int32 v1, EvalStackValue.Int32 v2 -> v1 <= v2
                 | EvalStackValue.Int32 i, EvalStackValue.NativeInt nativeIntSource -> failwith "todo"
                 | EvalStackValue.Int32 i, _ -> failwith $"invalid comparison, {i} with {value2}"
-                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> v1 <= v2
+                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.compareBits v1 v2 <= 0
                 | EvalStackValue.Int64 i, _ -> failwith $"invalid comparison, {i} with {value2}"
                 | EvalStackValue.NativeInt nativeIntSource, _ -> failwith "todo"
                 | EvalStackValue.Float v1, EvalStackValue.Float v2 -> failwith "todo"
@@ -279,7 +279,7 @@ module internal UnaryConstIlOp =
                 | EvalStackValue.Int32 v1, EvalStackValue.Int32 v2 -> v1 > v2
                 | EvalStackValue.Int32 i, EvalStackValue.NativeInt nativeIntSource -> failwith "todo"
                 | EvalStackValue.Int32 i, _ -> failwith $"invalid comparison, {i} with {value2}"
-                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> v1 > v2
+                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.compareBits v1 v2 > 0
                 | EvalStackValue.Int64 i, _ -> failwith $"invalid comparison, {i} with {value2}"
                 | EvalStackValue.NativeInt nativeIntSource, _ -> failwith "todo"
                 | EvalStackValue.Float v1, EvalStackValue.Float v2 -> failwith "todo"
@@ -308,7 +308,7 @@ module internal UnaryConstIlOp =
                 | EvalStackValue.Int32 v1, EvalStackValue.Int32 v2 -> v1 >= v2
                 | EvalStackValue.Int32 i, EvalStackValue.NativeInt nativeIntSource -> failwith "todo"
                 | EvalStackValue.Int32 i, _ -> failwith $"invalid comparison, {i} with {value2}"
-                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> v1 >= v2
+                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.compareBits v1 v2 >= 0
                 | EvalStackValue.Int64 i, _ -> failwith $"invalid comparison, {i} with {value2}"
                 | EvalStackValue.NativeInt nativeIntSource, _ -> failwith "todo"
                 | EvalStackValue.Float v1, EvalStackValue.Float v2 -> failwith "todo"
@@ -363,7 +363,7 @@ module internal UnaryConstIlOp =
                 | EvalStackValue.Int32 v1, EvalStackValue.Int32 v2 -> v1 <= v2
                 | EvalStackValue.Int32 i, EvalStackValue.NativeInt nativeIntSource -> failwith "todo"
                 | EvalStackValue.Int32 i, _ -> failwith $"invalid comparison, {i} with {value2}"
-                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> v1 <= v2
+                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.compareBits v1 v2 <= 0
                 | EvalStackValue.Int64 i, _ -> failwith $"invalid comparison, {i} with {value2}"
                 | EvalStackValue.NativeInt nativeIntSource, _ -> failwith "todo"
                 | EvalStackValue.Float v1, EvalStackValue.Float v2 -> failwith "todo"
@@ -405,7 +405,7 @@ module internal UnaryConstIlOp =
                 | EvalStackValue.Int32 v1, EvalStackValue.Int32 v2 -> v1 >= v2
                 | EvalStackValue.Int32 i, EvalStackValue.NativeInt nativeIntSource -> failwith "todo"
                 | EvalStackValue.Int32 i, _ -> failwith $"invalid comparison, {i} with {value2}"
-                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> v1 >= v2
+                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.compareBits v1 v2 >= 0
                 | EvalStackValue.Int64 i, _ -> failwith $"invalid comparison, {i} with {value2}"
                 | EvalStackValue.NativeInt nativeIntSource, _ -> failwith "todo"
                 | EvalStackValue.Float v1, EvalStackValue.Float v2 -> failwith "todo"

--- a/docs/plans/2026-05-04-conv-u8-managed-pointer.md
+++ b/docs/plans/2026-05-04-conv-u8-managed-pointer.md
@@ -1,0 +1,137 @@
+# Plumb pointer provenance through `Conv.U8 / Conv.I8`
+
+## Context
+
+Re-enabling `WoofWare.PawPrint.Test/sourcesPure/InterfaceDispatch.cs` (commit on `main` as a remove from the `unimplemented` list) trips the failure
+
+```
+System.Exception : Conv_U8: refusing to convert managed pointer
+  <<PE data System.Private.CoreLib ... managed resource System.Private.CoreLib.Strings.resources
+    at 812996 size 192483> as System.Byte>
+   at WoofWare.PawPrint.EvalStackValueModule.failReferenceConversion ... EvalStack.fs:61
+   at WoofWare.PawPrint.EvalStackValueModule.convToUInt64 ... EvalStack.fs:310
+   at WoofWare.PawPrint.NullaryIlOpModule.execute ... NullaryIlOp.fs:1258
+```
+
+The path: the test eventually loads a BCL string resource. `AssemblyNative_GetResource` (already implemented in `Native/NativeRuntimeAssembly.fs`) returns a `byte*` pointing into a `PeByteRange`. The BCL constructs an `UnmanagedMemoryStream` over that pointer, whose `Initialize(byte*, long, long, FileAccess)` runs a wraparound check (System.IO.UnmanagedMemoryStream.cs:160 in the .NET source):
+
+```csharp
+if (((byte*)((long)pointer + capacity)) < pointer)
+    throw new ArgumentOutOfRangeException(nameof(capacity), ...);
+```
+
+The IL is, verbatim:
+
+```
+LdArg1            // byte* pointer (ManagedPointer with [ReinterpretAs Byte])
+Conv_U8           // (long)pointer       <- we throw here
+LdArg3            // long capacity
+Add
+Conv_U            // (byte*)(...)
+LdArg1            // pointer again
+Bge_un_s skip     // skip throw if (advanced >= original) unsigned
+```
+
+Recent provenance work (`f2712de`, "Track provenance for cross-array pointer deltas") put us in a position where pointer arithmetic is symbolic; this is the next gap in that story — preserving provenance across the int64-widening / native-int truncation round-trip.
+
+## Why this is not just a special case
+
+The `Conv.U8 → Add → Conv.U → Bge.un` sequence is the BCL's portable wraparound idiom; it appears anywhere a managed-pointer-shaped argument needs to be advanced by a `long`. Other examples in the BCL include various `Memory<T>` / `Span<T>` constructors and several offset checks in `Buffer`/`Marshal`. Special-casing the four-instruction sequence buys nothing — we'd just hit the same failure with a different stack trace from another caller.
+
+## Architecture sensitivity
+
+The BCL emits this idiom because on 32-bit it really does detect wraparound:
+
+- 32-bit: `pointer` is 4 bytes. `Conv.U8` zero-extends 32→64. After `Add capacity`, the int64 may exceed `2^32`. `Conv.U` truncates back to 32 bits, wrapping mod `2^32`. `Bge.un` against the original 32-bit pointer fires when the truncation crossed `2^32`.
+- 64-bit: `pointer` is 8 bytes. `Conv.U8` is bit-preserving — the int64 *is* the address. `Add capacity` then `Conv.U` is a no-op. `Bge.un` essentially can't fire (would need ~2^63 bytes of capacity).
+
+PawPrint is committed to a 64-bit model (`NATIVE_INT_SIZE = 8` baked throughout). On that model the wraparound branch is statically vacuous and our job is just to keep provenance flowing.
+
+A first cut considered adding `Int64Source.ManagedPointer of ManagedPointerSource`. That conflates "a managed pointer" with "the int64 result of `conv.u8` on a managed pointer", which coincide only on 64-bit. Burying the assumption in a variant name made it invisible. Below uses a wrapper that names the *operation* (a widening), which is honest about the architecture commitment and confines it to one site.
+
+## Plan
+
+### 1. Extend `Int64Source` with an explicit widening variant
+
+`WoofWare.PawPrint/CliNumericType.fs:7` currently has `Int64Source = Verbatim | SyntheticCrossArrayOffset`. Add:
+
+```fsharp
+/// The result of `conv.i8` / `conv.u8` applied to a NativeInt (managed
+/// pointer, function pointer, verbatim, …). On a 64-bit interpreter this
+/// widening is a no-op at the bit level; on a 32-bit interpreter it would
+/// zero/sign-extend 32→64. Operations on this variant must respect that
+/// asymmetry: an int64 obtained this way can in principle outgrow the
+/// native word.
+| WidenedNativeInt of source : NativeIntSource * signed : bool
+```
+
+Normalise on construction: `WidenedNativeInt (NativeIntSource.Verbatim n, _) => Verbatim n`. The variant exists only to track non-verbatim provenance.
+
+Update the existing `Int64Source` helpers (`isZero`, `negate`, `shr`, `shl`, `add`, `bitAnd/Or/Xor/Not`, `isNonnegative`):
+- `isZero (WidenedNativeInt (src, _))` defers to `NativeIntSource.isZero src`.
+- `add` is wired through step 3.
+- Everything else `failwith` with a message that names the operation and explicitly says it's an unimplemented op on widened native bits — the next idiom that hits this gets a clear breadcrumb. *Do not* silently treat `WidenedNativeInt (NativeIntSource.ManagedPointer …, _)` as bit data; that would license bit-twiddling on byrefs.
+
+### 2. `Conv.U8` / `Conv.I8`: keep the provenance
+
+`EvalStack.fs:300` (`convToUInt64`) and `EvalStack.fs:271` (`convToInt64`) currently fail on `EvalStackValue.ManagedPointer _` and on `NativeInt (NativeIntSource.ManagedPointer _)` (except Null). Replace those arms with `Some (Int64Source.WidenedNativeInt (src, signed))` (where `src` is `NativeIntSource.ManagedPointer ptr` for the `EvalStackValue.ManagedPointer ptr` case). The Null special-case in `convToInt64` collapses naturally — `NativeIntSource.ManagedPointer Null` widens, then `Int64Source` operations on it reduce to "zero" via `NativeIntSource.isZero`. Same shape for `EvalStackValue.NativeInt src`.
+
+### 3. `Conv.U` / `Conv.I`: round-trip back
+
+`toUnsignedNativeInt` / `toNativeInt` already handle `EvalStackValue.Int64`. Extend the arms so:
+- `Int64 (WidenedNativeInt (src, _))` → `UnsignedNativeIntSource.FromManagedPointer ptr` / `NativeIntSource.ManagedPointer ptr` when `src` is a `ManagedPointer`, else direct return of `src`.
+
+The existing `Conv.U` / `Conv.I` handlers (`NullaryIlOp.fs:1089`, `:1187`) already wrap the result back into an `EvalStackValue.NativeInt`. On 64-bit this is a no-op; document that the truncation step is parameterised by the (currently-fixed) word size.
+
+### 4. `Add` (and `Sub`) for `WidenedNativeInt`
+
+`BinaryArithmetic.fs:692`. Mirror the existing `EvalStackValue.NativeInt (NativeIntSource.ManagedPointer …) + EvalStackValue.Int32` arms (`:717`, `:733`) for `EvalStackValue.Int64 (WidenedNativeInt (NativeIntSource.ManagedPointer …, _)) + EvalStackValue.Int64 (Verbatim …)` (and the symmetric form):
+
+- For the byref case, reuse `addInt32ManagedPtr` (which already handles `ArithmeticTarget.ByteViewTarget`, `BinaryArithmetic.fs:235`). The result keeps the `WidenedNativeInt` shape.
+- Use the existing fit-into-int32 policy (`nativeIntOffsetForPointerArithmetic`, `:679`); fail loudly on offsets that don't fit. The wraparound test case has capacity 192483, well within int32. Comment that this is the 64-bit assumption surfacing — on 32-bit, oversize offsets would force truncation behaviour we currently don't model.
+- For `WidenedNativeInt (Verbatim n, _) + Verbatim m`: caught by step 1's normalisation; reduces to `Verbatim (n + m)`.
+
+`Sub`: same shape. `Mul/Div/Rem/bit-ops` on `WidenedNativeInt (NativeIntSource.ManagedPointer …, _)`: fail loudly — those aren't pointer arithmetic.
+
+### 5. Unsigned comparisons of two byref-derived values
+
+After step 3, the wraparound `Bge.un` sees:
+- top: `EvalStackValue.NativeInt (NativeIntSource.ManagedPointer src')` (advanced by capacity)
+- next: `EvalStackValue.ManagedPointer src` (original, freshly LdArg'd)
+
+`cgtUn` / `cltUn` (`EvalStackValueComparisons.fs:80`, `:126`) — and via `not (…)`, `cgeUn`/`cleUn` — need:
+
+- `NativeInt (NativeIntSource.ManagedPointer …)` vs `ManagedPointer …` (and symmetric): collapse to the all-NativeInt arm. `ceq` already does this (`EvalStackValueComparisons.fs:274`); mirror.
+- Two byrefs sharing root and projection prefix, differing only in trailing `ByteOffset` under a trailing `ReinterpretAs`: compare the byte offsets numerically.
+- Different roots: keep the current "I've banned this case" failure (`:114`). Comparing addresses across distinct storage containers has no defensible answer in our model.
+
+Factor a new helper `ManagedPointerSource.tryByteOffsetWithinSameRoot : src -> src -> int64 option`. `Some n` ⇔ the second is the first advanced by `n` bytes (negative if behind); `None` otherwise. This generalises `tryStableAddressBits` (`ManagedPointerSource.fs:219`). Use it from the comparison arms above.
+
+### 6. Tests
+
+Property tests live in `WoofWare.PawPrint.Test/TestEvalStack.fs` or `TestNativeIntSource.fs`. For each kind of byte-addressable byref root (PE byte range, localloc, array element, string char):
+
+- `Conv.U8 → Conv.U` round-trip: result `ceq`s the original.
+- `Conv.U8 → ldc.i8 n → Add → Conv.U → ldarg orig → Bge.un` for `n ∈ [0, 2^31)`: never throws, branches taken.
+- `Conv.U8 → ldc.i8 n → Add → Conv.U` followed by `ldelem`/`ldind` reaching the offset address: agrees with the direct `ldelema/ldflda` path (provenance survives).
+
+Unit test the explicit `UnmanagedMemoryStream.Initialize`-style sequence end-to-end. Also assert the wraparound branch is statically not taken — this is the documentation that the BCL check is vacuous in our 64-bit model.
+
+`InterfaceDispatch.cs` is the integration test (already removed from `unimplemented` on the working branch).
+
+## Order of work
+
+1. Step 1 (Int64Source variant + helpers) + step 2 (`Conv.U8`/`Conv.I8`) + step 3 (`Conv.U`/`Conv.I`). Property test the round-trip without arithmetic.
+2. Step 4 (Add/Sub). Property test the round-trip with arithmetic.
+3. Step 5 (comparisons). Property test the wraparound idiom.
+4. Confirm `InterfaceDispatch.cs` passes; commit on a branch and run `codex review --base main`.
+
+Each step is independently reviewable; the property test from each step prevents the next from regressing the previous.
+
+## Risks / called out in PR description
+
+- **Other consumers of `(ulong)pointer`.** Loose use of pointer-bit operations in the BCL (alignment masks `& 0x7`, hash combiners, shifts) won't go through this plan. Step 1's "fail loudly with op name" requirement means the next failing idiom yields a clear "TODO: bitAnd on widened byref bits" error rather than a silent bit-twiddle. Broaden as needed; do not pre-emptively wire bit-ops to `tryStableAddressBits` in this PR.
+- **Provenance erosion.** Each new arm we add (Add/Sub, Conv.U/I/U8/I8, comparisons) is a place where dropping the `WidenedNativeInt` tag would silently lose provenance. The property test in step 6 enforces the contract.
+- **Same-root comparison contract.** Once non-null managed pointers can compare, be careful never to allow comparisons across distinct roots. Keep the strict same-root requirement.
+- **64-bit assumption is the wrapper's whole point.** `WidenedNativeInt`'s docstring should say so out loud, and step 4's offset-fits-int32 check should reference it. If anyone later wants 32-bit support, that's the single site to revisit.
+- **Spec deviation in the `Bge.un` arm.** ECMA-335 says `Bge.un` on managed pointers compares unsigned bit patterns. We're substituting "same root → compare offsets, different root → fail." This is consistent with the existing `cgtUn` "banned" stance and is a deliberate strengthening; one-line comment at the site.


### PR DESCRIPTION
The BCL's UnmanagedMemoryStream.Initialize runs a portable wraparound check `Conv.U8 -> Add -> Conv.U -> Bge.un` on a managed pointer. We were rejecting `Conv.U8` of a managed pointer outright, which blocked any code path that touches an UnmanagedMemoryStream (notably string resources via AssemblyNative_GetResource).

Confine the 64-bit interpreter assumption to a single Int64Source variant, `WidenedNativeInt`, so we can preserve byref provenance through the int64 round trip without conflating managed pointers and ordinary integers everywhere else. The smart constructor normalises the trivial cases (verbatim, synthetic cross-array, null) so only the genuinely opaque cases inflate to the new variant.

Conv.U8/Conv.I8 lift NativeInt sources to WidenedNativeInt; Conv.U/Conv.I strip the wrapping back to NativeInt; Add/Sub of a WidenedNativeInt managed pointer with a verbatim int64 dispatches through the existing ManagedPtrInt32 / Int32ManagedPtr arithmetic and rewraps the result.

Unsigned comparisons gain a sign-only ordering helper `tryByteAddressDeltaSign`, so cgt.un / clt.un can compare two byrefs that share a storage container even when their byref roots differ (e.g. `ArrayElement(arr, 0)` vs `ArrayElement(arr, 3)` after pointer arithmetic). The byte-accurate `tryByteOffsetWithinSameRoot` is preserved unchanged for callers that need the magnitude.

InterfaceDispatch.cs is past the original Conv_U8 failure but now hits a separate Unsafe.ByteOffset-over-PeByteRange issue.

(Entirely by Claude)