### PR TITLE
Add RuntimeTypeHandleTarget.GenericParameter case with stubs

### DIFF
--- a/WoofWare.PawPrint.Test/TestTypeResolution.fs
+++ b/WoofWare.PawPrint.Test/TestTypeResolution.fs
@@ -1040,6 +1040,8 @@ public class OpenBox<T> { }
         match constructedTarget with
         | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
             failwith "TypeSpec-like token was incorrectly classified as an open generic type definition"
+        | RuntimeTypeHandleTarget.GenericParameter _ ->
+            failwith "TypeSpec-like token was incorrectly classified as a generic parameter"
         | RuntimeTypeHandleTarget.Closed handle ->
             let constructed =
                 AllConcreteTypes.lookup handle state.ConcreteTypes

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -232,6 +232,13 @@ module Intrinsics =
                     | None ->
                         failwith
                             $"Type.get_IsValueType: assembly for open generic type definition is not loaded: %s{identity.AssemblyFullName}"
+                | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
+                    // CoreCLR derives IsValueType from generic-parameter constraints
+                    // (gpNotNullableValueTypeConstraint => true; gpReferenceTypeConstraint => false;
+                    // otherwise consults base type, which can be Object). Implement once constraint
+                    // metadata is wired in.
+                    failwith
+                        $"TODO: Type.get_IsValueType for generic parameter #%i{position} of %O{declaringType.TypeDefinition.Get}"
                 | RuntimeTypeHandleTarget.Closed ty ->
                     // TODO: structural handles such as typeof(int[]) still reach here as
                     // ConcreteTypeHandle.OneDimArrayZero, but this branch only handles nominal types.
@@ -250,12 +257,8 @@ module Intrinsics =
             // System.Enum. Enums cannot be generic, so an open generic type definition is never
             // an enum. Structural shapes (byref, pointer, single-dim szarray, multi-dim array)
             // never extend Enum either. CoreCLR additionally has an IsTypeDesc branch that
-            // returns IsSubclassOf(Enum) for generic parameters with the Enum constraint — that
-            // case is unreachable from here today: closed instantiations substitute `T` before
-            // `ldtoken` runs, and an unbound generic parameter fails loudly at ldtoken (see the
-            // TODO in IlMachineTypeResolution.fs that asks for a new RuntimeTypeHandleTarget
-            // generic-parameter case). When that case lands, the `match target with` below
-            // becomes non-exhaustive and warnings-as-errors will force it to be handled.
+            // returns IsSubclassOf(Enum) for generic parameters with an Enum-shaped constraint —
+            // implement that once constraint metadata reaches reflection paths.
             match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
             | [], MethodReturnType.Returns (ConcreteBool state.ConcreteTypes) -> ()
             | _ -> failwith "bad signature Type.get_IsEnum"
@@ -265,6 +268,9 @@ module Intrinsics =
             let isEnum, state =
                 match target with
                 | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ -> false, state
+                | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
+                    failwith
+                        $"TODO: Type.get_IsEnum for generic parameter #%i{position} of %O{declaringType.TypeDefinition.Get}"
                 | RuntimeTypeHandleTarget.Closed handle ->
                     match handle with
                     | ConcreteTypeHandle.Byref _
@@ -303,6 +309,9 @@ module Intrinsics =
             let isGenericType =
                 match target with
                 | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ -> true
+                // A generic parameter is itself not a generic type — it's a placeholder
+                // for one. Type.IsGenericType returns false on it in CoreCLR.
+                | RuntimeTypeHandleTarget.GenericParameter _ -> false
                 | RuntimeTypeHandleTarget.Closed ty ->
                     match ty with
                     | ConcreteTypeHandle.Concrete _ ->

--- a/WoofWare.PawPrint/MethodTableProjection.fs
+++ b/WoofWare.PawPrint/MethodTableProjection.fs
@@ -257,6 +257,9 @@ module internal MethodTableProjection =
         | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
             openGenericTypeInfoOrFail state identity
             |> categoryFlagsForTypeInfo baseClassTypes state
+        | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
+            failwith
+                $"TODO: categoryFlagsForRuntimeTypeHandleTarget for generic parameter #%i{position} of %O{declaringType.TypeDefinition.Get}"
 
     let private componentSize
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
@@ -694,10 +697,15 @@ module internal MethodTableProjection =
         | RuntimeTypeHandleTarget.Closed handle -> containsGcPointers loggerFactory baseClassTypes state handle
         | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
             openGenericContainsGcPointers loggerFactory baseClassTypes state identity
+        | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
+            failwith
+                $"TODO: containsGcPointersForRuntimeTypeHandleTarget for generic parameter #%i{position} of %O{declaringType.TypeDefinition.Get}"
 
     let private genericsFlags (state : IlMachineState) (methodTableFor : RuntimeTypeHandleTarget) : int32 =
         match methodTableFor with
         | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ -> genericsMaskTypicalInst
+        | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
+            failwith $"TODO: genericsFlags for generic parameter #%i{position} of %O{declaringType.TypeDefinition.Get}"
         | RuntimeTypeHandleTarget.Closed handle ->
             match tryArrayElement handle with
             | Some _ -> genericsMaskNonGeneric
@@ -726,6 +734,10 @@ module internal MethodTableProjection =
             else
                 true
         | RuntimeTypeHandleTarget.Closed _ -> false
+        | RuntimeTypeHandleTarget.GenericParameter _ ->
+            // A generic parameter T is itself an unbound variable, so its MethodTable contains
+            // generic variables. Treating this is conservatively correct for the flag's intent.
+            true
 
     let private containsGenericVariablesFlags
         (state : IlMachineState)
@@ -750,6 +762,7 @@ module internal MethodTableProjection =
                 Option.isSome (tryArrayElement handle)
                 || isStringType baseClassTypes state handle
             | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ -> false
+            | RuntimeTypeHandleTarget.GenericParameter _ -> false
 
         let containsGcPointers, state =
             containsGcPointersForRuntimeTypeHandleTarget loggerFactory baseClassTypes state methodTableFor
@@ -762,6 +775,7 @@ module internal MethodTableProjection =
                 int32<uint16> componentSize, state
             | RuntimeTypeHandleTarget.Closed _
             | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ -> 0, state
+            | RuntimeTypeHandleTarget.GenericParameter _ -> 0, state
 
         let flags =
             categoryFlagsForRuntimeTypeHandleTarget baseClassTypes state methodTableFor
@@ -828,12 +842,16 @@ module internal MethodTableProjection =
                 | RuntimeTypeHandleTarget.Closed handle -> Some (uint32Field (uint32 (baseSize handle)), state)
                 | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
                     failwith $"TODO: MethodTable::BaseSize projection for %O{methodTableFor}"
+                | RuntimeTypeHandleTarget.GenericParameter _ ->
+                    failwith $"TODO: MethodTable::BaseSize projection for %O{methodTableFor}"
             | "ComponentSize" ->
                 match methodTableFor with
                 | RuntimeTypeHandleTarget.Closed handle ->
                     let componentSize, state = componentSize baseClassTypes state handle
                     Some (CliType.Numeric (CliNumericType.UInt16 componentSize), state)
                 | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
+                    failwith $"TODO: MethodTable::ComponentSize projection for %O{methodTableFor}"
+                | RuntimeTypeHandleTarget.GenericParameter _ ->
                     failwith $"TODO: MethodTable::ComponentSize projection for %O{methodTableFor}"
             | "ElementType" ->
                 match methodTableFor with
@@ -844,11 +862,15 @@ module internal MethodTableProjection =
                     | None -> failwith $"TODO: MethodTable::ElementType projection for non-array type %O{handle}"
                 | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
                     failwith $"TODO: MethodTable::ElementType projection for %O{methodTableFor}"
+                | RuntimeTypeHandleTarget.GenericParameter _ ->
+                    failwith $"TODO: MethodTable::ElementType projection for %O{methodTableFor}"
             | "AuxiliaryData" ->
                 match methodTableFor with
                 | RuntimeTypeHandleTarget.Closed handle ->
                     Some (CliType.RuntimePointer (CliRuntimePointer.MethodTableAuxiliaryDataPtr handle), state)
                 | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
+                    failwith $"TODO: MethodTable::AuxiliaryData projection for %O{methodTableFor}"
+                | RuntimeTypeHandleTarget.GenericParameter _ ->
                     failwith $"TODO: MethodTable::AuxiliaryData projection for %O{methodTableFor}"
             | _ ->
                 failwith

--- a/WoofWare.PawPrint/Native/NativeArray.fs
+++ b/WoofWare.PawPrint/Native/NativeArray.fs
@@ -28,6 +28,8 @@ module NativeArray =
         match target with
         | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
             failwith $"TODO: %s{operation} for open generic type definition %O{identity}"
+        | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
+            failwith $"TODO: %s{operation} for generic parameter #%i{position} of %O{declaringType.TypeDefinition.Get}"
         | RuntimeTypeHandleTarget.Closed typeHandle ->
             if fromArrayType then
                 match typeHandle with

--- a/WoofWare.PawPrint/Native/NativeCall.fs
+++ b/WoofWare.PawPrint/Native/NativeCall.fs
@@ -69,6 +69,9 @@ module NativeCall =
         | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
             failwith
                 $"%s{operation}: expected closed RuntimeTypeHandleTarget in QCallTypeHandle._handle, but got open generic"
+        | RuntimeTypeHandleTarget.GenericParameter _ ->
+            failwith
+                $"%s{operation}: expected closed RuntimeTypeHandleTarget in QCallTypeHandle._handle, but got generic parameter"
 
     let gcHandleKindOfEvalStackValue (operation : string) (arg : EvalStackValue) : GcHandleKind =
         let value =
@@ -319,6 +322,9 @@ module NativeCall =
         =
         match typeHandleTarget with
         | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity -> identity.Assembly
+        | RuntimeTypeHandleTarget.GenericParameter (declaringType, _) ->
+            // A generic parameter belongs to the same assembly as its declaring type.
+            declaringType.Assembly
         | RuntimeTypeHandleTarget.Closed concreteTypeHandle ->
             // Unwrap Byref/Pointer/Array to reach the element type's Concrete handle.
             // In .NET, typeof(T[]).Assembly == typeof(T).Assembly, so arrays follow the

--- a/WoofWare.PawPrint/Native/NativeEnum.fs
+++ b/WoofWare.PawPrint/Native/NativeEnum.fs
@@ -23,6 +23,9 @@ module NativeEnum =
             match NativeCall.qCallTypeHandleToRuntimeTypeHandleTarget operation state arg with
             | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
                 failwith $"%s{operation}: expected a closed enum RuntimeTypeHandle, got open generic %O{identity}"
+            | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
+                failwith
+                    $"%s{operation}: expected a closed enum RuntimeTypeHandle, got generic parameter #%i{position} of %O{declaringType.TypeDefinition.Get}"
             | RuntimeTypeHandleTarget.Closed typeHandle ->
                 match typeHandle with
                 | ConcreteTypeHandle.Concrete _ -> typeHandle

--- a/WoofWare.PawPrint/Native/NativeRuntimeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeHelpers.fs
@@ -35,6 +35,8 @@ module NativeRuntimeHelpers =
             | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
                 failwith
                     $"TODO: RuntimeHelpers.RunClassConstructor for open generic type definition %O{typeHandleTarget}"
+            | RuntimeTypeHandleTarget.GenericParameter _ ->
+                failwith $"TODO: RuntimeHelpers.RunClassConstructor for generic parameter %O{typeHandleTarget}"
             | RuntimeTypeHandleTarget.Closed typeHandle ->
                 match typeHandle with
                 | ConcreteTypeHandle.Byref _

--- a/WoofWare.PawPrint/Native/NativeRuntimeType.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeType.fs
@@ -130,6 +130,8 @@ module NativeRuntimeType =
 
             let typeInfo = assembly.TypeDefs.[identity.TypeDefinition.Get]
             nominalCorElementType baseClassTypes state typeInfo
+        | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
+            failwith $"TODO: %s{operation} for generic parameter #%i{position} of %O{declaringType.TypeDefinition.Get}"
         | RuntimeTypeHandleTarget.Closed typeHandle ->
             match typeHandle with
             | ConcreteVoid state.ConcreteTypes -> 0x01
@@ -433,12 +435,14 @@ module NativeRuntimeType =
         : int32
         =
         // Generic parameter definitions have their own 0x2A metadata-token table.
-        // RuntimeTypeHandleTarget cannot represent those today; Ldtoken rejects unbound
-        // GenericTypeParameter/GenericMethodParameter tokens before allocating a RuntimeType.
-        // If we add a generic-parameter RuntimeTypeHandleTarget later, handle it here rather
-        // than projecting it through a TypeDef token.
+        // The current GenericParameter case carries declaring type + position only; constructing
+        // the GenericParam table token requires the GenericParameterHandle, which a later stage
+        // will plumb into the DU.
         match typeHandleTarget with
         | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity -> typeDefinitionToken identity.TypeDefinition.Get
+        | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
+            failwith
+                $"TODO: %s{operation} metadata token for generic parameter #%i{position} of %O{declaringType.TypeDefinition.Get}"
         | RuntimeTypeHandleTarget.Closed typeHandle ->
             match typeHandle with
             | ConcreteTypeHandle.Concrete _ ->
@@ -547,6 +551,9 @@ module NativeRuntimeType =
 
             let typeInfo = assembly.TypeDefs.[identity.TypeDefinition.Get]
             getOrAllocateDeclaringRuntimeType loggerFactory baseClassTypes state typeInfo
+        | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
+            failwith
+                $"TODO: RuntimeTypeHandle.GetDeclaringType for generic parameter #%i{position} of %O{declaringType.TypeDefinition.Get}"
         | RuntimeTypeHandleTarget.Closed typeHandle ->
             match typeHandle with
             | ConcreteTypeHandle.Byref _
@@ -618,6 +625,9 @@ module NativeRuntimeType =
                         IlMachineState.resolveBaseConcreteType loggerFactory baseClassTypes state typeHandle
 
                     baseHandle, state
+            | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
+                failwith
+                    $"TODO: RuntimeTypeHandle.GetBaseType for generic parameter #%i{position} of %O{declaringType.TypeDefinition.Get}"
 
         match baseHandle with
         | None -> None, state
@@ -645,6 +655,8 @@ module NativeRuntimeType =
         let elementHandle =
             match typeHandleTarget with
             | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ -> None
+            // A generic parameter is not an array/pointer/byref, so GetElementType returns null.
+            | RuntimeTypeHandleTarget.GenericParameter _ -> None
             | RuntimeTypeHandleTarget.Closed typeHandle ->
                 match typeHandle with
                 | ConcreteTypeHandle.Concrete _ -> None
@@ -716,6 +728,8 @@ module NativeRuntimeType =
         match typeHandleTarget with
         | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
             failwith $"TODO: %s{operation} for open generic type definition %O{identity}"
+        | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
+            failwith $"TODO: %s{operation} for generic parameter #%i{position} of %O{declaringType.TypeDefinition.Get}"
         | RuntimeTypeHandleTarget.Closed typeHandle -> walkClosedType state Set.empty typeHandle
 
     let private findCorelibType
@@ -897,6 +911,12 @@ module NativeRuntimeType =
         | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.OneDimArrayZero _)
         | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Array _) ->
             failwith $"TODO: %s{operation} for structural RuntimeTypeHandleTarget %O{target}"
+        | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
+            // A generic parameter is not itself a generic type definition, so it cannot be
+            // instantiated. Real CoreCLR throws ArgumentException; here we surface the misuse
+            // with a TODO until the caller path is exercised.
+            failwith
+                $"TODO: %s{operation}: cannot instantiate generic parameter #%i{position} of %O{declaringType.TypeDefinition.Get}"
 
     let private getOrAllocateRuntimeAssembly
         (loggerFactory : ILoggerFactory)
@@ -1134,6 +1154,8 @@ module NativeRuntimeType =
                 $"%s{name}, %s{assemblyDisplayName noVersion identity.Assembly}"
             else
                 name
+        | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
+            failwith $"TODO: %s{operation} for generic parameter #%i{position} of %O{declaringType.TypeDefinition.Get}"
 
     let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
         let state = ctx.State
@@ -1278,6 +1300,11 @@ module NativeRuntimeType =
                     // RuntimeType objects, so fail loudly rather than silently returning empty.
                     failwith
                         $"TODO: %s{operation} for open generic type definition %O{identity}: representing generic parameters as RuntimeType objects is not yet implemented"
+                | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
+                    // GetInstantiation on a generic parameter T returns Type.EmptyTypes in CoreCLR,
+                    // because a parameter has no instantiation of its own.
+                    failwith
+                        $"TODO: %s{operation} for generic parameter #%i{position} of %O{declaringType.TypeDefinition.Get}"
 
             // Empty: leave the caller's local null. RuntimeType.GetGenericArguments handles
             // null via `?? EmptyTypes`, matching native CopyRuntimeTypeHandles for 0 args.
@@ -1604,6 +1631,12 @@ module NativeRuntimeType =
                 | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
                     failwith
                         $"TODO: %s{operation} for open generic type definition %O{identity}; expected behavior is to enumerate the canonical type's non-literal fields"
+                | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
+                    // A generic parameter has no instance fields — its constraints can declare
+                    // field-bearing types but the parameter itself is not one. Real CoreCLR
+                    // returns an empty array for typeof(T).GetFields().
+                    failwith
+                        $"TODO: %s{operation} for generic parameter #%i{position} of %O{declaringType.TypeDefinition.Get}"
                 | RuntimeTypeHandleTarget.Closed typeHandle ->
                     match typeHandle with
                     | ConcreteTypeHandle.Byref _
@@ -1953,6 +1986,9 @@ module NativeRuntimeType =
                 | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
                     failwith
                         $"TODO: %s{operation} for open generic source type definition %O{identity}; need to model variance/identity rules for unbound generics"
+                | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
+                    failwith
+                        $"TODO: %s{operation} for generic parameter source #%i{position} of %O{declaringType.TypeDefinition.Get}"
 
             let targetHandle =
                 match targetTarget with
@@ -1960,6 +1996,9 @@ module NativeRuntimeType =
                 | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
                     failwith
                         $"TODO: %s{operation} for open generic target type definition %O{identity}; need to model variance/identity rules for unbound generics"
+                | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
+                    failwith
+                        $"TODO: %s{operation} for generic parameter target #%i{position} of %O{declaringType.TypeDefinition.Get}"
 
             // Reflection-only rule from CanCastToWorker(nullableCast: true): T is assignable
             // to Nullable<T> when queried via reflection, even though the runtime IL cast

--- a/WoofWare.PawPrint/NativeIntSource.fs
+++ b/WoofWare.PawPrint/NativeIntSource.fs
@@ -83,12 +83,18 @@ type UnsignedNativeIntSource =
 type RuntimeTypeHandleTarget =
     | Closed of ConcreteTypeHandle
     | OpenGenericTypeDefinition of ResolvedTypeIdentity
+    /// A generic type parameter (e.g. T in IEquatable<T>), identified by its declaring
+    /// type and zero-based position. Surfaced through reflection as a RuntimeType with
+    /// IsGenericParameter = true. Method generic parameters are not yet represented.
+    | GenericParameter of declaringType : ResolvedTypeIdentity * position : int
 
     override this.ToString () : string =
         match this with
         | RuntimeTypeHandleTarget.Closed handle -> string handle
         | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
             $"open generic definition %s{identity.Assembly.Name}/%O{identity.TypeDefinition.Get}"
+        | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
+            $"generic parameter #%i{position} of %s{declaringType.Assembly.Name}/%O{declaringType.TypeDefinition.Get}"
 
 [<RequireQualifiedAccess>]
 [<CustomEquality>]

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -74,6 +74,10 @@ module NullaryIlOp =
     let private typeHandleLowAddressBits (target : RuntimeTypeHandleTarget) : int64 =
         match target with
         | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ -> 0L
+        // Generic parameters in CoreCLR are TypeVarTypeDesc (a TypeDesc subclass), so they
+        // would carry the second-lowest tag bit. Without a real address we mirror the
+        // OpenGenericTypeDefinition convention until reflection paths require otherwise.
+        | RuntimeTypeHandleTarget.GenericParameter _ -> 0L
         | RuntimeTypeHandleTarget.Closed typeHandle ->
             match typeHandle with
             | ConcreteTypeHandle.Byref _


### PR DESCRIPTION
Pure scaffolding: introduces a third DU case for representing a generic type parameter as a RuntimeType target, identified by its declaring type and zero-based position. Every existing match site is widened to handle the new case. Sites that have a trivially-correct answer (e.g. get_IsGenericType returns false, typeAssemblyName returns the declaring type's assembly) implement that answer; sites whose semantics depend on later infrastructure return TODO failwith messages.

No callers construct GenericParameter targets yet, so all 596 existing tests continue to pass and the new arms are dead code until later stages plumb in the construction paths.