### PR TITLE
Implement String::FastAllocateString(MethodTable*, nint) InternalCall

### DIFF
--- a/WoofWare.PawPrint.Test/TestManagedHeap.fs
+++ b/WoofWare.PawPrint.Test/TestManagedHeap.fs
@@ -117,7 +117,7 @@ module TestManagedHeap =
         |> ignore
 
     [<Test>]
-    let ``setStringChar keeps firstChar field in sync`` () : unit =
+    let ``setStringChar updates the canonical views`` () : unit =
         let _, loggerFactory = LoggerFactory.makeTest ()
         let state = state loggerFactory
 
@@ -126,13 +126,10 @@ module TestManagedHeap =
 
         let heap = ManagedHeap.setStringChar addr 0 'z' state.ManagedHeap
 
-        let firstCharField =
-            FieldIdentity.requiredNonGenericInstanceFieldId state.ConcreteTypes baseClassTypes.String "_firstChar"
-
-        ManagedHeap.get addr heap
-        |> AllocatedNonArrayObject.DereferenceFieldById firstCharField
-        |> shouldEqual (CliType.ofChar 'z')
-
+        // Char 0 is exposed both through the byte-level view (used by byrefs and
+        // the synthetic `_firstChar` projection) and through the canonical
+        // `StringContents` value (used by structural ops).
+        ManagedHeap.getStringChar addr 0 heap |> shouldEqual 'z'
         ManagedHeap.getStringContents addr heap |> shouldEqual (Some "zb")
 
     [<Test>]

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -41,9 +41,8 @@ module TestPureCases =
             "IsAssignableToBasic.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringTypeHandle
             "RuntimeTypeGetInterfacesEmpty.cs" // past Span`1::get_Empty; now blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringTypeHandle
             "RuntimeTypeHandleGetInstantiationOpenGeneric.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringMethodForGenericParameter
-            "RuntimeHelpersGetHashCode.cs" // blocked by .NET 10 InternalCall String::FastAllocateString taking (MethodTable*, IntPtr) — signature change not yet handled
             "CastClassCrossAssembly.cs" // blocked by unimplemented JIT intrinsic IEnumerable`1::GetEnumerator
-            "InitializeArrayBoxedFieldHandle.cs" // past Math::Min; now blocked by unimplemented JIT intrinsic Span`1::get_Empty
+            "InitializeArrayBoxedFieldHandle.cs" // past String::FastAllocateString(MethodTable*, nint); now blocked by unimplemented MethodTable field projection for ParentMethodTable
             "GetElementTypeBasic.cs" // blocked by ldflda through synthetic MethodTableAuxiliaryData::ExposedClassObjectRaw field address
             "RuntimeTypeHandleTypeParameterDeclaringType.cs" // blocked by TypeHandle.GetCorElementType for generic parameter handles
             "MethodReflectionProbe.cs" // past Span`1.Clear and the introduced-method iterator (RuntimeType.GetMethodCandidates now walks each introduced method); now blocked by unimplemented InternalCall RuntimeMethodHandle::_GetUtf8Name (used to fetch each candidate's name)

--- a/WoofWare.PawPrint.Test/sourcesPure/CharToStringContent.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/CharToStringContent.cs
@@ -1,0 +1,20 @@
+using System;
+
+class Program
+{
+    static int Main(string[] args)
+    {
+        // Exercises the path where CoreLib calls FastAllocateString and then
+        // initialises the freshly-allocated string via `result._firstChar = c`
+        // (a direct stfld on the String._firstChar field). The interpreter must
+        // keep the StringContents / StringArrayData side tables in sync with
+        // that field write, otherwise indexer reads return the unsynchronised
+        // NUL even though `_firstChar` itself was updated.
+        string s = 'x'.ToString();
+
+        if (s.Length != 1) return 1;
+        if (s[0] != 'x') return 2;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -486,18 +486,17 @@ module IlMachineRuntimeMetadata =
                 ImmutableArray.Empty
 
         let fields =
-            let firstCharField =
-                FieldIdentity.requiredOwnInstanceField baseClassTypes.String "_firstChar"
-
+            // `_firstChar` is intentionally omitted: its canonical storage is
+            // `StringArrayData[dataOffset]`, and `RuntimeFieldProjection` synthesises
+            // ldfld/ldflda/stfld access against that side-table. Materialising a
+            // separate field cell would create a second source of truth for the
+            // same char and historically led to drift after `stfld _firstChar`
+            // (e.g. CoreLib's `String.CreateFromChar`'s `result._firstChar = c`)
+            // bypassed `setStringChar` and left the byte view at NUL.
             let stringLengthField =
                 FieldIdentity.requiredOwnInstanceField baseClassTypes.String "_stringLength"
 
             [
-                FieldIdentity.cliField
-                    stringType
-                    firstCharField
-                    (CliType.ofChar state.ManagedHeap.StringArrayData.[dataAddr])
-                    (AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes baseClassTypes.Char)
                 FieldIdentity.cliField
                     stringType
                     stringLengthField

--- a/WoofWare.PawPrint/ManagedHeap.fs
+++ b/WoofWare.PawPrint/ManagedHeap.fs
@@ -46,13 +46,15 @@ type ManagedHeap =
         /// so we'll have a special pool for their bytes.
         StringArrayData : ImmutableArray<char>
         /// Side-table mapping a String object's address to its full character content.
-        /// The managed representation of a String only carries _firstChar and _stringLength,
-        /// which is not enough to reconstruct the full text; we record it here at allocation
-        /// time so operations like String.Equals can compare full contents.
+        /// The managed representation of a String only carries `_stringLength` as a
+        /// regular field; the chars (including the metadata-level `_firstChar`) live
+        /// in `StringArrayData` and are projected via `RuntimeFieldProjection`. We
+        /// record the canonical text here at allocation time so operations like
+        /// `String.Equals` can compare full contents without re-reading the byte view.
         StringContents : ImmutableDictionary<ManagedHeapAddress, string>
         /// Side-table mapping a String object's address to the first character's index in
-        /// `StringArrayData`. String objects store `_firstChar` as a regular field, but
-        /// byrefs to it must be able to walk into the trailing character data.
+        /// `StringArrayData`. `_firstChar` and byref/trailing-data reads both walk
+        /// from this offset.
         StringDataOffsets : ImmutableDictionary<ManagedHeapAddress, int>
     }
 
@@ -178,22 +180,12 @@ module ManagedHeap =
         | Some contents -> contents
         | None -> failwith $"%s{operation}: string contents for %O{addr} were not recorded"
 
-    let private setFirstStringCharField (addr : ManagedHeapAddress) (value : char) (heap : ManagedHeap) : ManagedHeap =
-        match heap.NonArrayObjects.TryGetValue addr with
-        | false, _ -> heap
-        | true, stringObject ->
-            let stringObject =
-                AllocatedNonArrayObject.SetField "_firstChar" (CliType.ofChar value) stringObject
-
-            { heap with
-                NonArrayObjects = heap.NonArrayObjects |> Map.add addr stringObject
-            }
-
     /// Update a character in the runtime string data side-table. `charIndex` equal
     /// to the string length addresses the null terminator; that updates
-    /// `StringArrayData` but not the logical `StringContents` value. Character
-    /// zero is also mirrored into String._firstChar, keeping direct field reads
-    /// consistent with byref/trailing-data reads.
+    /// `StringArrayData` but not the logical `StringContents` value. The metadata-
+    /// level `_firstChar` field is a synthetic projection over
+    /// `StringArrayData[dataOffset]` (see `RuntimeFieldProjection`) and therefore
+    /// requires no separate mirror.
     let setStringChar (addr : ManagedHeapAddress) (charIndex : int) (value : char) (heap : ManagedHeap) : ManagedHeap =
         if charIndex < 0 then
             failwith $"string character index must be non-negative, got %d{charIndex} for %O{addr}"
@@ -212,12 +204,6 @@ module ManagedHeap =
             { heap with
                 StringArrayData = newArr.ToImmutable ()
             }
-
-        let heap =
-            if charIndex = 0 then
-                setFirstStringCharField addr value heap
-            else
-                heap
 
         if charIndex < contents.Length then
             let chars = contents.ToCharArray ()

--- a/WoofWare.PawPrint/Native/NativeString.fs
+++ b/WoofWare.PawPrint/Native/NativeString.fs
@@ -4,6 +4,48 @@ open System
 
 [<RequireQualifiedAccess>]
 module NativeString =
+    /// Allocate a blank `String` of the given length and push the heap reference.
+    let private allocateAndPushBlankString
+        (ctx : NativeCallContext)
+        (length : int)
+        (state : IlMachineState)
+        : IlMachineState
+        =
+        if length < 0 then
+            failwith "TODO: String.FastAllocateString with negative length should throw OutOfMemoryException"
+
+        let contents = String (char 0, length)
+
+        let addr, state =
+            IlMachineState.allocateManagedString ctx.LoggerFactory ctx.BaseClassTypes contents state
+
+        state
+        |> IlMachineState.pushToEvalStack (CliType.ObjectRef (Some addr)) ctx.Thread
+
+    /// Decode an `nint`-typed length argument. CoreLib's .NET 10 `FastAllocateString`
+    /// wrapper widens `int` to `nint` via `Conv.I`, which materialises as
+    /// `NativeInt.Verbatim`, but accept the broader set of representations that other
+    /// nint-length sites already produce so a future BCL refactor doesn't silently
+    /// degrade. Mirrors `NativeBuffer.byteCountOfArgument`. Reject negatives and
+    /// values that exceed `Int32.MaxValue`; CoreCLR throws OOM in both cases, but
+    /// we don't yet plumb guest exceptions through here.
+    let private nintLengthOfArgument (operation : string) (arg : CliType) : int =
+        let checkedLength (count : int64) : int =
+            if count < 0L then
+                failwith $"TODO: %s{operation} with negative length %d{count} should throw OutOfMemoryException"
+
+            if count > int64 System.Int32.MaxValue then
+                failwith
+                    $"TODO: %s{operation} with length %d{count} exceeding Int32.MaxValue should throw OutOfMemoryException"
+
+            int count
+
+        match CliType.unwrapPrimitiveLikeDeep arg with
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim count)) -> checkedLength count
+        | CliType.Numeric (CliNumericType.Int64 (Int64Source.Verbatim count)) -> checkedLength count
+        | CliType.Numeric (CliNumericType.Int32 count) -> checkedLength (int64 count)
+        | other -> failwith $"%s{operation}: expected nint length, got %O{other}"
+
     let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
@@ -24,23 +66,52 @@ module NativeString =
           MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.String) ->
             if instruction.Arguments.Length <> 1 then
                 failwith
-                    $"String.FastAllocateString: expected one native argument after matching signature, got %d{instruction.Arguments.Length}"
+                    $"String.FastAllocateString(int): expected one native argument after matching signature, got %d{instruction.Arguments.Length}"
 
             let length =
                 match CliType.unwrapPrimitiveLikeDeep instruction.Arguments.[0] with
                 | CliType.Numeric (CliNumericType.Int32 i) -> i
-                | other -> failwith $"String.FastAllocateString: expected int32 length, got %O{other}"
-
-            if length < 0 then
-                failwith "TODO: String.FastAllocateString with negative length should throw OutOfMemoryException"
-
-            let contents = String (char 0, length)
-
-            let addr, state =
-                IlMachineState.allocateManagedString ctx.LoggerFactory ctx.BaseClassTypes contents state
+                | other -> failwith $"String.FastAllocateString(int): expected int32 length, got %O{other}"
 
             state
-            |> IlMachineState.pushToEvalStack (CliType.ObjectRef (Some addr)) ctx.Thread
+            |> allocateAndPushBlankString ctx length
+            |> fun state -> (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            |> Some
+        | "System.Private.CoreLib",
+          "System",
+          "String",
+          "FastAllocateString",
+          [ ConcretePointer (ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                                               "System.Runtime.CompilerServices",
+                                                               "MethodTable",
+                                                               methodTableGenerics))
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.String) when
+            methodTableGenerics.IsEmpty
+            ->
+            // .NET 10 InternalCall: `FastAllocateString(MethodTable* pMT, nint length)`.
+            // The legacy `FastAllocateString(int)` overload is now a managed wrapper that
+            // calls this one with `TypeHandleOf<string>().AsMethodTable()`. CoreCLR uses
+            // pMT as the allocation type; we only ever expect System.String here, since
+            // that's what the wrapper passes — fail loudly if anything else surfaces.
+            // https://github.com/dotnet/runtime/blob/v10.0.7/src/coreclr/System.Private.CoreLib/src/System/String.CoreCLR.cs#L27-L34
+            let operation = "String.FastAllocateString(MethodTable*, nint)"
+
+            if instruction.Arguments.Length <> 2 then
+                failwith
+                    $"%s{operation}: expected two native arguments after matching signature, got %d{instruction.Arguments.Length}"
+
+            let methodTableHandle =
+                NativeCall.methodTableOfEvalStackValue operation (instruction.Arguments.[0] |> EvalStackValue.ofCliType)
+
+            match methodTableHandle with
+            | ConcretePrimitive state.ConcreteTypes PrimitiveType.String -> ()
+            | other -> failwith $"%s{operation}: expected MethodTable for System.String, got %O{other}"
+
+            let length = nintLengthOfArgument operation instruction.Arguments.[1]
+
+            state
+            |> allocateAndPushBlankString ctx length
             |> fun state -> (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
             |> Some
         | "System.Private.CoreLib",

--- a/WoofWare.PawPrint/RuntimeFieldProjection.fs
+++ b/WoofWare.PawPrint/RuntimeFieldProjection.fs
@@ -19,17 +19,59 @@ module internal RuntimeFieldProjection =
         && field.DeclaringType.Name = typeName
         && field.DeclaringType.Generics.IsEmpty
 
+    let private isStringFirstChar
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (field : FieldInfo<'typeGeneric, 'fieldGeneric>)
+        : bool
+        =
+        field.Name = "_firstChar"
+        && isCorelibType baseClassTypes field "System" "String"
+
     let private tryProjectStringTrailingDataFieldAddress
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (field : FieldInfo<'typeGeneric, 'fieldGeneric>)
         (addr : ManagedHeapAddress)
         : ManagedPointerSource option
         =
-        if
-            field.Name = "_firstChar"
-            && isCorelibType baseClassTypes field "System" "String"
-        then
+        if isStringFirstChar baseClassTypes field then
             ManagedPointerSource.Byref (ByrefRoot.StringCharAt (addr, 0), []) |> Some
+        else
+            None
+
+    /// `String._firstChar` is the metadata-level handle for char 0 of the inline
+    /// character data; PawPrint stores that data in `StringArrayData`. Load
+    /// projections synthesise the field's value from the side-table so there is
+    /// only one storage location to keep coherent.
+    let private tryProjectStringFirstCharLoad
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (field : FieldInfo<'typeGeneric, 'fieldGeneric>)
+        (addr : ManagedHeapAddress)
+        (heap : ManagedHeap)
+        : CliType option
+        =
+        if isStringFirstChar baseClassTypes field then
+            ManagedHeap.getStringChar addr 0 heap |> CliType.ofChar |> Some
+        else
+            None
+
+    /// Symmetric to `tryProjectStringFirstCharLoad`: route `stfld _firstChar`
+    /// writes through `setStringChar 0` so the byte view and the canonical
+    /// `StringContents` value stay coherent with the metadata-level field.
+    let private tryProjectStringFirstCharStore
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (field : FieldInfo<'typeGeneric, 'fieldGeneric>)
+        (addr : ManagedHeapAddress)
+        (value : CliType)
+        (heap : ManagedHeap)
+        : ManagedHeap option
+        =
+        if isStringFirstChar baseClassTypes field then
+            let c =
+                match value with
+                | CliType.Char (high, low) -> char (int high * 256 + int low)
+                | other -> failwith $"stfld String._firstChar: expected char value, got %O{other}"
+
+            ManagedHeap.setStringChar addr 0 c heap |> Some
         else
             None
 
@@ -126,3 +168,30 @@ module internal RuntimeFieldProjection =
             match tryProjectRawDataFieldAddress baseClassTypes field addr state with
             | Some projection -> Some projection
             | None -> tryProjectStringTrailingDataFieldAddress baseClassTypes field addr
+
+    /// Synthesise an `ldfld` value for fields whose canonical storage lives outside the
+    /// heap object's field map (currently `RawArrayData::Length` and `String._firstChar`).
+    /// Returns `None` for fields that should fall through to the standard field-map lookup.
+    let tryProjectFieldLoad
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (field : FieldInfo<'typeGeneric, 'fieldGeneric>)
+        (addr : ManagedHeapAddress)
+        (state : IlMachineState)
+        : CliType option
+        =
+        match RawArrayDataProjection.tryProjectField baseClassTypes field addr state with
+        | Some value -> Some value
+        | None -> tryProjectStringFirstCharLoad baseClassTypes field addr state.ManagedHeap
+
+    /// Route an `stfld` value for projected fields back to their canonical storage. Returns
+    /// the updated heap, or `None` for fields that should fall through to the standard
+    /// field-map write.
+    let tryProjectFieldStore
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (field : FieldInfo<'typeGeneric, 'fieldGeneric>)
+        (addr : ManagedHeapAddress)
+        (value : CliType)
+        (heap : ManagedHeap)
+        : ManagedHeap option
+        =
+        tryProjectStringFirstCharStore baseClassTypes field addr value heap

--- a/WoofWare.PawPrint/UnaryMetadataFieldOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataFieldOps.fs
@@ -96,16 +96,42 @@ module internal UnaryMetadataFieldOps =
                 match state.ManagedHeap.NonArrayObjects.TryGetValue addr with
                 | false, _ -> failwith $"todo: array {addr}"
                 | true, v ->
-                    let v = AllocatedNonArrayObject.SetFieldById fieldId valueToStore v
+                    // `String._firstChar` is mirrored across three locations: the
+                    // object field, the `StringArrayData` byte view (used for byref
+                    // and span reads, and for the `string[i]` indexer's pointer
+                    // arithmetic), and the canonical `StringContents` value (used by
+                    // `String.Equals` and similar). CoreLib initialises freshly
+                    // allocated strings through this exact stfld, e.g.
+                    // `String.CreateFromChar`'s `result._firstChar = c`, so route
+                    // these writes through `setStringChar` to keep all three views
+                    // consistent. Without this, `'x'.ToString()[0]` reads the
+                    // unsynchronised side-table NUL instead of the written char.
+                    let isStringFirstChar =
+                        field.DeclaringType.Assembly.Name = "System.Private.CoreLib"
+                        && field.DeclaringType.Namespace = "System"
+                        && field.DeclaringType.Name = "String"
+                        && field.Name = "_firstChar"
 
-                    let heap =
-                        { state.ManagedHeap with
-                            NonArrayObjects = state.ManagedHeap.NonArrayObjects |> Map.add addr v
+                    if isStringFirstChar then
+                        let charValue =
+                            match valueToStore with
+                            | CliType.Char (high, low) -> char (int high * 256 + int low)
+                            | other -> failwith $"stfld String._firstChar: expected char value, got %O{other}"
+
+                        { state with
+                            ManagedHeap = ManagedHeap.setStringChar addr 0 charValue state.ManagedHeap
                         }
+                    else
+                        let v = AllocatedNonArrayObject.SetFieldById fieldId valueToStore v
 
-                    { state with
-                        ManagedHeap = heap
-                    }
+                        let heap =
+                            { state.ManagedHeap with
+                                NonArrayObjects = state.ManagedHeap.NonArrayObjects |> Map.add addr v
+                            }
+
+                        { state with
+                            ManagedHeap = heap
+                        }
             | EvalStackValue.ManagedPointer src ->
                 IlMachineState.writeManagedByrefWithBase
                     baseClassTypes

--- a/WoofWare.PawPrint/UnaryMetadataFieldOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataFieldOps.fs
@@ -93,35 +93,17 @@ module internal UnaryMetadataFieldOps =
             | EvalStackValue.Float _ -> failwith "unexpectedly setting field on a float"
             | EvalStackValue.NullObjectRef -> failwith "unreachable: NullObjectRef handled above"
             | EvalStackValue.ObjectRef addr ->
-                match state.ManagedHeap.NonArrayObjects.TryGetValue addr with
-                | false, _ -> failwith $"todo: array {addr}"
-                | true, v ->
-                    // `String._firstChar` is mirrored across three locations: the
-                    // object field, the `StringArrayData` byte view (used for byref
-                    // and span reads, and for the `string[i]` indexer's pointer
-                    // arithmetic), and the canonical `StringContents` value (used by
-                    // `String.Equals` and similar). CoreLib initialises freshly
-                    // allocated strings through this exact stfld, e.g.
-                    // `String.CreateFromChar`'s `result._firstChar = c`, so route
-                    // these writes through `setStringChar` to keep all three views
-                    // consistent. Without this, `'x'.ToString()[0]` reads the
-                    // unsynchronised side-table NUL instead of the written char.
-                    let isStringFirstChar =
-                        field.DeclaringType.Assembly.Name = "System.Private.CoreLib"
-                        && field.DeclaringType.Namespace = "System"
-                        && field.DeclaringType.Name = "String"
-                        && field.Name = "_firstChar"
-
-                    if isStringFirstChar then
-                        let charValue =
-                            match valueToStore with
-                            | CliType.Char (high, low) -> char (int high * 256 + int low)
-                            | other -> failwith $"stfld String._firstChar: expected char value, got %O{other}"
-
-                        { state with
-                            ManagedHeap = ManagedHeap.setStringChar addr 0 charValue state.ManagedHeap
-                        }
-                    else
+                match
+                    RuntimeFieldProjection.tryProjectFieldStore baseClassTypes field addr valueToStore state.ManagedHeap
+                with
+                | Some heap ->
+                    { state with
+                        ManagedHeap = heap
+                    }
+                | None ->
+                    match state.ManagedHeap.NonArrayObjects.TryGetValue addr with
+                    | false, _ -> failwith $"todo: array {addr}"
+                    | true, v ->
                         let v = AllocatedNonArrayObject.SetFieldById fieldId valueToStore v
 
                         let heap =
@@ -320,7 +302,7 @@ module internal UnaryMetadataFieldOps =
             | EvalStackValue.Float f -> failwith "todo: float"
             | EvalStackValue.NullObjectRef -> failwith "unreachable: NullObjectRef handled above"
             | EvalStackValue.ObjectRef managedHeapAddress ->
-                match RawArrayDataProjection.tryProjectField baseClassTypes field managedHeapAddress state with
+                match RuntimeFieldProjection.tryProjectFieldLoad baseClassTypes field managedHeapAddress state with
                 | Some value -> IlMachineState.pushToEvalStack value thread state
                 | None ->
                     match state.ManagedHeap.NonArrayObjects.TryGetValue managedHeapAddress with


### PR DESCRIPTION
## Summary
- Add the .NET 10 InternalCall overload `String::FastAllocateString(MethodTable*, nint)` to `Native/NativeString.fs`. The legacy `(int)` form is now a managed wrapper that calls this one with `TypeHandleOf<string>().AsMethodTable()`. The MethodTable is strict-validated as `System.String` so we fail loudly if anything else surfaces, and we accept the broader nint encodings (`NativeInt.Verbatim`, `Int64.Verbatim`, `Int32`) the rest of CoreLib already produces. Adds `CharToStringContent.cs` as a regression test exercising `'x'.ToString()[0]`.
- Eliminate `String._firstChar` as duplicated storage. Previously char 0 lived in three places (the `_firstChar` field map entry, `StringArrayData[dataOffset]`, and `StringContents`) with manual sync points; CoreLib's `String.CreateFromChar` exposed this by initialising via `result._firstChar = c`, which the indexer/byref/span paths did not see. The fix makes `_firstChar` a synthetic projection over `StringArrayData`: `ldfld`/`ldflda`/`stfld _firstChar` all route through `getStringChar 0` / `setStringChar 0` so there is one canonical storage location, and the field is no longer materialized in the heap object's field map at allocation time.
- Generalize the field-projection seam: `RuntimeFieldProjection` now exposes `tryProjectFieldLoad` and `tryProjectFieldStore` siblings to the existing `tryProjectFieldAddress`, and `executeLdfld` / `executeStfld` consult them uniformly. This subsumes the previous ad-hoc `RawArrayDataProjection` call in `ldfld` and gives future synthetic fields one place to plug in.

## Test plan
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — all green
- [x] `codex review --base main` — no actionable correctness issues
- [x] `nix develop -c dotnet fantomas .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)