### PR TITLE
Implement Interlocked.Exchange JIT intrinsic

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/InterlockedExchangeReference.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/InterlockedExchangeReference.cs
@@ -1,0 +1,48 @@
+using System.Threading;
+
+namespace InterlockedExchangeReference
+{
+    class Marker
+    {
+    }
+
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            Marker a = new Marker();
+            Marker b = new Marker();
+            Marker location = null;
+
+            // null -> a: returns null, location is a.
+            Marker old = Interlocked.Exchange(ref location, a);
+            if (!ReferenceEquals(old, null) || !ReferenceEquals(location, a))
+            {
+                return 1;
+            }
+
+            // a -> b: returns a, location is b. Unlike CompareExchange, no comparand check.
+            old = Interlocked.Exchange(ref location, b);
+            if (!ReferenceEquals(old, a) || !ReferenceEquals(location, b))
+            {
+                return 2;
+            }
+
+            // b -> null: returns b, location is null.
+            old = Interlocked.Exchange(ref location, null);
+            if (!ReferenceEquals(old, b) || !ReferenceEquals(location, null))
+            {
+                return 3;
+            }
+
+            // null -> null: returns null, location stays null.
+            old = Interlocked.Exchange(ref location, null);
+            if (!ReferenceEquals(old, null) || !ReferenceEquals(location, null))
+            {
+                return 4;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/InterlockedExchangeScalars.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/InterlockedExchangeScalars.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Threading;
+
+class Program
+{
+    class Holder
+    {
+        public int Slot = -7;
+        public byte Narrow = 250;
+    }
+
+    static short StaticSlot = -11;
+
+    static int Main(string[] args)
+    {
+        sbyte sb = -1;
+        if (Interlocked.Exchange(ref sb, (sbyte)5) != -1 || sb != 5) return 1;
+        if (Interlocked.Exchange(ref sb, (sbyte)-100) != 5 || sb != -100) return 2;
+
+        byte b = 250;
+        if (Interlocked.Exchange(ref b, (byte)7) != 250 || b != 7) return 3;
+        if (Interlocked.Exchange(ref b, (byte)200) != 7 || b != 200) return 4;
+
+        short s = -1234;
+        if (Interlocked.Exchange(ref s, (short)2222) != -1234 || s != 2222) return 5;
+        if (Interlocked.Exchange(ref s, (short)-5555) != 2222 || s != -5555) return 6;
+
+        ushort us = 60000;
+        if (Interlocked.Exchange(ref us, (ushort)17) != 60000 || us != 17) return 7;
+        if (Interlocked.Exchange(ref us, (ushort)40000) != 17 || us != 40000) return 8;
+
+        int i = -100;
+        if (Interlocked.Exchange(ref i, 10) != -100 || i != 10) return 9;
+        if (Interlocked.Exchange(ref i, int.MinValue) != 10 || i != int.MinValue) return 10;
+
+        uint ui = uint.MaxValue;
+        if (Interlocked.Exchange(ref ui, 42U) != uint.MaxValue || ui != 42U) return 11;
+        if (Interlocked.Exchange(ref ui, 0U) != 42U || ui != 0U) return 12;
+
+        long l = long.MinValue;
+        if (Interlocked.Exchange(ref l, 99L) != long.MinValue || l != 99L) return 13;
+        if (Interlocked.Exchange(ref l, long.MaxValue) != 99L || l != long.MaxValue) return 14;
+
+        ulong ul = ulong.MaxValue;
+        if (Interlocked.Exchange(ref ul, 123UL) != ulong.MaxValue || ul != 123UL) return 15;
+        if (Interlocked.Exchange(ref ul, 0UL) != 123UL || ul != 0UL) return 16;
+
+        Holder holder = new Holder();
+        if (Interlocked.Exchange(ref holder.Slot, 12) != -7 || holder.Slot != 12) return 17;
+        if (Interlocked.Exchange(ref holder.Slot, int.MaxValue) != 12 || holder.Slot != int.MaxValue) return 18;
+        if (Interlocked.Exchange(ref holder.Narrow, (byte)9) != 250 || holder.Narrow != 9) return 19;
+        if (Interlocked.Exchange(ref holder.Narrow, (byte)0) != 9 || holder.Narrow != 0) return 20;
+
+        byte[] bytes = new byte[] { 33, 44 };
+        if (Interlocked.Exchange(ref bytes[1], (byte)55) != 44 || bytes[1] != 55) return 21;
+        if (Interlocked.Exchange(ref bytes[0], (byte)200) != 33 || bytes[0] != 200) return 22;
+
+        if (Interlocked.Exchange(ref StaticSlot, (short)22) != -11 || StaticSlot != 22) return 23;
+        if (Interlocked.Exchange(ref StaticSlot, (short)0) != 22 || StaticSlot != 0) return 24;
+
+        // IntPtr starting at zero: exercises the ManagedPointer Null → NativeInt decode path.
+        IntPtr ip = IntPtr.Zero;
+        IntPtr ipOld = Interlocked.Exchange(ref ip, new IntPtr(77));
+        if (ipOld != IntPtr.Zero || ip != new IntPtr(77)) return 25;
+        ipOld = Interlocked.Exchange(ref ip, new IntPtr(-9999));
+        if (ipOld != new IntPtr(77) || ip != new IntPtr(-9999)) return 26;
+
+        UIntPtr up = UIntPtr.Zero;
+        UIntPtr upOld = Interlocked.Exchange(ref up, new UIntPtr(77UL));
+        if (upOld != UIntPtr.Zero || up != new UIntPtr(77UL)) return 27;
+        upOld = Interlocked.Exchange(ref up, new UIntPtr(0UL));
+        if (upOld != new UIntPtr(77UL) || up != UIntPtr.Zero) return 28;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -32,6 +32,38 @@ module Intrinsics =
         =
         let intrinsicKey = methodKey state methodToCall
 
+        // Predicates shared by the Interlocked.CompareExchange / Interlocked.Exchange intrinsic arms,
+        // which both dispatch by the (location, value, [comparand]) shape of the overload.
+        let isReferenceTypeHandle (handle : ConcreteTypeHandle) : bool =
+            match handle with
+            | ConcreteTypeHandle.OneDimArrayZero _
+            | ConcreteTypeHandle.Array _ -> true
+            | ConcreteTypeHandle.Byref _
+            | ConcreteTypeHandle.Pointer _ -> false
+            | ConcreteTypeHandle.Concrete _ ->
+                match IlMachineState.tryGetConcreteTypeInfo state handle with
+                | Some (_, typeInfo) -> DumpedAssembly.isReferenceType baseClassTypes state._LoadedAssemblies typeInfo
+                | None ->
+                    failwith $"Interlocked reference-type intrinsic: concrete type handle %O{handle} has no TypeDef row"
+
+        let isNativeIntPrimitive (primitive : PrimitiveType) : bool =
+            match primitive with
+            | PrimitiveType.IntPtr
+            | PrimitiveType.UIntPtr -> true
+            | _ -> false
+
+        let isScalarIntegerPrimitive (primitive : PrimitiveType) : bool =
+            match primitive with
+            | PrimitiveType.SByte
+            | PrimitiveType.Byte
+            | PrimitiveType.Int16
+            | PrimitiveType.UInt16
+            | PrimitiveType.Int32
+            | PrimitiveType.UInt32
+            | PrimitiveType.Int64
+            | PrimitiveType.UInt64 -> true
+            | _ -> false
+
         // In general, some implementations are in:
         // https://github.com/dotnet/runtime/blob/108fa7856efcfd39bc991c2d849eabbf7ba5989c/src/coreclr/tools/Common/TypeSystem/IL/Stubs/UnsafeIntrinsics.cs#L192
         match methodToCall.DeclaringType.Assembly.Name, methodToCall.DeclaringType.Name, methodToCall.Name with
@@ -596,37 +628,6 @@ module Intrinsics =
             // Narrow scalar and reference-type overloads are JIT intrinsic boundaries too; handle
             // those primitives here instead of executing their Unsafe.As / InternalCall wrappers.
             // https://github.com/dotnet/runtime/blob/ec11903827fc28847d775ba17e0cd1ff56cfbc2e/src/libraries/System.Private.CoreLib/src/System/Threading/Interlocked.cs#L452
-            let isReferenceTypeHandle (handle : ConcreteTypeHandle) : bool =
-                match handle with
-                | ConcreteTypeHandle.OneDimArrayZero _
-                | ConcreteTypeHandle.Array _ -> true
-                | ConcreteTypeHandle.Byref _
-                | ConcreteTypeHandle.Pointer _ -> false
-                | ConcreteTypeHandle.Concrete _ ->
-                    match IlMachineState.tryGetConcreteTypeInfo state handle with
-                    | Some (_, typeInfo) ->
-                        DumpedAssembly.isReferenceType baseClassTypes state._LoadedAssemblies typeInfo
-                    | None ->
-                        failwith $"Interlocked.CompareExchange<T>: concrete type handle %O{handle} has no TypeDef row"
-
-            let isNativeIntPrimitive (primitive : PrimitiveType) : bool =
-                match primitive with
-                | PrimitiveType.IntPtr
-                | PrimitiveType.UIntPtr -> true
-                | _ -> false
-
-            let isScalarIntegerPrimitive (primitive : PrimitiveType) : bool =
-                match primitive with
-                | PrimitiveType.SByte
-                | PrimitiveType.Byte
-                | PrimitiveType.Int16
-                | PrimitiveType.UInt16
-                | PrimitiveType.Int32
-                | PrimitiveType.UInt32
-                | PrimitiveType.Int64
-                | PrimitiveType.UInt64 -> true
-                | _ -> false
-
             let executeScalarInteger (operation : string) (state : IlMachineState) : IlMachineState =
                 let comparand, state = IlMachineState.popEvalStack currentThread state
                 let value, state = IlMachineState.popEvalStack currentThread state
@@ -776,6 +777,121 @@ module Intrinsics =
                 // reinterpret-cast to integer overloads, so falling through would either re-enter
                 // this intrinsic path or lose the bit-level shape of the floating-point value.
                 // When a caller needs one of these, add a dedicated intrinsic arm.
+                None
+        | "System.Private.CoreLib", "Interlocked", "Exchange" ->
+            // Same intrinsic-boundary motivation as CompareExchange: the shipped CoreLib
+            // bodies for Exchange ride Unsafe.As / InternalCall paths that would either
+            // destroy NativeIntSource provenance for IntPtr/UIntPtr or re-enter this
+            // intrinsic at the wrong width. Implement the primitive directly.
+            // https://github.com/dotnet/runtime/blob/ec11903827fc28847d775ba17e0cd1ff56cfbc2e/src/libraries/System.Private.CoreLib/src/System/Threading/Interlocked.cs#L80
+            let executeScalarIntegerExchange (operation : string) (state : IlMachineState) : IlMachineState =
+                let value, state = IlMachineState.popEvalStack currentThread state
+                let byrefArg, state = IlMachineState.popEvalStack currentThread state
+
+                let byrefSrc = popManagedByrefArgument operation byrefArg
+                let currentValue = IlMachineState.readManagedByref state byrefSrc
+                let valueCli = EvalStackValue.toCliTypeCoerced currentValue value
+
+                // The intrinsic bypasses normal method-frame construction, so coerce the
+                // eval-stack value to the signedness/width of the overload before writing.
+                let state =
+                    IlMachineState.writeManagedByrefWithBase baseClassTypes state byrefSrc valueCli
+
+                state
+                |> IlMachineState.pushToEvalStack currentValue currentThread
+                |> IlMachineState.advanceProgramCounter currentThread
+
+            match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
+            | [ ConcreteByref (ConcretePrimitive state.ConcreteTypes locationPrimitive)
+                ConcretePrimitive state.ConcreteTypes valuePrimitive ],
+              MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes returnPrimitive) when
+                isNativeIntPrimitive locationPrimitive
+                && locationPrimitive = valuePrimitive
+                && locationPrimitive = returnPrimitive
+                ->
+
+                let value, state = IlMachineState.popEvalStack currentThread state
+                let byrefArg, state = IlMachineState.popEvalStack currentThread state
+
+                let byrefSrc =
+                    popManagedByrefArgument "Interlocked.Exchange(ref native-int,...)" byrefArg
+
+                // Eval-stack IntPtr/UIntPtr arguments are flattened to the primitive by the push
+                // boundary (see EvalStackValue.ofCliType), so a UserDefinedValueType IntPtr or
+                // UIntPtr is unreachable here by invariant.
+                let toNativeIntSource (v : EvalStackValue) : NativeIntSource =
+                    match v with
+                    | EvalStackValue.NativeInt src -> src
+                    | EvalStackValue.Int64 (Int64Source.Verbatim i) -> NativeIntSource.Verbatim i
+                    | EvalStackValue.Int32 i -> NativeIntSource.Verbatim (int64<int> i)
+                    | EvalStackValue.ManagedPointer src -> NativeIntSource.ManagedPointer src
+                    | EvalStackValue.NullObjectRef -> NativeIntSource.ManagedPointer ManagedPointerSource.Null
+                    | other ->
+                        failwith
+                            $"Interlocked.Exchange(ref native-int,...): unexpected native-int-shaped eval stack value %O{other}"
+
+                let valueSrc = toNativeIntSource value
+
+                let currentValue = IlMachineState.readManagedByref state byrefSrc
+
+                // `ref IntPtr` / `ref UIntPtr` derefs to a wrapper struct. Route the read/write through
+                // the eval-stack flatten/rewrap boundary: `ofCliType` peels the primitive-like
+                // wrapper to `NativeInt`, and `toCliTypeCoerced` reconstructs the wrapper shape
+                // on write. The primitive-like registry is the single source of truth for shape.
+                let currentSrc =
+                    match EvalStackValue.ofCliType currentValue with
+                    | EvalStackValue.NativeInt src -> src
+                    | EvalStackValue.Int64 (Int64Source.Verbatim i) -> NativeIntSource.Verbatim i
+                    | EvalStackValue.Int32 i -> NativeIntSource.Verbatim (int64<int> i)
+                    | other ->
+                        failwith
+                            $"Interlocked.Exchange(ref native-int,...): expected NativeInt at byref target, got %O{other}"
+
+                let newValue =
+                    EvalStackValue.toCliTypeCoerced currentValue (EvalStackValue.NativeInt valueSrc)
+
+                let state =
+                    IlMachineState.writeManagedByrefWithBase baseClassTypes state byrefSrc newValue
+
+                state
+                |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt currentSrc) currentThread
+                |> IlMachineState.advanceProgramCounter currentThread
+                |> Some
+            | [ ConcreteByref (ConcretePrimitive state.ConcreteTypes locationPrimitive)
+                ConcretePrimitive state.ConcreteTypes valuePrimitive ],
+              MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes returnPrimitive) when
+                isScalarIntegerPrimitive locationPrimitive
+                && locationPrimitive = valuePrimitive
+                && locationPrimitive = returnPrimitive
+                ->
+                executeScalarIntegerExchange "Interlocked.Exchange" state |> Some
+            | [ ConcreteByref locationType ; valueType ], MethodReturnType.Returns returnType when
+                locationType = valueType
+                && locationType = returnType
+                && isReferenceTypeHandle locationType
+                ->
+                // Reference-typed Exchange overloads are JIT/runtime intrinsic boundaries
+                // in CoreLib. Implement the object-reference primitive directly instead of
+                // trying to execute the generic Unsafe.As<T, object> path.
+                let value, state = IlMachineState.popEvalStack currentThread state
+                let byrefArg, state = IlMachineState.popEvalStack currentThread state
+
+                let byrefSrc = popManagedByrefArgument "Interlocked.Exchange<T>" byrefArg
+
+                let currentValue = IlMachineState.readManagedByref state byrefSrc
+
+                let valueCli = EvalStackValue.toCliTypeCoerced currentValue value
+
+                let state =
+                    IlMachineState.writeManagedByrefWithBase baseClassTypes state byrefSrc valueCli
+
+                state
+                |> IlMachineState.pushToEvalStack currentValue currentThread
+                |> IlMachineState.advanceProgramCounter currentThread
+                |> Some
+            | _ ->
+                // The float/double overloads are not yet intrinsified, matching the
+                // CompareExchange precedent above. Add a dedicated arm when first needed.
                 None
         | "System.Private.CoreLib", "BitConverter", "SingleToInt32Bits" ->
             match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with


### PR DESCRIPTION
Mirrors the existing Interlocked.CompareExchange intrinsic boundary in Intrinsics.fs but without the comparand pop and with an unconditional write. Three sub-arms handle native-int (IntPtr/UIntPtr), narrow/word/64-bit scalar integers, and reference-typed Exchange<T>. Float/double overloads remain unintrinsified, matching the CompareExchange precedent.

The shared (location, value, [comparand])-shape predicates have been lifted out of CompareExchange's match arm to be reusable across both intrinsics.