### PR TITLE
Implement Span<T>.Clear JIT intrinsic

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -35,7 +35,7 @@ module TestPureCases =
             "MakeGenericTypeStructConstraint.cs" // past MetadataImport::GetSigOfMethodDef; now blocked by unimplemented QCall ModuleHandle::ResolveMethod during ArgumentException ctor → ResourceManager init
             "MakeGenericTypeClassConstraint.cs" // past MetadataImport::GetSigOfMethodDef; now blocked by unimplemented QCall ModuleHandle::ResolveMethod during ArgumentException ctor → ResourceManager init
             "MakeGenericTypeNewConstraint.cs" // past MetadataImport::GetSigOfMethodDef; now blocked by unimplemented QCall ModuleHandle::ResolveMethod during ArgumentException ctor → ResourceManager init
-            "MethodReflectionProbe.cs" // past RuntimeTypeHandle::GetNumVirtuals; now blocked by JIT intrinsic Span`1.Clear() (used while RuntimeType.GetMethodCandidates allocates its `bool[numVirtuals]` overrides buffer)
+            "MethodReflectionProbe.cs" // past Span`1.Clear; now blocked by unimplemented InternalCall RuntimeTypeHandle::GetFirstIntroducedMethod (RuntimeType.GetMethodCandidates iterates the type's introduced methods to populate its candidate list)
         ]
         |> Set.ofList
 

--- a/WoofWare.PawPrint.Test/sourcesPure/SpanClear.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/SpanClear.cs
@@ -1,0 +1,91 @@
+using System;
+
+public class TestSpanClear
+{
+    static int ClearWholeIntArray()
+    {
+        int[] arr = new int[8];
+        for (int i = 0; i < arr.Length; i++)
+        {
+            arr[i] = i * 17 + 23;
+        }
+
+        arr.AsSpan().Clear();
+
+        for (int i = 0; i < arr.Length; i++)
+        {
+            if (arr[i] != 0)
+            {
+                return 100 + i;
+            }
+        }
+
+        return 0;
+    }
+
+    static int ClearSlicedIntArray()
+    {
+        int[] arr = new int[8];
+        for (int i = 0; i < arr.Length; i++)
+        {
+            arr[i] = i * 17 + 23;
+        }
+
+        arr.AsSpan(2, 4).Clear();
+
+        for (int i = 0; i < arr.Length; i++)
+        {
+            int expected = (i >= 2 && i < 6) ? 0 : (i * 17 + 23);
+            if (arr[i] != expected)
+            {
+                return 200 + i;
+            }
+        }
+
+        return 0;
+    }
+
+    static int ClearEmptySpan()
+    {
+        int[] arr = new int[4];
+        for (int i = 0; i < arr.Length; i++)
+        {
+            arr[i] = i + 1;
+        }
+
+        arr.AsSpan(2, 0).Clear();
+
+        for (int i = 0; i < arr.Length; i++)
+        {
+            if (arr[i] != i + 1)
+            {
+                return 300 + i;
+            }
+        }
+
+        return 0;
+    }
+
+    public static int Main(string[] argv)
+    {
+        int result = ClearWholeIntArray();
+        if (result != 0)
+        {
+            return result;
+        }
+
+        result = ClearSlicedIntArray();
+        if (result != 0)
+        {
+            return result;
+        }
+
+        result = ClearEmptySpan();
+        if (result != 0)
+        {
+            return result;
+        }
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -1975,6 +1975,74 @@ module Intrinsics =
             |> IlMachineState.pushToEvalStack' ptr currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Some
+        | "System.Private.CoreLib", "Span`1", "Clear" ->
+            // https://github.com/dotnet/runtime/blob/108fa7856efcfd39bc991c2d849eabbf7ba5989c/src/libraries/System.Private.CoreLib/src/System/Span.cs#L280
+            // Span<T>.Clear is a JIT intrinsic; the BCL IL falls through to
+            // SpanHelpers.ClearWithReferences / ClearWithoutReferences, the latter of
+            // which has a P/Invoke fallback for long zeroings. Model the JIT semantics
+            // directly: write default(T) to each of `_length` elements starting at
+            // `_reference`, using the same byref-projection helpers as get_Item.
+            let elementType : ConcreteTypeHandle =
+                methodToCall.DeclaringType.Generics |> Seq.exactlyOne
+
+            match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
+            | [], MethodReturnType.Void -> ()
+            | _ -> failwith $"bad signature for System.Span`1.Clear: %A{methodToCall.Signature}"
+
+            let receiver, state = IlMachineState.popEvalStack currentThread state
+
+            let span : CliValueType =
+                match receiver with
+                | EvalStackValue.ManagedPointer src ->
+                    match IlMachineState.readManagedByref state src with
+                    | CliType.ValueType vt -> vt
+                    | other -> failwith $"Span`1.Clear receiver byref read produced non-value-type %O{other}"
+                | EvalStackValue.UserDefinedValueType vt -> vt
+                | other -> failwith $"Span`1.Clear expected span receiver byref, got %O{other}"
+
+            let length : int =
+                let lengthField =
+                    IlMachineState.requiredOwnInstanceFieldId state span.Declared "_length"
+
+                match
+                    CliValueType.DereferenceFieldById lengthField span
+                    |> CliType.unwrapPrimitiveLike
+                with
+                | CliType.Numeric (CliNumericType.Int32 i) -> i
+                | other -> failwith $"Span`1.Clear expected _length to be int32, got %O{other}"
+
+            let reference : EvalStackValue =
+                let referenceField =
+                    IlMachineState.requiredOwnInstanceFieldId state span.Declared "_reference"
+
+                match
+                    CliValueType.DereferenceFieldById referenceField span
+                    |> CliType.unwrapPrimitiveLikeDeep
+                with
+                | CliType.RuntimePointer (CliRuntimePointer.Managed src) -> EvalStackValue.ManagedPointer src
+                | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.ManagedPointer src)) ->
+                    EvalStackValue.ManagedPointer src
+                | other -> failwith $"Span`1.Clear expected _reference to be a managed byref, got %O{other}"
+
+            let zero, state =
+                IlMachineState.cliTypeZeroOfHandle state baseClassTypes elementType
+
+            let state =
+                (state, { 0 .. length - 1 })
+                ||> Seq.fold (fun state i ->
+                    let ptr, state =
+                        offsetManagedPointerByElements baseClassTypes state elementType i reference
+
+                    let byrefSrc =
+                        match ptr with
+                        | EvalStackValue.ManagedPointer src -> src
+                        | other ->
+                            failwith $"Span`1.Clear: offsetManagedPointerByElements returned non-byref %O{other}"
+
+                    IlMachineState.writeManagedByrefWithBase baseClassTypes state byrefSrc zero
+                )
+
+            state |> IlMachineState.advanceProgramCounter currentThread |> Some
         | "System.Private.CoreLib", "RuntimeHelpers", "CreateSpan" ->
             // https://github.com/dotnet/runtime/blob/9e5e6aa7bc36aeb2a154709a9d1192030c30a2ef/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs#L153
             None


### PR DESCRIPTION
The BCL's IL falls through `RuntimeHelpers.IsReferenceOrContainsReferences` to one of `SpanHelpers.ClearWithReferences` / `ClearWithoutReferences`; the latter has a P/Invoke fallback for long zeroings. Model the JIT semantics directly: reuse the same field-projection pattern as `Span<T>.get_Item` to read `_reference` and `_length` from the span receiver, then write `default(T)` to each of the `_length` elements via the byref projection helpers (`offsetManagedPointerByElements` + `writeManagedByrefWithBase`).

Adds a focused `SpanClear.cs` test covering the whole-array, sliced, and empty cases over `int[]`. The probe test `MethodReflectionProbe.cs` advances past `Span<T>.Clear` and now stops at the next blocker, `RuntimeTypeHandle::GetFirstIntroducedMethod`; the `unimplemented` comment is updated accordingly.