### PR TITLE
Tag generic-parameter RuntimeTypeHandleTarget as a TypeDesc

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/TypeIsInterfaceGenericParameter.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/TypeIsInterfaceGenericParameter.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+
+namespace TypeIsInterfaceGenericParameter
+{
+    class Box<T> { }
+
+    class StructBox<T> where T : struct { }
+
+    class RefBox<T> where T : class { }
+
+    class StreamBox<T> where T : Stream { }
+
+    class DisposableBox<T> where T : IDisposable { }
+
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            // RuntimeType.get_IsInterface short-circuits via TypeHandle.IsTypeDesc.
+            // Generic parameters are TypeVarTypeDesc in CoreCLR — i.e. they ARE
+            // type-descs, so IsInterface must return false without ever consulting
+            // the (non-existent) MethodTable->Flags. Exercise this for every flavor
+            // of constraint we plan to support in subsequent BaseType stages.
+            Type unc = typeof(Box<>).GetGenericArguments()[0];
+            if (unc.IsInterface) return 1;
+
+            Type vt = typeof(StructBox<>).GetGenericArguments()[0];
+            if (vt.IsInterface) return 2;
+
+            Type rt = typeof(RefBox<>).GetGenericArguments()[0];
+            if (rt.IsInterface) return 3;
+
+            Type stream = typeof(StreamBox<>).GetGenericArguments()[0];
+            if (stream.IsInterface) return 4;
+
+            Type disp = typeof(DisposableBox<>).GetGenericArguments()[0];
+            if (disp.IsInterface) return 5;
+
+            return 0;
+        }
+    }
+}

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -74,10 +74,11 @@ module NullaryIlOp =
     let private typeHandleLowAddressBits (target : RuntimeTypeHandleTarget) : int64 =
         match target with
         | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ -> 0L
-        // Generic parameters in CoreCLR are TypeVarTypeDesc (a TypeDesc subclass), so they
-        // would carry the second-lowest tag bit. Without a real address we mirror the
-        // OpenGenericTypeDefinition convention until reflection paths require otherwise.
-        | RuntimeTypeHandleTarget.GenericParameter _ -> 0L
+        // Generic parameters in CoreCLR are TypeVarTypeDesc, a TypeDesc subclass, so the
+        // tagged-pointer encoding sets the second-lowest bit. Reflection paths such as
+        // `RuntimeType.get_IsInterface` rely on `TypeHandle.IsTypeDesc` to short-circuit
+        // before dereferencing a non-existent MethodTable; honour that contract.
+        | RuntimeTypeHandleTarget.GenericParameter _ -> 2L
         | RuntimeTypeHandleTarget.Closed typeHandle ->
             match typeHandle with
             | ConcreteTypeHandle.Byref _


### PR DESCRIPTION
`RuntimeType.get_IsInterface` (and other reflection paths) short-circuit on `TypeHandle.IsTypeDesc` before dereferencing the MethodTable; if the handle's second-lowest bit is set, the BCL never asks for `Flags` and returns false. Generic parameters in CoreCLR are `TypeVarTypeDesc`, a `TypeDesc` subclass, so they belong on the tagged side of that gate.

`typeHandleLowAddressBits` was returning 0 for the `GenericParameter` case, which made `IsTypeDesc` answer false and forced the BCL into the `AsMethodTable()->IsInterface` ldfld path. That path lands in `MethodTableProjection.flagsForRuntimeTypeHandleTarget`, which has no meaningful answer for an unbound parameter and immediately fails. The existing source comment already flagged this as a placeholder pending "reflection paths require otherwise"; calling `BaseType` on a generic parameter is exactly that requirement.

Returning 2 here aligns the handle's tag with CoreCLR semantics. The function feeds only `andNativeIntAddressBits`, which is invoked by managed BCL bit-tests like `IsTypeDesc` -- so the change is scoped to TypeDesc dispatch and does not affect callers that go through `AsMethodTable()` on non-TypeDesc handles.

Test `TypeIsInterfaceGenericParameter.cs` exercises `IsInterface` on parameters with each constraint flavour we expect to support next (unconstrained, `struct`, `class`, class-constraint, interface-only constraint); each returns false without hitting the MethodTable Flags TODO.

This is the first of three small steps toward `Type.BaseType` on a type-generic parameter; the next stages add `GetConstraints` and `GenericParameterAttributes` so the BCL's managed walk has the data it needs.