### PR TITLE
Add SuspendedForManagedCall WhatWeDid variant for native to managed continuations

### DIFF
--- a/WoofWare.PawPrint.App/DebuggerServer.fs
+++ b/WoofWare.PawPrint.App/DebuggerServer.fs
@@ -257,6 +257,7 @@ module DebuggerServer =
                 | WhatWeDid.BlockedOnClassInit blocker -> Some (threadIdValue blocker)
                 | WhatWeDid.Executed
                 | WhatWeDid.SuspendedForClassInit
+                | WhatWeDid.SuspendedForManagedCall
                 | WhatWeDid.ThrowingTypeInitializationException -> None
 
             {

--- a/WoofWare.PawPrint/AbstractMachine.fs
+++ b/WoofWare.PawPrint/AbstractMachine.fs
@@ -165,6 +165,11 @@ module AbstractMachine =
                 // A cctor was pushed; the native frame must stay on the stack so the dispatch loop
                 // runs the cctor first, then re-enters this native method on the next step.
                 ExecutionResult.Stepped (state, WhatWeDid.SuspendedForClassInit)
+            | ExecutionResult.Stepped (state, WhatWeDid.SuspendedForManagedCall) ->
+                // The native handler pushed a managed callee on top of itself; the native frame
+                // must stay on the stack so the dispatch loop runs the callee, then re-enters this
+                // native method on the next step.
+                ExecutionResult.Stepped (state, WhatWeDid.SuspendedForManagedCall)
             | ExecutionResult.Stepped (state, WhatWeDid.ThrowingTypeInitializationException) ->
                 // Exception dispatch has already unwound past this native frame to the matching
                 // handler, so returnStackFrame would pop the wrong frame.

--- a/WoofWare.PawPrint/IlMachineStateModel.fs
+++ b/WoofWare.PawPrint/IlMachineStateModel.fs
@@ -164,6 +164,15 @@ type WhatWeDid =
     | Executed
     /// We didn't run what you wanted, because we have to do class initialisation first.
     | SuspendedForClassInit
+    /// A native handler has set up a managed call as a continuation: it pushed a managed callee
+    /// frame on top of itself and now needs the dispatch loop to run that callee before returning
+    /// to the handler. The active frame is the new managed callee; the native handler frame
+    /// remains on the stack and will become active again when the callee returns. The native
+    /// handler will then be re-entered by the dispatch loop and is responsible for distinguishing
+    /// first entry from re-entry. This is the same shape as `SuspendedForClassInit` but
+    /// generalised for arbitrary managed continuations (e.g. invoking a default ctor on a
+    /// freshly-allocated object inside a QCall).
+    | SuspendedForManagedCall
     /// We can't proceed until this thread has finished the class initialisation work it's doing.
     | BlockedOnClassInit of threadBlockingUs : ThreadId
     /// A TypeInitializationException was thrown into the guest because a .cctor previously failed.

--- a/WoofWare.PawPrint/Native/NativeRuntimeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeHelpers.fs
@@ -63,6 +63,8 @@ module NativeRuntimeHelpers =
                         // this native method frame. executeOneStep re-enters here and
                         // ensureTypeInitialised will return Executed.
                         ExecutionResult.Stepped (state, WhatWeDid.SuspendedForClassInit) |> Some
+                    | WhatWeDid.SuspendedForManagedCall ->
+                        failwith "logic error: ensureTypeInitialised cannot suspend for an arbitrary managed call"
                     | WhatWeDid.ThrowingTypeInitializationException ->
                         (state, WhatWeDid.ThrowingTypeInitializationException)
                         |> ExecutionResult.Stepped

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -90,6 +90,8 @@ module Program =
             )
         | WhatWeDid.SuspendedForClassInit ->
             logger.LogTrace "Suspended execution of current method for class initialisation."
+        | WhatWeDid.SuspendedForManagedCall ->
+            logger.LogTrace "Suspended execution of native handler for a managed call continuation."
         | WhatWeDid.BlockedOnClassInit _ -> logger.LogTrace "Unable to execute because class has not yet initialised."
         | WhatWeDid.ThrowingTypeInitializationException ->
             logger.LogTrace "TypeInitializationException dispatched due to failed .cctor."
@@ -458,6 +460,8 @@ module Program =
 
         match init with
         | WhatWeDid.SuspendedForClassInit -> failwith "TODO: suspended for class init"
+        | WhatWeDid.SuspendedForManagedCall ->
+            failwith "logic error: ensureTypeInitialised cannot suspend for an arbitrary managed call"
         | WhatWeDid.BlockedOnClassInit _ -> failwith "logic error: surely this thread can't be blocked on class init"
         | WhatWeDid.ThrowingTypeInitializationException ->
             failwith "TypeInitializationException during entry point type initialisation"

--- a/WoofWare.PawPrint/Scheduler.fs
+++ b/WoofWare.PawPrint/Scheduler.fs
@@ -123,14 +123,20 @@ module Scheduler =
         match initOutcome with
         | WhatWeDid.Executed
         | WhatWeDid.SuspendedForClassInit
+        | WhatWeDid.SuspendedForManagedCall
         | WhatWeDid.ThrowingTypeInitializationException ->
             // The worker is free to run: either the type was already initialised
             // (Executed), a cctor frame was pushed on top of the target frame
             // (SuspendedForClassInit — the worker will run the cctor first, then
-            // fall into the target method), or the cached TypeInitializationException
-            // was dispatched onto the worker's frames (ThrowingTypeInit — the worker
-            // will run the exception handler / terminate on its next step). In all
-            // three cases the worker stays Runnable.
+            // fall into the target method), a managed callee was pushed on top of a
+            // native handler frame (SuspendedForManagedCall — the worker will run the
+            // callee first, then re-enter the native handler), or the cached
+            // TypeInitializationException was dispatched onto the worker's frames
+            // (ThrowingTypeInit — the worker will run the exception handler /
+            // terminate on its next step). In all four cases the worker stays Runnable.
+            // SuspendedForManagedCall isn't reachable from `ensureTypeInitialised`
+            // (which is what feeds this entry point) today, but listing it explicitly
+            // keeps the match exhaustive and documents the intended treatment.
             state
         | WhatWeDid.BlockedOnClassInit blocker ->
             // Another thread is mid-init of the worker's declaring type. StartInternal
@@ -177,7 +183,12 @@ module Scheduler =
             { state with
                 ThreadState = threadState
             }
-        | WhatWeDid.SuspendedForClassInit -> state
+        | WhatWeDid.SuspendedForClassInit
+        | WhatWeDid.SuspendedForManagedCall ->
+            // Mid-call work: another frame is now on top of `ran` and will run on its next turn.
+            // No scheduler-level transition is required for any thread; in particular, threads
+            // BlockedOnClassInit on `ran` stay parked because `ran`'s class init has not finished.
+            state
         | WhatWeDid.BlockedOnClassInit blocker ->
             { state with
                 ThreadState =

--- a/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
@@ -121,6 +121,8 @@ module internal UnaryMetadataObjectOps =
         match init with
         | WhatWeDid.BlockedOnClassInit state -> failwith "TODO: another thread is running the initialiser"
         | WhatWeDid.SuspendedForClassInit -> state, WhatWeDid.SuspendedForClassInit
+        | WhatWeDid.SuspendedForManagedCall ->
+            failwith "logic error: ensureTypeInitialised cannot suspend for an arbitrary managed call"
         | WhatWeDid.ThrowingTypeInitializationException -> state, WhatWeDid.ThrowingTypeInitializationException
         | WhatWeDid.Executed ->
 


### PR DESCRIPTION
## Summary
- Adds a new `WhatWeDid.SuspendedForManagedCall` variant for the case where a native handler pushes a managed callee on top of itself and needs the dispatch loop to run that callee before re-entering the handler.
- This is the same shape as `SuspendedForClassInit` but generalised for arbitrary managed continuations (e.g. invoking a default ctor on a freshly-allocated object inside a QCall).
- Wired through the abstract-machine dispatch loop, the scheduler, the debugger server, and the logger; defensive failwith arms added at the four call sites where `ensureTypeInitialised`'s result is matched (since that helper cannot legitimately return this variant).

## Why split from the consumer
The first consumer is `RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter`, which is the next PR. AGENTS.md asks us to PR infrastructure dependencies separately from their consumers, so this branch ships the seam alone.

## Test plan
- [x] All 590 tests pass
- [x] No new tests in this PR (no behavioural change yet — first consumer arrives in a follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)