### PR TITLE
Cover the full hardware-intrinsic surface in the scalar profile

### DIFF
--- a/WoofWare.PawPrint.Test/TestHardwareIntrinsicsProfile.fs
+++ b/WoofWare.PawPrint.Test/TestHardwareIntrinsicsProfile.fs
@@ -139,7 +139,7 @@ class Program
         runSource "Ssse3IsSupported.cs" source |> exitCodeOfRunOutcome |> shouldEqual 0
 
     [<Test>]
-    let ``Unimplemented class-level intrinsic fails before executing placeholder IL`` () : unit =
+    let ``Scalar-only profile reports Arm ArmBase unavailable`` () : unit =
         let source =
             """
 using System.Runtime.Intrinsics.Arm;
@@ -153,10 +153,23 @@ class Program
 }
 """
 
-        let ex =
-            Assert.Throws<System.Exception> (fun () -> runSource "ArmBaseIsSupported.cs" source |> ignore)
+        runSource "ArmBaseIsSupported.cs" source
+        |> exitCodeOfRunOutcome
+        |> shouldEqual 0
 
-        ex.Message |> shouldContainText "TODO: implement JIT intrinsic"
+    [<Test>]
+    let ``Scalar-only profile reports X86 Sse41 unavailable`` () : unit =
+        let source =
+            """
+using System.Runtime.Intrinsics.X86;
 
-        ex.Message
-        |> shouldContainText "System.Runtime.Intrinsics.Arm.ArmBase.get_IsSupported"
+class Program
+{
+    static int Main(string[] args)
+    {
+        return Sse41.IsSupported ? 1 : 0;
+    }
+}
+"""
+
+        runSource "Sse41IsSupported.cs" source |> exitCodeOfRunOutcome |> shouldEqual 0

--- a/WoofWare.PawPrint/IntrinsicHelpers.fs
+++ b/WoofWare.PawPrint/IntrinsicHelpers.fs
@@ -378,14 +378,112 @@ module internal IntrinsicHelpers =
         | "Vector512" -> profile.Vector512
         | other -> failwith $"Unexpected vector intrinsic type name: %s{other}"
 
+    // PawPrint emulates a deterministic scalar virtual CPU: every hardware-intrinsic
+    // family reports IsSupported = false so the BCL falls through to its scalar/portable
+    // path. The IL body of these `[Intrinsic]` getters is a recursive `return IsSupported;`
+    // stub that the JIT replaces with a constant; without an explicit fold here it would
+    // recurse forever. New ISAs landing in CoreLib must be added to this set.
+    //
+    // Coverage source: src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics
+    // in the dotnet/runtime tree. Listing harmless-but-unmatched names is fine; the lookup
+    // is keyed off the fully qualified declaring type name, so types absent from the
+    // running CoreLib simply never trigger a match.
     let scalarOnlyFalseIsSupportedIntrinsics =
         set
             [
+                // System.Runtime.Intrinsics.Arm
                 "System.Runtime.Intrinsics.Arm.AdvSimd"
                 "System.Runtime.Intrinsics.Arm.AdvSimd.Arm64"
+                "System.Runtime.Intrinsics.Arm.Aes"
+                "System.Runtime.Intrinsics.Arm.Aes.Arm64"
+                "System.Runtime.Intrinsics.Arm.ArmBase"
+                "System.Runtime.Intrinsics.Arm.ArmBase.Arm64"
+                "System.Runtime.Intrinsics.Arm.Crc32"
+                "System.Runtime.Intrinsics.Arm.Crc32.Arm64"
+                "System.Runtime.Intrinsics.Arm.Dp"
+                "System.Runtime.Intrinsics.Arm.Dp.Arm64"
                 "System.Runtime.Intrinsics.Arm.Rdm"
                 "System.Runtime.Intrinsics.Arm.Rdm.Arm64"
+                "System.Runtime.Intrinsics.Arm.Sha1"
+                "System.Runtime.Intrinsics.Arm.Sha1.Arm64"
+                "System.Runtime.Intrinsics.Arm.Sha256"
+                "System.Runtime.Intrinsics.Arm.Sha256.Arm64"
+                "System.Runtime.Intrinsics.Arm.Sve"
+                "System.Runtime.Intrinsics.Arm.Sve.Arm64"
+                "System.Runtime.Intrinsics.Arm.Sve2"
+                "System.Runtime.Intrinsics.Arm.Sve2.Arm64"
+                // System.Runtime.Intrinsics.Wasm
+                "System.Runtime.Intrinsics.Wasm.PackedSimd"
+                "System.Runtime.Intrinsics.Wasm.WasmBase"
+                // System.Runtime.Intrinsics.X86
+                "System.Runtime.Intrinsics.X86.Aes"
+                "System.Runtime.Intrinsics.X86.Aes.X64"
+                "System.Runtime.Intrinsics.X86.Avx"
+                "System.Runtime.Intrinsics.X86.Avx.X64"
+                "System.Runtime.Intrinsics.X86.Avx10v1"
+                "System.Runtime.Intrinsics.X86.Avx10v1.X64"
+                "System.Runtime.Intrinsics.X86.Avx10v1.V512"
+                "System.Runtime.Intrinsics.X86.Avx10v1.V512.X64"
+                "System.Runtime.Intrinsics.X86.Avx10v2"
+                "System.Runtime.Intrinsics.X86.Avx10v2.X64"
+                "System.Runtime.Intrinsics.X86.Avx10v2.V512"
+                "System.Runtime.Intrinsics.X86.Avx10v2.V512.X64"
+                "System.Runtime.Intrinsics.X86.Avx2"
+                "System.Runtime.Intrinsics.X86.Avx2.X64"
+                "System.Runtime.Intrinsics.X86.Avx512BW"
+                "System.Runtime.Intrinsics.X86.Avx512BW.VL"
+                "System.Runtime.Intrinsics.X86.Avx512BW.X64"
+                "System.Runtime.Intrinsics.X86.Avx512CD"
+                "System.Runtime.Intrinsics.X86.Avx512CD.VL"
+                "System.Runtime.Intrinsics.X86.Avx512CD.X64"
+                "System.Runtime.Intrinsics.X86.Avx512DQ"
+                "System.Runtime.Intrinsics.X86.Avx512DQ.VL"
+                "System.Runtime.Intrinsics.X86.Avx512DQ.X64"
+                "System.Runtime.Intrinsics.X86.Avx512F"
+                "System.Runtime.Intrinsics.X86.Avx512F.VL"
+                "System.Runtime.Intrinsics.X86.Avx512F.X64"
+                "System.Runtime.Intrinsics.X86.Avx512Vbmi"
+                "System.Runtime.Intrinsics.X86.Avx512Vbmi.VL"
+                "System.Runtime.Intrinsics.X86.Avx512Vbmi.X64"
+                "System.Runtime.Intrinsics.X86.Avx512Vbmi2"
+                "System.Runtime.Intrinsics.X86.Avx512Vbmi2.VL"
+                "System.Runtime.Intrinsics.X86.Avx512Vbmi2.X64"
+                "System.Runtime.Intrinsics.X86.AvxVnni"
+                "System.Runtime.Intrinsics.X86.AvxVnni.X64"
+                "System.Runtime.Intrinsics.X86.Bmi1"
+                "System.Runtime.Intrinsics.X86.Bmi1.X64"
+                "System.Runtime.Intrinsics.X86.Bmi2"
+                "System.Runtime.Intrinsics.X86.Bmi2.X64"
+                "System.Runtime.Intrinsics.X86.Fma"
+                "System.Runtime.Intrinsics.X86.Fma.X64"
+                "System.Runtime.Intrinsics.X86.Gfni"
+                "System.Runtime.Intrinsics.X86.Gfni.V256"
+                "System.Runtime.Intrinsics.X86.Gfni.V512"
+                "System.Runtime.Intrinsics.X86.Gfni.X64"
+                "System.Runtime.Intrinsics.X86.Lzcnt"
+                "System.Runtime.Intrinsics.X86.Lzcnt.X64"
+                "System.Runtime.Intrinsics.X86.Pclmulqdq"
+                "System.Runtime.Intrinsics.X86.Pclmulqdq.V256"
+                "System.Runtime.Intrinsics.X86.Pclmulqdq.V512"
+                "System.Runtime.Intrinsics.X86.Pclmulqdq.X64"
+                "System.Runtime.Intrinsics.X86.Popcnt"
+                "System.Runtime.Intrinsics.X86.Popcnt.X64"
+                "System.Runtime.Intrinsics.X86.Sse"
+                "System.Runtime.Intrinsics.X86.Sse.X64"
+                "System.Runtime.Intrinsics.X86.Sse2"
+                "System.Runtime.Intrinsics.X86.Sse2.X64"
+                "System.Runtime.Intrinsics.X86.Sse3"
+                "System.Runtime.Intrinsics.X86.Sse3.X64"
+                "System.Runtime.Intrinsics.X86.Sse41"
+                "System.Runtime.Intrinsics.X86.Sse41.X64"
+                "System.Runtime.Intrinsics.X86.Sse42"
+                "System.Runtime.Intrinsics.X86.Sse42.X64"
                 "System.Runtime.Intrinsics.X86.Ssse3"
+                "System.Runtime.Intrinsics.X86.Ssse3.X64"
+                "System.Runtime.Intrinsics.X86.X86Base"
+                "System.Runtime.Intrinsics.X86.X86Base.X64"
+                "System.Runtime.Intrinsics.X86.X86Serialize"
+                "System.Runtime.Intrinsics.X86.X86Serialize.X64"
             ]
 
     let byteTemplate : CliType = CliType.Numeric (CliNumericType.UInt8 0uy)


### PR DESCRIPTION
PawPrint emulates a deterministic scalar virtual CPU: every `System.Runtime.Intrinsics.{Arm,Wasm,X86}.*.IsSupported` getter must fold to false so the BCL falls through to its scalar code path. Without an explicit fold the recursive `[Intrinsic]` IL stub would loop forever.

The set in `scalarOnlyFalseIsSupportedIntrinsics` was being grown reactively, one intrinsic-family member at a time, as test paths exposed each one. That meant CoreLib IL on osx-arm64 would steer into AdvSimd (folded to false) while the same managed helper on linux-x64 steered into Sse41 (not in the set) and crashed with "TODO: implement JIT intrinsic". Determinism story per host RID: broken.

Enumerate every hardware-intrinsic class (and nested .X64 / .Arm64 / .VL / .V256 / .V512 sub-types) currently in CoreLib so the scalar profile is closed over the surface, not opportunistic. Listing names that are absent from older CoreLibs is harmless: the lookup keys off the fully qualified declaring type name, and types that never materialize never trigger a match.

The tripwire test that asserted ArmBase.IsSupported throws becomes moot once ArmBase is in the set; convert it (and add an Sse41 case) into positive scalar-profile tests mirroring the existing AdvSimd/Rdm/Ssse3 ones.