### PR TITLE
Lift through trailing Field projections for byref byte-view reads/writes

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -20,7 +20,7 @@ module TestPureCases =
             "AdvancedStructLayout.cs" // blocked after fixed-buffer pointer arithmetic by MarshalNative_SizeOfHelper for ByValTStr string marshalling
             "LdtokenField.cs" // TODO: read through `ReinterpretAs` as non-primitive type .VolatileObject
             "GenericEdgeCases.cs" // blocked after BitOperations.Log2 by unimplemented JIT intrinsic System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned (reached via int.ToString -> Number.UInt32ToDecStr)
-            "CrossAssemblyTypes.cs" // byte-view read at field-crossing offset: read of 4 bytes at byte offset 4 within a 4-byte field cell (readManagedByrefBytesAs)
+            "CrossAssemblyTypes.cs" // past Guid byref-byteview field crossing; now blocked by unimplemented JIT intrinsic System.Numerics.BitOperations.RotateLeft (reached via Dictionary hashing path)
             "InterfaceDispatch.cs" // past MetadataImport::GetCustomAttributeProps; now blocked by unimplemented InternalCall MetadataImport::GetParentToken
             "NullDereferenceTest.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
             "CastClassInvalid.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource

--- a/WoofWare.PawPrint.Test/sourcesPure/UnsafeFieldCrossing.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/UnsafeFieldCrossing.cs
@@ -1,0 +1,81 @@
+using System.Runtime.CompilerServices;
+
+// Mirrors the BCL pattern in Guid.GetHashCode / Guid.EqualsCore: a managed
+// pointer to a struct field is advanced by `Unsafe.Add` past the field
+// boundary into a sibling field of the same parent struct. Reads and writes
+// through the resulting byref must reach the sibling field's storage.
+public class TestUnsafeFieldCrossing
+{
+    private struct TwoInts
+    {
+        public int A;
+        public int B;
+    }
+
+    private struct ThreeInts
+    {
+        public int A;
+        public int B;
+        public int C;
+    }
+
+    // Forward read: `Unsafe.Add(ref s.A, 1)` lands at the start of `s.B`.
+    public static int Test1()
+    {
+        TwoInts s = new TwoInts { A = 0x11111111, B = 0x22222222 };
+        ref int rA = ref s.A;
+        int viaSibling = Unsafe.Add(ref rA, 1);
+        if (viaSibling != 0x22222222)
+            return 1;
+        return 0;
+    }
+
+    // Forward write: assigning through `Unsafe.Add(ref s.A, 1)` updates `s.B`
+    // and leaves `s.A` untouched.
+    public static int Test2()
+    {
+        TwoInts s = new TwoInts { A = 0x11111111, B = 0x22222222 };
+        ref int rA = ref s.A;
+        Unsafe.Add(ref rA, 1) = 0x77777777;
+        if (s.A != 0x11111111)
+            return 2;
+        if (s.B != 0x77777777)
+            return 3;
+        return 0;
+    }
+
+    // Negative offset: `Unsafe.Add(ref s.B, -1)` lands at the start of `s.A`.
+    public static int Test3()
+    {
+        TwoInts s = new TwoInts { A = 0x33333333, B = 0x44444444 };
+        ref int rB = ref s.B;
+        int viaSibling = Unsafe.Add(ref rB, -1);
+        if (viaSibling != 0x33333333)
+            return 4;
+        return 0;
+    }
+
+    // Multi-step forward walk across two field boundaries reads `s.C`.
+    public static int Test4()
+    {
+        ThreeInts s = new ThreeInts { A = 1, B = 2, C = 3 };
+        ref int rA = ref s.A;
+        int viaC = Unsafe.Add(ref rA, 2);
+        if (viaC != 3)
+            return 5;
+        return 0;
+    }
+
+    public static int Main(string[] argv)
+    {
+        int r = Test1();
+        if (r != 0) return r;
+        r = Test2();
+        if (r != 0) return r;
+        r = Test3();
+        if (r != 0) return r;
+        r = Test4();
+        if (r != 0) return r;
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -641,16 +641,35 @@ module IlMachineManagedByref =
                 readHeapValueBytesAs state addr byteOffset targetTemplate
             | ValueSome (byteViewRoot, prefixProjs, byteOffset) ->
                 let rootValue = readRootValue state byteViewRoot
-                let cell = readProjectedValue rootValue prefixProjs
-                let cellSize = byteAddressableCellSize $"single-cell byref %O{src}" cell
                 let targetSize = CliType.sizeOf targetTemplate
 
-                if byteOffset < 0 || targetSize > cellSize - byteOffset then
-                    failwith
-                        $"TODO: byte-view read at offset %d{byteOffset} for %d{targetSize} bytes does not fit in single primitive cell of size %d{cellSize}: %O{src}"
+                // CLR pointer arithmetic on a managed pointer to a struct
+                // field is allowed to cross into sibling fields of the parent
+                // (e.g. `Unsafe.Add(ref guid._a, 1)` reaches `_b`/`_c`). When
+                // the byte read overflows the immediate cell, lift back
+                // through trailing `Field` projections, accumulating each
+                // field's offset within its parent until the read fits.
+                let rec resolveCell (projs : ByrefProjection list) (offset : int) : CliType * int =
+                    let cell = readProjectedValue rootValue projs
+                    let cellSize = byteAddressableCellSize $"single-cell byref %O{src}" cell
+
+                    if offset >= 0 && targetSize <= cellSize - offset then
+                        cell, offset
+                    else
+                        match List.tryLast projs with
+                        | Some (ByrefProjection.Field field) ->
+                            let parentProjs = projs |> List.take (List.length projs - 1)
+                            let parentValue = readProjectedValue rootValue parentProjs
+                            let fieldOffset, _ = CliType.getFieldLayoutById field parentValue
+                            resolveCell parentProjs (offset + fieldOffset)
+                        | _ ->
+                            failwith
+                                $"TODO: byte-view read at offset %d{offset} for %d{targetSize} bytes does not fit in single primitive cell of size %d{cellSize}: %O{src}"
+
+                let cell, finalOffset = resolveCell prefixProjs byteOffset
 
                 let bytes =
-                    byteAddressableCellBytesAt $"single-cell byref %O{src}" byteOffset targetSize cell
+                    byteAddressableCellBytesAt $"single-cell byref %O{src}" finalOffset targetSize cell
 
                 CliType.ofBytesLike targetTemplate bytes
             | ValueNone ->
@@ -1016,17 +1035,38 @@ module IlMachineManagedByref =
             | ValueSome (ByrefRoot.HeapValue addr, [], byteOffset) -> writeHeapValueBytes state addr byteOffset bytes
             | ValueSome (byteViewRoot, prefixProjs, byteOffset) ->
                 let rootValue = readRootValue state byteViewRoot
-                let cell = readProjectedValue rootValue prefixProjs
-                let cellSize = byteAddressableCellSize $"single-cell byref %O{src}" cell
 
-                if byteOffset < 0 || bytes.Length > cellSize - byteOffset then
-                    failwith
-                        $"TODO: byte-view write at offset %d{byteOffset} for %d{bytes.Length} bytes does not fit in single primitive cell of size %d{cellSize}: %O{src}"
+                // Symmetric to the read path: when the byte write overflows
+                // the immediate cell, lift back through trailing `Field`
+                // projections so a write through e.g. `Unsafe.Add(ref s.A, 1)`
+                // updates the parent struct's sibling field.
+                let rec resolveCell
+                    (projs : ByrefProjection list)
+                    (offset : int)
+                    : ByrefProjection list * int * CliType
+                    =
+                    let cell = readProjectedValue rootValue projs
+                    let cellSize = byteAddressableCellSize $"single-cell byref %O{src}" cell
 
-                match withByteAddressableCellBytesAtIfChanged $"single-cell byref %O{src}" byteOffset bytes cell with
+                    if offset >= 0 && bytes.Length <= cellSize - offset then
+                        projs, offset, cell
+                    else
+                        match List.tryLast projs with
+                        | Some (ByrefProjection.Field field) ->
+                            let parentProjs = projs |> List.take (List.length projs - 1)
+                            let parentValue = readProjectedValue rootValue parentProjs
+                            let fieldOffset, _ = CliType.getFieldLayoutById field parentValue
+                            resolveCell parentProjs (offset + fieldOffset)
+                        | _ ->
+                            failwith
+                                $"TODO: byte-view write at offset %d{offset} for %d{bytes.Length} bytes does not fit in single primitive cell of size %d{cellSize}: %O{src}"
+
+                let liftedProjs, finalOffset, cell = resolveCell prefixProjs byteOffset
+
+                match withByteAddressableCellBytesAtIfChanged $"single-cell byref %O{src}" finalOffset bytes cell with
                 | None -> state
                 | Some updatedCell ->
-                    match applyProjectionsForWriteIfChanged rootValue prefixProjs updatedCell with
+                    match applyProjectionsForWriteIfChanged rootValue liftedProjs updatedCell with
                     | None -> state
                     | Some updatedRoot -> writeRootValue state byteViewRoot updatedRoot
             | ValueNone ->


### PR DESCRIPTION
When a managed pointer like `Unsafe.Add(ref s.A, 1)` is built off a struct field, the resulting byref ends with `[..., Field A, ReinterpretAs T, ByteOffset n]`, where `n` may exceed `A`'s size and reach into a sibling field of the parent struct (e.g. `B`). Both `readManagedByrefBytesAs` and `writeManagedByrefBytesOrTypedCell` previously failed on this with a TODO because the read/write didn't fit inside the immediate cell.

When the byte-view access overflows the immediate cell, walk back through trailing `Field` projections, accumulating each field's offset within its parent, until the access fits within the resolved cell. The write path returns the lifted projection list so the updated bytes are committed to the correct ancestor.

This unblocks the scalar `Guid.EqualsCore`/`GetHashCode` path used by PawPrint (since `Vector128.IsHardwareAccelerated` is false), which uses `Unsafe.AsRef(in _a)` + `Unsafe.Add` to read across all four 4-byte fields of `Guid`. `CrossAssemblyTypes.cs` advances past Guid comparison and now blocks on a separate downstream `BitOperations.RotateLeft` JIT intrinsic in the Dictionary hashing path; comment updated and test remains in `unimplemented`.

A focused regression test `UnsafeFieldCrossing.cs` exercises forward, backward, multi-step, and write-through field crossings on `TwoInts` and `ThreeInts` structs.