### PR TITLE
Update stale comments for MakeGenericType*Constraint unimplemented tests

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -31,9 +31,9 @@ module TestPureCases =
             "Threads.cs" // blocked by pointer arithmetic over a generated Data field after Interlocked.CompareExchange
             "TypeDefCustomAttributeEnum.cs" // blocked by unimplemented RuntimeTypeHandle.GetAttributes; exercises MetadataImport.Enum over TypeDef CustomAttribute rows
             "LdelemaArrayTypeMismatch.cs" // ArrayTypeMismatchException is raised correctly, but its ctor walks past MetadataImport::GetCustomAttributeProps and now reaches unimplemented MetadataImport::GetParentToken while constructing the message
-            "MakeGenericTypeStructConstraint.cs" // negative-path constraint validation works, but the ArgumentException ctor reaches the unimplemented JIT intrinsic System.ReadOnlySpan`1.GetPinnableReference()
-            "MakeGenericTypeClassConstraint.cs" // negative-path constraint validation works, but the ArgumentException ctor reaches the unimplemented JIT intrinsic System.ReadOnlySpan`1.GetPinnableReference()
-            "MakeGenericTypeNewConstraint.cs" // negative-path constraint validation works, but the ArgumentException ctor reaches the unimplemented JIT intrinsic System.ReadOnlySpan`1.GetPinnableReference()
+            "MakeGenericTypeStructConstraint.cs" // blocked by unimplemented QCall ModuleHandle::ResolveType (reached during MakeGenericType before the negative-path validator is invoked)
+            "MakeGenericTypeClassConstraint.cs" // blocked by unimplemented QCall ModuleHandle::ResolveType (reached during MakeGenericType before the negative-path validator is invoked)
+            "MakeGenericTypeNewConstraint.cs" // blocked by unimplemented QCall ModuleHandle::ResolveType (reached during MakeGenericType before the negative-path validator is invoked)
         ]
         |> Set.ofList
 


### PR DESCRIPTION
## Summary
- The three `MakeGenericType*Constraint.cs` entries in `unimplemented` had comments attributing the failure to the JIT intrinsic `System.ReadOnlySpan\`1.GetPinnableReference()`. That intrinsic was implemented in #425 and is no longer the blocker.
- Verified the actual current blocker by running each test through PawPrint:

  ```
  System.Exception : Unimplemented native method (PInvokeImpl QCall!ModuleHandle_ResolveType):
    System.Private.CoreLib System.ModuleHandle::ResolveType(...)
  ```

- The QCall is reached during `MakeGenericType` setup, before the negative-path constraint validator (added in #424) is invoked.

## Test plan
- [x] `nix develop -c dotnet test ... --filter "Name~MakeGenericTypeStructConstraint"` — confirms the current failure is `ModuleHandle::ResolveType`, not `GetPinnableReference`.
- [x] `nix develop -c dotnet fantomas .` — no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)