### PR TITLE
Probe Type.GetMethod() for method-generic parameter support

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -35,6 +35,7 @@ module TestPureCases =
             "MakeGenericTypeStructConstraint.cs" // past MetadataImport::GetSigOfMethodDef; now blocked by unimplemented QCall ModuleHandle::ResolveMethod during ArgumentException ctor → ResourceManager init
             "MakeGenericTypeClassConstraint.cs" // past MetadataImport::GetSigOfMethodDef; now blocked by unimplemented QCall ModuleHandle::ResolveMethod during ArgumentException ctor → ResourceManager init
             "MakeGenericTypeNewConstraint.cs" // past MetadataImport::GetSigOfMethodDef; now blocked by unimplemented QCall ModuleHandle::ResolveMethod during ArgumentException ctor → ResourceManager init
+            "MethodReflectionProbe.cs" // blocked by unimplemented InternalCall RuntimeTypeHandle::GetNumVirtuals (method enumeration for Type.GetMethod)
         ]
         |> Set.ofList
 

--- a/WoofWare.PawPrint.Test/sourcesPure/MethodReflectionProbe.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/MethodReflectionProbe.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Reflection;
+
+namespace MethodReflectionProbe
+{
+    class Foo
+    {
+        public static int Add(int a, int b) => a + b;
+    }
+
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            MethodInfo m = typeof(Foo).GetMethod("Add");
+            if (m == null) return 1;
+            if (m.Name != "Add") return 2;
+            return 0;
+        }
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/TypeGenericParameterAttributes.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/TypeGenericParameterAttributes.cs
@@ -1,54 +1,96 @@
 using System;
+using System.IO;
 using System.Reflection;
 
 namespace TypeGenericParameterAttributes
 {
     class Box<T> { }
+
     class StructBox<T> where T : struct { }
+
     class RefBox<T> where T : class { }
+
     class NewBox<T> where T : new() { }
 
-    interface ICov<out T> { }
-    interface IContra<in T> { }
+    class RefNewBox<T> where T : class, new() { }
+
+    class StreamBox<T> where T : Stream { }
+
+    class StreamNewBox<T> where T : Stream, new() { }
+
+    class DisposableBox<T> where T : IDisposable { }
+
+    class StructDisposableBox<T> where T : struct, IDisposable { }
+
+    class UnmanagedBox<T> where T : unmanaged { }
+
+    // C# 13 / .NET 9 `allows ref struct` sets GenericParameterAttributes.AllowByRefLike (0x20).
+    class AllowsRefStructBox<T> where T : allows ref struct { }
+
+    interface ICovariantOut<out T> { }
+
+    interface IContravariantIn<in T> { }
 
     class Program
     {
         static int Main(string[] args)
         {
-            // Unconstrained: None (0)
-            GenericParameterAttributes unc =
-                typeof(Box<>).GetGenericArguments()[0].GenericParameterAttributes;
-            if (unc != GenericParameterAttributes.None) return 1;
+            // Unconstrained: None (0x0)
+            Type unc = typeof(Box<>).GetGenericArguments()[0];
+            if ((int)unc.GenericParameterAttributes != 0x0) return 1;
 
-            // where T : struct -> NotNullableValueTypeConstraint | DefaultConstructorConstraint
-            GenericParameterAttributes st =
-                typeof(StructBox<>).GetGenericArguments()[0].GenericParameterAttributes;
-            if ((st & GenericParameterAttributes.NotNullableValueTypeConstraint) == 0) return 2;
-            if ((st & GenericParameterAttributes.DefaultConstructorConstraint) == 0) return 3;
+            // `where T : struct` sets NotNullableValueTypeConstraint (0x08) |
+            // DefaultConstructorConstraint (0x10) = 0x18.
+            Type vt = typeof(StructBox<>).GetGenericArguments()[0];
+            if ((int)vt.GenericParameterAttributes != 0x18) return 2;
+            if ((vt.GenericParameterAttributes & GenericParameterAttributes.NotNullableValueTypeConstraint) == 0) return 3;
+            if ((vt.GenericParameterAttributes & GenericParameterAttributes.DefaultConstructorConstraint) == 0) return 4;
 
-            // where T : class -> ReferenceTypeConstraint
-            GenericParameterAttributes rf =
-                typeof(RefBox<>).GetGenericArguments()[0].GenericParameterAttributes;
-            if ((rf & GenericParameterAttributes.ReferenceTypeConstraint) == 0) return 4;
+            // `where T : class` sets ReferenceTypeConstraint (0x04).
+            Type rt = typeof(RefBox<>).GetGenericArguments()[0];
+            if ((int)rt.GenericParameterAttributes != 0x04) return 5;
 
-            // where T : new() -> DefaultConstructorConstraint only (no struct/class flag)
-            GenericParameterAttributes nw =
-                typeof(NewBox<>).GetGenericArguments()[0].GenericParameterAttributes;
-            if ((nw & GenericParameterAttributes.DefaultConstructorConstraint) == 0) return 5;
-            if ((nw & GenericParameterAttributes.NotNullableValueTypeConstraint) != 0) return 6;
-            if ((nw & GenericParameterAttributes.ReferenceTypeConstraint) != 0) return 7;
+            // `where T : new()` sets DefaultConstructorConstraint (0x10) only.
+            Type nb = typeof(NewBox<>).GetGenericArguments()[0];
+            if ((int)nb.GenericParameterAttributes != 0x10) return 6;
 
-            // out T (covariant)
-            GenericParameterAttributes co =
-                typeof(ICov<>).GetGenericArguments()[0].GenericParameterAttributes;
-            if ((co & GenericParameterAttributes.Covariant) == 0) return 8;
-            if ((co & GenericParameterAttributes.Contravariant) != 0) return 9;
+            // `where T : class, new()` sets both (0x14).
+            Type rnb = typeof(RefNewBox<>).GetGenericArguments()[0];
+            if ((int)rnb.GenericParameterAttributes != 0x14) return 7;
 
-            // in T (contravariant)
-            GenericParameterAttributes contra =
-                typeof(IContra<>).GetGenericArguments()[0].GenericParameterAttributes;
-            if ((contra & GenericParameterAttributes.Contravariant) == 0) return 10;
-            if ((contra & GenericParameterAttributes.Covariant) != 0) return 11;
+            // A base-type constraint emits no flag bits; the constraint lives in the
+            // GenericParamConstraint table only.
+            Type stream = typeof(StreamBox<>).GetGenericArguments()[0];
+            if ((int)stream.GenericParameterAttributes != 0x0) return 8;
+
+            // Base-type + new() sets only DefaultConstructorConstraint.
+            Type sn = typeof(StreamNewBox<>).GetGenericArguments()[0];
+            if ((int)sn.GenericParameterAttributes != 0x10) return 9;
+
+            // Interface-only constraint: no flag bits.
+            Type disp = typeof(DisposableBox<>).GetGenericArguments()[0];
+            if ((int)disp.GenericParameterAttributes != 0x0) return 10;
+
+            // `where T : struct, IDisposable` keeps the struct flags.
+            Type sd = typeof(StructDisposableBox<>).GetGenericArguments()[0];
+            if ((int)sd.GenericParameterAttributes != 0x18) return 11;
+
+            // `where T : unmanaged` has the same struct flag bits (0x18).
+            Type um = typeof(UnmanagedBox<>).GetGenericArguments()[0];
+            if ((int)um.GenericParameterAttributes != 0x18) return 12;
+
+            // `out T` on an interface sets Covariant (0x01).
+            Type cov = typeof(ICovariantOut<>).GetGenericArguments()[0];
+            if ((int)cov.GenericParameterAttributes != 0x01) return 13;
+
+            // `in T` on an interface sets Contravariant (0x02).
+            Type con = typeof(IContravariantIn<>).GetGenericArguments()[0];
+            if ((int)con.GenericParameterAttributes != 0x02) return 14;
+
+            // `allows ref struct` sets AllowByRefLike (0x20).
+            Type ars = typeof(AllowsRefStructBox<>).GetGenericArguments()[0];
+            if ((int)ars.GenericParameterAttributes != 0x20) return 15;
+            if ((ars.GenericParameterAttributes & GenericParameterAttributes.AllowByRefLike) == 0) return 16;
 
             return 0;
         }

--- a/docs/plans/2026-05-09-method-generic-params-impl.md
+++ b/docs/plans/2026-05-09-method-generic-params-impl.md
@@ -1,0 +1,293 @@
+Implement this plan with each stage on its own branch, stacked as necessary on previous branches, so that a reviewer can review each branch in isolation.
+
+Design: [method-generic-params.md](2026-05-09-method-generic-params.md)
+
+## Stage 0: Probe whether `Type.GetMethod()` works
+
+**Dependencies**: None
+
+**Implements**: Design §6 (prerequisite verification)
+
+Every end-to-end test for method-generic parameters begins with
+`typeof(Foo).GetMethod("Bar")`. This goes through the BCL's
+`RuntimeType.GetMethodCandidates` → `RuntimeTypeHandle.GetMethodAt` (QCall) →
+method enumeration path. No existing pure test exercises `GetMethod`.
+
+Write a minimal test `MethodReflectionProbe.cs` in `sourcesPure/`:
+
+```csharp
+class Foo {
+    public static int Add(int a, int b) => a + b;
+}
+class Program {
+    static int Main(string[] args) {
+        var m = typeof(Foo).GetMethod("Add");
+        if (m == null) return 1;
+        if (m.Name != "Add") return 2;
+        return 0;
+    }
+}
+```
+
+If this test passes on PawPrint: proceed to Stage 1.
+If it fails: identify the missing InternalCall/QCall, implement it as a
+**separate prerequisite PR** (not part of this plan), and revisit. The failure
+message will pinpoint exactly which unimplemented primitive blocks the path.
+
+**Correctness oracle**:
+- The probe test passes on both PawPrint and the real runtime (exit code 0),
+  or the failure is clearly identified and logged as a dependency.
+
+**Result**: Probe failed. The blocker is:
+
+```
+Unimplemented native method (InternalCall):
+  System.Private.CoreLib System.RuntimeTypeHandle::GetNumVirtuals(System.RuntimeType) -> System.Int32
+```
+
+`GetNumVirtuals` is part of `RuntimeType.GetMethodCandidates` — the BCL calls it
+to enumerate methods on a type. Without it, `Type.GetMethod()` cannot work.
+
+The probe test is registered in the `unimplemented` set in `TestPureCases.fs`.
+Stage 1 (DU infrastructure) can proceed independently, but Stages 2+ are
+blocked until `GetNumVirtuals` (and likely `GetMethodAt` and related method
+enumeration InternalCalls/QCalls) are implemented.
+
+---
+
+## Stage 1: Add `MethodGenericParameter` DU case
+
+**Dependencies**: Stage 0 (GetMethod works)
+
+**Implements**: Design §1 (identity representation), §4 (consumer site updates)
+
+Add `MethodGenericParameter of declaringType : ResolvedTypeIdentity *
+declaringMethod : ComparableMethodDefinitionHandle * position : int` to
+`RuntimeTypeHandleTarget` in `NativeIntSource.fs`.
+
+Update every `match typeHandleTarget with` block that handles `GenericParameter`
+to also handle `MethodGenericParameter`. Implement trivially where the answer is
+obvious:
+
+| Site | Implementation |
+|------|---------------|
+| `ToString` | Format string with method handle and position |
+| `IsGenericVariable` | `true` |
+| `GetGenericVariableIndex` | `position` |
+| `GetInstantiation` | `ImmutableArray.Empty` |
+| `instantiateGenericRuntimeTypeTarget` | Fail (parameters can't be instantiated) |
+
+All other sites get TODO failwiths following the type-generic pattern, e.g.:
+```fsharp
+| RuntimeTypeHandleTarget.MethodGenericParameter (declaringType, declaringMethod, position) ->
+    failwith $"TODO: %s{operation} for method generic parameter #%i{position} of method %O{declaringMethod.Get} on %O{declaringType.TypeDefinition.Get}"
+```
+
+The compiler will ensure exhaustive matching; every site that handles
+`GenericParameter` must also handle `MethodGenericParameter`.
+
+**Correctness oracle**:
+- Project compiles with no new warnings.
+- All existing tests pass. No change in unimplemented test count.
+- The new DU case is exhaustively matched at every site (compiler-enforced).
+
+---
+
+## Stage 2: `GetToken` + `HasMethodInstantiation` + `GetMethodInstantiation`
+
+**Dependencies**: Stage 1
+
+**Implements**: Design §2 (GetMethodInstantiation entry point), §3
+(HasMethodInstantiation), §4 (GetToken consumer)
+
+Three pieces, all needed for the first testable end-to-end path:
+
+### 2a. `typeDefinitionTokenOfRuntimeTypeHandleTarget` — MethodGenericParameter arm
+
+Replace the TODO failwith with:
+```fsharp
+| RuntimeTypeHandleTarget.MethodGenericParameter (declaringType, declaringMethod, position) ->
+    let assembly =
+        state.LoadedAssembly declaringType.Assembly
+        |> Option.defaultWith (fun () ->
+            failwith $"...")
+    let methodInfo = assembly.Methods.[declaringMethod.Get]
+    if position >= methodInfo.Generics.Length then
+        failwith $"..."
+    let param, _md = methodInfo.Generics.[position]
+    MetadataToken.toInt (MetadataToken.GenericParameter param.Handle.Get)
+```
+
+This mirrors the type-generic `GenericParameter` arm but indexes into
+`methodInfo.Generics` instead of `typeInfo.Generics`.
+
+### 2b. `RuntimeMethodHandle.HasMethodInstantiation` InternalCall
+
+Takes an `IRuntimeMethodInfo` (or `RuntimeMethodHandleInternal`), returns bool.
+Look up the method via the method-handle registry, check whether its generic
+parameter count is > 0.
+
+### 2c. `RuntimeMethodHandle.GetMethodInstantiation` QCall
+
+Takes `(RuntimeMethodHandleInternal method, ObjectHandleOnStack types, BOOL
+fAsRuntimeTypeArray)`. Look up the method via the method-handle registry, read
+its `MethodDefinitionHandle`, find the declaring type's `ResolvedTypeIdentity`,
+construct `MethodGenericParameter(declaringType, methodHandle, position)` targets
+for each position, allocate RuntimeType objects, pack into a managed array, and
+write to the ObjectHandleOnStack.
+
+This mirrors how `RuntimeTypeHandle.GetInstantiation` (NativeRuntimeType.fs:1614-1644)
+constructs `GenericParameter` targets for type parameters.
+
+### 2d. `getOrAllocateTypeNameString` — MethodGenericParameter arm
+
+Replace the TODO with a lookup of the parameter name from
+`assembly.Methods.[declaringMethod].Generics.[position]` (the `GenericParameter.Name`
+field). This is needed because the managed `Type.Name` property reads the name
+string, which flows through this path.
+
+### Test
+
+`MethodGenericParameterReflection.cs` in `sourcesPure/`:
+
+```csharp
+using System;
+using System.Reflection;
+
+namespace MethodGenericParameterReflection
+{
+    class Util
+    {
+        public static TResult Identity<TResult>(TResult x) => x;
+        public static (TK, TV) Pair<TK, TV>(TK k, TV v) => (k, v);
+    }
+
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            MethodInfo identity = typeof(Util).GetMethod("Identity");
+            if (identity == null) return 1;
+
+            Type[] gargs = identity.GetGenericArguments();
+            if (gargs.Length != 1) return 2;
+
+            Type t = gargs[0];
+            if (!t.IsGenericParameter) return 3;
+            if (t.GenericParameterPosition != 0) return 4;
+            if ((t.MetadataToken >> 24) != 0x2A) return 5;
+            // Unconstrained method generic param: attributes = None (0x0)
+            if ((int)t.GenericParameterAttributes != 0x0) return 6;
+
+            // Two-parameter generic method
+            MethodInfo pair = typeof(Util).GetMethod("Pair");
+            if (pair == null) return 7;
+            Type[] pargs = pair.GetGenericArguments();
+            if (pargs.Length != 2) return 8;
+            if (pargs[0].GenericParameterPosition != 0) return 9;
+            if (pargs[1].GenericParameterPosition != 1) return 10;
+            // Distinct tokens
+            if (pargs[0].MetadataToken == pargs[1].MetadataToken) return 11;
+
+            return 0;
+        }
+    }
+}
+```
+
+**Correctness oracle**:
+- `MethodGenericParameterReflection.cs` passes on both PawPrint and the real runtime.
+- All existing tests continue to pass.
+
+---
+
+## Stage 3: `GetDeclaringMethod` for method-generic parameters
+
+**Dependencies**: Stage 2
+
+**Implements**: Design §4 (`GetDeclaringMethod` consumer)
+
+Replace the `GetDeclaringMethod` implementation (NativeRuntimeType.fs:2530-2540)
+to distinguish between type-generic and method-generic parameters:
+
+- `GenericParameter` → return null (unchanged)
+- `MethodGenericParameter` → return the `IRuntimeMethodInfo` for the declaring method
+
+This requires allocating a `RuntimeMethodInfoStub` for the declaring method,
+using the method-handle registry. The existing `MethodHandleRegistry.getOrAllocate`
+can produce the `RuntimeMethodHandle`; the stub wraps it as `IRuntimeMethodInfo`.
+
+Expand the test to check `DeclaringMethod`:
+
+```csharp
+// Type-generic parameter: DeclaringMethod is null
+Type typeParam = typeof(Box<>).GetGenericArguments()[0];
+if (typeParam.DeclaringMethod != null) return 20;
+
+// Method-generic parameter: DeclaringMethod is non-null
+Type methodParam = typeof(Util).GetMethod("Identity").GetGenericArguments()[0];
+if (methodParam.DeclaringMethod == null) return 21;
+if (methodParam.DeclaringMethod.Name != "Identity") return 22;
+```
+
+**Correctness oracle**:
+- Expanded test passes on both runtimes.
+- The `DeclaringMethod` property correctly distinguishes type-generic (null)
+  from method-generic (non-null) parameters.
+
+---
+
+## Stage 4: Constrained method-generic parameters
+
+**Dependencies**: Stage 2
+
+**Implements**: Design §4 (`GetConstraints` consumer, `Intrinsics.fs` sites)
+
+Test method-generic parameters with constraints:
+
+```csharp
+class Constrained
+{
+    static T MakeNew<T>() where T : new() => new T();
+    static void UseRef<T>(T x) where T : class { }
+    static void UseVal<T>(T x) where T : struct { }
+}
+```
+
+This exercises:
+- `GenericParameterAttributes` for constrained method-generic parameters
+  (already working from Stage 2 since `GetGenericParamProps` is token-based)
+- Potentially `GetConstraints` if the test checks constraint types
+
+Note: Stage 4 is independent of Stage 3 — both depend only on Stage 2.
+
+**Correctness oracle**:
+- Test `MethodGenericParameterConstraints.cs` passes on both runtimes.
+- Attribute values match: `new()` → 0x10, `class` → 0x04, `struct` → 0x18.
+
+---
+
+## Risks and open questions
+
+- **Stage 0 may fail.** `GetMethod` touches `RuntimeTypeHandle.GetMethodAt`,
+  `RuntimeMethodHandle.GetAttributes`, and other QCalls/InternalCalls that may
+  not be implemented. If Stage 0 fails, this entire plan is blocked behind a
+  method-reflection prerequisite PR. The probe test's error message will identify
+  exactly which primitive is missing.
+
+- **`GetMethodInstantiation` QCall dispatch.** PawPrint's QCall dispatch
+  mechanism may differ from its InternalCall dispatch. The implementation needs
+  to match whatever pattern QCalls like `GetConstraints` and `GetInstantiation`
+  use (ObjectHandleOnStack writes, managed array allocation).
+
+- **Method-handle registry coverage.** The `MethodHandleRegistry` maps
+  `MethodHandlePtr int64` → `MethodHandle`. For `GetMethodInstantiation` to
+  work, the method must have been registered when it was first reflected upon.
+  If `GetMethod` registers methods correctly, this should be fine. If not,
+  the registration path needs extending.
+
+- **`GetDeclaringMethod` return type.** The InternalCall returns
+  `IRuntimeMethodInfo`, which is an interface. PawPrint needs to produce a
+  `RuntimeMethodInfoStub` instance (or equivalent). The existing
+  `MethodHandleRegistry.getOrAllocate` produces `RuntimeMethodHandle` structs;
+  we may need the intermediate `RuntimeMethodInfoStub` allocation path.

--- a/docs/plans/2026-05-09-method-generic-params.md
+++ b/docs/plans/2026-05-09-method-generic-params.md
@@ -1,0 +1,139 @@
+# Design: Method-generic parameter RuntimeType support
+
+## Why
+
+`RuntimeTypeHandleTarget.GenericParameter` currently represents only **type**-generic
+parameters (e.g. `T` in `class Box<T>`). Method-generic parameters (e.g. `TResult`
+in `TResult Foo<TResult>()`) are explicitly noted as "not yet represented"
+(`NativeIntSource.fs:88`). This blocks any managed code that reflects on a
+generic method's type parameters:
+
+```csharp
+typeof(Foo).GetMethod("Bar").GetGenericArguments()[0].GenericParameterAttributes
+```
+
+The gap manifests at multiple sites:
+
+| Site | File:line | Current behaviour |
+|------|-----------|-------------------|
+| DU definition | `NativeIntSource.fs:88` | Comment: "Method generic parameters are not yet represented" |
+| `ldtoken !!n` | `IlMachineTypeResolution.fs:460-462` | `failwith "TODO: ldtoken for unbound generic method parameter"` |
+| `GetDeclaringMethod` | `NativeRuntimeType.fs:2530-2540` | Always returns null (correct for type params, wrong for method params) |
+| Constraint fold | `NativeRuntimeType.fs:1771-1773` | `failwith "... method-generic parameter constraint; impossible without a method context"` |
+
+## Design
+
+### 1. Identity representation
+
+Add a new DU case to `RuntimeTypeHandleTarget`:
+
+```fsharp
+| MethodGenericParameter of
+    declaringType : ResolvedTypeIdentity *
+    declaringMethod : ComparableMethodDefinitionHandle *
+    position : int
+```
+
+Why these three fields:
+
+- **`declaringType`**: Provides the assembly name for `LoadedAssembly` lookups and
+  the type identity for `GetDeclaringType`. Follows the type-generic `GenericParameter`
+  pattern.
+- **`declaringMethod`**: The method's `MethodDefinitionHandle` in the declaring type's
+  assembly. Needed to look up `assembly.Methods.[handle].Generics` for the
+  parameter metadata. Wrapped in `ComparableMethodDefinitionHandle` per the
+  existing pattern for handle-carrying DU cases.
+- **`position`**: Zero-based generic parameter index within the method's parameter list.
+
+Why not extend the existing `GenericParameter` case with an `Option<ComparableMethodDefinitionHandle>`:
+the two cases have genuinely different semantics at every consumer site
+(`GetDeclaringType` returns the type vs. the method's declaring type;
+`GetDeclaringMethod` returns null vs. a `RuntimeMethodInfo`;
+`GetToken` looks up `typeInfo.Generics` vs. `methodInfo.Generics`).
+Merging them would add branching at every match site rather than letting the
+DU do its job.
+
+### 2. Entry point: RuntimeMethodHandle.GetMethodInstantiation (QCall)
+
+In CoreCLR, `RuntimeMethodInfo.GetGenericArguments()` calls:
+```csharp
+RuntimeMethodHandle.GetMethodInstantiationPublic(this)
+```
+which is backed by the QCall `RuntimeMethodHandle_GetMethodInstantiation`. This
+returns a `RuntimeType[]` where each element represents one of the method's
+generic parameters.
+
+PawPrint must implement this QCall to construct `MethodGenericParameter` targets
+for each position, allocate `RuntimeType` objects for them, and pack them into
+a managed array. This mirrors how `RuntimeTypeHandle.GetInstantiation`
+(`NativeRuntimeType.fs:1614-1644`) constructs `GenericParameter` targets for type
+parameters.
+
+The QCall takes `(RuntimeMethodHandleInternal method, ObjectHandleOnStack types,
+BOOL fAsRuntimeTypeArray)`. PawPrint's method-handle registry maps
+`MethodHandlePtr int64` → `MethodHandle` → `MethodDefinitionHandle`. From the
+definition handle we can reach `assembly.Methods.[handle].Generics` to get the
+count and metadata.
+
+### 3. Entry point: `HasMethodInstantiation` (InternalCall)
+
+`RuntimeMethodHandle.HasMethodInstantiation` is an InternalCall that returns true
+if a method is generic. The managed `GetGenericArguments()` calls
+`GetMethodInstantiationPublic` unconditionally, but `IsGenericMethod` checks
+`HasMethodInstantiation`. Either way, this InternalCall needs implementation to
+avoid a dispatch failure when managed code queries whether a method is generic.
+
+### 4. Consumer site updates
+
+All `match typeHandleTarget with` blocks that handle `GenericParameter` need a
+`MethodGenericParameter` arm:
+
+| Site | What `MethodGenericParameter` should do |
+|------|-----------------------------------------|
+| `ToString` | `"method generic parameter #position of method handle on declaringType"` |
+| `typeDefinitionTokenOfRuntimeTypeHandleTarget` (GetToken) | Look up `assembly.Methods.[declaringMethod].Generics.[position].Handle` and return `MetadataToken.GenericParameter handle` |
+| `declaringRuntimeType` (GetDeclaringType) | Return the RuntimeType for `declaringType` (the type containing the method) |
+| `baseRuntimeType` (GetBaseType) | TODO — same status as type-generic params |
+| `corElementType` | TODO — same status as type-generic params |
+| `IsGenericVariable` | Return `true` |
+| `GetGenericVariableIndex` | Return `position` |
+| `GetDeclaringMethod` | Return the `IRuntimeMethodInfo` for the declaring method (non-null!) |
+| `requireEmptyInterfaceMap` | TODO — same status as type-generic params |
+| `instantiateGenericRuntimeTypeTarget` | Fail (parameters can't be instantiated) |
+| `getOrAllocateTypeNameString` | Return the parameter name from `assembly.Methods.[declaringMethod].Generics.[position]` |
+| `GetInstantiation` | Return empty (parameters have no instantiation) |
+| `GetConstraints` | Read constraints from the method's generic parameter metadata |
+| `MethodTableProjection` sites | TODO failwiths matching type-generic pattern |
+| `Intrinsics.fs` (IsValueType, IsEnum) | Mirror type-generic constraint-flag logic |
+
+### 5. What already works
+
+- **`GenericParameter.readAll`** and **`ComparableGenericParameterHandle`**: Already called
+  for method generics at `MethodInfo.fs:780`. The `Handle` field is populated for
+  both type-generic and method-generic parameters.
+- **`MetadataImport.GetGenericParamProps`**: Works with any 0x2A token. No changes needed.
+- **`MetadataToken.GenericParameter`** and **`MetadataToken.ofInt`**: Handle both
+  type and method parameter tokens.
+
+### 6. Prerequisite: `Type.GetMethod()` reflection
+
+An end-to-end test like `typeof(Foo).GetMethod("Bar").GetGenericArguments()[0]`
+requires `Type.GetMethod()` to work. This is a non-trivial reflection path going
+through `RuntimeType.GetMethodCandidates` → `RuntimeTypeHandle.GetMethodAt` (QCall)
+→ method enumeration. Whether this path works today is unverified.
+
+If `GetMethod` doesn't work yet, the test can't exercise method-generic parameters
+through the reflection API. The alternatives are:
+- Implement enough of the method reflection path to make `GetMethod` work (large scope)
+- Find a simpler entry point that creates method-generic parameter RuntimeTypes
+- Write infrastructure-only stages that are tested by "compiles and existing tests pass"
+
+### 7. Out of scope
+
+- **`ldtoken !!n` for unbound method generics.** This is an edge case for
+  open generic method definitions in metadata inspection. Low priority.
+- **Method-generic parameter constraints.** `GetConstraints` for method
+  parameters reads from `MethodInfo.Generics` instead of `TypeInfo.Generics`
+  but otherwise follows the same pattern.
+- **Cross-assembly method-generic parameters.** Tokens are scoped to the
+  declaring assembly; the `declaringType.Assembly` field provides the scope.


### PR DESCRIPTION
## Summary

- Adds `MethodReflectionProbe.cs` pure test to probe whether `Type.GetMethod()` works in PawPrint
- Registers it as unimplemented: blocked by `RuntimeTypeHandle::GetNumVirtuals` InternalCall (method enumeration)
- Adds design doc and implementation plan for method-generic parameter `RuntimeType` support

This is Stage 0 of the method-generic parameter plan. The probe identifies that `GetNumVirtuals` (and likely `GetMethodAt` and related method enumeration primitives) must be implemented before end-to-end tests for method-generic parameters can run.

## Test plan
- [x] Probe test passes as unimplemented (real-runtime exit code 0)
- [x] All 628 existing tests pass
- [x] Codex review clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)