### PR TITLE
Implement MetadataImport::GetSigOfMethodDef InternalCall

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -29,11 +29,12 @@ module TestPureCases =
             "RethrowStackTraceBoundary.cs" // stack trace rendering lacks CLR inner-exception boundary and parameterised frames
             "ThrowingCctorProperties.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
             "Threads.cs" // blocked by pointer arithmetic over a generated Data field after Interlocked.CompareExchange
-            "TypeDefCustomAttributeEnum.cs" // past RuntimeTypeHandle::GetAttributes; now blocked by unimplemented InternalCall MetadataImport::GetSigOfMethodDef
+            "TypeDefCustomAttributeEnum.cs" // past MetadataImport::GetSigOfMethodDef; now blocked by unimplemented QCall RuntimeMethodHandle::IsCAVisibleFromDecoratedType during attribute visibility check
+            "MetadataImportGetSigOfMethodDef.cs" // exercises MetadataImport::GetSigOfMethodDef successfully; now blocked at the next step by unimplemented QCall RuntimeMethodHandle::IsCAVisibleFromDecoratedType
             "LdelemaArrayTypeMismatch.cs" // ArrayTypeMismatchException is raised correctly, but its ctor walks past MetadataImport::GetCustomAttributeProps and now reaches unimplemented MetadataImport::GetParentToken while constructing the message
-            "MakeGenericTypeStructConstraint.cs" // past RuntimeTypeHandle::GetAttributes; now blocked by unimplemented InternalCall MetadataImport::GetSigOfMethodDef during ArgumentException ctor → ResourceManager init
-            "MakeGenericTypeClassConstraint.cs" // past RuntimeTypeHandle::GetAttributes; now blocked by unimplemented InternalCall MetadataImport::GetSigOfMethodDef during ArgumentException ctor → ResourceManager init
-            "MakeGenericTypeNewConstraint.cs" // past RuntimeTypeHandle::GetAttributes; now blocked by unimplemented InternalCall MetadataImport::GetSigOfMethodDef during ArgumentException ctor → ResourceManager init
+            "MakeGenericTypeStructConstraint.cs" // past MetadataImport::GetSigOfMethodDef; now blocked by unimplemented QCall ModuleHandle::ResolveMethod during ArgumentException ctor → ResourceManager init
+            "MakeGenericTypeClassConstraint.cs" // past MetadataImport::GetSigOfMethodDef; now blocked by unimplemented QCall ModuleHandle::ResolveMethod during ArgumentException ctor → ResourceManager init
+            "MakeGenericTypeNewConstraint.cs" // past MetadataImport::GetSigOfMethodDef; now blocked by unimplemented QCall ModuleHandle::ResolveMethod during ArgumentException ctor → ResourceManager init
         ]
         |> Set.ofList
 

--- a/WoofWare.PawPrint.Test/sourcesPure/MetadataImportGetSigOfMethodDef.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/MetadataImportGetSigOfMethodDef.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace MetadataImportGetSigOfMethodDef
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class MarkerAttribute : Attribute { }
+
+    [Marker]
+    public class Decorated { }
+
+    public class Plain { }
+
+    public class Program
+    {
+        public static int Main(string[] args)
+        {
+            // Attribute.IsDefined goes through RuntimeCustomAttributeData.IsCustomAttributeDefined,
+            // which calls scope.GetMethodSignature(caCtorToken) to read the attribute ctor's
+            // signature. For a MethodDef token (the [Marker] ctor lives in this assembly), the
+            // CoreLib path calls MetadataImport.GetSigOfMethodDef. We test both decorated and
+            // undecorated targets so we exercise both the "found" and "not found" code paths
+            // that nonetheless inspect candidate constructors via this InternalCall.
+            if (!Attribute.IsDefined(typeof(Decorated), typeof(MarkerAttribute))) return 1;
+            if (Attribute.IsDefined(typeof(Plain), typeof(MarkerAttribute))) return 2;
+
+            return 0;
+        }
+    }
+}

--- a/WoofWare.PawPrint/Native/NativeMetadataImport.fs
+++ b/WoofWare.PawPrint/Native/NativeMetadataImport.fs
@@ -648,6 +648,53 @@ module NativeMetadataImport =
         | "System.Private.CoreLib",
           "System.Reflection",
           "MetadataImport",
+          "GetSigOfMethodDef",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32
+            ConcreteByref (ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                                             "System.Reflection",
+                                                             "ConstArray",
+                                                             constArrayGenerics)) ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) when
+            constArrayGenerics.IsEmpty
+            ->
+            let operation = "MetadataImport.GetSigOfMethodDef"
+            let assemblyFullName = metadataImportHandleOfArg operation instruction.Arguments.[0]
+            let assembly = metadataImportAssembly operation state assemblyFullName
+
+            let mdToken =
+                match CliType.unwrapPrimitiveLikeDeep instruction.Arguments.[1] with
+                | CliType.Numeric (CliNumericType.Int32 mdToken) -> mdToken
+                | other -> failwith $"%s{operation}: expected Int32 methodToken argument, got %O{other}"
+
+            let signatureOut =
+                NativeCall.managedPointerOfPointerArgument operation "signature out pointer" instruction.Arguments.[2]
+
+            let methodDefHandle =
+                match MetadataToken.ofInt mdToken with
+                | MetadataToken.MethodDef h -> h
+                | token -> failwith $"%s{operation}: expected MethodDef token, got %O{token} from 0x%08x{mdToken}"
+
+            // The MetadataImport.GetSigOfMethodDef contract is "raw signature blob bytes
+            // for the supplied MethodDef token". PawPrint's MethodInfo decodes the signature
+            // eagerly; the unparsed blob is recovered on demand from the metadata reader.
+            let mr = metadataReaderOf assembly
+            let methodDef = mr.GetMethodDefinition methodDefHandle
+            let blob = ImmutableArray.Create<byte> (mr.GetBlobBytes methodDef.Signature)
+
+            let constArrayValue, state =
+                buildConstArray ctx.LoggerFactory ctx.BaseClassTypes operation blob state
+
+            let state =
+                IlMachineState.writeManagedByrefWithBase ctx.BaseClassTypes state signatureOut constArrayValue
+
+            let state =
+                IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread state
+
+            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+        | "System.Private.CoreLib",
+          "System.Reflection",
+          "MetadataImport",
           "GetParentToken",
           [ ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr
             ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32

--- a/WoofWare.PawPrint/Native/NativeMetadataImport.fs
+++ b/WoofWare.PawPrint/Native/NativeMetadataImport.fs
@@ -675,6 +675,12 @@ module NativeMetadataImport =
                 | MetadataToken.MethodDef h -> h
                 | token -> failwith $"%s{operation}: expected MethodDef token, got %O{token} from 0x%08x{mdToken}"
 
+            let mutable methodInfo =
+                Unchecked.defaultof<MethodInfo<GenericParamFromMetadata, GenericParamFromMetadata, TypeDefn>>
+
+            if not (assembly.Methods.TryGetValue (methodDefHandle, &methodInfo)) then
+                failwith $"%s{operation}: MethodDef token 0x%08x{mdToken} was not present in %s{assemblyFullName}"
+
             // The MetadataImport.GetSigOfMethodDef contract is "raw signature blob bytes
             // for the supplied MethodDef token". PawPrint's MethodInfo decodes the signature
             // eagerly; the unparsed blob is recovered on demand from the metadata reader.


### PR DESCRIPTION
## Summary

- Adds an InternalCall handler for `System.Reflection.MetadataImport::GetSigOfMethodDef`. It returns the raw MethodDef signature blob via `ConstArray`, matching the CoreCLR contract used by `RuntimeCustomAttributeData.FilterCustomAttributeRecord`.
- The blob is recovered on demand from the metadata reader (rather than cached on `MethodInfo`), since PawPrint already holds the parsed signature and the unparsed bytes are only needed by this narrow path.
- Adds `MetadataImportGetSigOfMethodDef.cs` exercising the path via `Attribute.IsDefined`. Five tests now move past `GetSigOfMethodDef`:
  - `TypeDefCustomAttributeEnum.cs` and the new test reach the visibility check `RuntimeMethodHandle::IsCAVisibleFromDecoratedType` next.
  - `MakeGenericType{Struct,Class,New}Constraint.cs` reach `ModuleHandle::ResolveMethod` (the parameterised-ctor branch of attribute filtering, exercised by `ResourceManager` init inside `ArgumentException`).
- Updates the `unimplemented` annotations to reflect the new blockers.

## Test plan
- [x] Full test suite passes (624 tests)
- [x] New `MetadataImportGetSigOfMethodDef.cs` test fails on the new blocker (`IsCAVisibleFromDecoratedType`) rather than on `GetSigOfMethodDef`
- [x] Original four blocked tests now reach their respective new blockers
- [x] Codex review reports no discrete correctness issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)