### PR TITLE
Resolve InitializeArray field-handle from heap stub when not registry-backed

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -20,7 +20,6 @@ module TestPureCases =
             "EnumSemantics.cs" // blocked after Enum_GetValuesAndNames by unimplemented RuntimeTypeHandle.GetElementType
             "AdvancedStructLayout.cs" // blocked after fixed-buffer pointer arithmetic by MarshalNative_SizeOfHelper for ByValTStr string marshalling
             "LdtokenField.cs" // TODO: read through `ReinterpretAs` as non-primitive type .VolatileObject
-            "InitializeArrayBoxedFieldHandle.cs" // blocked after MetadataImport FieldDef support by InitializeArray on a boxed RuntimeFieldHandle stub that is not in the field registry
             "GenericEdgeCases.cs" // blocked after Unsafe.ByteOffset over PE byte ranges by unimplemented JIT intrinsic System.UInt32.Log2
             "CrossAssemblyTypes.cs" // TODO: byref element offset on non-array byref without a trailing byte-view ReinterpretAs projection
             "InterfaceDispatch.cs" // past Unsafe.ByteOffset over a PeByteRange byref; now blocked by unimplemented InternalCall MetadataImport::GetCustomAttributeProps

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -1078,20 +1078,67 @@ module Intrinsics =
             // RuntimeFieldHandle is primitive-like (FlattenToObjectRef): its single `m_ptr`
             // (an IRuntimeFieldInfo ref) arrives on the stack flattened to an ObjectRef,
             // including after box/unbox round-trips (Unbox_Any flattens primitive-like types).
-            let runtimeFieldInfoStubAddr : ManagedHeapAddress =
+            // The referenced object can be either a RuntimeFieldInfoStub (the form that
+            // FieldHandleRegistry.getOrAllocate produces for ldtoken) or an RtFieldInfo
+            // (the form reflection's RuntimeTypeHandle.GetFields populates from the IntPtr
+            // ids returned by that QCall, https://github.com/dotnet/runtime/blob/9e5e6aa7bc36aeb2a154709a9d1192030c30a2ef/src/coreclr/System.Private.CoreLib/src/System/Reflection/RtFieldInfo.cs ).
+            let runtimeFieldInfoAddr : ManagedHeapAddress =
                 match fldHandle with
                 | EvalStackValue.ObjectRef addr -> addr
                 | EvalStackValue.NullObjectRef ->
                     failwith "TODO: throw ArgumentException for InitializeArray with null field handle"
                 | other -> failwith $"InitializeArray: expected RuntimeFieldHandle ObjectRef, got %O{other}"
 
-            // Look up the FieldHandle from the registry using the RuntimeFieldInfoStub address
+            // The address-keyed registry index is populated when PawPrint allocates a
+            // RuntimeFieldInfoStub. Reflection-produced RtFieldInfo objects are not in that
+            // index — they are constructed in managed code from the IntPtr field ids that
+            // RuntimeTypeHandle.GetFields returned, so we recover the FieldHandle by reading
+            // the heap object's `m_fieldHandle` slot and resolving it against the id-keyed
+            // index. Both RuntimeFieldInfoStub and RtFieldInfo declare a field with that name.
             let fieldHandle : FieldHandle =
-                match FieldHandleRegistry.resolveFieldFromAddress runtimeFieldInfoStubAddr state.FieldHandles with
+                match FieldHandleRegistry.resolveFieldFromAddress runtimeFieldInfoAddr state.FieldHandles with
+                | Some fh -> fh
+                | None ->
+
+                let heapObj = ManagedHeap.get runtimeFieldInfoAddr state.ManagedHeap
+
+                let typeInfo =
+                    match IlMachineState.tryGetConcreteTypeInfo state heapObj.ConcreteType with
+                    | Some (_, typeInfo) -> typeInfo
+                    | None ->
+                        failwith
+                            $"InitializeArray: object at %O{runtimeFieldInfoAddr} has concrete type %O{heapObj.ConcreteType} with no TypeDef row"
+
+                let fieldHandleField =
+                    typeInfo.Fields
+                    |> List.tryFind (fun field -> field.Name = "m_fieldHandle" && not field.IsStatic)
+                    |> Option.defaultWith (fun () ->
+                        failwith
+                            $"InitializeArray: object at %O{runtimeFieldInfoAddr} (type %s{typeInfo.Namespace}.%s{typeInfo.Name}) is not in the field handle registry and has no instance field 'm_fieldHandle' to recover the field id from"
+                    )
+
+                let fieldHandleId =
+                    let fieldId = FieldIdentity.fieldId heapObj.ConcreteType fieldHandleField
+
+                    match
+                        AllocatedNonArrayObject.DereferenceFieldById fieldId heapObj
+                        |> CliType.unwrapPrimitiveLikeDeep
+                    with
+                    | CliType.RuntimePointer (CliRuntimePointer.FieldRegistryHandle id) -> id
+                    | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.FieldHandlePtr id)) -> id
+                    | CliType.RuntimePointer (CliRuntimePointer.Verbatim 0L)
+                    | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim 0L)) ->
+                        failwith
+                            "TODO: throw ArgumentException for InitializeArray with null field handle (m_fieldHandle was zero)"
+                    | other ->
+                        failwith
+                            $"InitializeArray: m_fieldHandle on %s{typeInfo.Namespace}.%s{typeInfo.Name} did not contain a field-registry handle, got %O{other}"
+
+                match FieldHandleRegistry.resolveFieldFromId fieldHandleId state.FieldHandles with
                 | Some fh -> fh
                 | None ->
                     failwith
-                        $"InitializeArray: RuntimeFieldInfoStub at %O{runtimeFieldInfoStubAddr} not found in field handle registry"
+                        $"InitializeArray: m_fieldHandle id %d{fieldHandleId} on object at %O{runtimeFieldInfoAddr} (type %s{typeInfo.Namespace}.%s{typeInfo.Name}) was not present in the field handle registry"
 
             // Get the assembly and field definition
             let assemblyFullName = fieldHandle.GetAssemblyFullName ()

--- a/WoofWare.PawPrint/Native/NativeSignature.fs
+++ b/WoofWare.PawPrint/Native/NativeSignature.fs
@@ -4,6 +4,16 @@ open System.Collections.Immutable
 
 [<RequireQualifiedAccess>]
 module NativeSignature =
+    /// ECMA II.23.2.4 calling-convention byte for a field signature blob.
+    let private callingConventionField : int = 0x6
+
+    /// Deliberately bogus pointer value installed as the field-signature blob.
+    /// PawPrint does not yet serialise field signatures back to a COR-sig byte
+    /// stream. Anything that tries to read this pointer via the managed-pointer
+    /// boundary helpers will fail loudly through their catch-all rather than
+    /// silently treating it as null and producing an empty parse.
+    let private fieldSignatureBlobSentinel : int64 = 0xDEAD_BEEF_DEAD_BEEFL
+
     let private signatureObjectAddress (operation : string) (arg : CliType) : ManagedHeapAddress =
         match arg with
         | CliType.ObjectRef (Some addr) -> addr
@@ -161,6 +171,20 @@ module NativeSignature =
 
             let state =
                 setSignatureField state signatureAddr "m_returnTypeORfieldType" (CliType.ObjectRef (Some fieldTypeAddr))
+
+            let state =
+                setSignatureField
+                    state
+                    signatureAddr
+                    "m_managedCallingConventionAndArgIteratorFlags"
+                    (CliType.Numeric (CliNumericType.Int32 callingConventionField))
+
+            let state =
+                setSignatureField
+                    state
+                    signatureAddr
+                    "m_sig"
+                    (CliType.RuntimePointer (CliRuntimePointer.Verbatim fieldSignatureBlobSentinel))
 
             (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
         | _ -> None


### PR DESCRIPTION
The InitializeArrayBoxedFieldHandle test exercises the path where a field handle is obtained via reflection (RuntimeTypeHandle.GetFields -> RtFieldInfo) rather than from the ldtoken site that allocates a RuntimeFieldInfoStub through FieldHandleRegistry.getOrAllocate. The reflection-produced object is not in FieldHandleAddressToId, so the prior failure was 'RuntimeFieldInfoStub at ... not found in field handle registry'.

Add an address-miss fallback that reads the heap object's m_fieldHandle slot, unwraps the primitive-like value, and resolves it via FieldHandleIdToField. The field name is shared between RuntimeFieldInfoStub and RtFieldInfo so the same path covers both. Null m_fieldHandle is left as a TODO that needs a proper ArgumentException raise; an unrecognised pointer/source variant fails loudly rather than coercing.

While here, fully populate the Signature object in NativeSignature.GetSignature: write the FIELD calling-convention byte (0x6 per ECMA II.23.2.4) into
m_managedCallingConventionAndArgIteratorFlags, and a deliberately bogus sentinel into m_sig. PawPrint does not yet serialise field signatures back to a COR-sig blob, so any code that dereferences m_sig will trip the managed-pointer boundary's catch-all rather than parsing an implicit empty signature.

Supersedes #344