### PR TITLE
Stage B1: Read GenericParameterConstraint metadata

### DIFF
--- a/WoofWare.PawPrint.Domain/FieldInfo.fs
+++ b/WoofWare.PawPrint.Domain/FieldInfo.fs
@@ -63,7 +63,8 @@ module FieldInfo =
 
         let decType = mr.GetTypeDefinition declaringType
 
-        let typeGenerics = decType.GetGenericParameters () |> GenericParameter.readAll mr
+        let typeGenerics =
+            decType.GetGenericParameters () |> GenericParameter.readAll assembly mr
 
         let declaringTypeNamespace = mr.GetString decType.Namespace
         let declaringTypeName = mr.GetString decType.Name

--- a/WoofWare.PawPrint.Domain/GenericParameter.fs
+++ b/WoofWare.PawPrint.Domain/GenericParameter.fs
@@ -17,6 +17,16 @@ type GenericParamMetadata =
         Variance : GenericVariance option
         Constraint : GenericConstraint option
         RequiresParameterlessConstructor : bool
+        /// The general (base-type and interface) constraints declared on this parameter,
+        /// from the GenericParamConstraint table (ECMA-335 §II.22.21).
+        /// Each entry is the constraint type as a TypeDefn, decoded relative to
+        /// the assembly that owns the parameter.
+        ///
+        /// Note: this captures only the "must be assignable to" constraints. The
+        /// "struct" / "class" / "new()" flag-style constraints continue to live in
+        /// the <see cref="Constraint"/> and <see cref="RequiresParameterlessConstructor"/>
+        /// fields above.
+        Constraints : TypeDefn ImmutableArray
     }
 
 /// <summary>
@@ -39,7 +49,42 @@ type GenericParamFromMetadata = GenericParameter * GenericParamMetadata
 
 [<RequireQualifiedAccess>]
 module GenericParameter =
+    /// Decode a single constraint target (a TypeDef, TypeRef, or TypeSpec entity
+    /// handle from the GenericParamConstraint table) into a TypeDefn.
+    ///
+    /// TypeSpec targets are decoded through the normal signature decoder so that
+    /// e.g. <c>where T : IEnumerable&lt;int&gt;</c> becomes a
+    /// <see cref="TypeDefn.GenericInstantiation"/>. TypeDef and TypeRef targets
+    /// are top-level entity handles that are not embedded in a signature blob, so
+    /// we construct the TypeDefn directly. Constraint targets are restricted by
+    /// the metadata model (ECMA-335 §II.10.1.7) to non-final classes and
+    /// interfaces, so SignatureTypeKind.Class is always the correct kind.
+    let private decodeConstraintType
+        (assemblyName : AssemblyName)
+        (metadata : MetadataReader)
+        (handle : EntityHandle)
+        : TypeDefn
+        =
+        match handle.Kind with
+        | HandleKind.TypeDefinition ->
+            let typeDefHandle = TypeDefinitionHandle.op_Explicit handle
+
+            TypeDefn.FromDefinition (
+                ResolvedTypeIdentity.ofTypeDefinition assemblyName typeDefHandle,
+                SignatureTypeKind.Class
+            )
+        | HandleKind.TypeReference ->
+            let typeRefHandle = TypeReferenceHandle.op_Explicit handle
+            let typeRef = TypeRef.make metadata typeRefHandle
+            TypeDefn.FromReference (typeRef, SignatureTypeKind.Class)
+        | HandleKind.TypeSpecification ->
+            let typeSpecHandle = TypeSpecificationHandle.op_Explicit handle
+            let typeSpec = metadata.GetTypeSpecification typeSpecHandle
+            typeSpec.DecodeSignature (TypeDefn.typeProvider assemblyName, ())
+        | other -> failwith $"Unexpected GenericParamConstraint Type entity kind: %O{other}"
+
     let readAll
+        (assemblyName : AssemblyName)
         (metadata : MetadataReader)
         (param : GenericParameterHandleCollection)
         : GenericParamFromMetadata ImmutableArray
@@ -67,11 +112,21 @@ module GenericParameter =
                 else
                     None
 
+            let constraints =
+                let builder = ImmutableArray.CreateBuilder ()
+
+                for handle in param.GetConstraints () do
+                    let constr = metadata.GetGenericParameterConstraint handle
+                    builder.Add (decodeConstraintType assemblyName metadata constr.Type)
+
+                builder.ToImmutable ()
+
             let md =
                 {
                     Variance = variance
                     Constraint = constr
                     RequiresParameterlessConstructor = requiresParamlessCons
+                    Constraints = constraints
                 }
 
             let p =

--- a/WoofWare.PawPrint.Domain/GenericParameter.fs
+++ b/WoofWare.PawPrint.Domain/GenericParameter.fs
@@ -83,6 +83,30 @@ module GenericParameter =
             typeSpec.DecodeSignature (TypeDefn.typeProvider assemblyName, ())
         | other -> failwith $"Unexpected GenericParamConstraint Type entity kind: %O{other}"
 
+    /// True if this constraint row is the synthetic <c>System.ValueType</c>
+    /// reference Roslyn (and other compilers) emit alongside the
+    /// <c>NotNullableValueTypeConstraint</c> flag for <c>where T : struct</c>
+    /// (and <c>where T : unmanaged</c>). Such a row is fully redundant with
+    /// the flag, so we exclude it from <see cref="GenericParamMetadata.Constraints"/>
+    /// to keep the contract that flag-style constraints live only in the
+    /// flag-derived fields.
+    let private isSyntheticValueTypeConstraint (metadata : MetadataReader) (handle : EntityHandle) : bool =
+        match handle.Kind with
+        | HandleKind.TypeReference ->
+            let typeRef = metadata.GetTypeReference (TypeReferenceHandle.op_Explicit handle)
+
+            metadata.GetString typeRef.Namespace = "System"
+            && metadata.GetString typeRef.Name = "ValueType"
+        | HandleKind.TypeDefinition ->
+            // A direct TypeDef constraint to System.ValueType only happens
+            // when reading the corelib itself; it is still synthetic next to
+            // the value-type flag.
+            let typeDef = metadata.GetTypeDefinition (TypeDefinitionHandle.op_Explicit handle)
+
+            metadata.GetString typeDef.Namespace = "System"
+            && metadata.GetString typeDef.Name = "ValueType"
+        | _ -> false
+
     let readAll
         (assemblyName : AssemblyName)
         (metadata : MetadataReader)
@@ -112,12 +136,17 @@ module GenericParameter =
                 else
                     None
 
+            let isValueTypeFlagged =
+                param.Attributes.HasFlag GenericParameterAttributes.NotNullableValueTypeConstraint
+
             let constraints =
                 let builder = ImmutableArray.CreateBuilder ()
 
                 for handle in param.GetConstraints () do
                     let constr = metadata.GetGenericParameterConstraint handle
-                    builder.Add (decodeConstraintType assemblyName metadata constr.Type)
+
+                    if not (isValueTypeFlagged && isSyntheticValueTypeConstraint metadata constr.Type) then
+                        builder.Add (decodeConstraintType assemblyName metadata constr.Type)
 
                 builder.ToImmutable ()
 

--- a/WoofWare.PawPrint.Domain/MethodInfo.fs
+++ b/WoofWare.PawPrint.Domain/MethodInfo.fs
@@ -754,7 +754,7 @@ module MethodInfo =
 
         let declaringTypeGenericParams =
             metadataReader.GetTypeDefinition(declaringType).GetGenericParameters ()
-            |> GenericParameter.readAll metadataReader
+            |> GenericParameter.readAll assemblyName metadataReader
 
         let attrs =
             let result = ImmutableArray.CreateBuilder ()
@@ -777,7 +777,7 @@ module MethodInfo =
         let methodParams = Parameter.readAll metadataReader (methodDef.GetParameters ())
 
         let methodGenericParams =
-            GenericParameter.readAll metadataReader (methodDef.GetGenericParameters ())
+            GenericParameter.readAll assemblyName metadataReader (methodDef.GetGenericParameters ())
 
         let nativeImport =
             if methodDef.Attributes.HasFlag MethodAttributes.PinvokeImpl then

--- a/WoofWare.PawPrint.Domain/TypeInfo.fs
+++ b/WoofWare.PawPrint.Domain/TypeInfo.fs
@@ -293,7 +293,7 @@ module TypeInfo =
             |> Seq.toList
 
         let genericParams =
-            GenericParameter.readAll metadataReader (typeDef.GetGenericParameters ())
+            GenericParameter.readAll thisAssembly metadataReader (typeDef.GetGenericParameters ())
 
         let methods =
             methods

--- a/WoofWare.PawPrint.Domain/WoofWare.PawPrint.Domain.fsproj
+++ b/WoofWare.PawPrint.Domain/WoofWare.PawPrint.Domain.fsproj
@@ -13,7 +13,6 @@
         <Compile Include="TypeRef.fs" />
         <Compile Include="IlOp.fs" />
         <Compile Include="CustomAttribute.fs" />
-        <Compile Include="GenericParameter.fs" />
         <Compile Include="AssemblyReference.fs" />
         <Compile Include="EventDefn.fs" />
         <Compile Include="ComparableTypeDefinitionHandle.fs" />
@@ -22,6 +21,7 @@
         <Compile Include="ComparableSignatureHeader.fs" />
         <Compile Include="TypeIdentity.fs" />
         <Compile Include="TypeDefn.fs" />
+        <Compile Include="GenericParameter.fs" />
         <Compile Include="ConcreteType.fs" />
         <Compile Include="FieldInfo.fs" />
         <Compile Include="MethodInfo.fs" />

--- a/WoofWare.PawPrint.Test/TestGenericParamConstraints.fs
+++ b/WoofWare.PawPrint.Test/TestGenericParamConstraints.fs
@@ -97,3 +97,64 @@ public class C<T> where T : class { }
         let _, paramMd = cType.Generics.[0]
         Assert.That (paramMd.Constraint, Is.EqualTo (Some GenericConstraint.Reference))
         Assert.That (paramMd.Constraints.Length, Is.EqualTo 0)
+
+    [<Test>]
+    let ``where T : struct does not surface the synthetic System.ValueType row`` () =
+        // Roslyn emits a TypeRef to System.ValueType alongside the
+        // NotNullableValueTypeConstraint flag. That row is redundant with the
+        // flag, so it must not appear in Constraints.
+        let source =
+            """
+public class C<T> where T : struct { }
+"""
+
+        let assembly = loadAssembly "GenericParamConstraintsStructFlag" source
+        let cType = findType "C`1" assembly
+
+        let _, paramMd = cType.Generics.[0]
+        Assert.That (paramMd.Constraint, Is.EqualTo (Some GenericConstraint.NonNullableValue))
+        Assert.That (paramMd.RequiresParameterlessConstructor, Is.True)
+        Assert.That (paramMd.Constraints.Length, Is.EqualTo 0)
+
+    [<Test>]
+    let ``where T : struct, IComparable keeps the user constraint and drops the synthetic row`` () =
+        let source =
+            """
+using System;
+public class C<T> where T : struct, IComparable { }
+"""
+
+        let assembly = loadAssembly "GenericParamConstraintsStructPlusInterface" source
+        let cType = findType "C`1" assembly
+
+        let _, paramMd = cType.Generics.[0]
+        Assert.That (paramMd.Constraint, Is.EqualTo (Some GenericConstraint.NonNullableValue))
+        Assert.That (paramMd.Constraints.Length, Is.EqualTo 1)
+
+        match paramMd.Constraints.[0] with
+        | TypeDefn.FromReference (typeRef, _) ->
+            Assert.That (typeRef.Name, Is.EqualTo "IComparable")
+            Assert.That (typeRef.Namespace, Is.EqualTo "System")
+        | other -> Assert.Fail $"expected IComparable FromReference, got %O{other}"
+
+    [<Test>]
+    let ``where T : System.Enum surfaces the explicit constraint`` () =
+        // Unlike `struct`, an explicit Enum constraint is not a flag-style
+        // constraint: it must appear in Constraints.
+        let source =
+            """
+public class C<T> where T : System.Enum { }
+"""
+
+        let assembly = loadAssembly "GenericParamConstraintsEnum" source
+        let cType = findType "C`1" assembly
+
+        let _, paramMd = cType.Generics.[0]
+        Assert.That (paramMd.Constraint, Is.EqualTo (None : GenericConstraint option))
+        Assert.That (paramMd.Constraints.Length, Is.EqualTo 1)
+
+        match paramMd.Constraints.[0] with
+        | TypeDefn.FromReference (typeRef, _) ->
+            Assert.That (typeRef.Name, Is.EqualTo "Enum")
+            Assert.That (typeRef.Namespace, Is.EqualTo "System")
+        | other -> Assert.Fail $"expected System.Enum FromReference, got %O{other}"

--- a/WoofWare.PawPrint.Test/TestGenericParamConstraints.fs
+++ b/WoofWare.PawPrint.Test/TestGenericParamConstraints.fs
@@ -1,0 +1,99 @@
+namespace WoofWare.PawPrint.Test
+
+open System.IO
+open NUnit.Framework
+open WoofWare.PawPrint
+
+[<TestFixture>]
+module TestGenericParamConstraints =
+
+    let private loadAssembly (assemblyName : string) (source : string) : DumpedAssembly =
+        let image =
+            Roslyn.compileAssembly assemblyName Microsoft.CodeAnalysis.OutputKind.DynamicallyLinkedLibrary [] [ source ]
+
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use stream = new MemoryStream (image)
+        global.WoofWare.PawPrint.AssemblyApi.read loggerFactory None stream
+
+    let private findType (typeName : string) (assembly : DumpedAssembly) =
+        assembly.TypeDefs.Values |> Seq.find (fun ty -> ty.Name = typeName)
+
+    [<Test>]
+    let ``base-class and interface constraints are surfaced as Constraints array`` () =
+        let source =
+            """
+using System.Collections.Generic;
+
+public class MyBase { }
+
+public class C<T> where T : MyBase, IEnumerable<int> { }
+"""
+
+        let assembly = loadAssembly "GenericParamConstraintsTestAssembly" source
+        let cType = findType "C`1" assembly
+
+        Assert.That (cType.Generics.Length, Is.EqualTo 1)
+
+        let _, paramMd = cType.Generics.[0]
+        let constraints = paramMd.Constraints
+
+        Assert.That (constraints.Length, Is.EqualTo 2, $"expected 2 constraints, got %i{constraints.Length}")
+
+        let isMyBaseFromDefinition (t : TypeDefn) : bool =
+            match t with
+            | TypeDefn.FromDefinition (identity, _) ->
+                identity.AssemblyFullName = assembly.Name.FullName
+                && (
+                    match assembly.TypeDefs.TryGetValue identity.TypeDefinition.Get with
+                    | true, typeInfo -> typeInfo.Name = "MyBase"
+                    | false, _ -> false
+                )
+            | _ -> false
+
+        let isIEnumerableInt (t : TypeDefn) : bool =
+            match t with
+            | TypeDefn.GenericInstantiation (TypeDefn.FromReference (typeRef, _), args) ->
+                typeRef.Name = "IEnumerable`1"
+                && typeRef.Namespace = "System.Collections.Generic"
+                && args.Length = 1
+                && args.[0] = TypeDefn.PrimitiveType PrimitiveType.Int32
+            | _ -> false
+
+        Assert.That (
+            constraints |> Seq.exists isMyBaseFromDefinition,
+            $"expected MyBase FromDefinition in %A{constraints |> Seq.toList}"
+        )
+
+        Assert.That (
+            constraints |> Seq.exists isIEnumerableInt,
+            $"expected IEnumerable<int> GenericInstantiation in %A{constraints |> Seq.toList}"
+        )
+
+    [<Test>]
+    let ``no constraints yields an empty Constraints array`` () =
+        let source =
+            """
+public class C<T> { }
+"""
+
+        let assembly = loadAssembly "GenericParamConstraintsEmpty" source
+        let cType = findType "C`1" assembly
+
+        Assert.That (cType.Generics.Length, Is.EqualTo 1)
+        let _, paramMd = cType.Generics.[0]
+        Assert.That (paramMd.Constraints.Length, Is.EqualTo 0)
+
+    [<Test>]
+    let ``where T : class still yields an empty Constraints array`` () =
+        // The "class" flag-style constraint is captured in Constraint, not Constraints.
+        let source =
+            """
+public class C<T> where T : class { }
+"""
+
+        let assembly = loadAssembly "GenericParamConstraintsClassFlag" source
+        let cType = findType "C`1" assembly
+
+        let _, paramMd = cType.Generics.[0]
+        Assert.That (paramMd.Constraint, Is.EqualTo (Some GenericConstraint.Reference))
+        Assert.That (paramMd.Constraints.Length, Is.EqualTo 0)

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -42,6 +42,7 @@
     <Compile Include="TestNativeEnum.fs" />
     <Compile Include="TestMethodHandleRegistry.fs" />
     <Compile Include="TestMethodReturnType.fs" />
+    <Compile Include="TestGenericParamConstraints.fs" />
     <Compile Include="TestGcHandleRegistry.fs" />
     <Compile Include="TestPrimitiveLikeStructRegistry.fs" />
     <Compile Include="TestEvalStackPrimitiveLikeBoundary.fs" />


### PR DESCRIPTION
## Summary

- Extends `GenericParamMetadata` with `Constraints : TypeDefn ImmutableArray`, decoded from the `GenericParamConstraint` table (ECMA-335 §II.22.21).
- TypeDef/TypeRef constraint targets construct a `TypeDefn` directly (kind: `Class`, per ECMA-335 §II.10.1.7); TypeSpec targets go through the existing signature decoder, so e.g. `where T : IEnumerable<int>` becomes a `GenericInstantiation`.
- Filters Roslyn's synthetic `System.ValueType` row that accompanies the `NotNullableValueTypeConstraint` flag for `where T : struct` / `where T : unmanaged`, so flag-style constraints stay out of `Constraints`. Found by codex review.
- Plumbs the new `assemblyName` argument through `GenericParameter.readAll` call sites in `TypeInfo`, `MethodInfo`, and `FieldInfo`.

This is dead infrastructure for now — `Constraints` is read but not yet consumed by the interpreter. Subsequent Stage B work (B2–B4) will use it.

## Test plan

- [x] `nix develop -c dotnet build WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj`
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --no-build --filter "Name~GenericParamConstraints"` — 6 new tests pass:
  - `base-class and interface constraints are surfaced as Constraints array`
  - `no constraints yields an empty Constraints array`
  - `where T : class still yields an empty Constraints array`
  - `where T : struct does not surface the synthetic System.ValueType row`
  - `where T : struct, IComparable keeps the user constraint and drops the synthetic row`
  - `where T : System.Enum surfaces the explicit constraint`
- [x] Full test suite: 602/602 passing
- [x] `nix develop -c dotnet fantomas .` clean
- [x] `codex review --base main` returned no findings on the Stage B1 work

🤖 Generated with [Claude Code](https://claude.com/claude-code)