### PR TITLE
Add FunctionPointer concretization and reflection support

### DIFF
--- a/WoofWare.PawPrint.Domain/MethodInfo.fs
+++ b/WoofWare.PawPrint.Domain/MethodInfo.fs
@@ -854,7 +854,7 @@ module MethodInfo =
         | TypeDefn.FromReference (typeRef, signatureTypeKind) -> failwith "todo"
         | TypeDefn.FromDefinition (_identity, signatureTypeKind) -> failwith "todo"
         | TypeDefn.GenericInstantiation (generic, args) -> failwith "todo"
-        | TypeDefn.FunctionPointer typeMethodSignature -> failwith "todo"
+        | TypeDefn.FunctionPointer _ -> ResolvedBaseType.ValueType
         | TypeDefn.GenericTypeParameter index ->
             resolveBaseType methodGenerics executingMethod executingMethod.DeclaringType.Generics.[index]
         | TypeDefn.GenericMethodParameter index ->

--- a/WoofWare.PawPrint.Domain/TypeConcretisation.fs
+++ b/WoofWare.PawPrint.Domain/TypeConcretisation.fs
@@ -14,6 +14,9 @@ type ConcreteTypeHandle =
     /// A general array with explicit rank (potentially multi-dimensional), e.g. int[,] (rank=2).
     /// Rank is tracked so that int[,] and int[,,] are distinct types.
     | Array of element : ConcreteTypeHandle * rank : int
+    /// A function pointer type (e.g. `delegate*<int, int>` in C#). Distinct fnptr types
+    /// have distinct signatures, so the signature is the type identity.
+    | FunctionPointer of TypeMethodSignature<ConcreteTypeHandle>
 
     override this.ToString () =
         match this with
@@ -25,6 +28,18 @@ type ConcreteTypeHandle =
             let inside = if rank <= 1 then "*" else String.replicate (rank - 1) ","
 
             e.ToString () + "[" + inside + "]"
+        | ConcreteTypeHandle.FunctionPointer signature ->
+            let args =
+                signature.ParameterTypes
+                |> List.map (fun h -> h.ToString ())
+                |> String.concat " -> "
+
+            let returnStr =
+                match signature.ReturnType with
+                | MethodReturnType.Void -> "void"
+                | MethodReturnType.Returns ty -> ty.ToString ()
+
+            $"*({args} -> {returnStr})"
 
 type AllConcreteTypes =
     private
@@ -51,6 +66,7 @@ module AllConcreteTypes =
         | ConcreteTypeHandle.Pointer _ -> None // Pointer types are not stored in the mapping
         | ConcreteTypeHandle.OneDimArrayZero _ -> None // Array types are structural wrappers
         | ConcreteTypeHandle.Array _ -> None // Array types are structural wrappers
+        | ConcreteTypeHandle.FunctionPointer _ -> None // FunctionPointer types are structural wrappers
 
     let findExistingConcreteType
         (concreteTypes : AllConcreteTypes)
@@ -188,7 +204,8 @@ module ConcreteActivePatterns =
         | ConcreteTypeHandle.OneDimArrayZero _
         | ConcreteTypeHandle.Array _
         | ConcreteTypeHandle.Byref _
-        | ConcreteTypeHandle.Pointer _ -> None
+        | ConcreteTypeHandle.Pointer _
+        | ConcreteTypeHandle.FunctionPointer _ -> None
 
     /// Matches an array type whose element type is the given handle.
     let (|ConcreteGenericArray|_|)
@@ -427,6 +444,12 @@ module ConcreteActivePatterns =
     let (|ConcreteArray|_|) (handle : ConcreteTypeHandle) =
         match handle with
         | ConcreteTypeHandle.Array (inner, rank) -> Some (inner, rank)
+        | _ -> None
+
+    /// Active pattern to match function pointer types, returning the concretized signature.
+    let (|ConcreteFunctionPointer|_|) (handle : ConcreteTypeHandle) =
+        match handle with
+        | ConcreteTypeHandle.FunctionPointer signature -> Some signature
         | _ -> None
 
 type IAssemblyLoad =
@@ -718,7 +741,55 @@ module TypeConcretization =
                     voidTypeInfo.Name
                     ImmutableArray.Empty // Void has no generic parameters
 
-        | _ -> failwithf "TODO: Concretization of %A not implemented" typeDefn
+        | TypeDefn.FunctionPointer signature ->
+            // Function pointer types are structural: the signature is the type identity.
+            // Concretize each parameter and the return type under the current generic context.
+            let concretized, ctx =
+                concretizeMethodSignature ctx loadAssembly assembly typeGenerics methodGenerics signature
+
+            ConcreteTypeHandle.FunctionPointer concretized, ctx
+
+    and concretizeMethodSignature
+        (ctx : ConcretizationContext<DumpedAssembly>)
+        (loadAssembly : IAssemblyLoad)
+        (assembly : AssemblyName)
+        (typeGenerics : ImmutableArray<ConcreteTypeHandle>)
+        (methodGenerics : ImmutableArray<ConcreteTypeHandle>)
+        (signature : TypeMethodSignature<TypeDefn>)
+        : TypeMethodSignature<ConcreteTypeHandle> * ConcretizationContext<DumpedAssembly>
+        =
+        // Concretize return type only when the method actually returns a value.
+        let ctx, returnType =
+            MethodReturnType.map
+                ctx
+                (fun ctx ty ->
+                    let handle, ctx =
+                        concretizeType ctx loadAssembly assembly typeGenerics methodGenerics ty
+
+                    ctx, handle
+                )
+                signature.ReturnType
+
+        let paramHandles = ResizeArray<ConcreteTypeHandle> signature.ParameterTypes.Length
+        let mutable ctx = ctx
+
+        for paramType in signature.ParameterTypes do
+            let handle, newCtx =
+                concretizeType ctx loadAssembly assembly typeGenerics methodGenerics paramType
+
+            paramHandles.Add handle
+            ctx <- newCtx
+
+        let concretized =
+            {
+                Header = signature.Header
+                ReturnType = returnType
+                ParameterTypes = paramHandles |> List.ofSeq
+                GenericParameterCount = signature.GenericParameterCount
+                RequiredParameterCount = signature.RequiredParameterCount
+            }
+
+        concretized, ctx
 
     and private concretizeGenericInstantiation
         (ctx : ConcretizationContext<DumpedAssembly>)
@@ -812,40 +883,7 @@ module Concretization =
         (signature : TypeMethodSignature<TypeDefn>)
         : TypeMethodSignature<ConcreteTypeHandle> * TypeConcretization.ConcretizationContext<DumpedAssembly>
         =
-
-        // Concretize return type only when the method actually returns a value.
-        let ctx, returnType =
-            MethodReturnType.map
-                ctx
-                (fun ctx ty ->
-                    let handle, ctx =
-                        TypeConcretization.concretizeType ctx loadAssembly assembly typeArgs methodArgs ty
-
-                    ctx, handle
-                )
-                signature.ReturnType
-
-        // Concretize parameter types
-        let paramHandles = ResizeArray<ConcreteTypeHandle> ()
-        let mutable ctx = ctx
-
-        for paramType in signature.ParameterTypes do
-            let handle, newCtx =
-                TypeConcretization.concretizeType ctx loadAssembly assembly typeArgs methodArgs paramType
-
-            paramHandles.Add handle
-            ctx <- newCtx
-
-        let newSignature =
-            {
-                Header = signature.Header
-                ReturnType = returnType
-                ParameterTypes = paramHandles |> Seq.toList
-                GenericParameterCount = signature.GenericParameterCount
-                RequiredParameterCount = signature.RequiredParameterCount
-            }
-
-        newSignature, ctx
+        TypeConcretization.concretizeMethodSignature ctx loadAssembly assembly typeArgs methodArgs signature
 
     /// Helper to ensure base type assembly is loaded
     let private loadAssemblyReferenceByName
@@ -1131,6 +1169,14 @@ module Concretization =
                 concreteHandleToTypeDefn baseClassTypes elementHandle concreteTypes assemblies
 
             TypeDefn.Array (elementType, rank)
+        | ConcreteTypeHandle.FunctionPointer signature ->
+            let _, mapped =
+                TypeMethodSignature.map
+                    ()
+                    (fun () h -> (), concreteHandleToTypeDefn baseClassTypes h concreteTypes assemblies)
+                    signature
+
+            TypeDefn.FunctionPointer mapped
         | ConcreteTypeHandle.Concrete _ ->
             match AllConcreteTypes.lookup handle concreteTypes with
             | None -> failwith "Logic error: handle not found"

--- a/WoofWare.PawPrint.Test/TestFunctionPointerConcretization.fs
+++ b/WoofWare.PawPrint.Test/TestFunctionPointerConcretization.fs
@@ -1,0 +1,223 @@
+namespace WoofWare.PawPrint.Test
+
+open System.Collections.Immutable
+open System.Reflection.Metadata
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestFunctionPointerConcretization =
+
+    let private corelib : DumpedAssembly =
+        let corelibPath = typeof<obj>.Assembly.Location
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        Assembly.readFile loggerFactory corelibPath
+
+    let private baseClassTypes : BaseClassTypes<DumpedAssembly> =
+        Corelib.getBaseTypes corelib
+
+    let private loadedAssemblies : ImmutableDictionary<string, DumpedAssembly> =
+        ImmutableDictionary<string, DumpedAssembly>.Empty.Add (corelib.Name.FullName, corelib)
+
+    let private concreteTypes : AllConcreteTypes =
+        Corelib.concretizeAll loadedAssemblies baseClassTypes AllConcreteTypes.Empty
+
+    /// Default method-kind signature header. ECMA-335 II.23.2.1: low bits select the
+    /// calling convention; bit 0x10 is HASTHIS, bit 0x20 is EXPLICITTHIS, bit 0x40 is
+    /// VARARG. Plain method calling convention with no `this` is the canonical zero.
+    let private methodHeader : ComparableSignatureHeader =
+        ComparableSignatureHeader.Make (SignatureHeader (byte 0))
+
+    let private makeSignature
+        (parameters : TypeDefn list)
+        (returnType : MethodReturnType<TypeDefn>)
+        : TypeMethodSignature<TypeDefn>
+        =
+        {
+            Header = methodHeader
+            ParameterTypes = parameters
+            GenericParameterCount = 0
+            RequiredParameterCount = parameters.Length
+            ReturnType = returnType
+        }
+
+    let private state () : IlMachineState =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+
+        { IlMachineState.initial loggerFactory ImmutableArray.Empty corelib with
+            ConcreteTypes = concreteTypes
+        }
+
+    let private concretize (state : IlMachineState) (ty : TypeDefn) : IlMachineState * ConcreteTypeHandle =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+
+        IlMachineState.concretizeType
+            loggerFactory
+            baseClassTypes
+            state
+            corelib.Name
+            ImmutableArray.Empty
+            ImmutableArray.Empty
+            ty
+
+    [<Test>]
+    let ``Concretizing TypeDefn.FunctionPointer yields ConcreteTypeHandle.FunctionPointer`` () : unit =
+        let signature =
+            makeSignature
+                [ TypeDefn.PrimitiveType PrimitiveType.Int32 ]
+                (MethodReturnType.Returns (TypeDefn.PrimitiveType PrimitiveType.Int32))
+
+        let _, handle = concretize (state ()) (TypeDefn.FunctionPointer signature)
+
+        match handle with
+        | ConcreteTypeHandle.FunctionPointer concreteSig ->
+            concreteSig.GenericParameterCount |> shouldEqual 0
+            concreteSig.RequiredParameterCount |> shouldEqual 1
+            concreteSig.ParameterTypes.Length |> shouldEqual 1
+
+            match concreteSig.ReturnType with
+            | MethodReturnType.Returns _ -> ()
+            | MethodReturnType.Void -> Assert.Fail "Expected Returns, got Void"
+        | other -> Assert.Fail $"Expected FunctionPointer handle, got %O{other}"
+
+    [<Test>]
+    let ``Function pointer parameters are concretized`` () : unit =
+        let signature =
+            makeSignature
+                [ TypeDefn.PrimitiveType PrimitiveType.Int32 ]
+                (MethodReturnType.Returns (TypeDefn.PrimitiveType PrimitiveType.Int64))
+
+        let state, handle = concretize (state ()) (TypeDefn.FunctionPointer signature)
+
+        let int32Handle =
+            AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes baseClassTypes.Int32
+
+        let int64Handle =
+            AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes baseClassTypes.Int64
+
+        match handle with
+        | ConcreteTypeHandle.FunctionPointer concreteSig ->
+            concreteSig.ParameterTypes |> shouldEqual [ int32Handle ]
+            concreteSig.ReturnType |> shouldEqual (MethodReturnType.Returns int64Handle)
+        | other -> Assert.Fail $"Expected FunctionPointer handle, got %O{other}"
+
+    [<Test>]
+    let ``Void-returning function pointers are distinct from value-returning ones`` () : unit =
+        let returningSig =
+            makeSignature
+                [ TypeDefn.PrimitiveType PrimitiveType.Int32 ]
+                (MethodReturnType.Returns (TypeDefn.PrimitiveType PrimitiveType.Int32))
+
+        let voidSig =
+            makeSignature [ TypeDefn.PrimitiveType PrimitiveType.Int32 ] MethodReturnType.Void
+
+        let state, returningHandle =
+            concretize (state ()) (TypeDefn.FunctionPointer returningSig)
+
+        let _, voidHandle = concretize state (TypeDefn.FunctionPointer voidSig)
+
+        returningHandle |> shouldNotEqual voidHandle
+
+    [<Test>]
+    let ``Function pointers with different parameter types are distinct`` () : unit =
+        let intSig =
+            makeSignature
+                [ TypeDefn.PrimitiveType PrimitiveType.Int32 ]
+                (MethodReturnType.Returns (TypeDefn.PrimitiveType PrimitiveType.Int32))
+
+        let longSig =
+            makeSignature
+                [ TypeDefn.PrimitiveType PrimitiveType.Int64 ]
+                (MethodReturnType.Returns (TypeDefn.PrimitiveType PrimitiveType.Int32))
+
+        let state, intHandle = concretize (state ()) (TypeDefn.FunctionPointer intSig)
+        let _, longHandle = concretize state (TypeDefn.FunctionPointer longSig)
+
+        intHandle |> shouldNotEqual longHandle
+
+    [<Test>]
+    let ``Equivalent function pointer signatures concretize to equal handles (dedup)`` () : unit =
+        let firstSig =
+            makeSignature
+                [ TypeDefn.PrimitiveType PrimitiveType.Int32 ]
+                (MethodReturnType.Returns (TypeDefn.PrimitiveType PrimitiveType.Int32))
+
+        let secondSig =
+            makeSignature
+                [ TypeDefn.PrimitiveType PrimitiveType.Int32 ]
+                (MethodReturnType.Returns (TypeDefn.PrimitiveType PrimitiveType.Int32))
+
+        let state, firstHandle = concretize (state ()) (TypeDefn.FunctionPointer firstSig)
+        let _, secondHandle = concretize state (TypeDefn.FunctionPointer secondSig)
+
+        firstHandle |> shouldEqual secondHandle
+
+    [<Test>]
+    let ``Round-tripping a function pointer through concreteHandleToTypeDefn preserves the signature shape`` () : unit =
+        let original =
+            TypeDefn.FunctionPointer (
+                makeSignature
+                    [ TypeDefn.PrimitiveType PrimitiveType.Int32 ]
+                    (MethodReturnType.Returns (TypeDefn.PrimitiveType PrimitiveType.Int64))
+            )
+
+        let state, handle = concretize (state ()) original
+
+        let roundTripped =
+            Concretization.concreteHandleToTypeDefn baseClassTypes handle state.ConcreteTypes state._LoadedAssemblies
+
+        // The fnptr wrapper round-trips exactly; element TypeDefns may be re-expressed
+        // (e.g. PrimitiveType -> FromDefinition) by the inverse, so compare structure.
+        match roundTripped with
+        | TypeDefn.FunctionPointer roundTrippedSig ->
+            roundTrippedSig.GenericParameterCount |> shouldEqual 0
+            roundTrippedSig.RequiredParameterCount |> shouldEqual 1
+            roundTrippedSig.ParameterTypes.Length |> shouldEqual 1
+
+            match roundTrippedSig.ReturnType with
+            | MethodReturnType.Returns _ -> ()
+            | MethodReturnType.Void -> Assert.Fail "Expected Returns, got Void after round-trip"
+        | other -> Assert.Fail $"Expected FunctionPointer after round-trip, got %O{other}"
+
+    [<Test>]
+    let ``Round-tripping a void-returning function pointer preserves Void`` () : unit =
+        let original =
+            TypeDefn.FunctionPointer (
+                makeSignature [ TypeDefn.PrimitiveType PrimitiveType.Int32 ] MethodReturnType.Void
+            )
+
+        let state, handle = concretize (state ()) original
+
+        let roundTripped =
+            Concretization.concreteHandleToTypeDefn baseClassTypes handle state.ConcreteTypes state._LoadedAssemblies
+
+        match roundTripped with
+        | TypeDefn.FunctionPointer roundTrippedSig ->
+            match roundTrippedSig.ReturnType with
+            | MethodReturnType.Void -> ()
+            | MethodReturnType.Returns _ -> Assert.Fail "Expected Void after round-trip, got Returns"
+        | other -> Assert.Fail $"Expected FunctionPointer after round-trip, got %O{other}"
+
+    [<Test>]
+    let ``Round-tripping then re-concretizing yields the same handle`` () : unit =
+        let original =
+            TypeDefn.FunctionPointer (
+                makeSignature
+                    [ TypeDefn.PrimitiveType PrimitiveType.Int32 ]
+                    (MethodReturnType.Returns (TypeDefn.PrimitiveType PrimitiveType.Int32))
+            )
+
+        let state, firstHandle = concretize (state ()) original
+
+        let roundTripped =
+            Concretization.concreteHandleToTypeDefn
+                baseClassTypes
+                firstHandle
+                state.ConcreteTypes
+                state._LoadedAssemblies
+
+        let _, secondHandle = concretize state roundTripped
+
+        firstHandle |> shouldEqual secondHandle

--- a/WoofWare.PawPrint.Test/TestFunctionPointerConcretization.fs
+++ b/WoofWare.PawPrint.Test/TestFunctionPointerConcretization.fs
@@ -201,6 +201,22 @@ module TestFunctionPointerConcretization =
         | other -> Assert.Fail $"Expected FunctionPointer after round-trip, got %O{other}"
 
     [<Test>]
+    let ``CliType.zeroOf on a function pointer handle yields a null native int`` () : unit =
+        let signature =
+            makeSignature
+                [ TypeDefn.PrimitiveType PrimitiveType.Int32 ]
+                (MethodReturnType.Returns (TypeDefn.PrimitiveType PrimitiveType.Int32))
+
+        let state, handle = concretize (state ()) (TypeDefn.FunctionPointer signature)
+
+        let zero, _ =
+            CliType.zeroOf state.ConcreteTypes state._LoadedAssemblies baseClassTypes handle
+
+        match zero with
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim 0L)) -> ()
+        | other -> Assert.Fail $"Expected null native-int zero for fnptr default, got %O{other}"
+
+    [<Test>]
     let ``Round-tripping then re-concretizing yields the same handle`` () : unit =
         let original =
             TypeDefn.FunctionPointer (

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -42,6 +42,7 @@
     <Compile Include="TestNativeEnum.fs" />
     <Compile Include="TestMethodHandleRegistry.fs" />
     <Compile Include="TestMethodReturnType.fs" />
+    <Compile Include="TestFunctionPointerConcretization.fs" />
     <Compile Include="TestGenericParamConstraints.fs" />
     <Compile Include="TestGcHandleRegistry.fs" />
     <Compile Include="TestPrimitiveLikeStructRegistry.fs" />

--- a/WoofWare.PawPrint.Test/sourcesPure/FunctionPointerReflection.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/FunctionPointerReflection.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 unsafe class FunctionPointerReflection
 {
@@ -34,6 +35,23 @@ unsafe class FunctionPointerReflection
         if (t.ToString() != "System.Void()")
         {
             result |= 8;
+        }
+
+        // Generic instantiations inside a function pointer signature must be
+        // included when FormatNamespace is set. CoreCLR's AppendType emits the
+        // instantiation whenever FormatNamespace or FormatAssembly is set,
+        // independent of FormatFullInst.
+        var generic = typeof(delegate*<List<int>>);
+        if (generic.ToString() != "System.Collections.Generic.List`1[System.Int32]()")
+        {
+            result |= 16;
+        }
+
+        // Sanity check on the recursion's source: List<int>.ToString is the
+        // same instantiation-bearing form, with no surrounding fnptr wrapper.
+        if (typeof(List<int>).ToString() != "System.Collections.Generic.List`1[System.Int32]")
+        {
+            result |= 32;
         }
 
         return result;

--- a/WoofWare.PawPrint.Test/sourcesPure/FunctionPointerReflection.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/FunctionPointerReflection.cs
@@ -1,0 +1,41 @@
+using System;
+
+unsafe class FunctionPointerReflection
+{
+    static int Main(string[] args)
+    {
+        var t = typeof(delegate*<void>);
+        int result = 0;
+
+        // Function-pointer types are TypeDescs in CoreCLR and never subclass
+        // System.ValueType, so IsValueType is false.
+        if (t.IsValueType)
+        {
+            result |= 1;
+        }
+
+        // CoreCLR's TypeString::AppendType for FnPtrType returns the empty
+        // string when FormatNamespace is unset; Type.Name uses FormatBasic
+        // and so observes "" for a function pointer.
+        if (t.Name != "")
+        {
+            result |= 2;
+        }
+
+        // RuntimeType.GetName(TypeNameKind.FullName) gates on
+        // IsFunctionPointer and returns null without invoking ConstructName.
+        if (t.FullName != null)
+        {
+            result |= 4;
+        }
+
+        // ToString uses FormatNamespace, so the qualified return-type name
+        // (System.Void) is included around the parameter list.
+        if (t.ToString() != "System.Void()")
+        {
+            result |= 8;
+        }
+
+        return result;
+    }
+}

--- a/WoofWare.PawPrint/CliType.fs
+++ b/WoofWare.PawPrint/CliType.fs
@@ -1350,12 +1350,10 @@ module CliType =
             CliType.ObjectRef None, concreteTypes
 
         | ConcreteTypeHandle.FunctionPointer _ ->
-            // The zero value of a function pointer is a null fnptr; the existing
-            // NativeIntSource.FunctionPointer requires a MethodInfo, so we don't yet
-            // have a representation for a null fnptr. Fail loudly until that gap is
-            // filled rather than silently producing a wrong-shaped zero.
-            failwith
-                $"TODO: CliType.zeroOf does not yet support function pointer types (handle %O{handle}); a null-fnptr representation is needed"
+            // Function pointers are stored in a native-int slot: a non-null fnptr
+            // is NativeIntSource.FunctionPointer carrying a MethodInfo, and the
+            // null fnptr is the same shape with the canonical zero source.
+            CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim 0L)), concreteTypes
 
         | ConcreteTypeHandle.Concrete _ ->
             // This is a concrete type - look it up in the mapping

--- a/WoofWare.PawPrint/CliType.fs
+++ b/WoofWare.PawPrint/CliType.fs
@@ -1349,6 +1349,14 @@ module CliType =
             // Array types are reference types - the zero value is null
             CliType.ObjectRef None, concreteTypes
 
+        | ConcreteTypeHandle.FunctionPointer _ ->
+            // The zero value of a function pointer is a null fnptr; the existing
+            // NativeIntSource.FunctionPointer requires a MethodInfo, so we don't yet
+            // have a representation for a null fnptr. Fail loudly until that gap is
+            // filled rather than silently producing a wrong-shaped zero.
+            failwith
+                $"TODO: CliType.zeroOf does not yet support function pointer types (handle %O{handle}); a null-fnptr representation is needed"
+
         | ConcreteTypeHandle.Concrete _ ->
             // This is a concrete type - look it up in the mapping
             let concreteType =

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -347,6 +347,9 @@ module IlMachineRuntimeMetadata =
                     ImmutableArray.Empty
 
             state, Some arrayHandle
+        | ConcreteTypeHandle.FunctionPointer _ ->
+            failwith
+                $"TODO: resolveBaseConcreteType: function pointer types (%O{concreteType}) not yet supported; the runtime base type is System.ValueType but the lookup path needs adjusting"
         | ConcreteTypeHandle.Concrete _
         | ConcreteTypeHandle.Byref _
         | ConcreteTypeHandle.Pointer _ ->
@@ -828,7 +831,8 @@ module IlMachineRuntimeMetadata =
         | ConcreteTypeHandle.OneDimArrayZero _
         | ConcreteTypeHandle.Array _
         | ConcreteTypeHandle.Byref _
-        | ConcreteTypeHandle.Pointer _ -> None
+        | ConcreteTypeHandle.Pointer _
+        | ConcreteTypeHandle.FunctionPointer _ -> None
 
     let requiredOwnInstanceFieldId
         (state : IlMachineState)
@@ -865,7 +869,8 @@ module IlMachineRuntimeMetadata =
             | ConcreteTypeHandle.OneDimArrayZero _
             | ConcreteTypeHandle.Array _ -> true
             | ConcreteTypeHandle.Byref _
-            | ConcreteTypeHandle.Pointer _ -> false
+            | ConcreteTypeHandle.Pointer _
+            | ConcreteTypeHandle.FunctionPointer _ -> false
             | ConcreteTypeHandle.Concrete _ ->
                 match tryGetConcreteTypeInfo state handle with
                 | Some (_, typeInfo) -> DumpedAssembly.isReferenceType baseClassTypes state._LoadedAssemblies typeInfo
@@ -877,7 +882,8 @@ module IlMachineRuntimeMetadata =
             | ConcreteTypeHandle.Array (element, rank) -> Some (element, Some rank)
             | ConcreteTypeHandle.Concrete _
             | ConcreteTypeHandle.Byref _
-            | ConcreteTypeHandle.Pointer _ -> None
+            | ConcreteTypeHandle.Pointer _
+            | ConcreteTypeHandle.FunctionPointer _ -> None
 
         let rec checkInterfaces (state : IlMachineState) (current : ConcreteTypeHandle) : IlMachineState * bool =
             match tryGetConcreteTypeInfo state current with
@@ -926,7 +932,8 @@ module IlMachineRuntimeMetadata =
         and walkBase (state : IlMachineState) (current : ConcreteTypeHandle) : IlMachineState * bool =
             match current with
             | ConcreteTypeHandle.Byref _
-            | ConcreteTypeHandle.Pointer _ -> state, false
+            | ConcreteTypeHandle.Pointer _
+            | ConcreteTypeHandle.FunctionPointer _ -> state, false
             | ConcreteTypeHandle.Concrete _
             | ConcreteTypeHandle.OneDimArrayZero _
             | ConcreteTypeHandle.Array _ ->
@@ -1031,7 +1038,8 @@ module IlMachineRuntimeMetadata =
                         | ConcreteTypeHandle.Array _ -> true
                         | ConcreteTypeHandle.Concrete _
                         | ConcreteTypeHandle.Byref _
-                        | ConcreteTypeHandle.Pointer _ ->
+                        | ConcreteTypeHandle.Pointer _
+                        | ConcreteTypeHandle.FunctionPointer _ ->
                             match targetTypeInfo with
                             | Some (targetCt, targetTypeInfo) ->
                                 targetTypeInfo.IsInterface && not targetCt.Generics.IsEmpty
@@ -1043,4 +1051,5 @@ module IlMachineRuntimeMetadata =
                         state, false
         | ConcreteTypeHandle.Concrete _
         | ConcreteTypeHandle.Byref _
-        | ConcreteTypeHandle.Pointer _ -> walk state objType
+        | ConcreteTypeHandle.Pointer _
+        | ConcreteTypeHandle.FunctionPointer _ -> walk state objType

--- a/WoofWare.PawPrint/IlMachineStateExecution.fs
+++ b/WoofWare.PawPrint/IlMachineStateExecution.fs
@@ -362,7 +362,8 @@ module IlMachineStateExecution =
                 else
                     match currentTypeHandle with
                     | ConcreteTypeHandle.Byref _
-                    | ConcreteTypeHandle.Pointer _ -> state, None
+                    | ConcreteTypeHandle.Pointer _
+                    | ConcreteTypeHandle.FunctionPointer _ -> state, None
                     | ConcreteTypeHandle.Concrete _
                     | ConcreteTypeHandle.OneDimArrayZero _
                     | ConcreteTypeHandle.Array _ ->
@@ -598,7 +599,8 @@ module IlMachineStateExecution =
                     | None ->
                         match currentTypeHandle with
                         | ConcreteTypeHandle.Byref _
-                        | ConcreteTypeHandle.Pointer _ ->
+                        | ConcreteTypeHandle.Pointer _
+                        | ConcreteTypeHandle.FunctionPointer _ ->
                             failwith $"No metadata dispatch type available for virtual receiver %O{currentTypeHandle}"
                         | ConcreteTypeHandle.Concrete _
                         | ConcreteTypeHandle.OneDimArrayZero _
@@ -610,7 +612,8 @@ module IlMachineStateExecution =
                     else
                         match currentTypeHandle with
                         | ConcreteTypeHandle.Byref _
-                        | ConcreteTypeHandle.Pointer _ -> state, []
+                        | ConcreteTypeHandle.Pointer _
+                        | ConcreteTypeHandle.FunctionPointer _ -> state, []
                         | ConcreteTypeHandle.Concrete _
                         | ConcreteTypeHandle.OneDimArrayZero _
                         | ConcreteTypeHandle.Array _ ->

--- a/WoofWare.PawPrint/IntrinsicHelpers.fs
+++ b/WoofWare.PawPrint/IntrinsicHelpers.fs
@@ -97,7 +97,8 @@ module internal IntrinsicHelpers =
         | ConcreteTypeHandle.OneDimArrayZero _
         | ConcreteTypeHandle.Array _ -> state, true
         | ConcreteTypeHandle.Byref _
-        | ConcreteTypeHandle.Pointer _ -> state, false
+        | ConcreteTypeHandle.Pointer _
+        | ConcreteTypeHandle.FunctionPointer _ -> state, false
         | ConcreteTypeHandle.Concrete _ ->
             let concrete =
                 AllConcreteTypes.lookup handle state.ConcreteTypes

--- a/WoofWare.PawPrint/IntrinsicMethodKeys.fs
+++ b/WoofWare.PawPrint/IntrinsicMethodKeys.fs
@@ -85,6 +85,7 @@ module IntrinsicMethodKeys =
                 | None -> failwith $"Intrinsic method key requested for unknown concrete type handle: %O{handle}"
             | ConcreteTypeHandle.Byref _ -> "&"
             | ConcreteTypeHandle.Pointer _ -> "*"
+            | ConcreteTypeHandle.FunctionPointer _ -> "fnptr"
             | ConcreteTypeHandle.OneDimArrayZero _ -> "[]"
             | ConcreteTypeHandle.Array (_, rank) -> $"[%i{rank}]"
 

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -39,7 +39,8 @@ module Intrinsics =
             | ConcreteTypeHandle.OneDimArrayZero _
             | ConcreteTypeHandle.Array _ -> true
             | ConcreteTypeHandle.Byref _
-            | ConcreteTypeHandle.Pointer _ -> false
+            | ConcreteTypeHandle.Pointer _
+            | ConcreteTypeHandle.FunctionPointer _ -> false
             | ConcreteTypeHandle.Concrete _ ->
                 match IlMachineState.tryGetConcreteTypeInfo state handle with
                 | Some (_, typeInfo) -> DumpedAssembly.isReferenceType baseClassTypes state._LoadedAssemblies typeInfo
@@ -370,6 +371,7 @@ module Intrinsics =
                     match handle with
                     | ConcreteTypeHandle.Byref _
                     | ConcreteTypeHandle.Pointer _
+                    | ConcreteTypeHandle.FunctionPointer _
                     | ConcreteTypeHandle.OneDimArrayZero _
                     | ConcreteTypeHandle.Array _ -> false, state
                     | ConcreteTypeHandle.Concrete _ ->
@@ -416,6 +418,7 @@ module Intrinsics =
                         | None -> failwith $"Type.get_IsGenericType: concrete type handle was not registered: %O{ty}"
                     | ConcreteTypeHandle.Byref _
                     | ConcreteTypeHandle.Pointer _
+                    | ConcreteTypeHandle.FunctionPointer _
                     | ConcreteTypeHandle.OneDimArrayZero _
                     | ConcreteTypeHandle.Array _ -> false
 

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -305,14 +305,25 @@ module Intrinsics =
                     failwith
                         $"TODO: Type.get_IsValueType for method generic parameter #%i{position} of method %O{declaringMethod.Get} on %O{declaringType.TypeDefinition.Get}"
                 | RuntimeTypeHandleTarget.Closed ty ->
-                    // TODO: structural handles such as typeof(int[]) still reach here as
-                    // ConcreteTypeHandle.OneDimArrayZero, but this branch only handles nominal types.
-                    let typeInfo =
-                        match AllConcreteTypes.lookup ty state.ConcreteTypes with
-                        | Some ty -> state.LoadedAssembly(ty.Assembly).Value.TypeDefs.[ty.Definition.Get]
-                        | None -> failwith $"Type.get_IsValueType: expected nominal concrete type handle, got %O{ty}"
+                    match ty with
+                    // Byref, pointer, function-pointer, single-dim szarray, and multi-dim array
+                    // types are TypeDescs in CoreCLR; IsValueTypeImpl resolves to
+                    // IsSubclassOf(typeof(ValueType)) for TypeDescs, which is false for all of
+                    // these. They're absent from the nominal AllConcreteTypes mapping, so handle
+                    // them explicitly here rather than failing the lookup.
+                    | ConcreteTypeHandle.Byref _
+                    | ConcreteTypeHandle.Pointer _
+                    | ConcreteTypeHandle.FunctionPointer _
+                    | ConcreteTypeHandle.OneDimArrayZero _
+                    | ConcreteTypeHandle.Array _ -> false
+                    | ConcreteTypeHandle.Concrete _ ->
+                        let typeInfo =
+                            match AllConcreteTypes.lookup ty state.ConcreteTypes with
+                            | Some ty -> state.LoadedAssembly(ty.Assembly).Value.TypeDefs.[ty.Definition.Get]
+                            | None ->
+                                failwith $"Type.get_IsValueType: expected nominal concrete type handle, got %O{ty}"
 
-                    DumpedAssembly.isValueType baseClassTypes state._LoadedAssemblies typeInfo
+                        DumpedAssembly.isValueType baseClassTypes state._LoadedAssemblies typeInfo
 
             IlMachineState.pushToEvalStack (CliType.ofBool isValueType) currentThread state
             |> IlMachineState.advanceProgramCounter currentThread

--- a/WoofWare.PawPrint/ManagedPointerByteView.fs
+++ b/WoofWare.PawPrint/ManagedPointerByteView.fs
@@ -8,7 +8,9 @@ module ManagedPointerByteView =
         | ConcreteTypeHandle.Array (element, _) -> element
         | ConcreteTypeHandle.Concrete _
         | ConcreteTypeHandle.Byref _
-        | ConcreteTypeHandle.Pointer _ -> failwith $"array object has non-array concrete type: %O{arrObj.ConcreteType}"
+        | ConcreteTypeHandle.Pointer _
+        | ConcreteTypeHandle.FunctionPointer _ ->
+            failwith $"array object has non-array concrete type: %O{arrObj.ConcreteType}"
 
     let arrayElementSize
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)

--- a/WoofWare.PawPrint/MethodTableProjection.fs
+++ b/WoofWare.PawPrint/MethodTableProjection.fs
@@ -55,7 +55,8 @@ module internal MethodTableProjection =
             Some (element, Some rank)
         | ConcreteTypeHandle.Concrete _
         | ConcreteTypeHandle.Byref _
-        | ConcreteTypeHandle.Pointer _ -> None
+        | ConcreteTypeHandle.Pointer _
+        | ConcreteTypeHandle.FunctionPointer _ -> None
 
     let private isStringType
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
@@ -174,7 +175,8 @@ module internal MethodTableProjection =
         | ConcreteTypeHandle.OneDimArrayZero _
         | ConcreteTypeHandle.Array _ -> Some NATIVE_INT_SIZE
         | ConcreteTypeHandle.Byref _
-        | ConcreteTypeHandle.Pointer _ -> Some NATIVE_INT_SIZE
+        | ConcreteTypeHandle.Pointer _
+        | ConcreteTypeHandle.FunctionPointer _ -> Some NATIVE_INT_SIZE
         | ConcreteTypeHandle.Concrete _ ->
             match tryConcreteTypeInfo state handle with
             | None -> None
@@ -197,7 +199,8 @@ module internal MethodTableProjection =
         | ConcreteTypeHandle.OneDimArrayZero _
         | ConcreteTypeHandle.Array _ -> Some true
         | ConcreteTypeHandle.Byref _
-        | ConcreteTypeHandle.Pointer _ -> Some false
+        | ConcreteTypeHandle.Pointer _
+        | ConcreteTypeHandle.FunctionPointer _ -> Some false
         | ConcreteTypeHandle.Concrete _ ->
             match tryConcreteTypeInfo state handle with
             | None -> None
@@ -244,7 +247,8 @@ module internal MethodTableProjection =
             let _, typeInfo = concreteTypeInfoOrFail state handle
             categoryFlagsForTypeInfo baseClassTypes state typeInfo
         | ConcreteTypeHandle.Byref _
-        | ConcreteTypeHandle.Pointer _ -> 0
+        | ConcreteTypeHandle.Pointer _
+        | ConcreteTypeHandle.FunctionPointer _ -> 0
 
     let private categoryFlagsForRuntimeTypeHandleTarget
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
@@ -321,7 +325,8 @@ module internal MethodTableProjection =
 
                 containsGcPointers, state
         | ConcreteTypeHandle.Byref _
-        | ConcreteTypeHandle.Pointer _ -> false, state
+        | ConcreteTypeHandle.Pointer _
+        | ConcreteTypeHandle.FunctionPointer _ -> false, state
         | ConcreteTypeHandle.OneDimArrayZero _
         | ConcreteTypeHandle.Array _ -> failwith $"unreachable: array MethodTable %O{containsForHandle} handled above"
 
@@ -827,7 +832,8 @@ module internal MethodTableProjection =
                     failwith
                         $"TODO: MethodTable::GetNumInstanceFieldBytes projection for non-value type %O{methodTableFor}"
         | ConcreteTypeHandle.Byref _
-        | ConcreteTypeHandle.Pointer _ -> uint32 NATIVE_INT_SIZE, state
+        | ConcreteTypeHandle.Pointer _
+        | ConcreteTypeHandle.FunctionPointer _ -> uint32 NATIVE_INT_SIZE, state
         | ConcreteTypeHandle.OneDimArrayZero _
         | ConcreteTypeHandle.Array _ ->
             failwith $"TODO: MethodTable::GetNumInstanceFieldBytes projection for array type %O{methodTableFor}"

--- a/WoofWare.PawPrint/Native/NativeCall.fs
+++ b/WoofWare.PawPrint/Native/NativeCall.fs
@@ -335,6 +335,7 @@ module NativeCall =
 
     let typeAssemblyName
         (operation : string)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (state : IlMachineState)
         (typeHandleTarget : RuntimeTypeHandleTarget)
         : System.Reflection.AssemblyName
@@ -346,32 +347,32 @@ module NativeCall =
             // A generic parameter belongs to the same assembly as its declaring type.
             declaringType.Assembly
         | RuntimeTypeHandleTarget.Closed concreteTypeHandle ->
-            // Unwrap Byref/Pointer/Array to reach the element type's Concrete handle.
-            // In .NET, typeof(T[]).Assembly == typeof(T).Assembly, so arrays follow the
-            // same rule: return the element type's assembly.
-            let rec unwrapToConcreteHandle (h : ConcreteTypeHandle) : ConcreteTypeHandle =
+            // Unwrap Byref/Pointer/Array to reach the element type's assembly.
+            // In .NET, typeof(T[]).Assembly == typeof(T).Assembly, so arrays follow
+            // the element rule. Function pointers anchor to their return type's
+            // assembly (CoreCLR `MethodTable::GetAssembly` for FnPtr); for `void`
+            // returns, that assembly is corelib (where System.Void lives).
+            let rec assemblyNameOfHandle (h : ConcreteTypeHandle) : System.Reflection.AssemblyName =
                 match h with
-                | ConcreteTypeHandle.Concrete _ -> h
-                | ConcreteTypeHandle.Byref inner -> unwrapToConcreteHandle inner
-                | ConcreteTypeHandle.Pointer inner -> unwrapToConcreteHandle inner
-                | ConcreteTypeHandle.FunctionPointer _ ->
-                    // Function pointer types have no element type to unwrap; they're
-                    // structural types whose "assembly" isn't well-defined in the same
-                    // way as nominal types. Fail loudly until a real consumer needs this.
-                    failwith $"%s{operation}: cannot determine declaring assembly for function pointer type %O{h}"
-                | ConcreteTypeHandle.OneDimArrayZero inner -> unwrapToConcreteHandle inner
-                | ConcreteTypeHandle.Array (inner, _) -> unwrapToConcreteHandle inner
+                | ConcreteTypeHandle.Concrete _ ->
+                    let concreteType =
+                        AllConcreteTypes.lookup h state.ConcreteTypes
+                        |> Option.defaultWith (fun () ->
+                            failwith
+                                $"%s{operation}: could not find concrete type for handle %O{concreteTypeHandle} (unwrapped to %O{h})"
+                        )
 
-            let concreteHandle = unwrapToConcreteHandle concreteTypeHandle
+                    concreteType.Assembly
+                | ConcreteTypeHandle.Byref inner -> assemblyNameOfHandle inner
+                | ConcreteTypeHandle.Pointer inner -> assemblyNameOfHandle inner
+                | ConcreteTypeHandle.OneDimArrayZero inner -> assemblyNameOfHandle inner
+                | ConcreteTypeHandle.Array (inner, _) -> assemblyNameOfHandle inner
+                | ConcreteTypeHandle.FunctionPointer signature ->
+                    match signature.ReturnType with
+                    | MethodReturnType.Void -> baseClassTypes.Void.Assembly
+                    | MethodReturnType.Returns ret -> assemblyNameOfHandle ret
 
-            let concreteType =
-                AllConcreteTypes.lookup concreteHandle state.ConcreteTypes
-                |> Option.defaultWith (fun () ->
-                    failwith
-                        $"%s{operation}: could not find concrete type for handle %O{concreteTypeHandle} (unwrapped to %O{concreteHandle})"
-                )
-
-            concreteType.Assembly
+            assemblyNameOfHandle concreteTypeHandle
 
     let failUnimplemented (ctx : NativeCallContext) : ExecutionResult =
         let instruction = ctx.Instruction

--- a/WoofWare.PawPrint/Native/NativeCall.fs
+++ b/WoofWare.PawPrint/Native/NativeCall.fs
@@ -354,6 +354,11 @@ module NativeCall =
                 | ConcreteTypeHandle.Concrete _ -> h
                 | ConcreteTypeHandle.Byref inner -> unwrapToConcreteHandle inner
                 | ConcreteTypeHandle.Pointer inner -> unwrapToConcreteHandle inner
+                | ConcreteTypeHandle.FunctionPointer _ ->
+                    // Function pointer types have no element type to unwrap; they're
+                    // structural types whose "assembly" isn't well-defined in the same
+                    // way as nominal types. Fail loudly until a real consumer needs this.
+                    failwith $"%s{operation}: cannot determine declaring assembly for function pointer type %O{h}"
                 | ConcreteTypeHandle.OneDimArrayZero inner -> unwrapToConcreteHandle inner
                 | ConcreteTypeHandle.Array (inner, _) -> unwrapToConcreteHandle inner
 
@@ -391,6 +396,16 @@ module NativeCall =
                 match cth with
                 | ConcreteTypeHandle.Byref inner -> $"&({formatTypeHandle inner})"
                 | ConcreteTypeHandle.Pointer inner -> $"*({formatTypeHandle inner})"
+                | ConcreteTypeHandle.FunctionPointer signature ->
+                    let argStr =
+                        signature.ParameterTypes |> Seq.map formatTypeHandle |> String.concat ", "
+
+                    let retStr =
+                        match signature.ReturnType with
+                        | MethodReturnType.Void -> "void"
+                        | MethodReturnType.Returns ret -> formatTypeHandle ret
+
+                    $"fnptr({argStr}->{retStr})"
                 | ConcreteTypeHandle.OneDimArrayZero inner -> $"{formatTypeHandle inner}[]"
                 | ConcreteTypeHandle.Array (inner, rank) ->
                     let dims = if rank <= 1 then "*" else String.replicate (rank - 1) ","

--- a/WoofWare.PawPrint/Native/NativeEnum.fs
+++ b/WoofWare.PawPrint/Native/NativeEnum.fs
@@ -34,6 +34,7 @@ module NativeEnum =
                 | ConcreteTypeHandle.Concrete _ -> typeHandle
                 | ConcreteTypeHandle.Byref _
                 | ConcreteTypeHandle.Pointer _
+                | ConcreteTypeHandle.FunctionPointer _
                 | ConcreteTypeHandle.OneDimArrayZero _
                 | ConcreteTypeHandle.Array _ ->
                     failwith $"%s{operation}: expected exact concrete enum type handle, got non-concrete %O{typeHandle}"

--- a/WoofWare.PawPrint/Native/NativeRuntimeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeHelpers.fs
@@ -42,10 +42,11 @@ module NativeRuntimeHelpers =
                 match typeHandle with
                 | ConcreteTypeHandle.Byref _
                 | ConcreteTypeHandle.Pointer _
+                | ConcreteTypeHandle.FunctionPointer _
                 | ConcreteTypeHandle.OneDimArrayZero _
                 | ConcreteTypeHandle.Array _ ->
-                    // Pointer, byref, and array type descriptors have no .cctor; CoreCLR treats this
-                    // as a no-op. Return immediately.
+                    // Pointer, byref, fnptr, and array type descriptors have no .cctor;
+                    // CoreCLR treats this as a no-op. Return immediately.
                     (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
                 | ConcreteTypeHandle.Concrete _ ->
                     let state, typeInit =

--- a/WoofWare.PawPrint/Native/NativeRuntimeType.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeType.fs
@@ -141,6 +141,7 @@ module NativeRuntimeType =
             | ConcretePrimitive state.ConcreteTypes primitive -> primitiveCorElementType primitive
             | ConcreteTypeHandle.Byref _ -> 0x10
             | ConcreteTypeHandle.Pointer _ -> 0x0F
+            | ConcreteTypeHandle.FunctionPointer _ -> 0x1B
             | ConcreteTypeHandle.OneDimArrayZero _ -> 0x1D
             | ConcreteTypeHandle.Array _ -> 0x14
             | ConcreteTypeHandle.Concrete _ ->
@@ -206,6 +207,7 @@ module NativeRuntimeType =
                     $"%s{operation}: expected primitive or enum MethodTable, got %s{typeInfo.Namespace}.%s{typeInfo.Name}"
         | ConcreteTypeHandle.Byref _
         | ConcreteTypeHandle.Pointer _
+        | ConcreteTypeHandle.FunctionPointer _
         | ConcreteTypeHandle.OneDimArrayZero _
         | ConcreteTypeHandle.Array _ ->
             failwith $"%s{operation}: expected primitive or enum MethodTable, got %O{methodTableFor}"
@@ -393,6 +395,7 @@ module NativeRuntimeType =
             )
         | ConcreteTypeHandle.Byref _
         | ConcreteTypeHandle.Pointer _
+        | ConcreteTypeHandle.FunctionPointer _
         | ConcreteTypeHandle.OneDimArrayZero _
         | ConcreteTypeHandle.Array _ ->
             failwith
@@ -488,6 +491,7 @@ module NativeRuntimeType =
                 typeDefinitionToken concreteType.Definition.Get
             | ConcreteTypeHandle.Byref _
             | ConcreteTypeHandle.Pointer _
+            | ConcreteTypeHandle.FunctionPointer _
             | ConcreteTypeHandle.OneDimArrayZero _
             | ConcreteTypeHandle.Array _ -> mdTypeDefNil
 
@@ -632,6 +636,7 @@ module NativeRuntimeType =
             match typeHandle with
             | ConcreteTypeHandle.Byref _
             | ConcreteTypeHandle.Pointer _
+            | ConcreteTypeHandle.FunctionPointer _
             | ConcreteTypeHandle.OneDimArrayZero _
             | ConcreteTypeHandle.Array _ -> None, state
             | ConcreteTypeHandle.Concrete _ ->
@@ -691,7 +696,8 @@ module NativeRuntimeType =
             | RuntimeTypeHandleTarget.Closed typeHandle ->
                 match typeHandle with
                 | ConcreteTypeHandle.Byref _
-                | ConcreteTypeHandle.Pointer _ -> None, state
+                | ConcreteTypeHandle.Pointer _
+                | ConcreteTypeHandle.FunctionPointer _ -> None, state
                 | ConcreteTypeHandle.Concrete _
                 | ConcreteTypeHandle.OneDimArrayZero _
                 | ConcreteTypeHandle.Array _ ->
@@ -738,6 +744,11 @@ module NativeRuntimeType =
             | RuntimeTypeHandleTarget.Closed typeHandle ->
                 match typeHandle with
                 | ConcreteTypeHandle.Concrete _ -> None
+                // Function pointers expose no element type: there's no single referenced
+                // element type to surface (they're parametrised by a whole signature),
+                // and CoreCLR's IsFunctionPointer/GetFunctionPointerXxx APIs are the
+                // proper way to inspect them. Mirror Type.GetElementType() == null.
+                | ConcreteTypeHandle.FunctionPointer _ -> None
                 | ConcreteTypeHandle.Byref inner
                 | ConcreteTypeHandle.Pointer inner
                 | ConcreteTypeHandle.OneDimArrayZero inner -> Some inner
@@ -778,7 +789,8 @@ module NativeRuntimeType =
 
                 match typeHandle with
                 | ConcreteTypeHandle.Byref _
-                | ConcreteTypeHandle.Pointer _ ->
+                | ConcreteTypeHandle.Pointer _
+                | ConcreteTypeHandle.FunctionPointer _ ->
                     // CoreCLR treats these TypeDesc shapes as having no MethodTable interface map.
                     state
                 | ConcreteTypeHandle.OneDimArrayZero _
@@ -989,6 +1001,7 @@ module NativeRuntimeType =
                 genericArguments
         | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Byref _)
         | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Pointer _)
+        | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.FunctionPointer _)
         | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.OneDimArrayZero _)
         | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Array _) ->
             failwith $"TODO: %s{operation} for structural RuntimeTypeHandleTarget %O{target}"
@@ -1025,6 +1038,7 @@ module NativeRuntimeType =
             | Some concreteType -> lookupFromIdentity concreteType.Identity
         | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Byref _)
         | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Pointer _)
+        | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.FunctionPointer _)
         | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.OneDimArrayZero _)
         | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Array _) ->
             // Structural targets carry no open-generic definition. Downstream
@@ -1055,6 +1069,7 @@ module NativeRuntimeType =
                 | Some assembly -> Some assembly.TypeDefs.[concreteType.Definition.Get]
         | ConcreteTypeHandle.Byref _
         | ConcreteTypeHandle.Pointer _
+        | ConcreteTypeHandle.FunctionPointer _
         | ConcreteTypeHandle.OneDimArrayZero _
         | ConcreteTypeHandle.Array _ -> None
 
@@ -1363,6 +1378,16 @@ module NativeRuntimeType =
             match typeHandle with
             | ConcreteTypeHandle.Byref inner -> $"%s{concreteTypeHandleName inner}&"
             | ConcreteTypeHandle.Pointer inner -> $"%s{concreteTypeHandleName inner}*"
+            | ConcreteTypeHandle.FunctionPointer signature ->
+                let argStr =
+                    signature.ParameterTypes |> Seq.map concreteTypeHandleName |> String.concat ", "
+
+                let retStr =
+                    match signature.ReturnType with
+                    | MethodReturnType.Void -> "Void"
+                    | MethodReturnType.Returns ret -> concreteTypeHandleName ret
+
+                $"%s{retStr}(%s{argStr})"
             | ConcreteTypeHandle.OneDimArrayZero inner -> $"%s{concreteTypeHandleName inner}[]"
             | ConcreteTypeHandle.Array (inner, rank) ->
                 let dims = if rank <= 1 then "*" else System.String (',', rank - 1)
@@ -1690,6 +1715,7 @@ module NativeRuntimeType =
                         |> ImmutableArray.CreateRange
                     | ConcreteTypeHandle.Byref _
                     | ConcreteTypeHandle.Pointer _
+                    | ConcreteTypeHandle.FunctionPointer _
                     | ConcreteTypeHandle.OneDimArrayZero _
                     | ConcreteTypeHandle.Array _ ->
                         // Real .NET strips array/byref/pointer wrappers via GetRootElementType
@@ -2399,6 +2425,7 @@ module NativeRuntimeType =
                     match typeHandle with
                     | ConcreteTypeHandle.Byref _
                     | ConcreteTypeHandle.Pointer _
+                    | ConcreteTypeHandle.FunctionPointer _
                     | ConcreteTypeHandle.OneDimArrayZero _
                     | ConcreteTypeHandle.Array _ -> state, []
                     | ConcreteTypeHandle.Concrete _ ->
@@ -2850,6 +2877,7 @@ module NativeRuntimeType =
                     | _ -> false
                 | ConcreteTypeHandle.Byref _
                 | ConcreteTypeHandle.Pointer _
+                | ConcreteTypeHandle.FunctionPointer _
                 | ConcreteTypeHandle.OneDimArrayZero _
                 | ConcreteTypeHandle.Array _ -> false
 
@@ -2910,7 +2938,8 @@ module NativeRuntimeType =
                 | RuntimeTypeHandleTarget.Closed handle ->
                     match handle with
                     | ConcreteTypeHandle.Byref _
-                    | ConcreteTypeHandle.Pointer _ -> int System.Reflection.TypeAttributes.Public
+                    | ConcreteTypeHandle.Pointer _
+                    | ConcreteTypeHandle.FunctionPointer _ -> int System.Reflection.TypeAttributes.Public
                     | ConcreteTypeHandle.OneDimArrayZero _
                     | ConcreteTypeHandle.Array _ ->
                         // tdPublic | tdSealed | tdSerializable. The Serializable enum

--- a/WoofWare.PawPrint/Native/NativeRuntimeType.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeType.fs
@@ -2773,7 +2773,8 @@ module NativeRuntimeType =
             let typeHandleTarget =
                 NativeCall.runtimeTypeHandleTargetOfRuntimeTypeRef operation state runtimeTypeRef
 
-            let assemblyName = NativeCall.typeAssemblyName operation state typeHandleTarget
+            let assemblyName =
+                NativeCall.typeAssemblyName operation ctx.BaseClassTypes state typeHandleTarget
 
             let addr, state =
                 getOrAllocateRuntimeAssembly ctx.LoggerFactory ctx.BaseClassTypes assemblyName state
@@ -2800,7 +2801,8 @@ module NativeRuntimeType =
             let typeHandleTarget =
                 NativeCall.runtimeTypeHandleTargetOfRuntimeTypeRef operation state runtimeTypeRef
 
-            let assemblyName = NativeCall.typeAssemblyName operation state typeHandleTarget
+            let assemblyName =
+                NativeCall.typeAssemblyName operation ctx.BaseClassTypes state typeHandleTarget
 
             let addr, state =
                 getOrAllocateRuntimeModule ctx.LoggerFactory ctx.BaseClassTypes assemblyName state

--- a/WoofWare.PawPrint/Native/NativeRuntimeType.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeType.fs
@@ -528,9 +528,10 @@ module NativeRuntimeType =
         =
         match concreteType with
         | ConcreteTypeHandle.Byref _
-        | ConcreteTypeHandle.Pointer _ ->
-            // Byrefs and pointers are TypeDescs in CoreCLR with no MethodTable, so
-            // GetNumVirtuals returns 0 for them.
+        | ConcreteTypeHandle.Pointer _
+        | ConcreteTypeHandle.FunctionPointer _ ->
+            // Byrefs, pointers, and function pointers are TypeDescs in CoreCLR with no
+            // MethodTable, so GetNumVirtuals returns 0 for them.
             state, 0
         | ConcreteTypeHandle.OneDimArrayZero _
         | ConcreteTypeHandle.Array _ ->

--- a/WoofWare.PawPrint/Native/NativeRuntimeType.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeType.fs
@@ -1379,15 +1379,26 @@ module NativeRuntimeType =
             | ConcreteTypeHandle.Byref inner -> $"%s{concreteTypeHandleName inner}&"
             | ConcreteTypeHandle.Pointer inner -> $"%s{concreteTypeHandleName inner}*"
             | ConcreteTypeHandle.FunctionPointer signature ->
-                let argStr =
-                    signature.ParameterTypes |> Seq.map concreteTypeHandleName |> String.concat ", "
+                // CoreCLR's TypeString::AppendType for FnPtrType (vm/typestring.cpp ~791) only
+                // emits the signature when FormatNamespace is set; otherwise it emits the empty
+                // string. This matches user-visible reflection: typeof(delegate*<void>).Name is
+                // "" (FormatBasic), .ToString() is "System.Void()" (FormatNamespace), and
+                // .FullName is null (gated to null in the BCL before reaching ConstructName).
+                if not includeNamespace then
+                    ""
+                else
+                    let argStr =
+                        signature.ParameterTypes |> Seq.map concreteTypeHandleName |> String.concat ", "
 
-                let retStr =
-                    match signature.ReturnType with
-                    | MethodReturnType.Void -> "Void"
-                    | MethodReturnType.Returns ret -> concreteTypeHandleName ret
+                    let retStr =
+                        match signature.ReturnType with
+                        // Void has no metadata-driven concrete handle to recurse through, so
+                        // emit the qualified BCL name directly. CoreCLR recurses into the void
+                        // type's metadata and gets the namespace via the same FormatNamespace path.
+                        | MethodReturnType.Void -> "System.Void"
+                        | MethodReturnType.Returns ret -> concreteTypeHandleName ret
 
-                $"%s{retStr}(%s{argStr})"
+                    $"%s{retStr}(%s{argStr})"
             | ConcreteTypeHandle.OneDimArrayZero inner -> $"%s{concreteTypeHandleName inner}[]"
             | ConcreteTypeHandle.Array (inner, rank) ->
                 let dims = if rank <= 1 then "*" else System.String (',', rank - 1)

--- a/WoofWare.PawPrint/Native/NativeRuntimeType.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeType.fs
@@ -1370,7 +1370,6 @@ module NativeRuntimeType =
         : string
         =
         let includeNamespace = hasFormatFlag formatNamespaceFlag flags
-        let includeGenericInstantiation = hasFormatFlag formatFullInstFlag flags
         let includeAssembly = hasFormatFlag formatAssemblyFlag flags
         let noVersion = hasFormatFlag formatNoVersionFlag flags
 
@@ -1421,7 +1420,14 @@ module NativeRuntimeType =
                 let name = typeInfoDisplayName includeNamespace assembly typeInfo
 
                 let name =
-                    if includeGenericInstantiation && not concreteType.Generics.IsEmpty then
+                    // CoreCLR's TypeString::AppendType (vm/typestring.cpp ~1170) appends the
+                    // instantiation whenever FormatNamespace or FormatAssembly is set, regardless
+                    // of FormatFullInst. FormatFullInst only changes how the instantiation
+                    // arguments themselves are rendered (full namespace+assembly vs minimal).
+                    let appendInstantiation =
+                        (includeNamespace || includeAssembly) && not concreteType.Generics.IsEmpty
+
+                    if appendInstantiation then
                         let args =
                             concreteType.Generics |> Seq.map concreteTypeHandleName |> String.concat ","
 

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -83,7 +83,8 @@ module NullaryIlOp =
         | RuntimeTypeHandleTarget.Closed typeHandle ->
             match typeHandle with
             | ConcreteTypeHandle.Byref _
-            | ConcreteTypeHandle.Pointer _ ->
+            | ConcreteTypeHandle.Pointer _
+            | ConcreteTypeHandle.FunctionPointer _ ->
                 // CoreCLR tags TypeDesc handles by setting the second-lowest bit.
                 // PawPrint has no real address, but matching that low-bit contract
                 // lets managed CoreLib code run `TypeHandle.IsTypeDesc`.

--- a/WoofWare.PawPrint/UnaryMetadataCallOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataCallOps.fs
@@ -163,7 +163,8 @@ module internal UnaryMetadataCallOps =
                     | ConcreteTypeHandle.OneDimArrayZero _
                     | ConcreteTypeHandle.Array _
                     | ConcreteTypeHandle.Byref _
-                    | ConcreteTypeHandle.Pointer _ ->
+                    | ConcreteTypeHandle.Pointer _
+                    | ConcreteTypeHandle.FunctionPointer _ ->
                         failwith
                             $"constrained.call: static interface dispatch for non-concrete constrained type %O{constrainedTypeHandle} is not implemented"
 
@@ -412,9 +413,10 @@ module internal UnaryMetadataCallOps =
                     // concrete-type mapping (which doesn't store structural wrappers).
                     applyCase1 state, concretizedMethod, true
                 | ConcreteTypeHandle.Byref _
-                | ConcreteTypeHandle.Pointer _ ->
+                | ConcreteTypeHandle.Pointer _
+                | ConcreteTypeHandle.FunctionPointer _ ->
                     failwith
-                        $"constrained.callvirt: unexpected handle kind %O{tHandle}; pointers and byrefs cannot be generic type arguments"
+                        $"constrained.callvirt: unexpected handle kind %O{tHandle}; pointers, byrefs and fnptrs cannot be generic type arguments"
                 | ConcreteTypeHandle.Concrete _ ->
 
                 let tConcrete = AllConcreteTypes.lookup tHandle state.ConcreteTypes |> Option.get


### PR DESCRIPTION
## Summary
- Adds `ConcreteTypeHandle.FunctionPointer of TypeMethodSignature<ConcreteTypeHandle>` and wires it through `TypeConcretization.concretizeType`, so `delegate*<...>` types now have runtime identity (with structural dedup via DU equality).
- Threads the new variant through ~20 downstream exhaustive matches (CliType, IL ops, native runtime helpers, intrinsics).
- Implements CoreCLR-faithful reflection on fnptr `RuntimeType`s: `IsValueType=false`, `Name=""`, `FullName=null`, `ToString()="ReturnType(Args)"` with namespace-qualified types. `Type.Assembly`/`Type.Module` anchor to the return type's assembly (corelib for `void` returns), matching `MethodTable::GetAssembly` for FnPtr.
- Fixes a tangentially related bug in `concreteTypeHandleName`: nominal generic types now emit their instantiation list whenever `FormatNamespace` or `FormatAssembly` is set, matching `TypeString::AppendType` (`vm/typestring.cpp` ~1170). Previously `typeof(List<int>).ToString()` dropped the `[System.Int32]` suffix.

## Test plan
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test` — 644/644 passing on rebased branch
- [x] New `TestFunctionPointerConcretization.fs` with 8 unit tests (direct concretization, parameter/return concretization, void vs returning, parameter-type discrimination, signature dedup, round-trip equality)
- [x] New guest reflection test `sourcesPure/FunctionPointerReflection.cs` covers all four observable Type properties on `delegate*<void>` and `delegate*<List<int>>`
- [x] Three rounds of `codex review --base main`; final pass returned no actionable correctness issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)