### PR TITLE
Implement RuntimeTypeHandle::GetAttributes InternalCall

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -29,11 +29,11 @@ module TestPureCases =
             "RethrowStackTraceBoundary.cs" // stack trace rendering lacks CLR inner-exception boundary and parameterised frames
             "ThrowingCctorProperties.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
             "Threads.cs" // blocked by pointer arithmetic over a generated Data field after Interlocked.CompareExchange
-            "TypeDefCustomAttributeEnum.cs" // blocked by unimplemented RuntimeTypeHandle.GetAttributes; exercises MetadataImport.Enum over TypeDef CustomAttribute rows
+            "TypeDefCustomAttributeEnum.cs" // past RuntimeTypeHandle::GetAttributes; now blocked by unimplemented InternalCall MetadataImport::GetSigOfMethodDef
             "LdelemaArrayTypeMismatch.cs" // ArrayTypeMismatchException is raised correctly, but its ctor walks past MetadataImport::GetCustomAttributeProps and now reaches unimplemented MetadataImport::GetParentToken while constructing the message
-            "MakeGenericTypeStructConstraint.cs" // past ModuleHandle::ResolveType; now blocked by unimplemented InternalCall RuntimeTypeHandle::GetAttributes during ArgumentException ctor → ResourceManager init
-            "MakeGenericTypeClassConstraint.cs" // past ModuleHandle::ResolveType; now blocked by unimplemented InternalCall RuntimeTypeHandle::GetAttributes during ArgumentException ctor → ResourceManager init
-            "MakeGenericTypeNewConstraint.cs" // past ModuleHandle::ResolveType; now blocked by unimplemented InternalCall RuntimeTypeHandle::GetAttributes during ArgumentException ctor → ResourceManager init
+            "MakeGenericTypeStructConstraint.cs" // past RuntimeTypeHandle::GetAttributes; now blocked by unimplemented InternalCall MetadataImport::GetSigOfMethodDef during ArgumentException ctor → ResourceManager init
+            "MakeGenericTypeClassConstraint.cs" // past RuntimeTypeHandle::GetAttributes; now blocked by unimplemented InternalCall MetadataImport::GetSigOfMethodDef during ArgumentException ctor → ResourceManager init
+            "MakeGenericTypeNewConstraint.cs" // past RuntimeTypeHandle::GetAttributes; now blocked by unimplemented InternalCall MetadataImport::GetSigOfMethodDef during ArgumentException ctor → ResourceManager init
         ]
         |> Set.ofList
 

--- a/WoofWare.PawPrint.Test/sourcesPure/RuntimeTypeHandleAttributes.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/RuntimeTypeHandleAttributes.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace RuntimeTypeHandleAttributes
+{
+    public sealed class SealedClass { }
+    public abstract class AbstractClass { }
+    public class PlainClass { }
+
+    public class Program
+    {
+        public static int Main(string[] args)
+        {
+            // Type.Attributes calls RuntimeType.GetAttributeFlagsImpl, which is the
+            // managed wrapper around the RuntimeTypeHandle.GetAttributes InternalCall.
+
+            // Concrete reference type from CoreLib: System.String is sealed.
+            TypeAttributes stringAttrs = typeof(string).Attributes;
+            if ((stringAttrs & TypeAttributes.VisibilityMask) != TypeAttributes.Public) return 1;
+            if ((stringAttrs & TypeAttributes.Sealed) == 0) return 2;
+
+            // Concrete value type: System.Int32 is sealed (every value type is).
+            TypeAttributes intAttrs = typeof(int).Attributes;
+            if ((intAttrs & TypeAttributes.VisibilityMask) != TypeAttributes.Public) return 3;
+            if ((intAttrs & TypeAttributes.Sealed) == 0) return 4;
+
+            // Interface: System.IDisposable carries Interface and Abstract flags.
+            TypeAttributes disposableAttrs = typeof(IDisposable).Attributes;
+            if ((disposableAttrs & TypeAttributes.ClassSemanticsMask) != TypeAttributes.Interface) return 5;
+            if ((disposableAttrs & TypeAttributes.Abstract) == 0) return 6;
+
+            // Locally-defined sealed/abstract/plain classes.
+            if ((typeof(SealedClass).Attributes & TypeAttributes.Sealed) == 0) return 7;
+            if ((typeof(AbstractClass).Attributes & TypeAttributes.Abstract) == 0) return 8;
+            if ((typeof(PlainClass).Attributes & TypeAttributes.Sealed) != 0) return 9;
+            if ((typeof(PlainClass).Attributes & TypeAttributes.Abstract) != 0) return 10;
+
+            // Open generic type definition: List<> reports Public visibility, no Sealed/Abstract.
+            TypeAttributes listOpenAttrs = typeof(List<>).Attributes;
+            if ((listOpenAttrs & TypeAttributes.VisibilityMask) != TypeAttributes.Public) return 11;
+            if ((listOpenAttrs & TypeAttributes.Sealed) != 0) return 12;
+            if ((listOpenAttrs & TypeAttributes.Abstract) != 0) return 13;
+
+            // Generic type parameter: a TypeDesc in CoreCLR. CoreCLR returns tdPublic only.
+            Type tParam = typeof(List<>).GetGenericArguments()[0];
+            if (tParam.Attributes != TypeAttributes.Public) return 14;
+
+            // Single-dim zero-based array: not a TypeDesc; reports Public | Sealed | Serializable.
+            TypeAttributes intArrAttrs = typeof(int[]).Attributes;
+            if ((intArrAttrs & TypeAttributes.VisibilityMask) != TypeAttributes.Public) return 15;
+            if ((intArrAttrs & TypeAttributes.Sealed) == 0) return 16;
+            if ((intArrAttrs & TypeAttributes.Serializable) == 0) return 17;
+
+            // Multi-dim array: same shape as 1D array.
+            TypeAttributes int2DArrAttrs = typeof(int[,]).Attributes;
+            if ((int2DArrAttrs & TypeAttributes.Sealed) == 0) return 18;
+            if ((int2DArrAttrs & TypeAttributes.Serializable) == 0) return 19;
+
+            return 0;
+        }
+    }
+}

--- a/WoofWare.PawPrint/Native/NativeRuntimeType.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeType.fs
@@ -2564,4 +2564,77 @@ module NativeRuntimeType =
                 IlMachineState.pushToEvalStack (CliType.ofBool isAssignable) ctx.Thread state
 
             (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+        | "System.Private.CoreLib",
+          "System",
+          "RuntimeTypeHandle",
+          "GetAttributes",
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib", "System", "RuntimeType", runtimeTypeGenerics) ],
+          MethodReturnType.Returns (ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                                                      "System.Reflection",
+                                                                      "TypeAttributes",
+                                                                      typeAttributesGenerics)) when
+            runtimeTypeGenerics.IsEmpty && typeAttributesGenerics.IsEmpty
+            ->
+            // RuntimeTypeHandle.GetAttributes is the InternalCall boundary backing
+            // RuntimeType.GetAttributeFlagsImpl, which is what Type.Attributes calls.
+            // CoreCLR's implementation (runtimehandles.cpp ::GetAttributes) returns
+            // tdPublic (1) for any TypeDesc — generic variables, byrefs, pointers,
+            // function pointers — and otherwise returns the MethodTable's TypeAttributes.
+            // Arrays are not TypeDesc in CoreCLR; their synthesized MethodTable carries
+            // Public | Sealed | Serializable.
+            let operation = "RuntimeTypeHandle.GetAttributes"
+            let state = IlMachineState.loadArgument ctx.Thread 0 state
+            let runtimeTypeRef, state = IlMachineState.popEvalStack ctx.Thread state
+
+            let target =
+                NativeCall.runtimeTypeHandleTargetOfRuntimeTypeRef operation state runtimeTypeRef
+
+            let attributes : int32 =
+                match target with
+                | RuntimeTypeHandleTarget.GenericParameter _ -> int System.Reflection.TypeAttributes.Public
+                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
+                    let assembly =
+                        state.LoadedAssembly identity.Assembly
+                        |> Option.defaultWith (fun () ->
+                            failwith
+                                $"%s{operation}: assembly for open generic type definition is not loaded: %s{identity.AssemblyFullName}"
+                        )
+
+                    let typeInfo = assembly.TypeDefs.[identity.TypeDefinition.Get]
+                    int typeInfo.TypeAttributes
+                | RuntimeTypeHandleTarget.Closed handle ->
+                    match handle with
+                    | ConcreteTypeHandle.Byref _
+                    | ConcreteTypeHandle.Pointer _ -> int System.Reflection.TypeAttributes.Public
+                    | ConcreteTypeHandle.OneDimArrayZero _
+                    | ConcreteTypeHandle.Array _ ->
+                        // tdPublic | tdSealed | tdSerializable. The Serializable enum
+                        // member is deprecated for new managed code, but the bit is the
+                        // documented runtime convention for synthesized array MethodTables.
+                        int (
+                            System.Reflection.TypeAttributes.Public
+                            ||| System.Reflection.TypeAttributes.Sealed
+                        )
+                        ||| 0x2000
+                    | ConcreteTypeHandle.Concrete _ ->
+                        let concreteType =
+                            AllConcreteTypes.lookup handle state.ConcreteTypes
+                            |> Option.defaultWith (fun () ->
+                                failwith $"%s{operation}: concrete type handle was not registered: %O{handle}"
+                            )
+
+                        let assembly =
+                            state.LoadedAssembly concreteType.Assembly
+                            |> Option.defaultWith (fun () ->
+                                failwith
+                                    $"%s{operation}: assembly for concrete type is not loaded: %s{concreteType.Assembly.FullName}"
+                            )
+
+                        let typeInfo = assembly.TypeDefs.[concreteType.Definition.Get]
+                        int typeInfo.TypeAttributes
+
+            let state =
+                IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 attributes)) ctx.Thread state
+
+            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
         | _ -> None


### PR DESCRIPTION
## Summary
- Implements `System.RuntimeTypeHandle::GetAttributes(RuntimeType) -> TypeAttributes` as an InternalCall in `NativeRuntimeType.tryExecute`. It backs `RuntimeType.GetAttributeFlagsImpl`, which `Type.Attributes` calls. Multiple BCL paths (notably `ResourceManager` init during `ArgumentException` construction) reach it.
- Mirrors CoreCLR's `runtimehandles.cpp ::GetAttributes`: returns `tdPublic` for any TypeDesc (generic variables, byrefs, pointers, function pointers); for non-TypeDesc returns the underlying MethodTable's `TypeAttributes`. Arrays are not TypeDesc and carry `Public | Sealed | Serializable`.
- Adds focused test `RuntimeTypeHandleAttributes.cs` covering each branch (concrete reference/value type, interface, sealed/abstract/plain class, open generic, generic parameter, 1D and multi-dim arrays).
- The four blocked tests (`MakeGenericType{Struct,Class,New}Constraint.cs`, `TypeDefCustomAttributeEnum.cs`) advance past this intrinsic; comments updated to reflect the new blocker (`MetadataImport::GetSigOfMethodDef`).

## Test plan
- [x] Focused test `RuntimeTypeHandleAttributes.cs` passes
- [x] All 212 non-unimplemented pure tests pass
- [x] `MakeGenericType{Struct,Class,New}Constraint.cs` advance past `RuntimeTypeHandle::GetAttributes` (now blocked by `MetadataImport::GetSigOfMethodDef`)
- [x] `TypeDefCustomAttributeEnum.cs` advances past the same intrinsic
- [x] `codex review --base main` returned no actionable findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)