### PR TITLE
Whitelist RuntimeHelpers.IsKnownConstant as a safe JIT intrinsic

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -20,7 +20,7 @@ module TestPureCases =
             "AdvancedStructLayout.cs" // blocked after fixed-buffer pointer arithmetic by MarshalNative_SizeOfHelper for ByValTStr string marshalling
             "LdtokenField.cs" // TODO: read through `ReinterpretAs` as non-primitive type .VolatileObject
             "GenericEdgeCases.cs" // blocked after BitOperations.Log2 by unimplemented JIT intrinsic System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned (reached via int.ToString -> Number.UInt32ToDecStr)
-            "CrossAssemblyTypes.cs" // past Marvin string-hash RotateLeft; now blocked by unimplemented JIT intrinsic System.Runtime.CompilerServices.RuntimeHelpers.IsKnownConstant(int) (reached via Dictionary insertion path)
+            "CrossAssemblyTypes.cs" // past Marvin string-hash RotateLeft and RuntimeHelpers.IsKnownConstant; now blocked by .NET 10 InternalCall String::FastAllocateString taking (MethodTable*, IntPtr) — same blocker as RuntimeHelpersGetHashCode.cs
             "InterfaceDispatch.cs" // past MetadataImport::GetCustomAttributeProps; now blocked by unimplemented InternalCall MetadataImport::GetParentToken
             "NullDereferenceTest.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
             "CastClassInvalid.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource

--- a/WoofWare.PawPrint/IntrinsicMethodKeys.fs
+++ b/WoofWare.PawPrint/IntrinsicMethodKeys.fs
@@ -405,6 +405,18 @@ module IntrinsicMethodKeys =
                     IntrinsicParameterPattern.Exact "System.UIntPtr"
                     IntrinsicParameterPattern.Exact "System.Int32"
                 ]
+            // RuntimeHelpers.IsKnownConstant overloads (Type?, string?, char, generic struct T)
+            // are JIT-only intrinsics: every IL body is literally `ldc.i4.0; ret`. The JIT may
+            // rewrite the call to `ldc.i4.1` when the argument is a compile-time constant;
+            // PawPrint has no JIT, so executing the IL yields the documented fallback (false).
+            // The single Any-shaped pattern subsumes all overloads since the IL body is the same
+            // regardless of the argument type.
+            // https://github.com/dotnet/runtime/blob/d258af50034c192bf7f0a18856bf83d2903d98ae/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs#L168-L178
+            pattern
+                "System.Private.CoreLib"
+                "System.Runtime.CompilerServices.RuntimeHelpers"
+                "IsKnownConstant"
+                [ IntrinsicParameterPattern.Any ]
             // Volatile.Read/Write wrappers are managed field accesses through volatile struct
             // views. PawPrint does not currently model memory-ordering effects, but executing
             // the IL is deterministic and preserves the accessed value.


### PR DESCRIPTION
## Summary

- All four `RuntimeHelpers.IsKnownConstant` overloads (`Type?`, `string?`, `char`, generic struct `T`) have an IL body of literally `ldc.i4.0; ret`. The `[Intrinsic]` attribute exists only so the JIT can rewrite the call to `true` when the argument is a compile-time constant; PawPrint has no JIT, so executing the IL yields the documented fallback (false).
- A single `Any`-shaped pattern subsumes every overload, since the IL body is identical regardless of argument type.
- Stacked on #465 (BitOperations.RotateLeft). With both fixes applied, `CrossAssemblyTypes.cs` now advances past both intrinsics on the `Dictionary<string, int>` insertion path and stops at the .NET 10 `FastAllocateString(MethodTable*, IntPtr)` signature change — the same blocker already tracked for `RuntimeHelpersGetHashCode.cs`. Test comment updated accordingly.

## Test plan

- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 659/659 passing locally
- [x] Verified `CrossAssemblyTypes.cs` reaches the new blocker (FastAllocateString) end-to-end
- [x] `nix develop -c dotnet fantomas .` clean
- [x] `codex review --base add-rotate-left-intrinsic` — no findings

## Merge order

This PR is based on #465. After #465 lands, please rebase this onto `main` so the diff against `main` is just the IsKnownConstant lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)