### PR TITLE
Implement Math::Min as a safe JIT intrinsic

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -43,8 +43,7 @@ module TestPureCases =
             "RuntimeHelpersGetHashCode.cs" // blocked by .NET 10 InternalCall String::FastAllocateString taking (MethodTable*, IntPtr) — signature change not yet handled
             "CastClassCrossAssembly.cs" // blocked by unimplemented JIT intrinsic IEnumerable`1::GetEnumerator
             "RuntimeTypeGetInterfacesEmpty.cs" // blocked by unimplemented JIT intrinsic Span`1::get_Empty
-            "AssemblyGetType.cs" // blocked by unimplemented JIT intrinsic Math::Min
-            "InitializeArrayBoxedFieldHandle.cs" // blocked by unimplemented JIT intrinsic Math::Min
+            "InitializeArrayBoxedFieldHandle.cs" // past Math::Min; now blocked by unimplemented JIT intrinsic Span`1::get_Empty
             "GetElementTypeBasic.cs" // blocked by ldflda through synthetic MethodTableAuxiliaryData::ExposedClassObjectRaw field address
             "RuntimeTypeHandleTypeParameterDeclaringType.cs" // blocked by TypeHandle.GetCorElementType for generic parameter handles
             "MethodReflectionProbe.cs" // past Span`1.Clear; now blocked by unimplemented InternalCall RuntimeTypeHandle::GetFirstIntroducedMethod (RuntimeType.GetMethodCandidates iterates the type's introduced methods to populate its candidate list)

--- a/WoofWare.PawPrint/IntrinsicMethodKeys.fs
+++ b/WoofWare.PawPrint/IntrinsicMethodKeys.fs
@@ -336,6 +336,11 @@ module IntrinsicMethodKeys =
             anyParams "System.Private.CoreLib" "System.Math" "Abs"
             // https://github.com/dotnet/runtime/blob/d258af50034c192bf7f0a18856bf83d2903d98ae/src/libraries/System.Private.CoreLib/src/System/Math.cs#L965C10-L1062C19
             anyParams "System.Private.CoreLib" "System.Math" "Max"
+            // Mirror of Math.Max above: most overloads have a `(val1 <= val2) ? val1 : val2`
+            // IL body, and the [Intrinsic]-marked double/float overloads use the IEEE 754:2019
+            // `minimum` definition expressed in terms of IsNaN/IsNegative — both already supported.
+            // https://github.com/dotnet/runtime/blob/d258af50034c192bf7f0a18856bf83d2903d98ae/src/libraries/System.Private.CoreLib/src/System/Math.cs#L1064-L1187
+            anyParams "System.Private.CoreLib" "System.Math" "Min"
             // https://github.com/dotnet/runtime/blob/d258af50034c192bf7f0a18856bf83d2903d98ae/src/libraries/System.Private.CoreLib/src/System/Buffer.cs#L150
             anyParams "System.Private.CoreLib" "System.Buffer" "Memmove"
             // Managed fast paths use Unsafe.ReadUnaligned/WriteUnaligned; the native fallback remains


### PR DESCRIPTION
Math.Min has the same shape as Math.Max (already a safe intrinsic): the integer overloads collapse to `(val1 <= val2) ? val1 : val2` and the [Intrinsic]-marked double/float overloads execute the IEEE 754:2019 `minimum` definition through IsNaN/IsNegative, both of which PawPrint already supports. Allowing the IL body to run unblocks AssemblyGetType.cs (now passing) and advances InitializeArrayBoxedFieldHandle.cs to its next blocker (Span<T>::get_Empty).