### PR TITLE
MetadataImport.GetParentToken: cover GenericParam/ParamDef/Event/Property

### DIFF
--- a/WoofWare.PawPrint.Test/TestNativeMetadataImport.fs
+++ b/WoofWare.PawPrint.Test/TestNativeMetadataImport.fs
@@ -68,6 +68,17 @@ public class OuterMetadataField
     {
     }
 }
+
+public class TypesWithMembers
+{
+    public int InstanceMethod(int x, string y) => x + y.Length;
+
+    public T GenericMethod<T>(T value) => value;
+
+    public event System.EventHandler MyEvent;
+
+    public int MyProperty { get; set; }
+}
 """
 
     type private MetadataImportFixture =
@@ -83,6 +94,7 @@ public class OuterMetadataField
             ArgumentAttrType : TypeInfo<GenericParamFromMetadata, TypeDefn>
             OuterType : TypeInfo<GenericParamFromMetadata, TypeDefn>
             InnerType : TypeInfo<GenericParamFromMetadata, TypeDefn>
+            MembersType : TypeInfo<GenericParamFromMetadata, TypeDefn>
             InstanceField : FieldInfo<GenericParamFromMetadata, TypeDefn>
             StaticField : FieldInfo<GenericParamFromMetadata, TypeDefn>
             LiteralField : FieldInfo<GenericParamFromMetadata, TypeDefn>
@@ -165,6 +177,8 @@ public class OuterMetadataField
             assembly.TryGetNestedTypeDef outerType.TypeDefHandle "InnerMetadataField"
             |> Option.defaultWith (fun () -> failwith "nested type InnerMetadataField not found")
 
+        let membersType = requiredTopLevelType assembly "" "TypesWithMembers"
+
         let constArrayType = requiredTopLevelType corelib "System.Reflection" "ConstArray"
 
         let fieldByName (name : string) : FieldInfo<GenericParamFromMetadata, TypeDefn> =
@@ -211,6 +225,7 @@ public class OuterMetadataField
             ArgumentAttrType = argumentAttrType
             OuterType = outerType
             InnerType = innerType
+            MembersType = membersType
             InstanceField = fieldByName "InstanceField"
             StaticField = fieldByName "StaticField"
             LiteralField = fieldByName "LiteralField"
@@ -739,6 +754,105 @@ public class OuterMetadataField
         let handle : EntityHandle = MethodDefinitionHandle.op_Implicit handle
         MetadataTokens.GetToken handle
 
+    let private methodHandleByName
+        (typeInfo : TypeInfo<GenericParamFromMetadata, TypeDefn>)
+        (name : string)
+        : MethodDefinitionHandle
+        =
+        typeInfo.Methods
+        |> List.tryFind (fun method -> method.Name = name)
+        |> Option.map (fun method -> method.Handle)
+        |> Option.defaultWith (fun () -> failwith $"method %s{name} not found on %s{typeInfo.Name}")
+
+    let private firstGenericParameterOfType
+        (assembly : DumpedAssembly)
+        (typeHandle : TypeDefinitionHandle)
+        : GenericParameterHandle
+        =
+        let mr = assembly.PeReader.GetMetadataReader ()
+        let typeDef = mr.GetTypeDefinition typeHandle
+        let genericParams = typeDef.GetGenericParameters ()
+
+        if genericParams.Count = 0 then
+            failwith "expected at least one generic parameter on type"
+
+        genericParams.[0]
+
+    let private firstGenericParameterOfMethod
+        (assembly : DumpedAssembly)
+        (methodHandle : MethodDefinitionHandle)
+        : GenericParameterHandle
+        =
+        let mr = assembly.PeReader.GetMetadataReader ()
+        let methodDef = mr.GetMethodDefinition methodHandle
+        let genericParams = methodDef.GetGenericParameters ()
+
+        if genericParams.Count = 0 then
+            failwith "expected at least one generic parameter on method"
+
+        genericParams.[0]
+
+    let private firstParameterOfMethod
+        (assembly : DumpedAssembly)
+        (methodHandle : MethodDefinitionHandle)
+        : ParameterHandle
+        =
+        let mr = assembly.PeReader.GetMetadataReader ()
+        let methodDef = mr.GetMethodDefinition methodHandle
+        let parameters = methodDef.GetParameters ()
+        let mutable enumerator = parameters.GetEnumerator ()
+
+        if enumerator.MoveNext () then
+            enumerator.Current
+        else
+            failwith "expected at least one parameter on method"
+
+    let private firstEventOfType
+        (assembly : DumpedAssembly)
+        (typeHandle : TypeDefinitionHandle)
+        : EventDefinitionHandle
+        =
+        let mr = assembly.PeReader.GetMetadataReader ()
+        let typeDef = mr.GetTypeDefinition typeHandle
+        let events = typeDef.GetEvents ()
+        let mutable enumerator = events.GetEnumerator ()
+
+        if enumerator.MoveNext () then
+            enumerator.Current
+        else
+            failwith "expected at least one event on type"
+
+    let private firstPropertyOfType
+        (assembly : DumpedAssembly)
+        (typeHandle : TypeDefinitionHandle)
+        : PropertyDefinitionHandle
+        =
+        let mr = assembly.PeReader.GetMetadataReader ()
+        let typeDef = mr.GetTypeDefinition typeHandle
+        let properties = typeDef.GetProperties ()
+        let mutable enumerator = properties.GetEnumerator ()
+
+        if enumerator.MoveNext () then
+            enumerator.Current
+        else
+            failwith "expected at least one property on type"
+
+    let private genericParamToken (handle : GenericParameterHandle) : int32 =
+        let handle : EntityHandle = GenericParameterHandle.op_Implicit handle
+        MetadataTokens.GetToken handle
+
+    let private parameterToken (handle : ParameterHandle) : int32 =
+        let handle : EntityHandle = ParameterHandle.op_Implicit handle
+        MetadataTokens.GetToken handle
+
+    let private eventToken (handle : EventDefinitionHandle) : int32 =
+        let handle : EntityHandle = EventDefinitionHandle.op_Implicit handle
+        MetadataTokens.GetToken handle
+
+    let private propertyToken (handle : PropertyDefinitionHandle) : int32 =
+        let handle : EntityHandle = PropertyDefinitionHandle.op_Implicit handle
+        MetadataTokens.GetToken handle
+
     [<Test>]
     let ``MetadataImport GetParentToken returns nil for top-level TypeDef`` () : unit =
         let fixture = makeFixture ()
@@ -796,6 +910,72 @@ public class OuterMetadataField
 
         returnValue |> shouldEqual (EvalStackValue.Int32 0)
         parent |> shouldEqual (typeDefToken fixture.ParameterlessAttrType.TypeDefHandle)
+
+    [<Test>]
+    let ``MetadataImport GetParentToken returns owning TypeDef for type GenericParam`` () : unit =
+        let fixture = makeFixture ()
+
+        let genericParamHandle =
+            firstGenericParameterOfType fixture.Assembly fixture.GenericType.TypeDefHandle
+
+        let returnValue, parent, _ =
+            invokeGetParentToken fixture (genericParamToken genericParamHandle) fixture.State
+
+        returnValue |> shouldEqual (EvalStackValue.Int32 0)
+        parent |> shouldEqual (typeDefToken fixture.GenericType.TypeDefHandle)
+
+    [<Test>]
+    let ``MetadataImport GetParentToken returns owning MethodDef for method GenericParam`` () : unit =
+        let fixture = makeFixture ()
+
+        let methodHandle = methodHandleByName fixture.MembersType "GenericMethod"
+
+        let genericParamHandle = firstGenericParameterOfMethod fixture.Assembly methodHandle
+
+        let returnValue, parent, _ =
+            invokeGetParentToken fixture (genericParamToken genericParamHandle) fixture.State
+
+        returnValue |> shouldEqual (EvalStackValue.Int32 0)
+        parent |> shouldEqual (methodDefToken methodHandle)
+
+    [<Test>]
+    let ``MetadataImport GetParentToken returns owning MethodDef for ParamDef`` () : unit =
+        let fixture = makeFixture ()
+
+        let methodHandle = methodHandleByName fixture.MembersType "InstanceMethod"
+        let paramHandle = firstParameterOfMethod fixture.Assembly methodHandle
+
+        let returnValue, parent, _ =
+            invokeGetParentToken fixture (parameterToken paramHandle) fixture.State
+
+        returnValue |> shouldEqual (EvalStackValue.Int32 0)
+        parent |> shouldEqual (methodDefToken methodHandle)
+
+    [<Test>]
+    let ``MetadataImport GetParentToken returns owning TypeDef for Event`` () : unit =
+        let fixture = makeFixture ()
+
+        let eventHandle =
+            firstEventOfType fixture.Assembly fixture.MembersType.TypeDefHandle
+
+        let returnValue, parent, _ =
+            invokeGetParentToken fixture (eventToken eventHandle) fixture.State
+
+        returnValue |> shouldEqual (EvalStackValue.Int32 0)
+        parent |> shouldEqual (typeDefToken fixture.MembersType.TypeDefHandle)
+
+    [<Test>]
+    let ``MetadataImport GetParentToken returns owning TypeDef for Property`` () : unit =
+        let fixture = makeFixture ()
+
+        let propertyHandle =
+            firstPropertyOfType fixture.Assembly fixture.MembersType.TypeDefHandle
+
+        let returnValue, parent, _ =
+            invokeGetParentToken fixture (propertyToken propertyHandle) fixture.State
+
+        returnValue |> shouldEqual (EvalStackValue.Int32 0)
+        parent |> shouldEqual (typeDefToken fixture.MembersType.TypeDefHandle)
 
     [<Test>]
     let ``MetadataImport GetCustomAttributeProps returns ctor token and signature blob`` () : unit =

--- a/WoofWare.PawPrint/Native/NativeMetadataImport.fs
+++ b/WoofWare.PawPrint/Native/NativeMetadataImport.fs
@@ -14,6 +14,9 @@ module NativeMetadataImport =
     /// <c>MetadataImport.GetParentToken</c> for top-level types (no NestedClass row).
     let private metadataTypeDefNil : int32 = 0x02000000
 
+    let private metadataReaderOf (assembly : DumpedAssembly) : System.Reflection.Metadata.MetadataReader =
+        System.Reflection.Metadata.PEReaderExtensions.GetMetadataReader assembly.PeReader
+
     let private metadataTokenOfFieldDefinitionHandle
         (fieldHandle : System.Reflection.Metadata.FieldDefinitionHandle)
         : int32
@@ -196,6 +199,74 @@ module NativeMetadataImport =
             else
                 failwith $"%s{operation}: FieldDef token 0x%08x{mdToken} was not present in %s{assembly.Name.FullName}"
         | token -> failwith $"%s{operation}: expected FieldDef token, got %O{token} from 0x%08x{mdToken}"
+
+    /// Walk the assembly's methods to find which one owns <paramref name="paramHandle"/>.
+    /// CLI metadata exposes the param->method relation only via per-method ranges, so
+    /// answering "who owns this Param row?" requires iterating method definitions.
+    let private methodOwningParameter
+        (assembly : DumpedAssembly)
+        (paramHandle : System.Reflection.Metadata.ParameterHandle)
+        : System.Reflection.Metadata.MethodDefinitionHandle option
+        =
+        let mr = metadataReaderOf assembly
+
+        assembly.Methods.Keys
+        |> Seq.tryFind (fun methodHandle ->
+            let methodDef = mr.GetMethodDefinition methodHandle
+            let parameters = methodDef.GetParameters ()
+            let mutable enumerator = parameters.GetEnumerator ()
+            let mutable found = false
+
+            while not found && enumerator.MoveNext () do
+                if enumerator.Current = paramHandle then
+                    found <- true
+
+            found
+        )
+
+    /// Walk the assembly's TypeDefs to find which one owns <paramref name="eventHandle"/>.
+    let private typeOwningEvent
+        (assembly : DumpedAssembly)
+        (eventHandle : System.Reflection.Metadata.EventDefinitionHandle)
+        : System.Reflection.Metadata.TypeDefinitionHandle option
+        =
+        let mr = metadataReaderOf assembly
+
+        assembly.TypeDefs.Keys
+        |> Seq.tryFind (fun typeHandle ->
+            let typeDef = mr.GetTypeDefinition typeHandle
+            let events = typeDef.GetEvents ()
+            let mutable enumerator = events.GetEnumerator ()
+            let mutable found = false
+
+            while not found && enumerator.MoveNext () do
+                if enumerator.Current = eventHandle then
+                    found <- true
+
+            found
+        )
+
+    /// Walk the assembly's TypeDefs to find which one owns <paramref name="propertyHandle"/>.
+    let private typeOwningProperty
+        (assembly : DumpedAssembly)
+        (propertyHandle : System.Reflection.Metadata.PropertyDefinitionHandle)
+        : System.Reflection.Metadata.TypeDefinitionHandle option
+        =
+        let mr = metadataReaderOf assembly
+
+        assembly.TypeDefs.Keys
+        |> Seq.tryFind (fun typeHandle ->
+            let typeDef = mr.GetTypeDefinition typeHandle
+            let properties = typeDef.GetProperties ()
+            let mutable enumerator = properties.GetEnumerator ()
+            let mutable found = false
+
+            while not found && enumerator.MoveNext () do
+                if enumerator.Current = propertyHandle then
+                    found <- true
+
+            found
+        )
 
     /// Allocate a managed <c>byte[]</c> backing buffer for an unmanaged-looking blob and return
     /// a byref to its first element. Shared by the various <c>MetadataImport</c> arms that need
@@ -664,6 +735,47 @@ module NativeMetadataImport =
                     else
                         failwith
                             $"%s{operation}: MethodSpec token 0x%08x{mdToken} was not present in %s{assemblyFullName}"
+                | MetadataToken.GenericParameter genericParamHandle ->
+                    let mr = metadataReaderOf assembly
+
+                    let parent : System.Reflection.Metadata.EntityHandle =
+                        (mr.GetGenericParameter genericParamHandle).Parent
+
+                    if parent.IsNil then
+                        failwith
+                            $"%s{operation}: GenericParameter token 0x%08x{mdToken} has nil parent in %s{assemblyFullName}"
+                    else
+                        System.Reflection.Metadata.Ecma335.MetadataTokens.GetToken parent
+                | MetadataToken.Parameter paramHandle ->
+                    match methodOwningParameter assembly paramHandle with
+                    | Some methodHandle ->
+                        let parentHandle : System.Reflection.Metadata.EntityHandle =
+                            System.Reflection.Metadata.MethodDefinitionHandle.op_Implicit methodHandle
+
+                        System.Reflection.Metadata.Ecma335.MetadataTokens.GetToken parentHandle
+                    | None ->
+                        failwith
+                            $"%s{operation}: Parameter token 0x%08x{mdToken} had no owning method in %s{assemblyFullName}"
+                | MetadataToken.EventDefinition eventHandle ->
+                    match typeOwningEvent assembly eventHandle with
+                    | Some typeHandle ->
+                        let parentHandle : System.Reflection.Metadata.EntityHandle =
+                            System.Reflection.Metadata.TypeDefinitionHandle.op_Implicit typeHandle
+
+                        System.Reflection.Metadata.Ecma335.MetadataTokens.GetToken parentHandle
+                    | None ->
+                        failwith
+                            $"%s{operation}: Event token 0x%08x{mdToken} had no owning type in %s{assemblyFullName}"
+                | MetadataToken.PropertyDefinition propertyHandle ->
+                    match typeOwningProperty assembly propertyHandle with
+                    | Some typeHandle ->
+                        let parentHandle : System.Reflection.Metadata.EntityHandle =
+                            System.Reflection.Metadata.TypeDefinitionHandle.op_Implicit typeHandle
+
+                        System.Reflection.Metadata.Ecma335.MetadataTokens.GetToken parentHandle
+                    | None ->
+                        failwith
+                            $"%s{operation}: Property token 0x%08x{mdToken} had no owning type in %s{assemblyFullName}"
                 | token ->
                     failwith $"TODO: %s{operation} does not yet support token kind %O{token} for token 0x%08x{mdToken}"
 


### PR DESCRIPTION
## Summary
- Extend `MetadataImport.GetParentToken` to handle the four remaining token kinds deferred from #418: `GenericParameter`, `Parameter`, `EventDefinition`, `PropertyDefinition`.
- `GenericParameter` reads owner directly via `MetadataReader.GetGenericParameter(handle).Parent`. The other three walk methods/types because the CLI metadata schema only exposes the relation as per-owner ranges.
- Add five new tests covering: `GenericParam` owned by a type, `GenericParam` owned by a method, `ParamDef`, `Event`, `Property`.

## Test plan
- [x] `dotnet test --filter "Name~GetParentToken"` passes (10/10)
- [x] Full `dotnet test` passes (613/613)
- [x] `fantomas .` clean
- [x] codex review (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)