### PR TITLE
Make CustomAttribute.Parent load-bearing

### DIFF
--- a/WoofWare.PawPrint.Domain/Assembly.fs
+++ b/WoofWare.PawPrint.Domain/Assembly.fs
@@ -482,43 +482,38 @@ module Assembly =
 
             result.ToImmutable ()
 
-        let attrs =
-            let result = ImmutableDictionary.CreateBuilder ()
+        let attrs, (customAttributesByParentToken : ImmutableDictionary<int, ImmutableArray<int>>) =
+            let attrsBuilder =
+                ImmutableDictionary.CreateBuilder<CustomAttributeHandle, WoofWare.PawPrint.CustomAttribute> ()
 
-            for field in metadataReader.CustomAttributes do
-                let fieldDefn =
-                    metadataReader.GetCustomAttribute field |> CustomAttribute.make field
+            let groupedByParent = Dictionary<int, ImmutableArray<int>.Builder> ()
 
-                result.Add (field, fieldDefn)
+            for handle in metadataReader.CustomAttributes do
+                let typed = metadataReader.GetCustomAttribute handle |> CustomAttribute.make handle
 
-            result.ToImmutable ()
+                attrsBuilder.Add (handle, typed)
 
-        let customAttributesByParentToken : ImmutableDictionary<int, ImmutableArray<int>> =
-            let grouped = Dictionary<int, ImmutableArray<int>.Builder> ()
+                let parentToken = MetadataToken.toInt typed.Parent
 
-            for attr in metadataReader.CustomAttributes do
-                let raw = metadataReader.GetCustomAttribute attr
-                let parentToken = raw.Parent.GetHashCode ()
-                // CustomAttributeHandle.GetHashCode() returns the row number only;
-                // combine with the CustomAttribute table prefix to form the full metadata token.
-                let attrToken : int = 0x0C000000 ||| attr.GetHashCode ()
+                let attrAsEntity : EntityHandle = CustomAttributeHandle.op_Implicit handle
+                let attrToken = MetadataTokens.GetToken attrAsEntity
 
                 let builder =
-                    match grouped.TryGetValue parentToken with
+                    match groupedByParent.TryGetValue parentToken with
                     | true, b -> b
                     | false, _ ->
                         let b = ImmutableArray.CreateBuilder ()
-                        grouped.[parentToken] <- b
+                        groupedByParent.[parentToken] <- b
                         b
 
                 builder.Add attrToken
 
-            let result = ImmutableDictionary.CreateBuilder ()
+            let parentTokenResult = ImmutableDictionary.CreateBuilder ()
 
-            for kvp in grouped do
-                result.Add (kvp.Key, kvp.Value.ToImmutable ())
+            for kvp in groupedByParent do
+                parentTokenResult.Add (kvp.Key, kvp.Value.ToImmutable ())
 
-            result.ToImmutable ()
+            attrsBuilder.ToImmutable (), parentTokenResult.ToImmutable ()
 
         let logger = loggerFactory.CreateLogger assy.Name.Name
 

--- a/WoofWare.PawPrint.Domain/Tokens.fs
+++ b/WoofWare.PawPrint.Domain/Tokens.fs
@@ -146,7 +146,48 @@ module MetadataToken =
         if eh.IsNil then
             failwith $"Nil EntityHandle (kind {eh.Kind})"
         else
-            ofInt (eh.GetHashCode ())
+            ofInt (MetadataTokens.GetToken eh)
+
+    /// <summary>
+    /// Converts a MetadataToken back to its raw int32 metadata token representation.
+    /// </summary>
+    let toInt (token : MetadataToken) : int32 =
+        let handle : Handle =
+            match token with
+            | MetadataToken.ModuleDefinition h -> ModuleDefinitionHandle.op_Implicit h
+            | MetadataToken.MethodImplementation h -> MethodImplementationHandle.op_Implicit h
+            | MetadataToken.MethodDef h -> MethodDefinitionHandle.op_Implicit h
+            | MetadataToken.MethodSpecification h -> MethodSpecificationHandle.op_Implicit h
+            | MetadataToken.MemberReference h -> MemberReferenceHandle.op_Implicit h
+            | MetadataToken.TypeReference h -> TypeReferenceHandle.op_Implicit h
+            | MetadataToken.AssemblyReference h -> AssemblyReferenceHandle.op_Implicit h
+            | MetadataToken.TypeSpecification h -> TypeSpecificationHandle.op_Implicit h
+            | MetadataToken.TypeDefinition h -> TypeDefinitionHandle.op_Implicit h
+            | MetadataToken.FieldDefinition h -> FieldDefinitionHandle.op_Implicit h
+            | MetadataToken.Parameter h -> ParameterHandle.op_Implicit h
+            | MetadataToken.InterfaceImplementation h -> InterfaceImplementationHandle.op_Implicit h
+            | MetadataToken.ExportedType h -> ExportedTypeHandle.op_Implicit h
+            | MetadataToken.StandaloneSignature h -> StandaloneSignatureHandle.op_Implicit h
+            | MetadataToken.EventDefinition h -> EventDefinitionHandle.op_Implicit h
+            | MetadataToken.Constant h -> ConstantHandle.op_Implicit h
+            | MetadataToken.CustomAttribute h -> CustomAttributeHandle.op_Implicit h
+            | MetadataToken.DeclarativeSecurityAttribute h -> DeclarativeSecurityAttributeHandle.op_Implicit h
+            | MetadataToken.PropertyDefinition h -> PropertyDefinitionHandle.op_Implicit h
+            | MetadataToken.ModuleReference h -> ModuleReferenceHandle.op_Implicit h
+            | MetadataToken.AssemblyFile h -> AssemblyFileHandle.op_Implicit h
+            | MetadataToken.ManifestResource h -> ManifestResourceHandle.op_Implicit h
+            | MetadataToken.GenericParameter h -> GenericParameterHandle.op_Implicit h
+            | MetadataToken.AssemblyDefinition h -> AssemblyDefinitionHandle.op_Implicit h
+            | MetadataToken.GenericParameterConstraint h -> GenericParameterConstraintHandle.op_Implicit h
+            | MetadataToken.Document h -> DocumentHandle.op_Implicit h
+            | MetadataToken.MethodDebugInformation h -> MethodDebugInformationHandle.op_Implicit h
+            | MetadataToken.LocalScope h -> LocalScopeHandle.op_Implicit h
+            | MetadataToken.LocalVariable h -> LocalVariableHandle.op_Implicit h
+            | MetadataToken.LocalConstant h -> LocalConstantHandle.op_Implicit h
+            | MetadataToken.ImportScope h -> ImportScopeHandle.op_Implicit h
+            | MetadataToken.CustomDebugInformation h -> CustomDebugInformationHandle.op_Implicit h
+
+        MetadataTokens.GetToken handle
 
 /// A metadata token operand together with the assembly whose metadata tables own it.
 /// CLI metadata tokens are only meaningful relative to a module, so executable IL


### PR DESCRIPTION
Combine the two passes over metadataReader.CustomAttributes into one, and build the parent-token index from the typed CustomAttribute.Parent field rather than re-fetching the raw row. This makes the Parent field a real consumer rather than dead state.

Also switch ofEntityHandle and the new MetadataToken.toInt helper to use MetadataTokens.GetToken, which is the documented API for converting between handles and full 32-bit metadata tokens. Previously we relied on EntityHandle.GetHashCode() returning the token, which is an undocumented implementation detail (and CustomAttributeHandle.GetHashCode returns the row number alone, which had to be OR'd with the table tag manually).