### PR TITLE
RuntimeTypeHandle.GetElementType FCall

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -17,7 +17,7 @@ module TestPureCases =
 
     let unimplemented =
         [
-            "EnumSemantics.cs" // blocked after Enum_GetValuesAndNames by unimplemented RuntimeTypeHandle.GetElementType
+            "EnumSemantics.cs" // blocked after RuntimeTypeHandle.GetElementType by unimplemented RuntimeTypeHandle.GetInstantiation for open generic type definitions (Enum.GetValuesAndNames path)
             "AdvancedStructLayout.cs" // blocked after fixed-buffer pointer arithmetic by MarshalNative_SizeOfHelper for ByValTStr string marshalling
             "LdtokenField.cs" // TODO: read through `ReinterpretAs` as non-primitive type .VolatileObject
             "InitializeArrayBoxedFieldHandle.cs" // blocked after MetadataImport FieldDef support by InitializeArray on a boxed RuntimeFieldHandle stub that is not in the field registry

--- a/WoofWare.PawPrint.Test/sourcesPure/GetElementTypeBasic.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/GetElementTypeBasic.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+
+public class GetElementTypeBasic
+{
+    public static int Main(string[] argv)
+    {
+        // 1d szarray: int[] -> int
+        Type intArrayElement = typeof(int[]).GetElementType();
+        if (!object.ReferenceEquals(intArrayElement, typeof(int))) return 1;
+
+        // Multi-dim array: int[,] -> int (rank is dropped, not preserved)
+        Type intMatrixElement = typeof(int[,]).GetElementType();
+        if (!object.ReferenceEquals(intMatrixElement, typeof(int))) return 2;
+
+        // Higher-rank array: int[,,] -> int
+        Type intCubeElement = typeof(int[,,]).GetElementType();
+        if (!object.ReferenceEquals(intCubeElement, typeof(int))) return 3;
+
+        // Jagged array: int[][] -> int[] (element is itself a wrapper; exercises
+        // re-allocation through the type-handle registry).
+        Type jaggedElement = typeof(int[][]).GetElementType();
+        if (!object.ReferenceEquals(jaggedElement, typeof(int[]))) return 4;
+
+        // Reference-type array: string[] -> string
+        Type stringArrayElement = typeof(string[]).GetElementType();
+        if (!object.ReferenceEquals(stringArrayElement, typeof(string))) return 5;
+
+        // Concrete primitive: int -> null
+        if (typeof(int).GetElementType() != null) return 6;
+
+        // Concrete reference type: string -> null
+        if (typeof(string).GetElementType() != null) return 7;
+
+        // Closed generic: List<int> -> null
+        if (typeof(List<int>).GetElementType() != null) return 8;
+
+        // Open generic type definition: List<> -> null
+        if (typeof(List<>).GetElementType() != null) return 9;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/Native/NativeRuntimeType.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeType.fs
@@ -624,6 +624,42 @@ module NativeRuntimeType =
 
             Some addr, state
 
+    /// Returns the element handle of an array/byref/pointer wrapper, or None for
+    /// concrete types and open generic type definitions. This mirrors the .NET
+    /// rule that Type.GetElementType() returns null for anything that is not
+    /// an array, pointer, or by-ref type.
+    let private elementRuntimeType
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (typeHandleTarget : RuntimeTypeHandleTarget)
+        : ManagedHeapAddress option * IlMachineState
+        =
+        let elementHandle =
+            match typeHandleTarget with
+            | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ -> None
+            | RuntimeTypeHandleTarget.Closed typeHandle ->
+                match typeHandle with
+                | ConcreteTypeHandle.Concrete _ -> None
+                | ConcreteTypeHandle.Byref inner
+                | ConcreteTypeHandle.Pointer inner
+                | ConcreteTypeHandle.OneDimArrayZero inner -> Some inner
+                // Multi-dim arrays drop the rank: typeof(int[,]).GetElementType()
+                // returns typeof(int), not typeof(int[]).
+                | ConcreteTypeHandle.Array (inner, _) -> Some inner
+
+        match elementHandle with
+        | None -> None, state
+        | Some inner ->
+            let addr, state =
+                IlMachineState.getOrAllocateType
+                    loggerFactory
+                    baseClassTypes
+                    (RuntimeTypeHandleTarget.Closed inner)
+                    state
+
+            Some addr, state
+
     let private requireEmptyInterfaceMap
         (loggerFactory : ILoggerFactory)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
@@ -1501,6 +1537,30 @@ module NativeRuntimeType =
                 baseRuntimeType ctx.LoggerFactory ctx.BaseClassTypes state typeHandleTarget
 
             let state = NativeCall.pushObjectTarget baseTypeAddr ctx.Thread state
+
+            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+        | "System.Private.CoreLib",
+          "System",
+          "RuntimeTypeHandle",
+          "GetElementType",
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib", "System", "RuntimeType", runtimeTypeGenerics) ],
+          MethodReturnType.Returns (ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                                                      "System",
+                                                                      "RuntimeType",
+                                                                      returnTypeGenerics)) when
+            runtimeTypeGenerics.IsEmpty && returnTypeGenerics.IsEmpty
+            ->
+            let operation = "RuntimeTypeHandle.GetElementType"
+            let state = IlMachineState.loadArgument ctx.Thread 0 state
+            let runtimeTypeRef, state = IlMachineState.popEvalStack ctx.Thread state
+
+            let typeHandleTarget =
+                NativeCall.runtimeTypeHandleTargetOfRuntimeTypeRef operation state runtimeTypeRef
+
+            let elementTypeAddr, state =
+                elementRuntimeType ctx.LoggerFactory ctx.BaseClassTypes state typeHandleTarget
+
+            let state = NativeCall.pushObjectTarget elementTypeAddr ctx.Thread state
 
             (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
         | "System.Private.CoreLib",


### PR DESCRIPTION
Implement RuntimeTypeHandle.GetElementType as an InternalCall handler in the same shape as GetBaseType / GetDeclaringType. The new private helper elementRuntimeType destructures the RuntimeTypeHandleTarget directly: Byref / Pointer / OneDimArrayZero / Array yield the element handle (rank is dropped for multi-dim arrays, matching the .NET rule that typeof(int[,]).GetElementType() returns typeof(int), not typeof(int[])), while Concrete and OpenGenericTypeDefinition both return null.

Element types are re-allocated through IlMachineState.getOrAllocateType, so reflection equality holds (typeof(int[]).GetElementType() == typeof(int)) via the type-handle registry's deduplication, including for jagged elements that are themselves wrappers.

The GetElementTypeBasic test covers szarrays, multi-dim, higher-rank, jagged, reference-type elements, primitives, closed and open generics. Pointer and byref aren't exercised end-to-end because there is no path to construct typeof(T*) / typeof(ref T) from C# without MakeByRefType / MakePointerType, which are separate FCalls.

EnumSemantics.cs is no longer blocked on GetElementType but now hits RuntimeTypeHandle.GetInstantiation for open generic type definitions (Enum.GetValuesAndNames path); its unimplemented entry is updated to record the new blocker.