### PR TITLE
Improve diagnostics for RawData::Data and boxed byte-view rejections

### DIFF
--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -528,6 +528,22 @@ module IlMachineManagedByref =
 
         CliType.ofBytesLike targetTemplate buf
 
+    /// Render a `ConcreteTypeHandle` as `Namespace.Name [AssemblyShortName]` for
+    /// diagnostic messages. Falls back gracefully when the lookup chain breaks,
+    /// since this is called from failure paths that should not throw a second time.
+    let private describeConcreteType (state : IlMachineState) (handle : ConcreteTypeHandle) : string =
+        match AllConcreteTypes.lookup handle state.ConcreteTypes with
+        | None -> $"<unregistered concrete type %O{handle}>"
+        | Some concrete ->
+            match state.LoadedAssembly concrete.Assembly with
+            | None -> $"<unloaded assembly %O{concrete.Assembly} for concrete type %O{handle}>"
+            | Some assembly ->
+                match assembly.TypeDefs.TryGetValue concrete.Definition.Get with
+                | true, typeDef ->
+                    $"%s{typeDef.Namespace}.%s{typeDef.Name} [%s{assembly.Name.Name}] (concrete %O{handle})"
+                | false, _ ->
+                    $"<missing TypeDef %O{concrete.Definition.Get} in %s{assembly.Name.Name}> (concrete %O{handle})"
+
     let private heapValueForByteView
         (operation : string)
         (state : IlMachineState)
@@ -539,8 +555,10 @@ module IlMachineManagedByref =
         match CliValueType.ByteAddressability obj.Contents with
         | CliByteAddressability.ByteAddressable -> obj
         | CliByteAddressability.Rejected rejection ->
+            let typeDescription = describeConcreteType state obj.ConcreteType
+
             failwith
-                $"%s{operation}: refusing byte view over boxed %s{rejection.Description} at %O{addr}. Boxed value layout:\n%s{CliValueType.DescribeByteLayout (Some state.ConcreteTypes) obj.Contents}"
+                $"%s{operation}: refusing byte view over boxed %s{rejection.Description} of %s{typeDescription} at %O{addr}. Boxed value layout:\n%s{CliValueType.DescribeByteLayout (Some state.ConcreteTypes) obj.Contents}"
 
     let private heapValueByteSize
         (operation : string)

--- a/WoofWare.PawPrint/RuntimeFieldProjection.fs
+++ b/WoofWare.PawPrint/RuntimeFieldProjection.fs
@@ -52,6 +52,22 @@ module internal RuntimeFieldProjection =
         =
         isCorelibType baseClassTypes field "System.Runtime.CompilerServices" "RawData"
 
+    /// Render a `ConcreteTypeHandle` as `Namespace.Name [AssemblyShortName] (concrete H)`
+    /// for diagnostic messages. Falls back gracefully when the lookup chain breaks,
+    /// since this is called from failure paths that should not throw a second time.
+    let private describeConcreteType (state : IlMachineState) (handle : ConcreteTypeHandle) : string =
+        match AllConcreteTypes.lookup handle state.ConcreteTypes with
+        | None -> $"<unregistered concrete type %O{handle}>"
+        | Some concrete ->
+            match state.LoadedAssembly concrete.Assembly with
+            | None -> $"<unloaded assembly %O{concrete.Assembly} for concrete type %O{handle}>"
+            | Some assembly ->
+                match assembly.TypeDefs.TryGetValue concrete.Definition.Get with
+                | true, typeDef ->
+                    $"%s{typeDef.Namespace}.%s{typeDef.Name} [%s{assembly.Name.Name}] (concrete %O{handle})"
+                | false, _ ->
+                    $"<missing TypeDef %O{concrete.Definition.Get} in %s{assembly.Name.Name}> (concrete %O{handle})"
+
     let private requireBoxedValueType
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (addr : ManagedHeapAddress)
@@ -59,24 +75,34 @@ module internal RuntimeFieldProjection =
         : unit
         =
         match state.ManagedHeap.NonArrayObjects.TryGetValue addr with
-        | false, _ -> failwith $"RawData::Data projection expected boxed value type object at %O{addr}, got array"
+        | false, _ ->
+            let arrayDescription =
+                match state.ManagedHeap.Arrays.TryGetValue addr with
+                | true, arr -> describeConcreteType state arr.ConcreteType
+                | false, _ -> "<no heap object at this address>"
+
+            failwith
+                $"RawData::Data projection expected boxed value type object at %O{addr}, got array %s{arrayDescription}"
         | true, obj ->
             let concrete =
                 AllConcreteTypes.lookup obj.ConcreteType state.ConcreteTypes
                 |> Option.defaultWith (fun () ->
-                    failwith $"RawData::Data projection found unregistered concrete type %O{obj.ConcreteType}"
+                    failwith
+                        $"RawData::Data projection found unregistered concrete type %O{obj.ConcreteType} at %O{addr}"
                 )
 
             let assembly =
                 state.LoadedAssembly concrete.Assembly
                 |> Option.defaultWith (fun () ->
-                    failwith $"RawData::Data projection needs loaded assembly %O{concrete.Assembly}"
+                    failwith
+                        $"RawData::Data projection needs loaded assembly %O{concrete.Assembly} for concrete type %O{obj.ConcreteType} at %O{addr}"
                 )
 
             let typeDef = assembly.TypeDefs.[concrete.Definition.Get]
 
             if not (DumpedAssembly.isValueType baseClassTypes state._LoadedAssemblies typeDef) then
-                failwith $"RawData::Data projection expected boxed value type at %O{addr}, got %O{obj.ConcreteType}"
+                failwith
+                    $"RawData::Data projection expected boxed value type at %O{addr}, got %s{typeDef.Namespace}.%s{typeDef.Name} [%s{assembly.Name.Name}] (concrete %O{obj.ConcreteType})"
 
     let private tryProjectRawDataFieldAddress
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)


### PR DESCRIPTION
## Summary

- `RuntimeFieldProjection.requireBoxedValueType` and `IlMachineManagedByref.heapValueForByteView` previously printed only the opaque `ConcreteTypeHandle` integer when they refused a projection or byte view, leaving no clue which managed type triggered the failure.
- Each site now resolves the handle via a small private `describeConcreteType` helper that walks `ConcreteTypes` → `LoadedAssembly` → `TypeDefs` and renders `Namespace.Name [AssemblyShortName] (concrete H)`. The helper degrades gracefully if any step fails, so the diagnostic path itself never throws a second exception.
- The "got array" branch additionally reports the array's concrete element type instead of just naming the kind.

No behaviour change; this is a strict diagnostic improvement. Existing substring assertions ("got array", "expected boxed value type", "refusing byte view", "Boxed value layout:") are preserved.

## Test plan

- [x] `nix develop -c dotnet test ... --filter "Name~RawData"` (8/8 passing)
- [x] `nix develop -c dotnet test ... --filter "Name~byte"` (65/65 passing)
- [x] `nix develop -c dotnet test ... --filter "Name~projection"` (68/68 passing)
- [x] `nix develop -c dotnet fantomas .` clean
- [x] `codex review --base main` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)