### PR TITLE
Honour PeByteRange byrefs in Unsafe.ByteOffset

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -21,10 +21,10 @@ module TestPureCases =
             "AdvancedStructLayout.cs" // blocked after fixed-buffer pointer arithmetic by MarshalNative_SizeOfHelper for ByValTStr string marshalling
             "LdtokenField.cs" // TODO: read through `ReinterpretAs` as non-primitive type .VolatileObject
             "InitializeArrayBoxedFieldHandle.cs" // blocked after MetadataImport FieldDef support by InitializeArray on a boxed RuntimeFieldHandle stub that is not in the field registry
-            "GenericEdgeCases.cs" // TODO: Unsafe.ByteOffset on unsupported byref: Pointer(<<PE data...>>)
+            "GenericEdgeCases.cs" // blocked after Unsafe.ByteOffset over PE byte ranges by unimplemented JIT intrinsic System.UInt32.Log2
             "UnsafeAs.cs" // TODO: read through `ReinterpretAs` as non-primitive type .FourBytes
             "CrossAssemblyTypes.cs" // TODO: byref element offset on non-array byref without a trailing byte-view ReinterpretAs projection
-            "InterfaceDispatch.cs" // past the UnmanagedMemoryStream wraparound check; now blocked on Unsafe.ByteOffset over a PeByteRange byref
+            "InterfaceDispatch.cs" // past Unsafe.ByteOffset over a PeByteRange byref; now blocked by unimplemented InternalCall MetadataImport::GetCustomAttributeProps
             "NullDereferenceTest.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
             "CastClassInvalid.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
             "CastclassFailures.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource

--- a/WoofWare.PawPrint.Test/sourcesPure/UnsafeByteOffsetPeByteRange.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/UnsafeByteOffsetPeByteRange.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+public class TestUnsafeByteOffsetPeByteRange
+{
+    // ReadOnlySpan<byte> bound from a byte literal is backed by PE image
+    // bytes (RuntimeHelpers.CreateSpan), giving byrefs whose root is a
+    // PeByteRange. Unsafe.ByteOffset between two such byrefs must produce
+    // the honest signed byte delta, not a synthetic cross-storage sentinel.
+    private static ReadOnlySpan<byte> Bytes => [10, 20, 30, 40, 50, 60, 70, 80];
+
+    public static int Test1()
+    {
+        ReadOnlySpan<byte> data = Bytes;
+        ref byte first = ref MemoryMarshal.GetReference(data);
+        ref byte same = ref MemoryMarshal.GetReference(data);
+        if ((long)Unsafe.ByteOffset(ref first, ref same) != 0L)
+            return 1;
+        return 0;
+    }
+
+    public static int Test2()
+    {
+        ReadOnlySpan<byte> data = Bytes;
+        ref byte first = ref MemoryMarshal.GetReference(data);
+        ref byte third = ref Unsafe.Add(ref first, 2);
+        if ((long)Unsafe.ByteOffset(ref first, ref third) != 2L)
+            return 2;
+        if ((long)Unsafe.ByteOffset(ref third, ref first) != -2L)
+            return 3;
+        return 0;
+    }
+
+    public static int Test3()
+    {
+        ReadOnlySpan<byte> data = Bytes;
+        ref byte first = ref MemoryMarshal.GetReference(data);
+        ref byte third = ref Unsafe.Add(ref first, 2);
+        ref byte sixth = ref Unsafe.Add(ref first, 5);
+        if ((long)Unsafe.ByteOffset(ref third, ref sixth) != 3L)
+            return 4;
+        if ((long)Unsafe.ByteOffset(ref sixth, ref third) != -3L)
+            return 5;
+        return 0;
+    }
+
+    // Cross-storage ByteOffset between a PE byte range and an array byref
+    // must be anti-symmetric and non-zero (the synthetic sentinel path).
+    public static int Test4()
+    {
+        ReadOnlySpan<byte> data = Bytes;
+        ref byte peRef = ref MemoryMarshal.GetReference(data);
+        byte[] heap = new byte[] { 99 };
+        long forward = (long)Unsafe.ByteOffset(ref peRef, ref heap[0]);
+        long backward = (long)Unsafe.ByteOffset(ref heap[0], ref peRef);
+        if (forward + backward != 0L)
+            return 6;
+        if (forward == 0L)
+            return 7;
+        return 0;
+    }
+
+    public static int Main(string[] argv)
+    {
+        int r = Test1();
+        if (r != 0) return r;
+        r = Test2();
+        if (r != 0) return r;
+        r = Test3();
+        if (r != 0) return r;
+        r = Test4();
+        if (r != 0) return r;
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -1535,6 +1535,8 @@ module Intrinsics =
                     ByteStorageIdentity.Array arr, int64 i * int64 elementSize + projectionByteOffset projs
                 | ManagedPointerSource.Byref (ByrefRoot.StringCharAt (str, charIndex), projs) ->
                     ByteStorageIdentity.String str, int64 charIndex * 2L + projectionByteOffset projs
+                | ManagedPointerSource.Byref (ByrefRoot.PeByteRange peByteRange, projs) ->
+                    ByteStorageIdentity.PeByteRange peByteRange, projectionByteOffset projs
                 | _ -> failwith $"TODO: Unsafe.ByteOffset on unsupported byref: %O{v}"
 
             let storage1, originOffset = extractByteLocation origin


### PR DESCRIPTION
extractByteLocation in the Unsafe.ByteOffset intrinsic previously fell through to the TODO failure for byrefs rooted at a PE byte range, even though PeByteRangePointer is already a first-class ByteStorageIdentity case used elsewhere (e.g. NativeBuffer.byteLocation). Add the missing arm so two byrefs into the same PE-data range produce an honest signed byte delta rather than the cross-storage synthetic sentinel, and so cross-storage deltas vs. heap byrefs come out correctly anti-symmetric.

Adds a focused test in sourcesPure exercising both same-range and cross-storage shapes via ReadOnlySpan<byte> literal data.