### PR TITLE
Whitelist BitOperations.RotateLeft as a safe JIT intrinsic

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -20,7 +20,7 @@ module TestPureCases =
             "AdvancedStructLayout.cs" // blocked after fixed-buffer pointer arithmetic by MarshalNative_SizeOfHelper for ByValTStr string marshalling
             "LdtokenField.cs" // TODO: read through `ReinterpretAs` as non-primitive type .VolatileObject
             "GenericEdgeCases.cs" // blocked after BitOperations.Log2 by unimplemented JIT intrinsic System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned (reached via int.ToString -> Number.UInt32ToDecStr)
-            "CrossAssemblyTypes.cs" // past Guid byref-byteview field crossing; now blocked by unimplemented JIT intrinsic System.Numerics.BitOperations.RotateLeft (reached via Dictionary hashing path)
+            "CrossAssemblyTypes.cs" // past Marvin string-hash RotateLeft; now blocked by unimplemented JIT intrinsic System.Runtime.CompilerServices.RuntimeHelpers.IsKnownConstant(int) (reached via Dictionary insertion path)
             "InterfaceDispatch.cs" // past MetadataImport::GetCustomAttributeProps; now blocked by unimplemented InternalCall MetadataImport::GetParentToken
             "NullDereferenceTest.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
             "CastClassInvalid.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource

--- a/WoofWare.PawPrint/IntrinsicMethodKeys.fs
+++ b/WoofWare.PawPrint/IntrinsicMethodKeys.fs
@@ -373,6 +373,38 @@ module IntrinsicMethodKeys =
                 "System.UIntPtr"
                 "Log2"
                 [ IntrinsicParameterPattern.Exact "System.UIntPtr" ]
+            // BitOperations.RotateLeft is marked [Intrinsic] only so the JIT can lower it to a
+            // single ROL instruction; the IL bodies are pure shift+OR over the existing primitive
+            // numeric ops PawPrint already supports:
+            //   uint:  (value << offset) | (value >> (32 - offset))
+            //   ulong: (value << offset) | (value >> (64 - offset))
+            //   nuint: forwards to the uint or ulong overload depending on TARGET_64BIT.
+            // Reached through the Marvin string-hash path (Dictionary<string, …> keying).
+            // https://github.com/dotnet/runtime/blob/d258af50034c192bf7f0a18856bf83d2903d98ae/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs#L675
+            pattern
+                "System.Private.CoreLib"
+                "System.Numerics.BitOperations"
+                "RotateLeft"
+                [
+                    IntrinsicParameterPattern.Exact "System.UInt32"
+                    IntrinsicParameterPattern.Exact "System.Int32"
+                ]
+            pattern
+                "System.Private.CoreLib"
+                "System.Numerics.BitOperations"
+                "RotateLeft"
+                [
+                    IntrinsicParameterPattern.Exact "System.UInt64"
+                    IntrinsicParameterPattern.Exact "System.Int32"
+                ]
+            pattern
+                "System.Private.CoreLib"
+                "System.Numerics.BitOperations"
+                "RotateLeft"
+                [
+                    IntrinsicParameterPattern.Exact "System.UIntPtr"
+                    IntrinsicParameterPattern.Exact "System.Int32"
+                ]
             // Volatile.Read/Write wrappers are managed field accesses through volatile struct
             // views. PawPrint does not currently model memory-ordering effects, but executing
             // the IL is deterministic and preserves the accessed value.


### PR DESCRIPTION
## Summary

- The `uint`/`ulong`/`nuint` overloads of `System.Numerics.BitOperations.RotateLeft` are marked `[Intrinsic]` only so the JIT can lower them to a single `ROL` instruction; their IL bodies are pure shift+OR over primitives PawPrint already supports.
- Adding the three patterns to `safeIntrinsics` lets PawPrint execute the IL directly. Same precedent as the `UInt32.Log2`/`UInt64.Log2`/`UIntPtr.Log2` wrappers immediately above in the same file.
- This unblocks the Marvin string-hash path (`Dictionary<string, …>` insertion) past `RotateLeft`. `CrossAssemblyTypes.cs` advances and now stops at the next JIT intrinsic, `RuntimeHelpers.IsKnownConstant(int)`; the comment in `unimplemented` is updated accordingly.

## Test plan

- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 659/659 passing locally
- [x] `nix develop -c dotnet fantomas .` clean
- [x] `codex review --base main` — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)