### PR TITLE
Implement RuntimeTypeHandle_GetInstantiation QCall

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/RuntimeTypeHandleGetInstantiationClosedGeneric.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/RuntimeTypeHandleGetInstantiationClosedGeneric.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace RuntimeTypeHandleGetInstantiationClosedGeneric
+{
+    class Box<T> { }
+
+    class Pair<T, U> { }
+
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            Type[] none = typeof(int).GetGenericArguments();
+            if (none.Length != 0) return 1;
+
+            Type[] one = typeof(Box<int>).GetGenericArguments();
+            if (one.Length != 1) return 2;
+            if (one[0] != typeof(int)) return 3;
+
+            Type[] two = typeof(Pair<string, int>).GetGenericArguments();
+            if (two.Length != 2) return 4;
+            if (two[0] != typeof(string)) return 5;
+            if (two[1] != typeof(int)) return 6;
+
+            return 0;
+        }
+    }
+}

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -13,6 +13,7 @@ module NativeQCall =
             "MarshalNative_SizeOfHelper", NativeMarshal.tryExecuteQCall "MarshalNative_SizeOfHelper"
             "Buffer_MemMove", NativeBuffer.tryExecuteQCall "Buffer_MemMove"
             "RuntimeTypeHandle_ConstructName", NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_ConstructName"
+            "RuntimeTypeHandle_GetInstantiation", NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_GetInstantiation"
             "MethodTable_CanCompareBitsOrUseFastGetHashCode",
             NativeRuntimeType.tryExecuteQCall "MethodTable_CanCompareBitsOrUseFastGetHashCode"
             "Array_CreateInstance", NativeArray.tryExecuteQCall "Array_CreateInstance"

--- a/WoofWare.PawPrint/Native/NativeRuntimeType.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeType.fs
@@ -1097,6 +1097,109 @@ module NativeRuntimeType =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 ret)) ctx.Thread state
 
             (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+        | "RuntimeTypeHandle_GetInstantiation",
+          "System.Private.CoreLib",
+          "System",
+          "RuntimeTypeHandle",
+          "GetInstantiation",
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "QCallTypeHandle",
+                                              qCallGenerics)
+            ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "ObjectHandleOnStack",
+                                              objectHandleGenerics)
+            _ ],
+          MethodReturnType.Void when qCallGenerics.IsEmpty && objectHandleGenerics.IsEmpty ->
+            let operation = "RuntimeTypeHandle.GetInstantiation"
+            let qCallHandle = instruction.Arguments.[0] |> EvalStackValue.ofCliType
+
+            let typeHandleTarget =
+                NativeCall.qCallTypeHandleToRuntimeTypeHandleTarget operation state qCallHandle
+
+            let retTypes =
+                NativeCall.objectHandleOnStackTarget operation state "retTypes" instruction.Arguments.[1]
+
+            // Interop.BOOL is an int32-backed enum. TRUE selects RuntimeType[]; FALSE selects Type[].
+            let asRuntimeTypeArray =
+                match CliType.unwrapPrimitiveLikeDeep instruction.Arguments.[2] with
+                | CliType.Numeric (CliNumericType.Int32 i) -> i <> 0
+                | other -> failwith $"%s{operation}: expected Interop.BOOL as Int32, got %O{other}"
+
+            let genericArguments : ImmutableArray<ConcreteTypeHandle> =
+                match typeHandleTarget with
+                | RuntimeTypeHandleTarget.Closed handle ->
+                    match handle with
+                    | ConcreteTypeHandle.Concrete _ ->
+                        let concreteType =
+                            AllConcreteTypes.lookup handle state.ConcreteTypes
+                            |> Option.defaultWith (fun () ->
+                                failwith $"%s{operation}: concrete type handle was not registered: %O{handle}"
+                            )
+
+                        concreteType.Generics
+                    | ConcreteTypeHandle.Byref _
+                    | ConcreteTypeHandle.Pointer _
+                    | ConcreteTypeHandle.OneDimArrayZero _
+                    | ConcreteTypeHandle.Array _ ->
+                        // Real .NET strips array/byref/pointer wrappers via GetRootElementType
+                        // before reaching this QCall, but be defensive: these wrappers carry
+                        // no generic instantiation of their own.
+                        ImmutableArray.Empty
+                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
+                    // Real .NET returns Type[] { typeof(T), ... } where each T is a generic
+                    // parameter. PawPrint cannot yet represent generic parameters as
+                    // RuntimeType objects, so fail loudly rather than silently returning empty.
+                    failwith
+                        $"TODO: %s{operation} for open generic type definition %O{identity}: representing generic parameters as RuntimeType objects is not yet implemented"
+
+            // Empty: leave the caller's local null. RuntimeType.GetGenericArguments handles
+            // null via `?? EmptyTypes`, matching native CopyRuntimeTypeHandles for 0 args.
+            if genericArguments.IsEmpty then
+                (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            else
+                let elementTypeName = if asRuntimeTypeArray then "RuntimeType" else "Type"
+
+                let state, _, elementTypeHandle =
+                    concretizeNonGenericCorelibType ctx.LoggerFactory ctx.BaseClassTypes state "System" elementTypeName
+
+                let arrayAddr, state =
+                    IlMachineState.allocateArray
+                        (ConcreteTypeHandle.OneDimArrayZero elementTypeHandle)
+                        (fun () -> CliType.ObjectRef None)
+                        genericArguments.Length
+                        state
+
+                let state =
+                    ((state, 0), genericArguments)
+                    ||> Seq.fold (fun (state, index) genericHandle ->
+                        let runtimeTypeAddr, state =
+                            IlMachineState.getOrAllocateType
+                                ctx.LoggerFactory
+                                ctx.BaseClassTypes
+                                (RuntimeTypeHandleTarget.Closed genericHandle)
+                                state
+
+                        let state =
+                            IlMachineState.setArrayValue
+                                arrayAddr
+                                (CliType.ObjectRef (Some runtimeTypeAddr))
+                                index
+                                state
+
+                        state, index + 1
+                    )
+                    |> fst
+
+                let state =
+                    IlMachineState.writeManagedByrefWithBase
+                        ctx.BaseClassTypes
+                        state
+                        retTypes
+                        (CliType.ObjectRef (Some arrayAddr))
+
+                (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
         | _ -> None
 
     let tryExecute (ctx : NativeCallContext) : ExecutionResult option =


### PR DESCRIPTION
Returns the generic type arguments for a RuntimeTypeHandle. This is the QCall entry point invoked when managed code calls Type.GetGenericArguments() on a closed generic type.

For closed concrete types we read .Generics off the registered concrete type and allocate a Type[]/RuntimeType[] populated with cached RuntimeType instances. For empty results we leave the caller's local null, matching the BCL's `?? EmptyTypes` fallback. Open generic definitions raise a TODO failwith because PawPrint cannot yet represent generic parameters as RuntimeType objects.