### PR TITLE
Implement DeclaringType for type-generic parameter RuntimeTypes

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/RuntimeTypeHandleTypeParameterDeclaringType.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/RuntimeTypeHandleTypeParameterDeclaringType.cs
@@ -1,0 +1,49 @@
+using System;
+
+namespace RuntimeTypeHandleTypeParameterDeclaringType
+{
+    class Box<T> { }
+
+    class Pair<T, U> { }
+
+    class Outer
+    {
+        public class Inner<X> { }
+    }
+
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            // The DeclaringType of a type-generic parameter is the open generic type
+            // that owns it. Reference equality must hold against typeof(Box<>) — the
+            // RuntimeType registry keys on structural identity, so the parameter's
+            // DeclaringType and the original typeof(Box<>) must be the same instance.
+            Type boxOpen = typeof(Box<>);
+            Type boxParam = boxOpen.GetGenericArguments()[0];
+            if (boxParam.DeclaringType == null) return 1;
+            if (!object.ReferenceEquals(boxParam.DeclaringType, boxOpen)) return 2;
+
+            // Both parameters of Pair<,> must report Pair<,> itself as their declaring
+            // type, not different types. Their position differs but their owner is shared.
+            Type pairOpen = typeof(Pair<,>);
+            Type[] pairParams = pairOpen.GetGenericArguments();
+            if (pairParams[0].DeclaringType == null) return 3;
+            if (pairParams[1].DeclaringType == null) return 4;
+            if (!object.ReferenceEquals(pairParams[0].DeclaringType, pairOpen)) return 5;
+            if (!object.ReferenceEquals(pairParams[1].DeclaringType, pairOpen)) return 6;
+
+            // For a parameter on a nested generic type, the declaring type is the nested
+            // type itself (Outer.Inner<>), not the enclosing Outer. This distinguishes
+            // "declaring type of a parameter" from "declaring type of a type" — for the
+            // latter, typeof(Outer.Inner<>).DeclaringType is Outer.
+            Type innerOpen = typeof(Outer.Inner<>);
+            Type innerParam = innerOpen.GetGenericArguments()[0];
+            if (innerParam.DeclaringType == null) return 7;
+            if (!object.ReferenceEquals(innerParam.DeclaringType, innerOpen)) return 8;
+            if (object.ReferenceEquals(innerParam.DeclaringType, typeof(Outer))) return 9;
+
+            return 0;
+        }
+    }
+}

--- a/WoofWare.PawPrint/Native/NativeRuntimeType.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeType.fs
@@ -551,9 +551,20 @@ module NativeRuntimeType =
 
             let typeInfo = assembly.TypeDefs.[identity.TypeDefinition.Get]
             getOrAllocateDeclaringRuntimeType loggerFactory baseClassTypes state typeInfo
-        | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
-            failwith
-                $"TODO: RuntimeTypeHandle.GetDeclaringType for generic parameter #%i{position} of %O{declaringType.TypeDefinition.Get}"
+        | RuntimeTypeHandleTarget.GenericParameter (declaringType, _) ->
+            // The DeclaringType of a type-generic parameter is the open generic type
+            // that declares it, not that type's enclosing type. CoreCLR exposes the
+            // same RuntimeType you would get from typeof(...): going through the
+            // structural-equality registry preserves reference equality with the
+            // existing OpenGenericTypeDefinition allocation.
+            let addr, state =
+                IlMachineState.getOrAllocateType
+                    loggerFactory
+                    baseClassTypes
+                    (RuntimeTypeHandleTarget.OpenGenericTypeDefinition declaringType)
+                    state
+
+            Some addr, state
         | RuntimeTypeHandleTarget.Closed typeHandle ->
             match typeHandle with
             | ConcreteTypeHandle.Byref _


### PR DESCRIPTION
Resolves the TODO in declaringRuntimeType for the GenericParameter case. The declaring type of a type-generic parameter is the open generic type that owns it (not the open type's enclosing type), so we route through getOrAllocateType with OpenGenericTypeDefinition to keep reference equality with the existing typeof(...) allocation via the structural registry.

The new test asserts:
- Box<>'s T.DeclaringType is reference-equal to typeof(Box<>).
- Both Pair<,> parameters share the same declaring-type instance.
- For a parameter of a nested generic Outer.Inner<>, DeclaringType is the nested type itself, distinguishing it from typeof(Outer.Inner<>) .DeclaringType (which is the enclosing Outer).