### PR TITLE
Implement Span<T>/ReadOnlySpan<T>.GetPinnableReference intrinsic

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/ReadOnlySpanGetPinnableReference.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/ReadOnlySpanGetPinnableReference.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace ReadOnlySpanGetPinnableReference
+{
+    // Exercises ReadOnlySpan<T>.GetPinnableReference() and Span<T>.GetPinnableReference().
+    // Both methods are JIT-intrinsics on real .NET, but their IL bodies just allocate
+    // a null managed pointer, branch on _length, optionally overwrite the pointer with
+    // _reference, and return.  PawPrint already models all those primitives, so the
+    // managed body is safe to run; this test pins the contract.
+    public class Program
+    {
+        public static int Main(string[] args)
+        {
+            // Non-empty ReadOnlySpan: pinnable reference must resolve to element 0.
+            int[] backing = new int[] { 42, 100 };
+            ReadOnlySpan<int> ros = backing;
+            ref readonly int rosRef = ref ros.GetPinnableReference();
+            if (rosRef != 42) return 1;
+
+            // Non-empty Span: pinnable reference must resolve to element 0.
+            Span<int> span = backing;
+            ref int spanRef = ref span.GetPinnableReference();
+            if (spanRef != 42) return 2;
+
+            // Mutating through the pinnable reference flows back into the backing array
+            // (sanity-check: this is a real byref, not a copy).
+            spanRef = 7;
+            if (backing[0] != 7) return 3;
+
+            // Empty ReadOnlySpan: GetPinnableReference returns a null ref. The caller is
+            // expected not to dereference it, so we only check that the call itself
+            // succeeds and produces something we can hand to Unsafe.IsNullRef.
+            ReadOnlySpan<int> empty = default;
+            ref readonly int emptyRef = ref empty.GetPinnableReference();
+            if (!System.Runtime.CompilerServices.Unsafe.IsNullRef(in emptyRef)) return 4;
+
+            return 0;
+        }
+    }
+}

--- a/WoofWare.PawPrint/IntrinsicMethodKeys.fs
+++ b/WoofWare.PawPrint/IntrinsicMethodKeys.fs
@@ -252,6 +252,11 @@ module IntrinsicMethodKeys =
                     IntrinsicParameterPattern.Exact "System.Int32"
                 ]
             pattern "System.Private.CoreLib" "System.ReadOnlySpan`1" "ToArray" []
+            // IL body is `Unsafe.NullRef<T>(); if (_length != 0) ret = ref _reference; return ret`.
+            // Unsafe.NullRef is implemented as an intrinsic in Intrinsics.fs; the field reads
+            // and managed-byref assignment are already-modelled span primitives.
+            // https://github.com/dotnet/runtime/blob/108fa7856efcfd39bc991c2d849eabbf7ba5989c/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs#L289
+            pattern "System.Private.CoreLib" "System.ReadOnlySpan`1" "GetPinnableReference" []
             // IL body is `ldarg.0; ldfld _length; ret`.
             pattern "System.Private.CoreLib" "System.Span`1" "get_Length" []
             // IL body is `ldarg.0; ldfld _length; ldc.i4.0; ceq; ret`.
@@ -277,6 +282,8 @@ module IntrinsicMethodKeys =
                     IntrinsicParameterPattern.Byref
                     IntrinsicParameterPattern.Exact "System.Int32"
                 ]
+            // IL body delegates to the array-backed constructor above.
+            pattern "System.Private.CoreLib" "System.Span`1" "op_Implicit" [ IntrinsicParameterPattern.SzArray ]
             // IL body constructs ReadOnlySpan<T> over this span's `_reference` and `_length`.
             pattern
                 "System.Private.CoreLib"
@@ -308,6 +315,9 @@ module IntrinsicMethodKeys =
                     IntrinsicParameterPattern.Exact "System.Int32"
                 ]
             pattern "System.Private.CoreLib" "System.Span`1" "ToArray" []
+            // Same IL body as ReadOnlySpan<T>.GetPinnableReference above.
+            // https://github.com/dotnet/runtime/blob/108fa7856efcfd39bc991c2d849eabbf7ba5989c/src/libraries/System.Private.CoreLib/src/System/Span.cs#L282
+            pattern "System.Private.CoreLib" "System.Span`1" "GetPinnableReference" []
             // https://github.com/dotnet/runtime/blob/9e5e6aa7bc36aeb2a154709a9d1192030c30a2ef/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs#L153
             anyParams "System.Private.CoreLib" "System.Runtime.CompilerServices.RuntimeHelpers" "CreateSpan"
             // https://github.com/dotnet/runtime/blob/d258af50034c192bf7f0a18856bf83d2903d98ae/src/libraries/System.Private.CoreLib/src/System/Math.cs#L127


### PR DESCRIPTION
## Summary

- Add `Span\`1.GetPinnableReference()` and `ReadOnlySpan\`1.GetPinnableReference()` to `safeIntrinsics`. Both methods are JIT intrinsics on real .NET, but their IL bodies (`Unsafe.NullRef<T>(); if (_length != 0) ret = ref _reference; return ret`) only exercise primitives PawPrint already models, so we can run the managed IL unchanged.
- Add `Span\`1.op_Implicit(T[])` to `safeIntrinsics`. Its IL is `new Span<T>(array)`, and the array-backed constructor is already a safe intrinsic; the corresponding `ReadOnlySpan\`1` overload was already in the list.
- Add a pure-source test (`ReadOnlySpanGetPinnableReference.cs`) covering: non-empty `ReadOnlySpan<T>` resolves to element 0; non-empty `Span<T>` resolves to element 0; mutation through the `Span` byref propagates to the backing array; `default(ReadOnlySpan<int>)` produces a null pinnable reference (verified via `Unsafe.IsNullRef`).

This unblocks PR #424's Stage B2 negative-path tests, which currently fail because `ArgumentException`'s constructor reaches `GetPinnableReference` internally.

## Test plan

- [x] `nix develop -c dotnet test --filter "Name~ReadOnlySpanGetPinnableReference"` passes
- [x] Full test suite passes (614 / 614)
- [x] `nix develop -c dotnet fantomas .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)