### PR TITLE
Stage B2: validate special generic-parameter constraints

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -31,6 +31,9 @@ module TestPureCases =
             "Threads.cs" // blocked by pointer arithmetic over a generated Data field after Interlocked.CompareExchange
             "TypeDefCustomAttributeEnum.cs" // blocked by unimplemented RuntimeTypeHandle.GetAttributes; exercises MetadataImport.Enum over TypeDef CustomAttribute rows
             "LdelemaArrayTypeMismatch.cs" // ArrayTypeMismatchException is raised correctly, but its ctor walks past MetadataImport::GetCustomAttributeProps and now reaches unimplemented MetadataImport::GetParentToken while constructing the message
+            "MakeGenericTypeStructConstraint.cs" // negative-path constraint validation works, but the ArgumentException ctor reaches the unimplemented JIT intrinsic System.ReadOnlySpan`1.GetPinnableReference()
+            "MakeGenericTypeClassConstraint.cs" // negative-path constraint validation works, but the ArgumentException ctor reaches the unimplemented JIT intrinsic System.ReadOnlySpan`1.GetPinnableReference()
+            "MakeGenericTypeNewConstraint.cs" // negative-path constraint validation works, but the ArgumentException ctor reaches the unimplemented JIT intrinsic System.ReadOnlySpan`1.GetPinnableReference()
         ]
         |> Set.ofList
 

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -17,7 +17,6 @@ module TestPureCases =
 
     let unimplemented =
         [
-            "EnumSemantics.cs" // blocked after RuntimeTypeHandle.GetElementType by unimplemented RuntimeTypeHandle.GetInstantiation for open generic type definitions (Enum.GetValuesAndNames path)
             "AdvancedStructLayout.cs" // blocked after fixed-buffer pointer arithmetic by MarshalNative_SizeOfHelper for ByValTStr string marshalling
             "LdtokenField.cs" // TODO: read through `ReinterpretAs` as non-primitive type .VolatileObject
             "GenericEdgeCases.cs" // blocked after BitOperations.Log2 by unimplemented JIT intrinsic System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned (reached via int.ToString -> Number.UInt32ToDecStr)

--- a/WoofWare.PawPrint.Test/sourcesPure/MakeGenericTypeClassConstraint.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/MakeGenericTypeClassConstraint.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace MakeGenericTypeClassConstraint
+{
+    // CoreCLR's RuntimeTypeHandle.Instantiate validates the where-T:class
+    // (ReferenceTypeConstraint) flag and throws ArgumentException when a
+    // value-type argument is supplied. PawPrint must do the same.
+    public class WhereClass<T> where T : class { }
+
+    public class Program
+    {
+        public static int Main(string[] args)
+        {
+            // Negative: typeof(WhereClass<>).MakeGenericType(typeof(int)) must throw.
+            try
+            {
+                typeof(WhereClass<>).MakeGenericType(typeof(int));
+                return 1;
+            }
+            catch (ArgumentException)
+            {
+                // expected
+            }
+
+            // Positive: string satisfies the constraint.
+            Type closed = typeof(WhereClass<>).MakeGenericType(typeof(string));
+            if (closed != typeof(WhereClass<string>)) return 2;
+
+            return 0;
+        }
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/MakeGenericTypeNewConstraint.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/MakeGenericTypeNewConstraint.cs
@@ -1,0 +1,48 @@
+using System;
+
+namespace MakeGenericTypeNewConstraint
+{
+    // CoreCLR's RuntimeTypeHandle.Instantiate validates the where-T:new()
+    // (DefaultConstructorConstraint) flag and throws ArgumentException
+    // when the supplied type has no public parameterless ctor.
+    public class WhereNew<T> where T : new() { }
+
+    public class WithPublicDefault
+    {
+        public WithPublicDefault() { }
+    }
+
+    public class WithoutPublicDefault
+    {
+        // Only a private parameterless ctor — does not satisfy `new()`.
+        private WithoutPublicDefault() { }
+        public WithoutPublicDefault(int unused) { }
+    }
+
+    public class Program
+    {
+        public static int Main(string[] args)
+        {
+            // Negative: typeof(WhereNew<>).MakeGenericType(typeof(WithoutPublicDefault)) must throw.
+            try
+            {
+                typeof(WhereNew<>).MakeGenericType(typeof(WithoutPublicDefault));
+                return 1;
+            }
+            catch (ArgumentException)
+            {
+                // expected
+            }
+
+            // Positive: a class with a public parameterless ctor satisfies the constraint.
+            Type closedClass = typeof(WhereNew<>).MakeGenericType(typeof(WithPublicDefault));
+            if (closedClass != typeof(WhereNew<WithPublicDefault>)) return 2;
+
+            // Positive: value types implicitly satisfy the new() constraint.
+            Type closedStruct = typeof(WhereNew<>).MakeGenericType(typeof(int));
+            if (closedStruct != typeof(WhereNew<int>)) return 3;
+
+            return 0;
+        }
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/MakeGenericTypeStructConstraint.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/MakeGenericTypeStructConstraint.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace MakeGenericTypeStructConstraint
+{
+    // CoreCLR's RuntimeTypeHandle.Instantiate validates the where-T:struct
+    // (NotNullableValueTypeConstraint) flag and throws ArgumentException
+    // when a reference-type argument is supplied. PawPrint must do the same.
+    public class WhereStruct<T> where T : struct { }
+
+    public class Program
+    {
+        public static int Main(string[] args)
+        {
+            // Negative: typeof(WhereStruct<>).MakeGenericType(typeof(string)) must throw.
+            try
+            {
+                typeof(WhereStruct<>).MakeGenericType(typeof(string));
+                return 1;
+            }
+            catch (ArgumentException)
+            {
+                // expected
+            }
+
+            // Positive: int satisfies the constraint.
+            Type closed = typeof(WhereStruct<>).MakeGenericType(typeof(int));
+            if (closed != typeof(WhereStruct<int>)) return 2;
+
+            return 0;
+        }
+    }
+}

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -16,6 +16,7 @@ module NativeQCall =
             "RuntimeTypeHandle_CreateInstanceForAnotherGenericParameter",
             NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_CreateInstanceForAnotherGenericParameter"
             "RuntimeTypeHandle_GetInstantiation", NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_GetInstantiation"
+            "RuntimeTypeHandle_Instantiate", NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_Instantiate"
             "MethodTable_CanCompareBitsOrUseFastGetHashCode",
             NativeRuntimeType.tryExecuteQCall "MethodTable_CanCompareBitsOrUseFastGetHashCode"
             "Array_CreateInstance", NativeArray.tryExecuteQCall "Array_CreateInstance"

--- a/WoofWare.PawPrint/Native/NativeRuntimeType.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeType.fs
@@ -1289,6 +1289,13 @@ module NativeRuntimeType =
                         readTypeHandleInstantiationElement operation state instantiationPointer index
                 ]
 
+            // TODO: PawPrint does not yet validate generic constraints here.
+            // CoreCLR's Instantiate verifies constraints declared on the type
+            // definition (`where T : struct`, `where T : class`, base-class /
+            // interface satisfaction, etc.) and throws ArgumentException /
+            // VerificationException for invalid combinations. Until we model
+            // generic-parameter constraints, illegal instantiations succeed
+            // silently and produce a closed type that real .NET would reject.
             let instantiatedHandle, state =
                 instantiateGenericRuntimeTypeTarget
                     ctx.LoggerFactory
@@ -1344,13 +1351,26 @@ module NativeRuntimeType =
                 | other -> failwith $"%s{operation}: expected Interop.BOOL as Int32, got %O{other}"
 
             // Each entry is Some handle for a representable parameter, or None for a
-            // generic parameter that PawPrint cannot yet model as a RuntimeType. The
-            // None case only arises for open generic type definitions; closed types
-            // always yield Some entries. Surface entries straight to the allocated
-            // Type[] so callers that only need the array length (e.g. MakeGenericType's
-            // arity check, which delegates element validation to the supplied
-            // typeArguments rather than the generic parameters) work, while callers
-            // that dereference an entry get a NullReferenceException at the call site.
+            // generic parameter that PawPrint cannot yet model as a RuntimeType.
+            // The None case only arises for open generic type definitions; closed
+            // types always yield Some entries.
+            //
+            // KNOWN DIVERGENCE FROM CORECLR: CoreCLR returns a real RuntimeType
+            // representing each generic parameter (with IsGenericParameter = true,
+            // Name = "T", DeclaringType = the open generic, etc.). PawPrint does
+            // not yet have a RuntimeTypeHandleTarget case for generic parameters,
+            // so we emit null entries instead. Concretely:
+            //   - Callers that only read the array length work correctly. The
+            //     primary in-use path is RuntimeType.MakeGenericType(Type[]) for
+            //     a single RuntimeType argument: it only uses Length for the arity
+            //     check and then delegates to RuntimeTypeHandle.Instantiate, never
+            //     touching genericParameters[i].
+            //   - Callers that dereference an entry NRE at the call site. This
+            //     includes user code calling typeof(Box<>).GetGenericArguments()[i]
+            //     and CoreCLR's SanityCheckGenericArguments, which is invoked from
+            //     the multi-argument MakeGenericType path.
+            // Resolving this divergence requires representing generic parameters
+            // as RuntimeTypes; see RuntimeTypeHandleTarget.
             let genericArguments : ConcreteTypeHandle option list =
                 match typeHandleTarget with
                 | RuntimeTypeHandleTarget.Closed handle ->

--- a/WoofWare.PawPrint/Native/NativeRuntimeType.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeType.fs
@@ -1244,6 +1244,75 @@ module NativeRuntimeType =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 ret)) ctx.Thread state
 
             (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+        | "RuntimeTypeHandle_Instantiate",
+          "System.Private.CoreLib",
+          "System",
+          "RuntimeTypeHandle",
+          "Instantiate",
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "QCallTypeHandle",
+                                              qCallGenerics)
+            ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr)
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32
+            ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "ObjectHandleOnStack",
+                                              objectHandleGenerics) ],
+          MethodReturnType.Void when qCallGenerics.IsEmpty && objectHandleGenerics.IsEmpty ->
+            let operation = "RuntimeTypeHandle.Instantiate"
+
+            if instruction.Arguments.Length <> 4 then
+                failwith $"%s{operation}: expected four native arguments, got %d{instruction.Arguments.Length}"
+
+            let typeHandleTarget =
+                NativeCall.qCallTypeHandleToRuntimeTypeHandleTarget
+                    operation
+                    state
+                    (instruction.Arguments.[0] |> EvalStackValue.ofCliType)
+
+            let instantiationPointer =
+                NativeCall.managedPointerOfPointerArgument operation "pInst" instruction.Arguments.[1]
+
+            let genericArgumentCount =
+                NativeCall.int32Argument operation instruction.Arguments.[2]
+
+            if genericArgumentCount < 0 then
+                failwith $"%s{operation}: numGenericArgs must be non-negative, got %d{genericArgumentCount}"
+
+            let retType =
+                NativeCall.objectHandleOnStackTarget operation state "type" instruction.Arguments.[3]
+
+            let genericArguments =
+                [
+                    for index in 0 .. genericArgumentCount - 1 ->
+                        readTypeHandleInstantiationElement operation state instantiationPointer index
+                ]
+
+            let instantiatedHandle, state =
+                instantiateGenericRuntimeTypeTarget
+                    ctx.LoggerFactory
+                    ctx.BaseClassTypes
+                    operation
+                    state
+                    typeHandleTarget
+                    genericArguments
+
+            let runtimeTypeAddr, state =
+                IlMachineState.getOrAllocateType
+                    ctx.LoggerFactory
+                    ctx.BaseClassTypes
+                    (RuntimeTypeHandleTarget.Closed instantiatedHandle)
+                    state
+
+            let state =
+                IlMachineState.writeManagedByrefWithBase
+                    ctx.BaseClassTypes
+                    state
+                    retType
+                    (CliType.ObjectRef (Some runtimeTypeAddr))
+
+            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
         | "RuntimeTypeHandle_GetInstantiation",
           "System.Private.CoreLib",
           "System",
@@ -1274,7 +1343,15 @@ module NativeRuntimeType =
                 | CliType.Numeric (CliNumericType.Int32 i) -> i <> 0
                 | other -> failwith $"%s{operation}: expected Interop.BOOL as Int32, got %O{other}"
 
-            let genericArguments : ImmutableArray<ConcreteTypeHandle> =
+            // Each entry is Some handle for a representable parameter, or None for a
+            // generic parameter that PawPrint cannot yet model as a RuntimeType. The
+            // None case only arises for open generic type definitions; closed types
+            // always yield Some entries. Surface entries straight to the allocated
+            // Type[] so callers that only need the array length (e.g. MakeGenericType's
+            // arity check, which delegates element validation to the supplied
+            // typeArguments rather than the generic parameters) work, while callers
+            // that dereference an entry get a NullReferenceException at the call site.
+            let genericArguments : ConcreteTypeHandle option list =
                 match typeHandleTarget with
                 | RuntimeTypeHandleTarget.Closed handle ->
                     match handle with
@@ -1285,7 +1362,7 @@ module NativeRuntimeType =
                                 failwith $"%s{operation}: concrete type handle was not registered: %O{handle}"
                             )
 
-                        concreteType.Generics
+                        concreteType.Generics |> Seq.map Some |> Seq.toList
                     | ConcreteTypeHandle.Byref _
                     | ConcreteTypeHandle.Pointer _
                     | ConcreteTypeHandle.OneDimArrayZero _
@@ -1293,13 +1370,17 @@ module NativeRuntimeType =
                         // Real .NET strips array/byref/pointer wrappers via GetRootElementType
                         // before reaching this QCall, but be defensive: these wrappers carry
                         // no generic instantiation of their own.
-                        ImmutableArray.Empty
+                        []
                 | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
-                    // Real .NET returns Type[] { typeof(T), ... } where each T is a generic
-                    // parameter. PawPrint cannot yet represent generic parameters as
-                    // RuntimeType objects, so fail loudly rather than silently returning empty.
-                    failwith
-                        $"TODO: %s{operation} for open generic type definition %O{identity}: representing generic parameters as RuntimeType objects is not yet implemented"
+                    let assembly =
+                        state.LoadedAssembly identity.Assembly
+                        |> Option.defaultWith (fun () ->
+                            failwith
+                                $"%s{operation}: assembly is not loaded for open generic type definition: %s{identity.AssemblyFullName}"
+                        )
+
+                    let typeInfo = assembly.TypeDefs.[identity.TypeDefinition.Get]
+                    List.replicate typeInfo.Generics.Length None
                 | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
                     // GetInstantiation on a generic parameter T returns Type.EmptyTypes in CoreCLR,
                     // because a parameter has no instantiation of its own.
@@ -1308,7 +1389,7 @@ module NativeRuntimeType =
 
             // Empty: leave the caller's local null. RuntimeType.GetGenericArguments handles
             // null via `?? EmptyTypes`, matching native CopyRuntimeTypeHandles for 0 args.
-            if genericArguments.IsEmpty then
+            if List.isEmpty genericArguments then
                 (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
             else
                 let elementTypeName = if asRuntimeTypeArray then "RuntimeType" else "Type"
@@ -1325,22 +1406,21 @@ module NativeRuntimeType =
 
                 let state =
                     ((state, 0), genericArguments)
-                    ||> Seq.fold (fun (state, index) genericHandle ->
-                        let runtimeTypeAddr, state =
-                            IlMachineState.getOrAllocateType
-                                ctx.LoggerFactory
-                                ctx.BaseClassTypes
-                                (RuntimeTypeHandleTarget.Closed genericHandle)
-                                state
+                    ||> List.fold (fun (state, index) genericHandle ->
+                        let value, state =
+                            match genericHandle with
+                            | None -> CliType.ObjectRef None, state
+                            | Some handle ->
+                                let runtimeTypeAddr, state =
+                                    IlMachineState.getOrAllocateType
+                                        ctx.LoggerFactory
+                                        ctx.BaseClassTypes
+                                        (RuntimeTypeHandleTarget.Closed handle)
+                                        state
 
-                        let state =
-                            IlMachineState.setArrayValue
-                                arrayAddr
-                                (CliType.ObjectRef (Some runtimeTypeAddr))
-                                index
-                                state
+                                CliType.ObjectRef (Some runtimeTypeAddr), state
 
-                        state, index + 1
+                        IlMachineState.setArrayValue arrayAddr value index state, index + 1
                     )
                     |> fst
 

--- a/WoofWare.PawPrint/Native/NativeRuntimeType.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeType.fs
@@ -918,6 +918,182 @@ module NativeRuntimeType =
             failwith
                 $"TODO: %s{operation}: cannot instantiate generic parameter #%i{position} of %O{declaringType.TypeDefinition.Get}"
 
+    /// Open-generic type-definition behind a `RuntimeTypeHandleTarget`, used by the
+    /// constraint validator to look up the type definition's `Generics` (which carry
+    /// the constraint metadata read by Stage B1). Closed concrete handles are
+    /// canonicalised to their open generic identity, mirroring the canonicalisation
+    /// in `instantiateGenericRuntimeTypeTarget`.
+    let private openGenericTypeInfoForValidation
+        (state : IlMachineState)
+        (target : RuntimeTypeHandleTarget)
+        : TypeInfo<GenericParamFromMetadata, TypeDefn> option
+        =
+        let lookupFromIdentity (identity : ResolvedTypeIdentity) =
+            match state.LoadedAssembly identity.Assembly with
+            | None -> None
+            | Some assembly -> Some assembly.TypeDefs.[identity.TypeDefinition.Get]
+
+        match target with
+        | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity -> lookupFromIdentity identity
+        | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete _ as handle) ->
+            match AllConcreteTypes.lookup handle state.ConcreteTypes with
+            | None -> None
+            | Some concreteType -> lookupFromIdentity concreteType.Identity
+        | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Byref _)
+        | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Pointer _)
+        | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.OneDimArrayZero _)
+        | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Array _) ->
+            // Structural targets carry no open-generic definition. Downstream
+            // `instantiateGenericRuntimeTypeTarget` rejects them with `failwith`,
+            // so we leave validation to that path.
+            None
+        | RuntimeTypeHandleTarget.GenericParameter _ ->
+            // A generic parameter is not itself a generic type definition.
+            // Downstream code rejects this with `failwith`; no constraint to check.
+            None
+
+    /// Resolves a single closed generic argument to its underlying nominal `TypeInfo`,
+    /// or `None` if the argument is a structural shape (array, byref, pointer) that
+    /// has no nominal definition.
+    let private nominalTypeInfoOfArgument
+        (state : IlMachineState)
+        (arg : ConcreteTypeHandle)
+        : TypeInfo<GenericParamFromMetadata, TypeDefn> option
+        =
+        match arg with
+        | ConcreteTypeHandle.Concrete _ ->
+            match AllConcreteTypes.lookup arg state.ConcreteTypes with
+            | None -> None
+            | Some concreteType ->
+                match state.LoadedAssembly concreteType.Assembly with
+                | None -> None
+                | Some assembly -> Some assembly.TypeDefs.[concreteType.Definition.Get]
+        | ConcreteTypeHandle.Byref _
+        | ConcreteTypeHandle.Pointer _
+        | ConcreteTypeHandle.OneDimArrayZero _
+        | ConcreteTypeHandle.Array _ -> None
+
+    /// True iff `arg` resolves to a value type (i.e., a struct or enum).
+    let private argumentIsValueType
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (arg : ConcreteTypeHandle)
+        : bool
+        =
+        match nominalTypeInfoOfArgument state arg with
+        | None -> false // arrays / byref / pointer are not value types
+        | Some typeInfo -> DumpedAssembly.isValueType baseClassTypes state._LoadedAssemblies typeInfo
+
+    /// True iff `arg` is the corelib's `System.Nullable\`1` definition. Roslyn emits
+    /// the value-type constraint for `where T : struct` as the
+    /// `NotNullableValueTypeConstraint` flag, which forbids `Nullable<T>` even though
+    /// `Nullable<T>` is itself a value type.
+    let private argumentIsNullable
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (arg : ConcreteTypeHandle)
+        : bool
+        =
+        match nominalTypeInfoOfArgument state arg with
+        | None -> false
+        | Some typeInfo ->
+            typeInfo.Namespace = "System"
+            && typeInfo.Name = "Nullable`1"
+            && typeInfo.Assembly.FullName = baseClassTypes.Corelib.Name.FullName
+
+    /// True iff `arg` satisfies the `where T : new()` constraint:
+    /// - value types implicitly satisfy it (every value type has a parameterless ctor);
+    /// - reference types must be non-abstract, non-interface, and define a public
+    ///   parameterless instance ctor;
+    /// - structural shapes (array / byref / pointer) never satisfy it.
+    let private argumentSatisfiesNewConstraint
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (arg : ConcreteTypeHandle)
+        : bool
+        =
+        match nominalTypeInfoOfArgument state arg with
+        | None -> false
+        | Some typeInfo ->
+            if DumpedAssembly.isValueType baseClassTypes state._LoadedAssemblies typeInfo then
+                true
+            elif typeInfo.IsInterface then
+                false
+            elif typeInfo.TypeAttributes.HasFlag System.Reflection.TypeAttributes.Abstract then
+                false
+            else
+                typeInfo.Methods
+                |> List.exists (fun m ->
+                    m.Name = ".ctor"
+                    && not m.IsStatic
+                    && m.Parameters.IsEmpty
+                    && (m.MethodAttributes &&& System.Reflection.MethodAttributes.MemberAccessMask) = System.Reflection.MethodAttributes.Public
+                )
+
+    /// Validate the special-constraint flags
+    /// (`NotNullableValueTypeConstraint` / `ReferenceTypeConstraint` /
+    /// `DefaultConstructorConstraint`) declared on `typeInfo.Generics` against the
+    /// supplied closed `genericArguments`. Returns `Some message` describing the
+    /// first violation (suitable for an `ArgumentException` message), or `None` if
+    /// all flag-style constraints are satisfied.
+    ///
+    /// This does NOT validate base-type / interface (`Constraints`) requirements —
+    /// those land in Stage B3.
+    ///
+    /// CoreCLR throws either `ArgumentException` or `VerificationException`
+    /// depending on the call path; we always raise `ArgumentException`, matching
+    /// the most commonly observed user-facing exception from
+    /// `RuntimeType.MakeGenericType`. TODO: revisit if a different surface (e.g. a
+    /// guest path that goes through verification rather than reflection) needs the
+    /// other exception type.
+    let private validateSpecialConstraints
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (typeInfo : TypeInfo<GenericParamFromMetadata, TypeDefn>)
+        (genericArguments : ConcreteTypeHandle list)
+        : string option
+        =
+        if typeInfo.Generics.Length <> List.length genericArguments then
+            // Arity mismatch: defer to downstream to surface a more specific error.
+            None
+        else
+            let violationFor (param : GenericParameter) (paramMd : GenericParamMetadata) (arg : ConcreteTypeHandle) =
+                let isValue = argumentIsValueType baseClassTypes state arg
+
+                let valueTypeViolation () =
+                    if paramMd.Constraint = Some GenericConstraint.NonNullableValue then
+                        if not isValue || argumentIsNullable baseClassTypes state arg then
+                            Some
+                                $"GenericArguments[%i{param.SequenceNumber}], '%s{param.Name}', on '%s{typeInfo.Namespace}.%s{typeInfo.Name}', violates the constraint of type 'System.ValueType'."
+                        else
+                            None
+                    else
+                        None
+
+                let referenceTypeViolation () =
+                    if paramMd.Constraint = Some GenericConstraint.Reference && isValue then
+                        Some
+                            $"GenericArguments[%i{param.SequenceNumber}], '%s{param.Name}', on '%s{typeInfo.Namespace}.%s{typeInfo.Name}', violates the constraint of type 'class'."
+                    else
+                        None
+
+                let newConstraintViolation () =
+                    if
+                        paramMd.RequiresParameterlessConstructor
+                        && not (argumentSatisfiesNewConstraint baseClassTypes state arg)
+                    then
+                        Some
+                            $"GenericArguments[%i{param.SequenceNumber}], '%s{param.Name}', on '%s{typeInfo.Namespace}.%s{typeInfo.Name}', violates the constraint of type 'new()'."
+                    else
+                        None
+
+                valueTypeViolation ()
+                |> Option.orElseWith referenceTypeViolation
+                |> Option.orElseWith newConstraintViolation
+
+            Seq.zip typeInfo.Generics genericArguments
+            |> Seq.tryPick (fun ((param, paramMd), arg) -> violationFor param paramMd arg)
+
     let private getOrAllocateRuntimeAssembly
         (loggerFactory : ILoggerFactory)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
@@ -1289,13 +1465,41 @@ module NativeRuntimeType =
                         readTypeHandleInstantiationElement operation state instantiationPointer index
                 ]
 
-            // TODO: PawPrint does not yet validate generic constraints here.
-            // CoreCLR's Instantiate verifies constraints declared on the type
-            // definition (`where T : struct`, `where T : class`, base-class /
-            // interface satisfaction, etc.) and throws ArgumentException /
-            // VerificationException for invalid combinations. Until we model
-            // generic-parameter constraints, illegal instantiations succeed
-            // silently and produce a closed type that real .NET would reject.
+            // Stage B2: validate the special-constraint flags
+            // (NotNullableValueTypeConstraint / ReferenceTypeConstraint /
+            // DefaultConstructorConstraint) before instantiating. Base-type and
+            // interface (`Constraints` array) requirements are not yet validated;
+            // those will land in Stage B3.
+            let constraintViolation =
+                openGenericTypeInfoForValidation state typeHandleTarget
+                |> Option.bind (fun typeInfo ->
+                    validateSpecialConstraints ctx.BaseClassTypes state typeInfo genericArguments
+                )
+
+            match constraintViolation with
+            | Some _message ->
+                // raiseRuntimeException pushes the ArgumentException ctor frame on top of
+                // this native QCall frame and arms `dispatchAsExceptionOnReturn`, so when
+                // the ctor finishes its `Ret` will dispatch.  From the QCall dispatch
+                // loop's point of view we have set up a managed continuation, exactly the
+                // shape described by `SuspendedForManagedCall`: the native frame must
+                // stay on the stack while the ctor runs.  We override the
+                // `WhatWeDid.Executed` that `raiseRuntimeException` returns (which is
+                // the right answer for IL-handler callers, where the ctor frame becomes
+                // the new active frame and no QCall return-frame logic runs over it).
+                // Exception dispatch on the ctor's `Ret` will eventually unwind the
+                // native QCall frame too, so we never re-enter this handler.
+                let state, _ =
+                    IlMachineStateExecution.raiseRuntimeException
+                        ctx.LoggerFactory
+                        ctx.BaseClassTypes
+                        ctx.BaseClassTypes.ArgumentException
+                        ctx.Thread
+                        state
+
+                ExecutionResult.Stepped (state, WhatWeDid.SuspendedForManagedCall) |> Some
+            | None ->
+
             let instantiatedHandle, state =
                 instantiateGenericRuntimeTypeTarget
                     ctx.LoggerFactory


### PR DESCRIPTION
## Summary
- Wires the Stage B1 constraint metadata into the `RuntimeTypeHandle.Instantiate` QCall handler. Before producing a closed handle, the special-constraint flags declared on the open generic's parameters (`NotNullableValueTypeConstraint`, `ReferenceTypeConstraint`, `DefaultConstructorConstraint`) are validated against the supplied closed arguments.
- On any violation a managed `ArgumentException` is raised via `IlMachineStateExecution.raiseRuntimeException`. Because we are in a QCall native frame the helper's `WhatWeDid.Executed` is overridden with `SuspendedForManagedCall` so the dispatch loop leaves the native frame in place while the ctor runs; the eventual `Ret` will fire `dispatchAsExceptionOnReturn` and unwind the native frame as part of normal handler-search.
- Base-type / interface (`Constraints` array) requirements are still not validated — those land in Stage B3.

## Notes / divergence
- The three new C# tests (`MakeGenericTypeStructConstraint.cs`, `MakeGenericTypeClassConstraint.cs`, `MakeGenericTypeNewConstraint.cs`) are added to `unimplemented` because the `ArgumentException` ctor reaches the unimplemented JIT intrinsic ``System.ReadOnlySpan`1.GetPinnableReference()``. The validator itself is correct; the negative-path tests will pass once that intrinsic lands.

## Test plan
- [x] `nix develop -c dotnet build WoofWare.PawPrint.slnx`
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` (610 / 610 pass)
- [x] `nix develop -c dotnet fantomas .`
- [ ] `codex review --base main` (running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)