### PR TITLE
Spike EnumSemantics blockers

### DIFF
--- a/WoofWare.PawPrint.Test/TestGcHandleRegistry.fs
+++ b/WoofWare.PawPrint.Test/TestGcHandleRegistry.fs
@@ -15,7 +15,7 @@ module TestGcHandleRegistry =
             GcHandleRegistry.empty ()
             |> GcHandleRegistry.allocate
                 GcHandleKind.WeakTrackResurrection
-                (GcHandleOwner.TypeAssociated (ConcreteTypeHandle.Concrete 12))
+                (GcHandleOwner.TypeAssociated (RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete 12)))
                 None
 
         GcHandleRegistry.target handle registry |> shouldEqual None

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -17,7 +17,6 @@ module TestPureCases =
 
     let unimplemented =
         [
-            "EnumSemantics.cs" // blocked by unimplemented QCall Enum_GetValuesAndNames after RawData boxed value byte view
             "AdvancedStructLayout.cs" // blocked after fixed-buffer pointer arithmetic by MarshalNative_SizeOfHelper for ByValTStr string marshalling
             "LdtokenField.cs" // TODO: read through `ReinterpretAs` as non-primitive type .VolatileObject
             "InitializeArrayBoxedFieldHandle.cs" // blocked after RuntimeTypeHandle.GetFields by MetadataImport.Enum over FieldDef rows

--- a/WoofWare.PawPrint/GcHandleRegistry.fs
+++ b/WoofWare.PawPrint/GcHandleRegistry.fs
@@ -10,7 +10,7 @@ type GcHandleKind =
 
 [<RequireQualifiedAccess>]
 type GcHandleOwner =
-    | TypeAssociated of ConcreteTypeHandle
+    | TypeAssociated of RuntimeTypeHandleTarget
     | GuestAllocated
 
 type GcHandleCell =

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -21,6 +21,30 @@ module Intrinsics =
 
     open IntrinsicHelpers
 
+    let private runtimeTypeHandleTargetOfRuntimeTypeRef
+        (operation : string)
+        (state : IlMachineState)
+        (runtimeTypeRef : EvalStackValue)
+        : RuntimeTypeHandleTarget
+        =
+        let runtimeTypeAddr =
+            match runtimeTypeRef with
+            | EvalStackValue.ObjectRef addr -> addr
+            | EvalStackValue.NullObjectRef -> failwith $"TODO: %s{operation} with null Type argument"
+            | other -> failwith $"%s{operation}: expected ObjectRef for RuntimeType argument, got %O{other}"
+
+        let heapObj = ManagedHeap.get runtimeTypeAddr state.ManagedHeap
+
+        let handleField =
+            IlMachineState.requiredOwnInstanceFieldId state heapObj.ConcreteType "m_handle"
+
+        match
+            AllocatedNonArrayObject.DereferenceFieldById handleField heapObj
+            |> CliType.unwrapPrimitiveLike
+        with
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.TypeHandlePtr target)) -> target
+        | other -> failwith $"%s{operation}: expected TypeHandlePtr in RuntimeType.m_handle, got %O{other}"
+
     let call
         (loggerFactory : ILoggerFactory)
         (baseClassTypes : BaseClassTypes<_>)
@@ -245,6 +269,50 @@ module Intrinsics =
             IlMachineState.pushToEvalStack (CliType.ofBool isValueType) currentThread state
             |> IlMachineState.advanceProgramCounter currentThread
             |> Some
+        | "System.Private.CoreLib", "Type", "get_IsEnum" ->
+            match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
+            | [], MethodReturnType.Returns (ConcreteBool state.ConcreteTypes) -> ()
+            | _ -> failwith "bad signature Type.get_IsEnum"
+
+            let target, state = popRuntimeTypeHandle currentThread state
+
+            let isEnum =
+                match target with
+                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ -> false
+                | RuntimeTypeHandleTarget.Closed ty ->
+                    match ty with
+                    | ConcreteTypeHandle.Concrete _ ->
+                        let ty =
+                            match AllConcreteTypes.lookup ty state.ConcreteTypes with
+                            | Some ty -> state.LoadedAssembly(ty.Assembly).Value.TypeDefs.[ty.Definition.Get]
+                            | None -> failwith $"Type.get_IsEnum: concrete type handle was not registered: %O{ty}"
+
+                        match ty.BaseType with
+                        | Some (BaseTypeInfo.TypeDef baseHandle) ->
+                            ty.Assembly = baseClassTypes.Corelib.Name
+                            && baseHandle = baseClassTypes.Enum.TypeDefHandle
+                        | Some (BaseTypeInfo.TypeRef baseRef) ->
+                            let assembly =
+                                state.LoadedAssembly (ty.Assembly)
+                                |> Option.defaultWith (fun () ->
+                                    failwith $"Type.get_IsEnum: assembly is not loaded: %s{ty.Assembly.FullName}"
+                                )
+
+                            let baseRef = assembly.TypeRefs.[baseRef]
+                            baseRef.Namespace = "System" && baseRef.Name = "Enum"
+                        | Some (BaseTypeInfo.ForeignAssemblyType (assembly, baseHandle)) ->
+                            assembly = baseClassTypes.Corelib.Name
+                            && baseHandle = baseClassTypes.Enum.TypeDefHandle
+                        | Some (BaseTypeInfo.TypeSpec _) -> false
+                        | None -> false
+                    | ConcreteTypeHandle.Byref _
+                    | ConcreteTypeHandle.Pointer _
+                    | ConcreteTypeHandle.OneDimArrayZero _
+                    | ConcreteTypeHandle.Array _ -> false
+
+            IlMachineState.pushToEvalStack (CliType.ofBool isEnum) currentThread state
+            |> IlMachineState.advanceProgramCounter currentThread
+            |> Some
         | "System.Private.CoreLib", "Type", "get_IsGenericType" ->
             match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
             | [], MethodReturnType.Returns (ConcreteBool state.ConcreteTypes) -> ()
@@ -267,6 +335,36 @@ module Intrinsics =
                     | ConcreteTypeHandle.Array _ -> false
 
             IlMachineState.pushToEvalStack (CliType.ofBool isGenericType) currentThread state
+            |> IlMachineState.advanceProgramCounter currentThread
+            |> Some
+        | "System.Private.CoreLib", "Type", "IsAssignableTo" ->
+            match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
+            | [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib", "System", "Type", generics) ],
+              MethodReturnType.Returns (ConcreteBool state.ConcreteTypes) when generics.IsEmpty -> ()
+            | _ -> failwith "bad signature Type.IsAssignableTo"
+
+            let targetArg, state = IlMachineState.popEvalStack currentThread state
+
+            let source, state = popRuntimeTypeHandle currentThread state
+
+            let target =
+                match targetArg with
+                | EvalStackValue.NullObjectRef -> None
+                | EvalStackValue.ObjectRef _ ->
+                    Some (runtimeTypeHandleTargetOfRuntimeTypeRef "Type.IsAssignableTo" state targetArg)
+                | other -> failwith $"Type.IsAssignableTo: expected Type argument, got %O{other}"
+
+            let state, isAssignable =
+                match source, target with
+                | _, None -> state, false
+                | RuntimeTypeHandleTarget.Closed source, Some (RuntimeTypeHandleTarget.Closed target) ->
+                    IlMachineState.isConcreteTypeAssignableTo loggerFactory baseClassTypes state source target
+                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity, _ ->
+                    failwith $"TODO: Type.IsAssignableTo for open generic source %O{identity}"
+                | _, Some (RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity) ->
+                    failwith $"TODO: Type.IsAssignableTo for open generic target %O{identity}"
+
+            IlMachineState.pushToEvalStack (CliType.ofBool isAssignable) currentThread state
             |> IlMachineState.advanceProgramCounter currentThread
             |> Some
         | "System.Private.CoreLib", "Unsafe", "AsPointer" ->
@@ -1299,6 +1397,42 @@ module Intrinsics =
             |> IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 size)) currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Some
+        | "System.Private.CoreLib", "Unsafe", "BitCast" ->
+            // Spike implementation of the JIT intrinsic: reinterpret the source
+            // storage bytes as the target storage shape. This deliberately keeps
+            // object/reference-shaped storage out of scope via the byte layout
+            // helpers.
+            let source, target =
+                match Seq.toList methodToCall.Generics with
+                | [ source ; target ] -> source, target
+                | _ -> failwith "bad generics Unsafe.BitCast"
+
+            match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
+            | [ sourceParam ], MethodReturnType.Returns targetRet when sourceParam = source && targetRet = target -> ()
+            | _ -> failwith "bad signature Unsafe.BitCast"
+
+            let value, state = IlMachineState.popEvalStack currentThread state
+
+            let sourceZero, state =
+                IlMachineState.cliTypeZeroOfHandle state baseClassTypes source
+
+            let targetZero, state =
+                IlMachineState.cliTypeZeroOfHandle state baseClassTypes target
+
+            let sourceValue = EvalStackValue.toCliTypeCoerced sourceZero value
+            let sourceSize = CliType.sizeOf sourceValue
+            let targetSize = CliType.sizeOf targetZero
+
+            if sourceSize <> targetSize then
+                failwith
+                    $"Unsafe.BitCast: source type %O{source} has size %i{sourceSize}, target type %O{target} has size %i{targetSize}"
+
+            let result = sourceValue |> CliType.ToBytes |> CliType.ofBytesLike targetZero
+
+            state
+            |> IlMachineState.pushToEvalStack result currentThread
+            |> IlMachineState.advanceProgramCounter currentThread
+            |> Some
         | "System.Private.CoreLib", "Unsafe", "AreSame" ->
             // https://github.com/dotnet/runtime/blob/108fa7856efcfd39bc991c2d849eabbf7ba5989c/src/coreclr/tools/Common/TypeSystem/IL/Stubs/UnsafeIntrinsics.cs#L55
             // The source-level IL body throws PlatformNotSupportedException; the JIT replaces it with ceq on two byrefs.
@@ -1464,6 +1598,8 @@ module Intrinsics =
                     ByteStorageIdentity.Array arr, int64 i * int64 elementSize + projectionByteOffset projs
                 | ManagedPointerSource.Byref (ByrefRoot.StringCharAt (str, charIndex), projs) ->
                     ByteStorageIdentity.String str, int64 charIndex * 2L + projectionByteOffset projs
+                | ManagedPointerSource.Byref (ByrefRoot.PeByteRange peByteRange, projs) ->
+                    ByteStorageIdentity.PeByteRange peByteRange, projectionByteOffset projs
                 | _ -> failwith $"TODO: Unsafe.ByteOffset on unsupported byref: %O{v}"
 
             let storage1, originOffset = extractByteLocation origin

--- a/WoofWare.PawPrint/MethodTableProjection.fs
+++ b/WoofWare.PawPrint/MethodTableProjection.fs
@@ -7,6 +7,7 @@ open Microsoft.Extensions.Logging
 module internal MethodTableProjection =
     let private hasComponentSizeFlag : int32 = Int32.MinValue
     let private containsGcPointersFlag : int32 = 0x01000000
+    let private genericsMaskTypicalInst : int32 = 0x00000030
 
     let private categoryInterface : int32 = 0x000C0000
     let private categoryValueType : int32 = 0x00040000
@@ -322,6 +323,43 @@ module internal MethodTableProjection =
 
         flags, state
 
+    let private openGenericCategoryFlags
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (identity : ResolvedTypeIdentity)
+        : int32
+        =
+        let assembly =
+            state.LoadedAssembly identity.Assembly
+            |> Option.defaultWith (fun () ->
+                failwith
+                    $"Open generic MethodTable projection could not find loaded assembly %s{identity.AssemblyFullName}"
+            )
+
+        let typeInfo = assembly.TypeDefs.[identity.TypeDefinition.Get]
+
+        let categoryFlags =
+            if typeInfo.IsInterface then
+                categoryInterface
+            elif
+                typeInfo.Assembly.FullName = baseClassTypes.Corelib.Name.FullName
+                && typeInfo.Namespace = "System"
+                && typeInfo.Name = "Nullable`1"
+            then
+                categoryNullable
+            elif DumpedAssembly.isValueType baseClassTypes state._LoadedAssemblies typeInfo then
+                if isTruePrimitive baseClassTypes typeInfo then
+                    categoryTruePrimitive
+                else
+                    categoryValueType
+            else
+                0
+
+        if typeInfo.Generics.IsEmpty then
+            categoryFlags
+        else
+            categoryFlags ||| genericsMaskTypicalInst
+
     let numInstanceFieldBytes
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (state : IlMachineState)
@@ -380,6 +418,24 @@ module internal MethodTableProjection =
             | _ ->
                 failwith
                     $"TODO: MethodTable field projection for System.Runtime.CompilerServices.MethodTable::{field.Name} on %O{methodTableFor}"
+
+    let tryProjectOpenGenericField
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (field : FieldInfo<'typeGeneric, 'fieldGeneric>)
+        (identity : ResolvedTypeIdentity)
+        (state : IlMachineState)
+        : (CliType * IlMachineState) option
+        =
+        if not (isMethodTableField baseClassTypes field) then
+            None
+        else
+            match field.Name with
+            | "Flags" ->
+                let flags = openGenericCategoryFlags baseClassTypes state identity
+                Some (uint32Field (uint32 flags), state)
+            | _ ->
+                failwith
+                    $"TODO: MethodTable field projection for System.Runtime.CompilerServices.MethodTable::{field.Name} on open generic definition %O{identity}"
 
     let tryProjectAuxiliaryDataField
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)

--- a/WoofWare.PawPrint/Native/NativeDispatch.fs
+++ b/WoofWare.PawPrint/Native/NativeDispatch.fs
@@ -12,38 +12,41 @@ module NativeDispatch =
                 match NativeMarshal.tryExecute ctx with
                 | Some result -> Some result
                 | None ->
-                    match NativeQCall.tryExecute ctx with
+                    match NativeRuntimeHelpers.tryExecute ctx with
                     | Some result -> Some result
                     | None ->
-                        // QCall migration note: some name-based native handlers below still model
-                        // CoreCLR QCalls on newer runtimes. Move each to NativeQCall as its import
-                        // metadata is needed, then delete the corresponding name-based fallback.
-                        match NativeMetadataImport.tryExecute ctx with
+                        match NativeQCall.tryExecute ctx with
                         | Some result -> Some result
                         | None ->
-                            match NativeGcHandle.tryExecute ctx with
+                            // QCall migration note: some name-based native handlers below still model
+                            // CoreCLR QCalls on newer runtimes. Move each to NativeQCall as its import
+                            // metadata is needed, then delete the corresponding name-based fallback.
+                            match NativeMetadataImport.tryExecute ctx with
                             | Some result -> Some result
                             | None ->
-                                match NativeRuntimeFieldHandle.tryExecute ctx with
+                                match NativeGcHandle.tryExecute ctx with
                                 | Some result -> Some result
                                 | None ->
-                                    match NativeRuntimeType.tryExecute ctx with
+                                    match NativeRuntimeFieldHandle.tryExecute ctx with
                                     | Some result -> Some result
                                     | None ->
-                                        match NativeRuntimeAssembly.tryExecute ctx with
+                                        match NativeRuntimeType.tryExecute ctx with
                                         | Some result -> Some result
                                         | None ->
-                                            match NativeThreading.tryExecute ctx with
+                                            match NativeRuntimeAssembly.tryExecute ctx with
                                             | Some result -> Some result
                                             | None ->
-                                                match NativeType.tryExecute ctx with
+                                                match NativeThreading.tryExecute ctx with
                                                 | Some result -> Some result
                                                 | None ->
-                                                    match NativeString.tryExecute ctx with
+                                                    match NativeType.tryExecute ctx with
                                                     | Some result -> Some result
                                                     | None ->
-                                                        match NativeSystemNative.tryExecute ctx with
+                                                        match NativeString.tryExecute ctx with
                                                         | Some result -> Some result
-                                                        | None -> NativeDebugger.tryExecute ctx
+                                                        | None ->
+                                                            match NativeSystemNative.tryExecute ctx with
+                                                            | Some result -> Some result
+                                                            | None -> NativeDebugger.tryExecute ctx
 
     let failUnimplemented (ctx : NativeCallContext) : ExecutionResult = NativeCall.failUnimplemented ctx

--- a/WoofWare.PawPrint/Native/NativeEnum.fs
+++ b/WoofWare.PawPrint/Native/NativeEnum.fs
@@ -1,0 +1,279 @@
+namespace WoofWare.PawPrint
+
+open System
+open System.Reflection
+open System.Reflection.Metadata
+open System.Reflection.PortableExecutable
+
+[<RequireQualifiedAccess>]
+module NativeEnum =
+    type private EnumFieldValue =
+        {
+            Name : string
+            ValueBits : uint64
+        }
+
+    let private enumUnderlyingPrimitive
+        (operation : string)
+        (typeInfo : TypeInfo<GenericParamFromMetadata, TypeDefn>)
+        : PrimitiveType
+        =
+        let instanceFields =
+            typeInfo.Fields |> List.filter (fun field -> not field.IsStatic)
+
+        match instanceFields with
+        | [ field ] when field.Name = "value__" ->
+            match field.Signature with
+            | TypeDefn.PrimitiveType primitive -> primitive
+            | other -> failwith $"%s{operation}: enum value__ field had non-primitive signature %O{other}"
+        | _ ->
+            failwith
+                $"%s{operation}: expected enum type %s{typeInfo.Namespace}.%s{typeInfo.Name} to have one value__ instance field"
+
+    let private enumStoragePrimitive (operation : string) (underlying : PrimitiveType) : PrimitiveType =
+        match underlying with
+        | PrimitiveType.SByte
+        | PrimitiveType.Byte -> PrimitiveType.Byte
+        | PrimitiveType.Int16
+        | PrimitiveType.UInt16 -> PrimitiveType.UInt16
+        | PrimitiveType.Int32
+        | PrimitiveType.UInt32 -> PrimitiveType.UInt32
+        | PrimitiveType.Int64
+        | PrimitiveType.UInt64 -> PrimitiveType.UInt64
+        | other -> failwith $"TODO: %s{operation} for enum underlying type %O{other}"
+
+    let private primitiveTypeInfo
+        (operation : string)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (primitive : PrimitiveType)
+        : TypeInfo<GenericParamFromMetadata, TypeDefn>
+        =
+        match primitive with
+        | PrimitiveType.Byte -> baseClassTypes.Byte
+        | PrimitiveType.UInt16 -> baseClassTypes.UInt16
+        | PrimitiveType.UInt32 -> baseClassTypes.UInt32
+        | PrimitiveType.UInt64 -> baseClassTypes.UInt64
+        | other -> failwith $"%s{operation}: unsupported enum storage primitive %O{other}"
+
+    let private storageValueOfBits (operation : string) (storage : PrimitiveType) (bits : uint64) : CliType =
+        match storage with
+        | PrimitiveType.Byte -> CliType.Numeric (CliNumericType.UInt8 (byte bits))
+        | PrimitiveType.UInt16 -> CliType.Numeric (CliNumericType.UInt16 (uint16 bits))
+        | PrimitiveType.UInt32 ->
+            let value = BitConverter.ToInt32 (BitConverter.GetBytes (uint32 bits), 0)
+
+            CliType.Numeric (CliNumericType.Int32 value)
+        | PrimitiveType.UInt64 ->
+            let value = BitConverter.ToInt64 (BitConverter.GetBytes bits, 0)
+
+            CliType.Numeric (CliNumericType.Int64 (Int64Source.Verbatim value))
+        | other -> failwith $"%s{operation}: unsupported enum storage primitive %O{other}"
+
+    let private readEnumConstantBits
+        (operation : string)
+        (assembly : DumpedAssembly)
+        (field : FieldInfo<GenericParamFromMetadata, TypeDefn>)
+        (underlying : PrimitiveType)
+        : uint64
+        =
+        let metadataReader = assembly.PeReader.GetMetadataReader ()
+        let fieldDef = metadataReader.GetFieldDefinition field.Handle
+        let constantHandle = fieldDef.GetDefaultValue ()
+
+        if constantHandle.IsNil then
+            failwith $"%s{operation}: enum literal field %s{field.Name} did not have a metadata constant"
+
+        let constant = metadataReader.GetConstant constantHandle
+        let mutable reader = metadataReader.GetBlobReader constant.Value
+
+        match underlying with
+        | PrimitiveType.SByte
+        | PrimitiveType.Byte -> reader.ReadByte () |> uint64
+        | PrimitiveType.Int16
+        | PrimitiveType.UInt16 -> reader.ReadUInt16 () |> uint64
+        | PrimitiveType.Int32
+        | PrimitiveType.UInt32 -> reader.ReadUInt32 () |> uint64
+        | PrimitiveType.Int64
+        | PrimitiveType.UInt64 -> reader.ReadUInt64 ()
+        | other -> failwith $"TODO: %s{operation} for enum underlying type %O{other}"
+
+    let private enumLiteralFields
+        (typeInfo : TypeInfo<GenericParamFromMetadata, TypeDefn>)
+        : FieldInfo<GenericParamFromMetadata, TypeDefn> list
+        =
+        typeInfo.Fields
+        |> List.filter (fun field -> field.IsStatic && field.Attributes.HasFlag FieldAttributes.Literal)
+
+    let private allocateValuesArray
+        (operation : string)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (storage : PrimitiveType)
+        (values : EnumFieldValue list)
+        : ManagedHeapAddress * IlMachineState
+        =
+        let elementType = primitiveTypeInfo operation baseClassTypes storage
+
+        let elementHandle =
+            AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes elementType
+
+        let zero = CliType.zeroOfPrimitive state.ConcreteTypes baseClassTypes storage
+
+        let arrayAddr, state =
+            IlMachineState.allocateArray
+                (ConcreteTypeHandle.OneDimArrayZero elementHandle)
+                (fun () -> zero)
+                values.Length
+                state
+
+        let state =
+            ((state, 0), values)
+            ||> List.fold (fun (state, index) value ->
+                let element = storageValueOfBits operation storage value.ValueBits
+                IlMachineState.setArrayValue arrayAddr element index state, index + 1
+            )
+            |> fst
+
+        arrayAddr, state
+
+    let private allocateNamesArray
+        (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (values : EnumFieldValue list)
+        : ManagedHeapAddress * IlMachineState
+        =
+        let elementHandle =
+            AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes baseClassTypes.String
+
+        let arrayAddr, state =
+            IlMachineState.allocateArray
+                (ConcreteTypeHandle.OneDimArrayZero elementHandle)
+                (fun () -> CliType.ObjectRef None)
+                values.Length
+                state
+
+        let state =
+            ((state, 0), values)
+            ||> List.fold (fun (state, index) value ->
+                let nameAddr, state =
+                    IlMachineState.allocateManagedString loggerFactory baseClassTypes value.Name state
+
+                IlMachineState.setArrayValue arrayAddr (CliType.ObjectRef (Some nameAddr)) index state, index + 1
+            )
+            |> fst
+
+        arrayAddr, state
+
+    let private boolArgument (operation : string) (arg : CliType) : bool =
+        match CliType.unwrapPrimitiveLikeDeep arg with
+        | CliType.Bool b -> b <> 0uy
+        | CliType.Numeric (CliNumericType.Int32 i) -> i <> 0
+        | other -> failwith $"%s{operation}: expected BOOL argument as int32, got %O{other}"
+
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
+        let state = ctx.State
+        let instruction = ctx.Instruction
+
+        match
+            entryPoint,
+            ctx.TargetAssembly.Name.Name,
+            ctx.TargetType.Namespace,
+            ctx.TargetType.Name,
+            instruction.ExecutingMethod.Name,
+            instruction.ExecutingMethod.Signature.ParameterTypes,
+            instruction.ExecutingMethod.Signature.ReturnType
+        with
+        | "Enum_GetValuesAndNames",
+          "System.Private.CoreLib",
+          "System",
+          "Enum",
+          "GetEnumValuesAndNames",
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "QCallTypeHandle",
+                                              qCallGenerics)
+            ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "ObjectHandleOnStack",
+                                              valuesHandleGenerics)
+            ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "ObjectHandleOnStack",
+                                              namesHandleGenerics)
+            ConcreteType state.ConcreteTypes ("System.Private.CoreLib", _, "BOOL", boolGenerics) ],
+          MethodReturnType.Void when
+            qCallGenerics.IsEmpty
+            && valuesHandleGenerics.IsEmpty
+            && namesHandleGenerics.IsEmpty
+            && boolGenerics.IsEmpty
+            ->
+            let operation = "Enum.GetEnumValuesAndNames"
+
+            if instruction.Arguments.Length <> 4 then
+                failwith $"%s{operation}: expected four native arguments, got %d{instruction.Arguments.Length}"
+
+            let enumTypeHandle =
+                NativeCall.qCallTypeHandleToConcreteTypeHandle
+                    operation
+                    state
+                    (instruction.Arguments.[0] |> EvalStackValue.ofCliType)
+
+            let valuesOut =
+                NativeCall.objectHandleOnStackTarget operation state "values" instruction.Arguments.[1]
+
+            let namesOut =
+                NativeCall.objectHandleOnStackTarget operation state "names" instruction.Arguments.[2]
+
+            let getNames = boolArgument operation instruction.Arguments.[3]
+
+            let concreteType =
+                AllConcreteTypes.lookup enumTypeHandle state.ConcreteTypes
+                |> Option.defaultWith (fun () ->
+                    failwith $"%s{operation}: enum concrete type handle was not registered: %O{enumTypeHandle}"
+                )
+
+            let enumAssembly =
+                state.LoadedAssembly concreteType.Assembly
+                |> Option.defaultWith (fun () ->
+                    failwith $"%s{operation}: enum assembly is not loaded: %s{concreteType.Assembly.FullName}"
+                )
+
+            let enumTypeInfo = enumAssembly.TypeDefs.[concreteType.Definition.Get]
+            let underlying = enumUnderlyingPrimitive operation enumTypeInfo
+            let storage = enumStoragePrimitive operation underlying
+
+            let values =
+                enumLiteralFields enumTypeInfo
+                |> List.map (fun field ->
+                    {
+                        Name = field.Name
+                        ValueBits = readEnumConstantBits operation enumAssembly field underlying
+                    }
+                )
+
+            let valuesAddr, state =
+                allocateValuesArray operation ctx.BaseClassTypes state storage values
+
+            let state =
+                IlMachineState.writeManagedByrefWithBase
+                    ctx.BaseClassTypes
+                    state
+                    valuesOut
+                    (CliType.ObjectRef (Some valuesAddr))
+
+            let state =
+                if getNames then
+                    let namesAddr, state =
+                        allocateNamesArray ctx.LoggerFactory ctx.BaseClassTypes state values
+
+                    IlMachineState.writeManagedByrefWithBase
+                        ctx.BaseClassTypes
+                        state
+                        namesOut
+                        (CliType.ObjectRef (Some namesAddr))
+                else
+                    state
+
+            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+        | _ -> None

--- a/WoofWare.PawPrint/Native/NativeGcHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeGcHandle.fs
@@ -34,7 +34,7 @@ module NativeGcHandle =
             let gcHandleType = instruction.Arguments.[1] |> EvalStackValue.ofCliType
 
             let typeHandle =
-                NativeCall.qCallTypeHandleToConcreteTypeHandle operation state qCallHandle
+                NativeCall.qCallTypeHandleToRuntimeTypeHandleTarget operation state qCallHandle
 
             let kind = NativeCall.gcHandleKindOfEvalStackValue operation gcHandleType
 
@@ -68,7 +68,7 @@ module NativeGcHandle =
             // unregister the handle before destroying it; PawPrint has one process-wide
             // handle registry, but keeping the type association visible makes a future
             // collector/loader model easier to add.
-            NativeCall.qCallTypeHandleToConcreteTypeHandle operation state qCallHandle
+            NativeCall.qCallTypeHandleToRuntimeTypeHandleTarget operation state qCallHandle
             |> ignore
 
             let handle = NativeCall.gcHandleAddressOfEvalStackValue operation objHandle

--- a/WoofWare.PawPrint/Native/NativeMetadataImport.fs
+++ b/WoofWare.PawPrint/Native/NativeMetadataImport.fs
@@ -165,11 +165,11 @@ module NativeMetadataImport =
 
             let isSupportedEmptyEnumeration =
                 (tokenType = metadataTokenTypeExportedType && parent = 0)
-                || (tokenType = metadataTokenTypeCustomAttribute && parent = mdAssemblyToken)
+                || tokenType = metadataTokenTypeCustomAttribute
 
             if not isSupportedEmptyEnumeration then
                 failwith
-                    $"TODO: %s{operation} only supports empty ExportedType enumeration for assembly forwarding checks and empty assembly CustomAttribute enumeration; got token type 0x%08x{tokenType}, parent 0x%08x{parent}"
+                    $"TODO: %s{operation} only supports empty ExportedType enumeration for assembly forwarding checks and empty CustomAttribute enumeration; got token type 0x%08x{tokenType}, parent 0x%08x{parent}"
 
             let lengthOut =
                 NativeCall.managedPointerOfPointerArgument operation "length" instruction.Arguments.[3]

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -13,9 +13,14 @@ module NativeQCall =
             "MarshalNative_SizeOfHelper", NativeMarshal.tryExecuteQCall "MarshalNative_SizeOfHelper"
             "Buffer_MemMove", NativeBuffer.tryExecuteQCall "Buffer_MemMove"
             "RuntimeTypeHandle_ConstructName", NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_ConstructName"
+            "RuntimeTypeHandle_Instantiate", NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_Instantiate"
+            "RuntimeTypeHandle_CreateInstanceForAnotherGenericParameter",
+            NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_CreateInstanceForAnotherGenericParameter"
+            "RuntimeTypeHandle_GetInstantiation", NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_GetInstantiation"
             "MethodTable_CanCompareBitsOrUseFastGetHashCode",
             NativeRuntimeType.tryExecuteQCall "MethodTable_CanCompareBitsOrUseFastGetHashCode"
             "Array_CreateInstance", NativeArray.tryExecuteQCall "Array_CreateInstance"
+            "Enum_GetValuesAndNames", NativeEnum.tryExecuteQCall "Enum_GetValuesAndNames"
             "AssemblyNative_GetResource", NativeRuntimeAssembly.tryExecuteQCall "AssemblyNative_GetResource"
             "AssemblyNative_GetTypeCore", NativeRuntimeAssembly.tryExecuteQCall "AssemblyNative_GetTypeCore"
             // The CoreLib source is a Kernel32 LibraryImport, but the runtime

--- a/WoofWare.PawPrint/Native/NativeRuntimeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeHelpers.fs
@@ -2,6 +2,40 @@ namespace WoofWare.PawPrint
 
 [<RequireQualifiedAccess>]
 module NativeRuntimeHelpers =
+    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+        let state = ctx.State
+        let instruction = ctx.Instruction
+
+        match
+            ctx.TargetAssembly.Name.Name,
+            ctx.TargetType.Namespace,
+            ctx.TargetType.Name,
+            instruction.ExecutingMethod.Name,
+            instruction.ExecutingMethod.Signature.ParameterTypes,
+            instruction.ExecutingMethod.Signature.ReturnType
+        with
+        | "System.Private.CoreLib",
+          "System.Runtime.CompilerServices",
+          "RuntimeHelpers",
+          "GetHashCode",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.Object ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
+            if instruction.Arguments.Length <> 1 then
+                failwith
+                    $"RuntimeHelpers.GetHashCode: expected one native argument, got %d{instruction.Arguments.Length}"
+
+            let hash =
+                match instruction.Arguments.[0] |> EvalStackValue.ofCliType with
+                | EvalStackValue.ObjectRef (ManagedHeapAddress addr) -> addr
+                | EvalStackValue.NullObjectRef -> 0
+                | other -> failwith $"RuntimeHelpers.GetHashCode: expected object ref, got %O{other}"
+
+            let state =
+                IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 hash)) ctx.Thread state
+
+            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+        | _ -> None
+
     let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
         let state = ctx.State
         let instruction = ctx.Instruction

--- a/WoofWare.PawPrint/Native/NativeRuntimeType.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeType.fs
@@ -56,8 +56,11 @@ module NativeRuntimeType =
                 ByrefRoot.LocalMemoryByte (thread, frame, block, byteOffset + (index * nativeIntSize)),
                 []
             )
-        // GetFields is currently reached through stackalloc local memory or
-        // IntPtr[] buffers. Other Span roots should fail with their shape intact.
+        | ManagedPointerSource.Byref (ByrefRoot.LocalVariable _, []) when index = 0 -> buffer
+        | ManagedPointerSource.Byref (ByrefRoot.Argument _, []) when index = 0 -> buffer
+        // Native IntPtr buffers are currently reached through stackalloc local
+        // memory, IntPtr[] buffers, or a single byref local. Other Span roots
+        // should fail with their shape intact.
         | _ -> failwith $"%s{operation}: unsupported IntPtr result buffer pointer shape %O{buffer}"
 
     let private writeFieldHandleElement
@@ -757,6 +760,184 @@ module NativeRuntimeType =
             0
             state
 
+    let private boolArgument (operation : string) (arg : CliType) : bool =
+        match CliType.unwrapPrimitiveLikeDeep arg with
+        | CliType.Bool b -> b <> 0uy
+        | CliType.Numeric (CliNumericType.Int32 i) -> i <> 0
+        | other -> failwith $"%s{operation}: expected BOOL argument as int32, got %O{other}"
+
+    let private genericInstantiation
+        (operation : string)
+        (state : IlMachineState)
+        (target : RuntimeTypeHandleTarget)
+        : ConcreteTypeHandle option list
+        =
+        match target with
+        | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
+            let assembly =
+                state.LoadedAssembly identity.Assembly
+                |> Option.defaultWith (fun () ->
+                    failwith
+                        $"%s{operation}: assembly for open generic type definition is not loaded: %s{identity.AssemblyFullName}"
+                )
+
+            let typeInfo = assembly.TypeDefs.[identity.TypeDefinition.Get]
+
+            // Spike limitation: RuntimeTypeHandleTarget cannot represent generic
+            // parameter RuntimeTypes today. For MakeGenericType's current path,
+            // CoreLib only needs this array's length for the generic definition.
+            List.replicate typeInfo.Generics.Length None
+        | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete _ as concreteHandle) ->
+            let concreteType =
+                AllConcreteTypes.lookup concreteHandle state.ConcreteTypes
+                |> Option.defaultWith (fun () ->
+                    failwith $"%s{operation}: concrete type handle was not registered: %O{concreteHandle}"
+                )
+
+            concreteType.Generics |> Seq.map Some |> Seq.toList
+        | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Byref _)
+        | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Pointer _)
+        | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.OneDimArrayZero _)
+        | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Array _) -> []
+
+    let private readTypeHandleInstantiationElement
+        (operation : string)
+        (state : IlMachineState)
+        (buffer : ManagedPointerSource)
+        (index : int)
+        : ConcreteTypeHandle
+        =
+        let ptr = nativeIntElementPointer operation buffer index
+
+        match IlMachineState.readManagedByref state ptr |> CliType.unwrapPrimitiveLikeDeep with
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed handle))) ->
+            handle
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity))) ->
+            failwith $"TODO: %s{operation} with open generic type argument %O{identity}"
+        | other -> failwith $"%s{operation}: expected TypeHandlePtr in instantiation buffer, got %O{other}"
+
+    let private instantiateOpenGenericTypeDefinition
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (operation : string)
+        (state : IlMachineState)
+        (genericDefinition : ResolvedTypeIdentity)
+        (genericArguments : ConcreteTypeHandle list)
+        : ConcreteTypeHandle * IlMachineState
+        =
+        let assembly =
+            state.LoadedAssembly genericDefinition.Assembly
+            |> Option.defaultWith (fun () ->
+                failwith
+                    $"%s{operation}: assembly for open generic type definition is not loaded: %s{genericDefinition.AssemblyFullName}"
+            )
+
+        let typeInfo = assembly.TypeDefs.[genericDefinition.TypeDefinition.Get]
+
+        if typeInfo.Generics.Length <> genericArguments.Length then
+            failwith
+                $"%s{operation}: generic arity mismatch for %s{typeInfo.Namespace}.%s{typeInfo.Name}; definition has %i{typeInfo.Generics.Length} parameters, but call supplied %i{genericArguments.Length} arguments"
+
+        let signatureTypeKind =
+            DumpedAssembly.signatureTypeKind baseClassTypes state._LoadedAssemblies typeInfo
+
+        let genericDefn = TypeDefn.FromDefinition (genericDefinition, signatureTypeKind)
+
+        let genericArgDefns =
+            genericArguments
+            |> List.map (fun handle ->
+                Concretization.concreteHandleToTypeDefn
+                    baseClassTypes
+                    handle
+                    state.ConcreteTypes
+                    state._LoadedAssemblies
+            )
+            |> ImmutableArray.CreateRange
+
+        let state, instantiatedHandle =
+            IlMachineState.concretizeType
+                loggerFactory
+                baseClassTypes
+                state
+                genericDefinition.Assembly
+                ImmutableArray.Empty
+                ImmutableArray.Empty
+                (TypeDefn.GenericInstantiation (genericDefn, genericArgDefns))
+
+        instantiatedHandle, state
+
+    let private instantiateGenericRuntimeTypeTarget
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (operation : string)
+        (state : IlMachineState)
+        (target : RuntimeTypeHandleTarget)
+        (genericArguments : ConcreteTypeHandle list)
+        : ConcreteTypeHandle * IlMachineState
+        =
+        match target with
+        | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
+            instantiateOpenGenericTypeDefinition loggerFactory baseClassTypes operation state identity genericArguments
+        | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete _ as typeHandle) ->
+            let concreteType =
+                AllConcreteTypes.lookup typeHandle state.ConcreteTypes
+                |> Option.defaultWith (fun () ->
+                    failwith $"%s{operation}: concrete type handle was not registered: %O{typeHandle}"
+                )
+
+            instantiateOpenGenericTypeDefinition
+                loggerFactory
+                baseClassTypes
+                operation
+                state
+                concreteType.Identity
+                genericArguments
+        | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Byref _)
+        | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Pointer _)
+        | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.OneDimArrayZero _)
+        | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Array _) ->
+            failwith $"TODO: %s{operation} for structural RuntimeTypeHandleTarget %O{target}"
+
+    let private allocateTypeArray
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (asRuntimeTypeArray : bool)
+        (elements : ConcreteTypeHandle option list)
+        (state : IlMachineState)
+        : ManagedHeapAddress * IlMachineState
+        =
+        let typeName = if asRuntimeTypeArray then "RuntimeType" else "Type"
+
+        let state, _, elementHandle =
+            concretizeNonGenericCorelibType loggerFactory baseClassTypes state "System" typeName
+
+        let arrayAddr, state =
+            IlMachineState.allocateArray
+                (ConcreteTypeHandle.OneDimArrayZero elementHandle)
+                (fun () -> CliType.ObjectRef None)
+                elements.Length
+                state
+
+        ((state, 0), elements)
+        ||> List.fold (fun (state, index) element ->
+            let value, state =
+                match element with
+                | None -> CliType.ObjectRef None, state
+                | Some element ->
+                    let runtimeTypeAddr, state =
+                        IlMachineState.getOrAllocateType
+                            loggerFactory
+                            baseClassTypes
+                            (RuntimeTypeHandleTarget.Closed element)
+                            state
+
+                    CliType.ObjectRef (Some runtimeTypeAddr), state
+
+            IlMachineState.setArrayValue arrayAddr value index state, index + 1
+        )
+        |> fst
+        |> fun state -> arrayAddr, state
+
     let private allocateManagedObjectOfConcreteType
         (loggerFactory : ILoggerFactory)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
@@ -1065,6 +1246,197 @@ module NativeRuntimeType =
                     (CliType.ObjectRef (Some nameAddr))
 
             (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+        | "RuntimeTypeHandle_Instantiate",
+          "System.Private.CoreLib",
+          "System",
+          "RuntimeTypeHandle",
+          "Instantiate",
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "QCallTypeHandle",
+                                              qCallGenerics)
+            ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr)
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32
+            ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "ObjectHandleOnStack",
+                                              objectHandleGenerics) ],
+          MethodReturnType.Void when qCallGenerics.IsEmpty && objectHandleGenerics.IsEmpty ->
+            let operation = "RuntimeTypeHandle.Instantiate"
+
+            if instruction.Arguments.Length <> 4 then
+                failwith $"%s{operation}: expected four native arguments, got %d{instruction.Arguments.Length}"
+
+            let typeHandleTarget =
+                NativeCall.qCallTypeHandleToRuntimeTypeHandleTarget
+                    operation
+                    state
+                    (instruction.Arguments.[0] |> EvalStackValue.ofCliType)
+
+            let instantiationPointer =
+                NativeCall.managedPointerOfPointerArgument operation "pInst" instruction.Arguments.[1]
+
+            let genericArgumentCount =
+                NativeCall.int32Argument operation instruction.Arguments.[2]
+
+            let retType =
+                NativeCall.objectHandleOnStackTarget operation state "type" instruction.Arguments.[3]
+
+            let genericArguments =
+                [
+                    for index in 0 .. genericArgumentCount - 1 ->
+                        readTypeHandleInstantiationElement operation state instantiationPointer index
+                ]
+
+            let instantiatedHandle, state =
+                instantiateGenericRuntimeTypeTarget
+                    ctx.LoggerFactory
+                    ctx.BaseClassTypes
+                    operation
+                    state
+                    typeHandleTarget
+                    genericArguments
+
+            let runtimeTypeAddr, state =
+                IlMachineState.getOrAllocateType
+                    ctx.LoggerFactory
+                    ctx.BaseClassTypes
+                    (RuntimeTypeHandleTarget.Closed instantiatedHandle)
+                    state
+
+            let state =
+                IlMachineState.writeManagedByrefWithBase
+                    ctx.BaseClassTypes
+                    state
+                    retType
+                    (CliType.ObjectRef (Some runtimeTypeAddr))
+
+            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+        | "RuntimeTypeHandle_CreateInstanceForAnotherGenericParameter",
+          "System.Private.CoreLib",
+          "System",
+          "RuntimeTypeHandle",
+          "CreateInstanceForAnotherGenericParameter",
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "QCallTypeHandle",
+                                              qCallGenerics)
+            ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr)
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32
+            ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "ObjectHandleOnStack",
+                                              objectHandleGenerics) ],
+          MethodReturnType.Void when qCallGenerics.IsEmpty && objectHandleGenerics.IsEmpty ->
+            let operation = "RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter"
+
+            if instruction.Arguments.Length <> 4 then
+                failwith $"%s{operation}: expected four native arguments, got %d{instruction.Arguments.Length}"
+
+            let typeHandleTarget =
+                NativeCall.qCallTypeHandleToRuntimeTypeHandleTarget
+                    operation
+                    state
+                    (instruction.Arguments.[0] |> EvalStackValue.ofCliType)
+
+            let instantiationPointer =
+                NativeCall.managedPointerOfPointerArgument operation "pInstArray" instruction.Arguments.[1]
+
+            let genericArgumentCount =
+                NativeCall.int32Argument operation instruction.Arguments.[2]
+
+            let retObject =
+                NativeCall.objectHandleOnStackTarget operation state "instantiatedObject" instruction.Arguments.[3]
+
+            let genericArguments =
+                [
+                    for index in 0 .. genericArgumentCount - 1 ->
+                        readTypeHandleInstantiationElement operation state instantiationPointer index
+                ]
+
+            let instantiatedHandle, state =
+                instantiateGenericRuntimeTypeTarget
+                    ctx.LoggerFactory
+                    ctx.BaseClassTypes
+                    operation
+                    state
+                    typeHandleTarget
+                    genericArguments
+
+            let concreteType =
+                AllConcreteTypes.lookup instantiatedHandle state.ConcreteTypes
+                |> Option.defaultWith (fun () ->
+                    failwith $"%s{operation}: instantiated handle was not registered: %O{instantiatedHandle}"
+                )
+
+            let assembly =
+                state.LoadedAssembly concreteType.Assembly
+                |> Option.defaultWith (fun () ->
+                    failwith $"%s{operation}: assembly is not loaded: %s{concreteType.Assembly.FullName}"
+                )
+
+            let typeInfo = assembly.TypeDefs.[concreteType.Definition.Get]
+
+            let objectAddr, state =
+                allocateManagedObjectOfConcreteType
+                    ctx.LoggerFactory
+                    ctx.BaseClassTypes
+                    state
+                    typeInfo
+                    instantiatedHandle
+
+            let state =
+                IlMachineState.writeManagedByrefWithBase
+                    ctx.BaseClassTypes
+                    state
+                    retObject
+                    (CliType.ObjectRef (Some objectAddr))
+
+            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+        | "RuntimeTypeHandle_GetInstantiation",
+          "System.Private.CoreLib",
+          "System",
+          "RuntimeTypeHandle",
+          "GetInstantiation",
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "QCallTypeHandle",
+                                              qCallGenerics)
+            ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "ObjectHandleOnStack",
+                                              objectHandleGenerics)
+            ConcreteType state.ConcreteTypes ("System.Private.CoreLib", _, "BOOL", boolGenerics) ],
+          MethodReturnType.Void when qCallGenerics.IsEmpty && objectHandleGenerics.IsEmpty && boolGenerics.IsEmpty ->
+            let operation = "RuntimeTypeHandle.GetInstantiation"
+
+            if instruction.Arguments.Length <> 3 then
+                failwith $"%s{operation}: expected three native arguments, got %d{instruction.Arguments.Length}"
+
+            let typeHandleTarget =
+                NativeCall.qCallTypeHandleToRuntimeTypeHandleTarget
+                    operation
+                    state
+                    (instruction.Arguments.[0] |> EvalStackValue.ofCliType)
+
+            let outTypes =
+                NativeCall.objectHandleOnStackTarget operation state "types" instruction.Arguments.[1]
+
+            let asRuntimeTypeArray = boolArgument operation instruction.Arguments.[2]
+
+            let instantiation = genericInstantiation operation state typeHandleTarget
+
+            let typeArrayAddr, state =
+                allocateTypeArray ctx.LoggerFactory ctx.BaseClassTypes asRuntimeTypeArray instantiation state
+
+            let state =
+                IlMachineState.writeManagedByrefWithBase
+                    ctx.BaseClassTypes
+                    state
+                    outTypes
+                    (CliType.ObjectRef (Some typeArrayAddr))
+
+            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
         | "MethodTable_CanCompareBitsOrUseFastGetHashCode",
           "System.Private.CoreLib",
           "System",
@@ -1290,6 +1662,46 @@ module NativeRuntimeType =
 
             let state =
                 IlMachineState.pushToEvalStack (CliType.ObjectRef (Some arrayAddr)) ctx.Thread state
+
+            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+        | "System.Private.CoreLib",
+          "System",
+          "RuntimeTypeHandle",
+          "GetElementType",
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib", "System", "RuntimeType", runtimeTypeGenerics) ],
+          MethodReturnType.Returns (ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                                                      "System",
+                                                                      "RuntimeType",
+                                                                      returnTypeGenerics)) when
+            runtimeTypeGenerics.IsEmpty && returnTypeGenerics.IsEmpty
+            ->
+            let operation = "RuntimeTypeHandle.GetElementType"
+            let state = IlMachineState.loadArgument ctx.Thread 0 state
+            let runtimeTypeRef, state = IlMachineState.popEvalStack ctx.Thread state
+
+            let typeHandleTarget =
+                NativeCall.runtimeTypeHandleTargetOfRuntimeTypeRef operation state runtimeTypeRef
+
+            let state, result =
+                match typeHandleTarget with
+                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ -> state, CliType.ObjectRef None
+                | RuntimeTypeHandleTarget.Closed typeHandle ->
+                    match typeHandle with
+                    | ConcreteTypeHandle.Byref element
+                    | ConcreteTypeHandle.Pointer element
+                    | ConcreteTypeHandle.OneDimArrayZero element
+                    | ConcreteTypeHandle.Array (element, _) ->
+                        let elementTypeAddr, state =
+                            IlMachineState.getOrAllocateType
+                                ctx.LoggerFactory
+                                ctx.BaseClassTypes
+                                (RuntimeTypeHandleTarget.Closed element)
+                                state
+
+                        state, CliType.ObjectRef (Some elementTypeAddr)
+                    | ConcreteTypeHandle.Concrete _ -> state, CliType.ObjectRef None
+
+            let state = IlMachineState.pushToEvalStack result ctx.Thread state
 
             (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
         | "System.Private.CoreLib",

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -1925,5 +1925,9 @@ module NullaryIlOp =
             (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
         | Arglist -> failwith "TODO: Arglist unimplemented"
         | Ckfinite -> failwith "TODO: Ckfinite unimplemented"
-        | Readonly -> failwith "TODO: Readonly unimplemented"
+        | Readonly ->
+            state
+            |> IlMachineState.advanceProgramCounter currentThread
+            |> Tuple.withRight WhatWeDid.Executed
+            |> ExecutionResult.Stepped
         | Refanytype -> failwith "TODO: Refanytype unimplemented"

--- a/WoofWare.PawPrint/UnaryMetadataFieldOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataFieldOps.fs
@@ -279,8 +279,11 @@ module internal UnaryMetadataFieldOps =
                     failwith
                         $"TODO: ldfld {field.DeclaringType.Namespace}.{field.DeclaringType.Name}::{field.Name} through MethodTableAuxiliaryDataPtr %O{methodTableFor}"
             | EvalStackValue.NativeInt (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity)) ->
-                failwith
-                    $"TODO: ldfld {field.DeclaringType.Namespace}.{field.DeclaringType.Name}::{field.Name} through open generic RuntimeTypeHandleTarget %O{identity}"
+                match MethodTableProjection.tryProjectOpenGenericField baseClassTypes field identity state with
+                | Some (value, state) -> IlMachineState.pushToEvalStack value thread state
+                | None ->
+                    failwith
+                        $"TODO: ldfld {field.DeclaringType.Namespace}.{field.DeclaringType.Name}::{field.Name} through open generic RuntimeTypeHandleTarget %O{identity}"
             | EvalStackValue.NativeInt nativeIntSource -> failwith $"todo: nativeint {nativeIntSource}"
             | EvalStackValue.Float f -> failwith "todo: float"
             | EvalStackValue.NullObjectRef -> failwith "unreachable: NullObjectRef handled above"

--- a/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
+++ b/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
@@ -85,6 +85,7 @@
     <Compile Include="Native\NativeBuffer.fs" />
     <Compile Include="Native\NativeRuntimeType.fs" />
     <Compile Include="Native\NativeArray.fs" />
+    <Compile Include="Native\NativeEnum.fs" />
     <Compile Include="Native\NativeKernel32.fs" />
     <Compile Include="Native\NativeRuntimeAssembly.fs" />
     <Compile Include="Native\NativeQCall.fs" />


### PR DESCRIPTION
Remove EnumSemantics from the unimplemented list and add exploratory runtime support to hack through the blockers exposed by the test.