### PR TITLE
Wire ArrayTypeMismatchException into BaseClassTypes

### DIFF
--- a/WoofWare.PawPrint.Domain/TypeInfo.fs
+++ b/WoofWare.PawPrint.Domain/TypeInfo.fs
@@ -208,6 +208,7 @@ type BaseClassTypes<'corelib> =
         TypeInitializationException : TypeInfo<GenericParamFromMetadata, TypeDefn>
         IndexOutOfRangeException : TypeInfo<GenericParamFromMetadata, TypeDefn>
         InvalidCastException : TypeInfo<GenericParamFromMetadata, TypeDefn>
+        ArrayTypeMismatchException : TypeInfo<GenericParamFromMetadata, TypeDefn>
         MissingFieldException : TypeInfo<GenericParamFromMetadata, TypeDefn>
         MissingMethodException : TypeInfo<GenericParamFromMetadata, TypeDefn>
         NotSupportedException : TypeInfo<GenericParamFromMetadata, TypeDefn>

--- a/WoofWare.PawPrint/Corelib.fs
+++ b/WoofWare.PawPrint/Corelib.fs
@@ -96,6 +96,10 @@ module Corelib =
             findCorelibType corelib "System" "IndexOutOfRangeException"
 
         let invalidCastException = findCorelibType corelib "System" "InvalidCastException"
+
+        let arrayTypeMismatchException =
+            findCorelibType corelib "System" "ArrayTypeMismatchException"
+
         let missingFieldException = findCorelibType corelib "System" "MissingFieldException"
 
         let missingMethodException =
@@ -152,6 +156,7 @@ module Corelib =
             TypeInitializationException = typeInitializationException
             IndexOutOfRangeException = indexOutOfRangeException
             InvalidCastException = invalidCastException
+            ArrayTypeMismatchException = arrayTypeMismatchException
             MissingFieldException = missingFieldException
             MissingMethodException = missingMethodException
             NotSupportedException = notSupportedException


### PR DESCRIPTION
Adds the ArrayTypeMismatchException slot to BaseClassTypes alongside the other system exceptions, populated from System.ArrayTypeMismatch- Exception in the corelib. Pure plumbing; no behaviour changes.