### PR TITLE
Allocate multi-dim arrays via newobj T[,]::.ctor

### DIFF
--- a/WoofWare.PawPrint.Test/TestBinaryArithmetic.fs
+++ b/WoofWare.PawPrint.Test/TestBinaryArithmetic.fs
@@ -69,6 +69,7 @@ module TestBinaryArithmetic =
         {
             ConcreteType = ConcreteTypeHandle.OneDimArrayZero int32Handle
             Length = values.Length
+            Lengths = ImmutableArray.Create values.Length
             Elements = elements
         }
 

--- a/WoofWare.PawPrint.Test/TestManagedHeap.fs
+++ b/WoofWare.PawPrint.Test/TestManagedHeap.fs
@@ -42,6 +42,7 @@ module TestManagedHeap =
             {
                 ConcreteType = intArrayHandle
                 Length = 0
+                Lengths = ImmutableArray.Create 0
                 Elements = ImmutableArray.Empty
             }
 
@@ -49,6 +50,7 @@ module TestManagedHeap =
             {
                 ConcreteType = stringArrayHandle
                 Length = 0
+                Lengths = ImmutableArray.Create 0
                 Elements = ImmutableArray.Empty
             }
 
@@ -67,6 +69,7 @@ module TestManagedHeap =
             {
                 ConcreteType = arrayHandle
                 Length = 0
+                Lengths = ImmutableArray.Create 0
                 Elements = ImmutableArray.Empty
             }
 

--- a/WoofWare.PawPrint.Test/TestManagedHeap.fs
+++ b/WoofWare.PawPrint.Test/TestManagedHeap.fs
@@ -255,9 +255,9 @@ module TestManagedHeap =
 
     [<Test>]
     let ``allocateMultiDimArray: rank-4 product overflow is detected before wrapping`` () : unit =
-        // 65536^4 = 2^64, which overflows Int32 *and* Int64; in particular, doing the
-        // multiplication in Int64 would still wrap to 0 here. The divide-before-multiply
-        // guard must fire *before* the running product is multiplied past Int32.MaxValue.
+        // 65536^2 = 2^32 already overflows the UInt32 running product, so the guard
+        // must fire at dimension 1 — before any silent wrap and well before we'd
+        // attempt to allocate a backing store.
         let _, loggerFactory = LoggerFactory.makeTest ()
         let state = state loggerFactory
 
@@ -265,6 +265,72 @@ module TestManagedHeap =
         let arrayHandle = ConcreteTypeHandle.Array (elementHandle, 4)
         let zero = CliType.Numeric (CliNumericType.Int32 0)
         let lengths = ImmutableArray.CreateRange [ 65536 ; 65536 ; 65536 ; 65536 ]
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () ->
+                IlMachineState.allocateMultiDimArray arrayHandle (fun () -> zero) lengths state
+                |> ignore
+            )
+
+        exn.Message |> shouldContainText "overflows UInt32"
+
+    [<Test>]
+    let ``allocateMultiDimArray: trailing zero rescues a prefix that fits in UInt32`` () : unit =
+        // Per CoreCLR (vm/gchelpers.cpp): the running product is uint32, and 50000 *
+        // 50000 = 2,500,000,000 fits in uint32 even though it exceeds Int32.MaxValue.
+        // The trailing 0 then brings the product back to 0 and the array is allocated
+        // empty — i.e. a transient prefix overshoot must NOT abort allocation.
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        let state = state loggerFactory
+
+        let elementHandle = ConcreteTypeHandle.Concrete 1
+        let arrayHandle = ConcreteTypeHandle.Array (elementHandle, 3)
+        let zero = CliType.Numeric (CliNumericType.Int32 0)
+        let lengths = ImmutableArray.CreateRange [ 50000 ; 50000 ; 0 ]
+
+        let addr, state =
+            IlMachineState.allocateMultiDimArray arrayHandle (fun () -> zero) lengths state
+
+        let array = state.ManagedHeap.Arrays.[addr]
+        array.Length |> shouldEqual 0
+        array.Lengths |> shouldEqual lengths
+        array.Elements.Length |> shouldEqual 0
+
+    [<Test>]
+    let ``allocateMultiDimArray: prefix that overflows UInt32 still throws even if a later dim is zero`` () : unit =
+        // 65536 * 65536 = 2^32 overflows UInt32 itself, so codex's "trailing zero rescues"
+        // fix must NOT extend to the case where the multiply genuinely overflows. CoreCLR
+        // throws OutOfMemoryException at the multiplication step here, regardless of the
+        // final 0 dimension.
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        let state = state loggerFactory
+
+        let elementHandle = ConcreteTypeHandle.Concrete 1
+        let arrayHandle = ConcreteTypeHandle.Array (elementHandle, 4)
+        let zero = CliType.Numeric (CliNumericType.Int32 0)
+        let lengths = ImmutableArray.CreateRange [ 65536 ; 65536 ; 65536 ; 0 ]
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () ->
+                IlMachineState.allocateMultiDimArray arrayHandle (fun () -> zero) lengths state
+                |> ignore
+            )
+
+        exn.Message |> shouldContainText "overflows UInt32"
+
+    [<Test>]
+    let ``allocateMultiDimArray: final product exceeding Int32 is rejected even if it fits in UInt32`` () : unit =
+        // Int32.MaxValue * 2 = UInt32.MaxValue - 1, which fits in UInt32 (the per-step
+        // multiply check passes: Int32.MaxValue == UInt32.MaxValue / 2, not strictly
+        // greater). But the final product exceeds Int32.MaxValue, so it can't index our
+        // backing store; the post-loop guard must catch it.
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        let state = state loggerFactory
+
+        let elementHandle = ConcreteTypeHandle.Concrete 1
+        let arrayHandle = ConcreteTypeHandle.Array (elementHandle, 2)
+        let zero = CliType.Numeric (CliNumericType.Int32 0)
+        let lengths = ImmutableArray.CreateRange [ System.Int32.MaxValue ; 2 ]
 
         let exn =
             Assert.Throws<System.Exception> (fun () ->

--- a/WoofWare.PawPrint.Test/TestManagedHeap.fs
+++ b/WoofWare.PawPrint.Test/TestManagedHeap.fs
@@ -212,3 +212,82 @@ module TestManagedHeap =
             |> ManagedHeap.recordStringContents addr2 "abcdeg"
 
         ManagedHeap.stringsEqual addr1 addr2 heap |> shouldEqual false
+
+    [<Test>]
+    let ``allocateMultiDimArray: 2D zero-init has product Length and verbatim Lengths`` () : unit =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        let state = state loggerFactory
+
+        let elementHandle = ConcreteTypeHandle.Concrete 1
+        let arrayHandle = ConcreteTypeHandle.Array (elementHandle, 2)
+        let zero = CliType.Numeric (CliNumericType.Int32 0)
+        let lengths = ImmutableArray.CreateRange [ 3 ; 4 ]
+
+        let addr, state =
+            IlMachineState.allocateMultiDimArray arrayHandle (fun () -> zero) lengths state
+
+        let array = state.ManagedHeap.Arrays.[addr]
+        array.ConcreteType |> shouldEqual arrayHandle
+        array.Length |> shouldEqual 12
+        array.Lengths |> shouldEqual lengths
+        array.Elements.Length |> shouldEqual 12
+
+        for i = 0 to 11 do
+            array.Elements.[i] |> shouldEqual zero
+
+    [<Test>]
+    let ``allocateMultiDimArray: zero dimension yields empty backing store`` () : unit =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        let state = state loggerFactory
+
+        let elementHandle = ConcreteTypeHandle.Concrete 1
+        let arrayHandle = ConcreteTypeHandle.Array (elementHandle, 3)
+        let zero = CliType.Numeric (CliNumericType.Int32 0)
+        let lengths = ImmutableArray.CreateRange [ 5 ; 0 ; 7 ]
+
+        let addr, state =
+            IlMachineState.allocateMultiDimArray arrayHandle (fun () -> zero) lengths state
+
+        let array = state.ManagedHeap.Arrays.[addr]
+        array.Length |> shouldEqual 0
+        array.Lengths |> shouldEqual lengths
+        array.Elements.Length |> shouldEqual 0
+
+    [<Test>]
+    let ``allocateMultiDimArray: rank-4 product overflow is detected before wrapping`` () : unit =
+        // 65536^4 = 2^64, which overflows Int32 *and* Int64; in particular, doing the
+        // multiplication in Int64 would still wrap to 0 here. The divide-before-multiply
+        // guard must fire *before* the running product is multiplied past Int32.MaxValue.
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        let state = state loggerFactory
+
+        let elementHandle = ConcreteTypeHandle.Concrete 1
+        let arrayHandle = ConcreteTypeHandle.Array (elementHandle, 4)
+        let zero = CliType.Numeric (CliNumericType.Int32 0)
+        let lengths = ImmutableArray.CreateRange [ 65536 ; 65536 ; 65536 ; 65536 ]
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () ->
+                IlMachineState.allocateMultiDimArray arrayHandle (fun () -> zero) lengths state
+                |> ignore
+            )
+
+        exn.Message |> shouldContainText "exceeds Int32.MaxValue"
+
+    [<Test>]
+    let ``allocateMultiDimArray: negative length is rejected`` () : unit =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        let state = state loggerFactory
+
+        let elementHandle = ConcreteTypeHandle.Concrete 1
+        let arrayHandle = ConcreteTypeHandle.Array (elementHandle, 2)
+        let zero = CliType.Numeric (CliNumericType.Int32 0)
+        let lengths = ImmutableArray.CreateRange [ 3 ; -1 ]
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () ->
+                IlMachineState.allocateMultiDimArray arrayHandle (fun () -> zero) lengths state
+                |> ignore
+            )
+
+        exn.Message |> shouldContainText "negative length"

--- a/WoofWare.PawPrint.Test/sourcesPure/MultiDimArrayNewobj.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/MultiDimArrayNewobj.cs
@@ -1,0 +1,27 @@
+namespace HelloWorldApp
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            var a = new int[3, 4];
+            if ((object)a == null)
+            {
+                return 1;
+            }
+
+            var b = new int[3, 4];
+            if ((object)b == null)
+            {
+                return 2;
+            }
+
+            if (object.ReferenceEquals(a, b))
+            {
+                return 3;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -88,6 +88,8 @@ module IlMachineState =
 
     let allocateArray = IlMachineThreadState.allocateArray
 
+    let allocateMultiDimArray = IlMachineThreadState.allocateMultiDimArray
+
     let allocateStringData = IlMachineThreadState.allocateStringData
 
     let setStringData = IlMachineThreadState.setStringData

--- a/WoofWare.PawPrint/IlMachineThreadState.fs
+++ b/WoofWare.PawPrint/IlMachineThreadState.fs
@@ -336,6 +336,64 @@ module IlMachineThreadState =
             {
                 ConcreteType = arrayType
                 Length = len
+                Lengths = ImmutableArray.Create len
+                Elements = initialisation
+            }
+
+        let alloc, heap = state.ManagedHeap |> ManagedHeap.allocateArray o
+
+        let state =
+            { state with
+                ManagedHeap = heap
+            }
+
+        alloc, state
+
+    /// Allocate a multi-dimensional array of `arrayType` (which should be a
+    /// `ConcreteTypeHandle.Array (elementHandle, rank)`), zero-initialised in row-major
+    /// layout. Each entry of `dimensionLengths` must be non-negative and the array
+    /// must have rank >= 1; multi-dim arrays with non-zero lower bounds are not
+    /// representable here (C# never emits them, and ECMA-335 II.14.2 calls them out
+    /// as a separate constructor form).
+    let allocateMultiDimArray
+        (arrayType : ConcreteTypeHandle)
+        (zeroOfType : unit -> CliType)
+        (dimensionLengths : ImmutableArray<int>)
+        (state : IlMachineState)
+        : ManagedHeapAddress * IlMachineState
+        =
+        if dimensionLengths.Length = 0 then
+            failwith
+                "TODO: cannot allocate multi-dim array with rank 0; this should have been ruled out at the dispatch site"
+
+        // Compute the total length in int64 to detect Int32 overflow loudly rather than
+        // silently wrapping into a too-small backing store. The runtime raises
+        // OverflowException in this case; we currently fail fast.
+        let mutable totalLength64 = 1L
+
+        for i = 0 to dimensionLengths.Length - 1 do
+            let d = dimensionLengths.[i]
+
+            if d < 0 then
+                failwith
+                    $"TODO: multi-dim array constructor was given a negative length %d{d} at dimension %d{i}; should raise OverflowException"
+
+            totalLength64 <- totalLength64 * int64 d
+
+        if totalLength64 > int64 System.Int32.MaxValue then
+            failwith
+                $"TODO: multi-dim array total length %d{totalLength64} exceeds Int32.MaxValue; should raise OverflowException"
+
+        let totalLength = int totalLength64
+
+        let initialisation =
+            (fun _ -> zeroOfType ()) |> Seq.init totalLength |> ImmutableArray.CreateRange
+
+        let o : AllocatedArray =
+            {
+                ConcreteType = arrayType
+                Length = totalLength
+                Lengths = dimensionLengths
                 Elements = initialisation
             }
 

--- a/WoofWare.PawPrint/IlMachineThreadState.fs
+++ b/WoofWare.PawPrint/IlMachineThreadState.fs
@@ -366,10 +366,12 @@ module IlMachineThreadState =
             failwith
                 "TODO: cannot allocate multi-dim array with rank 0; this should have been ruled out at the dispatch site"
 
-        // Compute the total length in int64 to detect Int32 overflow loudly rather than
-        // silently wrapping into a too-small backing store. The runtime raises
-        // OverflowException in this case; we currently fail fast.
-        let mutable totalLength64 = 1L
+        // Detect Int32 overflow on the running product *before* multiplying, so we never
+        // silently wrap (which would yield a too-small backing store). The runtime raises
+        // OverflowException for these cases; we currently fail fast.  Once `totalLength`
+        // reaches 0 (some dimension was zero), the array is empty and no further dimension
+        // can grow it, so we short-circuit.
+        let mutable totalLength = 1
 
         for i = 0 to dimensionLengths.Length - 1 do
             let d = dimensionLengths.[i]
@@ -378,13 +380,13 @@ module IlMachineThreadState =
                 failwith
                     $"TODO: multi-dim array constructor was given a negative length %d{d} at dimension %d{i}; should raise OverflowException"
 
-            totalLength64 <- totalLength64 * int64 d
-
-        if totalLength64 > int64 System.Int32.MaxValue then
-            failwith
-                $"TODO: multi-dim array total length %d{totalLength64} exceeds Int32.MaxValue; should raise OverflowException"
-
-        let totalLength = int totalLength64
+            if d = 0 || totalLength = 0 then
+                totalLength <- 0
+            elif totalLength > System.Int32.MaxValue / d then
+                failwith
+                    $"TODO: multi-dim array total length exceeds Int32.MaxValue at dimension %d{i}; should raise OverflowException"
+            else
+                totalLength <- totalLength * d
 
         let initialisation =
             (fun _ -> zeroOfType ()) |> Seq.init totalLength |> ImmutableArray.CreateRange

--- a/WoofWare.PawPrint/IlMachineThreadState.fs
+++ b/WoofWare.PawPrint/IlMachineThreadState.fs
@@ -366,12 +366,16 @@ module IlMachineThreadState =
             failwith
                 "TODO: cannot allocate multi-dim array with rank 0; this should have been ruled out at the dispatch site"
 
-        // Detect Int32 overflow on the running product *before* multiplying, so we never
-        // silently wrap (which would yield a too-small backing store). The runtime raises
-        // OverflowException for these cases; we currently fail fast.  Once `totalLength`
-        // reaches 0 (some dimension was zero), the array is empty and no further dimension
-        // can grow it, so we short-circuit.
-        let mutable totalLength = 1
+        // Match CoreCLR's product-overflow rule (vm/gchelpers.cpp `AllocateArrayEx`):
+        // accumulate the running product in unsigned 32-bit, throwing OutOfMemoryException
+        // only if the multiply itself would overflow UInt32 — *not* on a transient prefix
+        // that exceeds Int32.MaxValue but later gets zeroed by a 0 dimension. So
+        // `new int[50000, 50000, 0]` allocates an empty array (the prefix 2.5e9 fits in
+        // UInt32 and the trailing zero brings the product back to 0), while
+        // `new int[65536, 65536, ...]` throws because 65536 * 65536 overflows UInt32 at
+        // the multiply step regardless of any later zero. After the loop, the final
+        // product must also fit in Int32, since our backing-store length is Int32.
+        let mutable totalLength : uint32 = 1u
 
         for i = 0 to dimensionLengths.Length - 1 do
             let d = dimensionLengths.[i]
@@ -380,13 +384,18 @@ module IlMachineThreadState =
                 failwith
                     $"TODO: multi-dim array constructor was given a negative length %d{d} at dimension %d{i}; should raise OverflowException"
 
-            if d = 0 || totalLength = 0 then
-                totalLength <- 0
-            elif totalLength > System.Int32.MaxValue / d then
+            let dU = uint32 d
+            // Multiplying by zero is always safe; it just zeroes the running product.
+            if dU <> 0u && totalLength > System.UInt32.MaxValue / dU then
                 failwith
-                    $"TODO: multi-dim array total length exceeds Int32.MaxValue at dimension %d{i}; should raise OverflowException"
-            else
-                totalLength <- totalLength * d
+                    $"TODO: multi-dim array running product overflows UInt32 at dimension %d{i}; should raise OutOfMemoryException"
+
+            totalLength <- totalLength * dU
+
+        if totalLength > uint32 System.Int32.MaxValue then
+            failwith "TODO: multi-dim array total length exceeds Int32.MaxValue; should raise OutOfMemoryException"
+
+        let totalLength = int totalLength
 
         let initialisation =
             (fun _ -> zeroOfType ()) |> Seq.init totalLength |> ImmutableArray.CreateRange

--- a/WoofWare.PawPrint/ManagedHeap.fs
+++ b/WoofWare.PawPrint/ManagedHeap.fs
@@ -33,7 +33,15 @@ type AllocatedNonArrayObject =
 type AllocatedArray =
     {
         ConcreteType : ConcreteTypeHandle
+        /// Total element count, equal to the product of `Lengths`. For szarrays this is just
+        /// the array length; for multi-dim arrays it is the size of the flat backing store.
         Length : int
+        /// Per-dimension lengths in row-major order. Length is 1 for szarrays, equal to the
+        /// rank for multi-dim arrays. Multiplying these produces `Length`.
+        Lengths : ImmutableArray<int>
+        /// Backing store in row-major order. For multi-dim arrays the element at
+        /// `(i_0, ..., i_{n-1})` lives at flat offset
+        /// `((((i_0)*d_1)+i_1)*d_2 + i_2)*...*d_{n-1} + i_{n-1}`, where `d_k = Lengths.[k]`.
         Elements : ImmutableArray<CliType>
     }
 

--- a/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
@@ -92,6 +92,18 @@ module internal UnaryMetadataObjectOps =
         let currentMethod = ctx.CurrentMethod
         let thread = ctx.Thread
 
+        // ECMA-335 II.14.2 / CoreCLR: a rank-1 ELEMENT_TYPE_ARRAY constructor
+        // (`newobj instance void T[0...]::.ctor(int32)`) morphs at runtime to an
+        // SZARRAY (`T[]`) — the resulting object's type identity is the SZARRAY,
+        // not a rank-1 MdArray, which is observable through GetType, casts and
+        // assignability. We don't yet implement that morphing, so reject the
+        // rank-1 constructor form rather than silently producing a
+        // `ConcreteTypeHandle.Array(_, 1)` with the wrong runtime type. C# never
+        // emits this form, so this path is exercised only by hand-rolled IL.
+        if rank = 1 then
+            failwith
+                "TODO: rank-1 ELEMENT_TYPE_ARRAY newobj should morph to SZARRAY (OneDimArrayZero) per CoreCLR semantics; not yet implemented"
+
         let methodSig =
             match signature with
             | MemberSignature.Method m -> m

--- a/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
@@ -72,6 +72,89 @@ module internal UnaryMetadataObjectOps =
                     state
         | other -> failwith $"Castclass: unexpected eval stack value {other}"
 
+    /// Implements `newobj T[<rank>]::.ctor(int32, ..., int32)` — the runtime-synthesized constructor
+    /// for a multi-dimensional array of element type `elementType`. Pops `rank` Int32 lengths off
+    /// the eval stack (top-of-stack is the rightmost argument), allocates a zero-initialised
+    /// row-major buffer via `IlMachineState.allocateMultiDimArray`, and pushes the resulting
+    /// object reference. ECMA-335 II.14.2 also defines a `2*rank`-parameter form for non-zero
+    /// lower bounds; that is not yet implemented (C# never emits it).
+    let private executeMultiDimArrayNewobj
+        (ctx : UnaryMetadataIlOpContext)
+        (state : IlMachineState)
+        (elementType : TypeDefn)
+        (rank : int)
+        (signature : MemberSignature)
+        : IlMachineState * WhatWeDid
+        =
+        let loggerFactory = ctx.LoggerFactory
+        let baseClassTypes = ctx.BaseClassTypes
+        let activeAssy = ctx.ActiveAssembly
+        let currentMethod = ctx.CurrentMethod
+        let thread = ctx.Thread
+
+        let methodSig =
+            match signature with
+            | MemberSignature.Method m -> m
+            | MemberSignature.Field _ ->
+                failwith
+                    $"BUG: multi-dim array newobj for rank %d{rank} had a field signature; expected method signature"
+
+        let paramCount = methodSig.ParameterTypes.Length
+
+        if paramCount <> rank then
+            failwith
+                $"TODO: multi-dim array newobj for rank %d{rank} has %d{paramCount} parameters; only the zero-lower-bound form (%d{rank} Int32 lengths) is implemented"
+
+        for paramTy in methodSig.ParameterTypes do
+            match paramTy with
+            | TypeDefn.PrimitiveType PrimitiveType.Int32 -> ()
+            | other ->
+                failwith
+                    $"TODO: multi-dim array newobj for rank %d{rank} has non-Int32 parameter type %O{other}; only Int32 lengths are supported"
+
+        // Pop `rank` Int32 lengths off the eval stack. The top of stack is the rightmost
+        // argument (i.e. dimension index rank-1), so fill the array right-to-left.
+        let lengths = Array.zeroCreate<int> rank
+        let mutable s = state
+
+        for i = rank - 1 downto 0 do
+            let v, s' = IlMachineState.popEvalStack thread s
+
+            match v with
+            | EvalStackValue.Int32 n ->
+                lengths.[i] <- n
+                s <- s'
+            | other ->
+                failwith $"unexpectedly popped non-Int32 value %O{other} as multi-dim array length at dimension %d{i}"
+
+        let dimensionLengths = lengths |> ImmutableArray.CreateRange
+        let state = s
+
+        let typeGenerics = currentMethod.DeclaringType.Generics
+        let methodGenerics = currentMethod.Generics
+
+        let state, zeroOfType, elementHandle =
+            IlMachineState.cliTypeZeroOf
+                loggerFactory
+                baseClassTypes
+                activeAssy
+                elementType
+                typeGenerics
+                methodGenerics
+                state
+
+        let arrayType = ConcreteTypeHandle.Array (elementHandle, rank)
+
+        let alloc, state =
+            IlMachineState.allocateMultiDimArray arrayType (fun () -> zeroOfType) dimensionLengths state
+
+        let state =
+            state
+            |> IlMachineState.pushToEvalStack (CliType.ObjectRef (Some alloc)) thread
+            |> IlMachineState.advanceProgramCounter thread
+
+        state, WhatWeDid.Executed
+
     let executeNewobj (ctx : UnaryMetadataIlOpContext) (state : IlMachineState) : IlMachineState * WhatWeDid =
         let loggerFactory = ctx.LoggerFactory
         let baseClassTypes = ctx.BaseClassTypes
@@ -82,6 +165,32 @@ module internal UnaryMetadataObjectOps =
 
         let heapValueByref (addr : ManagedHeapAddress) : ManagedPointerSource =
             ManagedPointerSource.Byref (ByrefRoot.HeapValue addr, [])
+
+        // Multi-dimensional array constructors are runtime-synthesized (ECMA-335 II.14.2): the
+        // metadata token is a MemberReference whose parent is a TypeSpec of TypeDefn.Array.
+        // There's no managed body to resolve, so detect that shape up front and route to the
+        // multi-dim allocation path. szarrays still go through `newarr`, not `newobj`, so we
+        // don't need to handle TypeDefn.OneDimensionalArrayLowerBoundZero here.
+        let multiDimSpec =
+            match metadataToken with
+            | MemberReference mrHandle ->
+                match activeAssy.Members.TryGetValue mrHandle with
+                | true, memberRef ->
+                    match memberRef.Parent with
+                    | MetadataToken.TypeSpecification specHandle ->
+                        match activeAssy.TypeSpecs.TryGetValue specHandle with
+                        | true, ts ->
+                            match ts.Signature with
+                            | TypeDefn.Array (elt, rank) -> Some (elt, rank, memberRef.Signature)
+                            | _ -> None
+                        | false, _ -> None
+                    | _ -> None
+                | false, _ -> None
+            | _ -> None
+
+        match multiDimSpec with
+        | Some (elementType, rank, sig0) -> executeMultiDimArrayNewobj ctx state elementType rank sig0
+        | None ->
 
         let state, ctor, typeArgsFromMetadata =
             match metadataToken with


### PR DESCRIPTION
## Summary

- Wire `newobj` for runtime-synthesized multi-dim array constructors (e.g. `int[3, 4]::.ctor(int, int)`), routing the dispatch to a new `IlMachineState.allocateMultiDimArray` primitive. szarrays still go through `newarr`, not `newobj`, so this path is scoped to `MemberReference` whose parent is a `TypeSpec` of `TypeDefn.Array`.
- Add `Lengths : ImmutableArray<int>` to `AllocatedArray` so multi-dim shape information is preserved on the heap (existing szarray sites populate it with the single-element length).
- Match CoreCLR's product-overflow rule (`vm/gchelpers.cpp::AllocateArrayEx`): accumulate the running product as `UInt32`, throw `OutOfMemoryException` only when the multiply itself would overflow `UInt32`, then post-loop reject products that don't fit in `Int32`. This correctly allows `new int[50000, 50000, 0]` (trailing zero rescues a transient prefix > Int32.MaxValue) while still rejecting `new int[65536, 65536, 65536, 65536]`.
- Reject the rank-1 `ELEMENT_TYPE_ARRAY` constructor form with a TODO `failwith` — CoreCLR morphs that to SZARRAY, but we don't yet implement the morphing and silently producing a `ConcreteTypeHandle.Array(_, 1)` would have observably-wrong runtime type. C# never emits this form.
- Cover the new primitive with seven unit tests in `TestManagedHeap.fs` (basic 2D, zero-dim, trailing-zero rescue, prefix that genuinely overflows UInt32, final product > Int32.MaxValue but ≤ UInt32.MaxValue, rank-4 overflow, negative length) and a smoke integration test `MultiDimArrayNewobj.cs` that allocates two distinct 2D arrays and verifies non-null/non-aliasing.

## Test plan
- [x] `nix develop -c dotnet build` clean (warnings-as-errors)
- [x] `nix develop -c dotnet test` — 671 / 671 pass
- [x] `nix develop -c dotnet fantomas .` — no formatting drift
- [x] Three rounds of `codex review --base main`; all flagged findings (P2 Int32-product overflow, P3 rank-1 morphing, P2 trailing-zero handling) addressed; final pass clean
- [x] `MultiDimArrayNewobj.cs` integration test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)