### PR TITLE
Implement String..ctor(char*) InternalCall

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/StringCtorCharPointer.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/StringCtorCharPointer.cs
@@ -77,6 +77,29 @@ unsafe class StringCtorCharPointer
         return 0;
     }
 
+    static int TestEmptyResultsAreCanonical()
+    {
+        // CoreCLR returns the canonical empty string (i.e. the same reference as
+        // the "" literal) when the input pointer is null or empty. PawPrint must
+        // preserve that identity so reference comparisons agree with .NET.
+        string fromNull = new string((char*)null);
+        char[] terminated = { '\0' };
+        string fromEmptyArray;
+        fixed (char* p = terminated)
+        {
+            fromEmptyArray = new string(p);
+        }
+
+        if (!ReferenceEquals(fromNull, ""))
+            return 50;
+        if (!ReferenceEquals(fromEmptyArray, ""))
+            return 51;
+        if (!ReferenceEquals(fromNull, fromEmptyArray))
+            return 52;
+
+        return 0;
+    }
+
     static int Main(string[] args)
     {
         int result = TestFixedManagedCharArray();
@@ -96,6 +119,10 @@ unsafe class StringCtorCharPointer
             return result;
 
         result = TestEmbeddedNullStops();
+        if (result != 0)
+            return result;
+
+        result = TestEmptyResultsAreCanonical();
         if (result != 0)
             return result;
 

--- a/WoofWare.PawPrint.Test/sourcesPure/StringCtorCharPointer.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/StringCtorCharPointer.cs
@@ -1,0 +1,104 @@
+using System;
+
+unsafe class StringCtorCharPointer
+{
+    static int TestFixedManagedCharArray()
+    {
+        char[] chars = { 'h', 'e', 'l', 'l', 'o', '\0' };
+        fixed (char* p = chars)
+        {
+            string s = new string(p);
+            if (s.Length != 5)
+                return 1;
+            if (s != "hello")
+                return 2;
+        }
+
+        return 0;
+    }
+
+    static int TestEmptyTerminatedManagedCharArray()
+    {
+        char[] chars = { '\0' };
+        fixed (char* p = chars)
+        {
+            string s = new string(p);
+            if (s.Length != 0)
+                return 10;
+            if (s != "")
+                return 11;
+        }
+
+        return 0;
+    }
+
+    static int TestNullPointer()
+    {
+        // Per CoreCLR's String.Ctor(char*) source, a null char* yields String.Empty.
+        string s = new string((char*)null);
+        if (s.Length != 0)
+            return 20;
+        if (s != "")
+            return 21;
+
+        return 0;
+    }
+
+    static int TestStackallocTerminated()
+    {
+        char* p = stackalloc char[4];
+        p[0] = 'h';
+        p[1] = 'i';
+        p[2] = '!';
+        p[3] = '\0';
+
+        string s = new string(p);
+        if (s.Length != 3)
+            return 30;
+        if (s != "hi!")
+            return 31;
+
+        return 0;
+    }
+
+    static int TestEmbeddedNullStops()
+    {
+        // The constructor stops at the first NUL, even if more chars follow.
+        char[] chars = { 'a', 'b', '\0', 'c', 'd' };
+        fixed (char* p = chars)
+        {
+            string s = new string(p);
+            if (s.Length != 2)
+                return 40;
+            if (s != "ab")
+                return 41;
+        }
+
+        return 0;
+    }
+
+    static int Main(string[] args)
+    {
+        int result = TestFixedManagedCharArray();
+        if (result != 0)
+            return result;
+
+        result = TestEmptyTerminatedManagedCharArray();
+        if (result != 0)
+            return result;
+
+        result = TestNullPointer();
+        if (result != 0)
+            return result;
+
+        result = TestStackallocTerminated();
+        if (result != 0)
+            return result;
+
+        result = TestEmbeddedNullStops();
+        if (result != 0)
+            return result;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -60,6 +60,9 @@ module IlMachineState =
 
     let mapFrame = IlMachineThreadState.mapFrame
 
+    let withReplacedConstructedObject =
+        IlMachineThreadState.withReplacedConstructedObject
+
     let pushToEvalStack' = IlMachineThreadState.pushToEvalStack'
 
     let pushToEvalStack = IlMachineThreadState.pushToEvalStack

--- a/WoofWare.PawPrint/IlMachineThreadState.fs
+++ b/WoofWare.PawPrint/IlMachineThreadState.fs
@@ -38,6 +38,45 @@ module IlMachineThreadState =
             ThreadState = state.ThreadState |> Map.add thread threadState
         }
 
+    /// Replace the `WasConstructingObj` of the active frame's `ReturnState` with `Some newAddr`.
+    /// Used by InternalCall constructors that allocate the constructed object themselves
+    /// (e.g. `String..ctor(char*)`): the placeholder allocated by `executeNewobj` is discarded
+    /// and the next `returnStackFrame` pushes `newAddr` onto the caller's eval stack instead.
+    /// Fails loudly if invoked outside a constructor frame.
+    let withReplacedConstructedObject
+        (newAddr : ManagedHeapAddress)
+        (thread : ThreadId)
+        (state : IlMachineState)
+        : IlMachineState
+        =
+        let threadState = state.ThreadState.[thread]
+        let activeFrameId = threadState.ActiveMethodState
+
+        let updateFrame (frame : MethodState) : MethodState =
+            match frame.ReturnState with
+            | None ->
+                failwith
+                    $"withReplacedConstructedObject: active frame %s{frame.ExecutingMethod.Name} has no ReturnState; cannot redirect a non-existent constructor return"
+            | Some returnState ->
+                match returnState.WasConstructingObj with
+                | None ->
+                    failwith
+                        $"withReplacedConstructedObject: active frame %s{frame.ExecutingMethod.Name} is not a constructor frame (WasConstructingObj is None)"
+                | Some _ ->
+                    { frame with
+                        ReturnState =
+                            Some
+                                { returnState with
+                                    WasConstructingObj = Some newAddr
+                                }
+                    }
+
+        let threadState = ThreadState.mapFrame activeFrameId updateFrame threadState
+
+        { state with
+            ThreadState = state.ThreadState |> Map.add thread threadState
+        }
+
     let pushToEvalStack' (o : EvalStackValue) (thread : ThreadId) (state : IlMachineState) =
         let activeThreadState = state.ThreadState.[thread]
 

--- a/WoofWare.PawPrint/Native/NativeString.fs
+++ b/WoofWare.PawPrint/Native/NativeString.fs
@@ -61,15 +61,31 @@ module NativeString =
             let ptr =
                 NativeCall.managedPointerOfPointerArgument operation "value" instruction.Arguments.[1]
 
-            // CoreCLR's String.Ctor(char*) returns String.Empty when ptr == null,
-            // rather than throwing ArgumentNullException.
+            // CoreCLR's String.Ctor(char*) returns String.Empty when ptr == null
+            // or the first char is NUL, rather than throwing or allocating fresh.
+            // The returned reference must be the canonical empty string so that
+            // `(object)new string((char*)null) == (object)""` holds, matching
+            // .NET. We thread through `InternedStrings` so the address is shared
+            // with `Ldstr ""` regardless of which site materialises it first.
             let contents =
                 match ptr with
                 | ManagedPointerSource.Null -> ""
                 | _ -> NativeCall.readNullTerminatedUtf16 operation ctx.BaseClassTypes state ptr
 
             let newAddr, state =
-                IlMachineState.allocateManagedString ctx.LoggerFactory ctx.BaseClassTypes contents state
+                if contents = "" then
+                    match state.InternedStrings.TryGetValue "" with
+                    | true, addr -> addr, state
+                    | false, _ ->
+                        let addr, state =
+                            IlMachineState.allocateManagedString ctx.LoggerFactory ctx.BaseClassTypes "" state
+
+                        addr,
+                        { state with
+                            InternedStrings = state.InternedStrings.Add ("", addr)
+                        }
+                else
+                    IlMachineState.allocateManagedString ctx.LoggerFactory ctx.BaseClassTypes contents state
 
             // Redirect the pending newobj result to our freshly-allocated string;
             // the placeholder allocated by executeNewobj is left as garbage.

--- a/WoofWare.PawPrint/Native/NativeString.fs
+++ b/WoofWare.PawPrint/Native/NativeString.fs
@@ -43,4 +43,38 @@ module NativeString =
             |> IlMachineState.pushToEvalStack (CliType.ObjectRef (Some addr)) ctx.Thread
             |> fun state -> (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
             |> Some
+        | "System.Private.CoreLib",
+          "System",
+          "String",
+          ".ctor",
+          [ ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.Char) ],
+          MethodReturnType.Void ->
+            let operation = "String..ctor(char*)"
+
+            // Newobj-driven constructor frames carry `this` as Arguments.[0]
+            // (the placeholder allocated by executeNewobj) and the user-visible
+            // char* as Arguments.[1].
+            if instruction.Arguments.Length <> 2 then
+                failwith
+                    $"%s{operation}: expected 2 arguments (this, char*) after matching signature, got %d{instruction.Arguments.Length}"
+
+            let ptr =
+                NativeCall.managedPointerOfPointerArgument operation "value" instruction.Arguments.[1]
+
+            // CoreCLR's String.Ctor(char*) returns String.Empty when ptr == null,
+            // rather than throwing ArgumentNullException.
+            let contents =
+                match ptr with
+                | ManagedPointerSource.Null -> ""
+                | _ -> NativeCall.readNullTerminatedUtf16 operation ctx.BaseClassTypes state ptr
+
+            let newAddr, state =
+                IlMachineState.allocateManagedString ctx.LoggerFactory ctx.BaseClassTypes contents state
+
+            // Redirect the pending newobj result to our freshly-allocated string;
+            // the placeholder allocated by executeNewobj is left as garbage.
+            state
+            |> IlMachineState.withReplacedConstructedObject newAddr ctx.Thread
+            |> fun state -> (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            |> Some
         | _ -> None

--- a/docs/plans/2026-05-09-string-ctor-char-pointer.md
+++ b/docs/plans/2026-05-09-string-ctor-char-pointer.md
@@ -1,0 +1,101 @@
+# Plan: Implement `String..ctor(char*)`
+
+## Context
+
+`String..ctor(char*)` is a CoreLib InternalCall constructor that builds a managed `string` from a null-terminated UTF-16 character pointer. In the .NET BCL it is declared as `extern unsafe String(char* value)` with `[MethodImpl(MethodImplOptions.InternalCall)]`. WoofWare.PawPrint does not implement it, so any guest code using `new string(p)` over a `char*` traps. This is the user's "Blocker 13".
+
+The fix is mostly mechanical: PawPrint already has every primitive needed — a UTF-16 null-terminator scanner over `ManagedPointerSource`, a managed-string allocator, and a native-dispatch seam for InternalCall String methods. The only missing piece is the per-method handler and a small helper to redirect the result of an `Newobj`-driven constructor frame to a different heap address (because strings are allocated to a fixed length, so we can't mutate the placeholder in place — we must allocate a fresh, correctly-sized string and arrange for *that* address to be pushed when the constructor frame returns).
+
+## Approach
+
+1. **Native handler in `NativeString.fs`**, alongside the existing `FastAllocateString` case. Match on assembly `System.Private.CoreLib`, namespace `System`, type `String`, method `.ctor`, parameter list `[ char* ]`, return type `void`.
+2. The handler:
+   - Reads the second method argument (`Arguments.[0]` is `this`; `Arguments.[1]` is the `char*`).
+   - Coerces it to a `ManagedPointerSource` via the existing `NativeCall.managedPointerOfPointerArgument` helper. That helper already maps both `Verbatim 0L` and a literal null managed pointer to `ManagedPointerSource.Null`, and unwraps `NativeIntSource.ManagedPointer p` to `p`.
+   - If null, the resulting string is empty (CoreCLR's `String.Ctor(char* ptr)` returns `Empty` when `ptr == null`; see `dotnet/.../System/String.cs:124-141`). Otherwise, calls `NativeCall.readNullTerminatedUtf16` to scan UTF-16 chars until `\0`. That helper is already correctly bounded (32767-char defensive scan limit) and already produces an F# `string`.
+   - Allocates a fresh managed string of the right length via `IlMachineState.allocateManagedString` to get a new `ManagedHeapAddress`.
+   - **Crucially**, replaces `WasConstructingObj` on the current frame's `ReturnState` with the new address. The placeholder allocated by `executeNewobj` (`UnaryMetadataObjectOps.fs:150`) stays on the heap as garbage but isn't referenced. After the native handler returns `Stepped Executed`, `AbstractMachine` calls `returnStackFrame` (`AbstractMachine.fs:182`), which inspects `WasConstructingObj` (`IlMachineThreadState.fs:182-211`) and pushes the address it finds. By the time we get there, that's our new string, not the placeholder.
+3. **A small new helper** in `IlMachineThreadState.fs` (or `IlMachineState.fs` re-export) to mutate `ReturnState.WasConstructingObj` on the active frame. This uses `ThreadState.mapFrame` and is roughly:
+   ```fsharp
+   let withReplacedConstructedObject (newAddr : ManagedHeapAddress) (thread : ThreadId) (state : IlMachineState) : IlMachineState
+   ```
+   It fails loudly if `ReturnState` is `None` or if `WasConstructingObj` is already `None` — both would indicate this helper was called outside a constructor frame, which is a logic error.
+
+This keeps the change small, reuses existing infrastructure, and matches the existing dispatch idiom in `NativeString.fs`. It does not require touching `executeNewobj` or `callMethod`.
+
+## Files to modify
+
+- `WoofWare.PawPrint/IlMachineThreadState.fs` — add the `withReplacedConstructedObject` helper (placed near the existing `setFrame` helpers around line 13–22).
+- `WoofWare.PawPrint/IlMachineState.fs` — re-export the new helper alongside other re-exports (around line 80).
+- `WoofWare.PawPrint/Native/NativeString.fs` — add the `.ctor(char*)` case to the pattern match in `tryExecute` (around line 19–46).
+- `WoofWare.PawPrint.Test/sourcesPure/StringCtorCharPointer.cs` — new test (auto-discovered by the `sourcesPure` mechanism).
+
+## Implementation sketch
+
+In `NativeString.fs`, alongside `FastAllocateString`:
+
+```fsharp
+| "System.Private.CoreLib",
+  "System",
+  "String",
+  ".ctor",
+  [ ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.Char) ],
+  MethodReturnType.Void ->
+    let operation = "String..ctor(char*)"
+    if instruction.Arguments.Length <> 2 then
+        failwith
+            $"%s{operation}: expected 2 args (this, char*) after matching signature, got %d{instruction.Arguments.Length}"
+
+    let ptr =
+        NativeCall.managedPointerOfPointerArgument operation "value" instruction.Arguments.[1]
+
+    let contents =
+        match ptr with
+        | ManagedPointerSource.Null -> ""
+        | _ ->
+            NativeCall.readNullTerminatedUtf16 operation ctx.BaseClassTypes state ptr
+
+    let newAddr, state =
+        IlMachineState.allocateManagedString ctx.LoggerFactory ctx.BaseClassTypes contents state
+
+    state
+    |> IlMachineState.withReplacedConstructedObject newAddr ctx.Thread
+    |> fun state -> (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+    |> Some
+```
+
+Note: `Arguments.[0]` is `this` (the placeholder string ref); we deliberately ignore it. The `readNullTerminatedUtf16` helper already throws on unsupported source variants; we don't add new variant handling here.
+
+## Edge cases
+
+- **Null pointer (`(char*)0`).** Returns `""`. Matches CoreCLR's `Ctor(char*)` source. The user's `string s = new string((char*)null)` test should yield an empty string.
+- **Non-null `NativeIntSource.Verbatim` (raw native address).** Falls through `managedPointerOfPointerArgument` to its `failwith`. This is consistent with current PawPrint scope: there is no model for arbitrary unmanaged memory, and this constructor variant is realistically only callable from guest code via `fixed` over a managed array (which produces `ManagedPointerSource.Byref _`) or via `null` (handled above). If a guest program ever does pass a raw address, the failure message will clearly indicate the missing capability.
+- **Unterminated input.** `readNullTerminatedUtf16` enforces a 32767-char defensive scan ceiling and fails with a clear message — consistent behavior, not specific to this caller.
+- **`stackalloc char[N]` followed by `new string(p)`.** Produces a `Byref` over a `LocalMemoryByte` root; the `readNullTerminatedUtf16` `Byref _` arm handles this transparently via `ManagedPointerByteView.addByteOffset` arithmetic.
+
+## Test
+
+`WoofWare.PawPrint.Test/sourcesPure/StringCtorCharPointer.cs` — exit code 0 on success. Cover:
+
+- `fixed (char* p = chars)` over a managed `char[]` ending in `'\0'` → `new string(p)` equals the expected literal.
+- Empty input: `char[] { '\0' }` → empty string.
+- `new string((char*)null)` → empty string.
+- `stackalloc char[]` containing terminated UTF-16 → matches expected literal.
+
+The test files in `sourcesPure/` are auto-registered (see `TestPureCases.fs`); no manual wiring needed unless the test ends up needing to be on the `unimplemented` list.
+
+If anything about the *current* `unimplemented` set should reference this work (e.g. tests that were blocked on `String..ctor(char*)`), that's a follow-up — let's not bundle it.
+
+## Verification
+
+1. Build: `nix develop -c dotnet build WoofWare.PawPrint.slnx`.
+2. Format: `nix develop -c dotnet fantomas .`.
+3. Run the new test: `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --filter "Name~StringCtorCharPointer" --verbosity normal`.
+4. Full suite to check for regressions: `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --verbosity normal`.
+5. After committing on a non-main branch: invoke `codex review --base main` per the project workflow in `CLAUDE.md`, address findings.
+
+## Out of scope (intentional)
+
+- `String..ctor(char*, int, int)` and the `sbyte*` overloads — they're separate InternalCalls.
+- Reading from arbitrary `NativeIntSource.Verbatim` addresses — requires a model for unmanaged memory that doesn't currently exist (see exploration notes).
+- Refactoring `readNullTerminatedUtf16` to allow `Null` (it currently `failwith`s with a TODO referencing `ArgumentNullException`). The String ctor wants different null behavior (return `""`, not throw), so we handle null *before* delegating, which leaves the helper's existing contract intact for its other callers (`AssemblyNative_GetResource`, `NativeKernel32`).


### PR DESCRIPTION
## Summary
- Adds a native handler for `String..ctor(char*)` so guest code that constructs strings from null-terminated UTF-16 pointers (e.g. via `fixed` over a managed `char[]`, or `stackalloc char[]`) executes correctly.
- Introduces `withReplacedConstructedObject` to redirect the result of a `newobj`-driven constructor frame to a freshly-allocated string. Strings have fixed length, so the placeholder that `executeNewobj` allocates can't be mutated in place; we allocate a correctly-sized string and patch `WasConstructingObj` instead.
- Matches CoreCLR's contract that null or empty inputs return `String.Empty` (the canonical interned reference) by routing the empty case through `InternedStrings`, so `(object)new string((char*)null) == (object)""` holds.

## Test plan
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --filter "Name~StringCtorCharPointer" --verbosity normal` passes.
- [x] Full suite: 628/628 pass.
- [x] `nix develop -c dotnet fantomas .` is a no-op.
- [x] `codex review --base main` returns no actionable findings on the final diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)