### PR TITLE
Implement Span<T>::get_Empty / ReadOnlySpan<T>::get_Empty as safe intrinsics

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -39,10 +39,10 @@ module TestPureCases =
             "EnumSemantics.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringTypeHandle
             "GetDeclaringTypeNestedGeneric.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringTypeHandle
             "IsAssignableToBasic.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringTypeHandle
+            "RuntimeTypeGetInterfacesEmpty.cs" // past Span`1::get_Empty; now blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringTypeHandle
             "RuntimeTypeHandleGetInstantiationOpenGeneric.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringMethodForGenericParameter
             "RuntimeHelpersGetHashCode.cs" // blocked by .NET 10 InternalCall String::FastAllocateString taking (MethodTable*, IntPtr) — signature change not yet handled
             "CastClassCrossAssembly.cs" // blocked by unimplemented JIT intrinsic IEnumerable`1::GetEnumerator
-            "RuntimeTypeGetInterfacesEmpty.cs" // blocked by unimplemented JIT intrinsic Span`1::get_Empty
             "AssemblyGetType.cs" // blocked by unimplemented JIT intrinsic Math::Min
             "InitializeArrayBoxedFieldHandle.cs" // blocked by unimplemented JIT intrinsic Math::Min
             "GetElementTypeBasic.cs" // blocked by ldflda through synthetic MethodTableAuxiliaryData::ExposedClassObjectRaw field address

--- a/WoofWare.PawPrint.Test/sourcesPure/SpanEmpty.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/SpanEmpty.cs
@@ -1,0 +1,42 @@
+using System;
+
+public class TestSpanEmpty
+{
+    static int IntSpanEmpty()
+    {
+        Span<int> s = Span<int>.Empty;
+        if (s.Length != 0) return 1;
+        if (!s.IsEmpty) return 2;
+        return 0;
+    }
+
+    static int IntReadOnlySpanEmpty()
+    {
+        ReadOnlySpan<int> s = ReadOnlySpan<int>.Empty;
+        if (s.Length != 0) return 11;
+        if (!s.IsEmpty) return 12;
+        return 0;
+    }
+
+    static int ObjectSpanEmpty()
+    {
+        Span<object> s = Span<object>.Empty;
+        if (s.Length != 0) return 21;
+        if (!s.IsEmpty) return 22;
+        return 0;
+    }
+
+    public static int Main(string[] argv)
+    {
+        int result = IntSpanEmpty();
+        if (result != 0) return result;
+
+        result = IntReadOnlySpanEmpty();
+        if (result != 0) return result;
+
+        result = ObjectSpanEmpty();
+        if (result != 0) return result;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/IntrinsicMethodKeys.fs
+++ b/WoofWare.PawPrint/IntrinsicMethodKeys.fs
@@ -268,10 +268,19 @@ module IntrinsicMethodKeys =
             // and managed-byref assignment are already-modelled span primitives.
             // https://github.com/dotnet/runtime/blob/108fa7856efcfd39bc991c2d849eabbf7ba5989c/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs#L289
             pattern "System.Private.CoreLib" "System.ReadOnlySpan`1" "GetPinnableReference" []
+            // IL body for both Span<T>.Empty and ReadOnlySpan<T>.Empty is
+            // `.locals init (valuetype S V_0) ldloca.s V_0; initobj S; ldloc.0; ret` —
+            // i.e. just returning `default(...)`. The `[Intrinsic]` attribute is for
+            // JIT inlining; the IL is safe to execute directly.
+            // https://github.com/dotnet/runtime/blob/108fa7856efcfd39bc991c2d849eabbf7ba5989c/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs#L214
+            pattern "System.Private.CoreLib" "System.ReadOnlySpan`1" "get_Empty" []
             // IL body is `ldarg.0; ldfld _length; ret`.
             pattern "System.Private.CoreLib" "System.Span`1" "get_Length" []
             // IL body is `ldarg.0; ldfld _length; ldc.i4.0; ceq; ret`.
             pattern "System.Private.CoreLib" "System.Span`1" "get_IsEmpty" []
+            // See ReadOnlySpan<T>.get_Empty above; the IL body is the same `default(Span<T>)` shape.
+            // https://github.com/dotnet/runtime/blob/108fa7856efcfd39bc991c2d849eabbf7ba5989c/src/libraries/System.Private.CoreLib/src/System/Span.cs#L219
+            pattern "System.Private.CoreLib" "System.Span`1" "get_Empty" []
             // Same constructor shape as ReadOnlySpan<T>; the `(void*, int)` constructor is
             // handled explicitly below.
             pattern "System.Private.CoreLib" "System.Span`1" ".ctor" [ IntrinsicParameterPattern.SzArray ]


### PR DESCRIPTION
The IL body for both is simply `initobj` on a local of the span type followed by `ldloc; ret` — i.e. `default(Span<T>)`. The `[Intrinsic]` attribute is for JIT inlining only; the IL is safe to execute directly, so add these to the safeIntrinsics list and let the existing dispatch fall through.