### PR TITLE
Implement RuntimeTypeHandle::GetDeclaringTypeHandleForGenericVariable QCall

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -43,7 +43,7 @@ module TestPureCases =
             "RuntimeTypeGetInterfacesEmpty.cs" // past Span`1::get_Empty; now blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringTypeHandle
             "RuntimeTypeHandleGetInstantiationOpenGeneric.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringMethodForGenericParameter
             "InitializeArrayBoxedFieldHandle.cs" // past String::FastAllocateString(MethodTable*, nint); now blocked by unimplemented MethodTable field projection for ParentMethodTable
-            "RuntimeTypeHandleTypeParameterDeclaringType.cs" // past TypeHandle.GetCorElementType for generic parameter handles (now returns ELEMENT_TYPE_VAR/MVAR); blocked next by unimplemented QCall RuntimeTypeHandle::GetDeclaringTypeHandleForGenericVariable
+            "RuntimeTypeHandleTypeParameterDeclaringType.cs" // past RuntimeTypeHandle::GetDeclaringTypeHandleForGenericVariable QCall (now returns the open-generic declaring-type handle); blocked next by ldflda on MethodTableAuxiliaryData::ExposedClassObjectRaw for OpenGenericTypeDefinition targets (tryProjectAuxiliaryDataFieldAddress only handles Closed)
             "MethodReflectionProbe.cs" // past RuntimeMethodHandle::GetUtf8NameInternal (RuntimeType.GetMethodCandidates can now read each candidate's name); now blocked by unimplemented InternalCall RuntimeMethodHandle::GetAttributes (used by the candidate filter to inspect each method's MethodAttributes)
         ]
         |> Set.ofList

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -20,6 +20,8 @@ module NativeQCall =
             "RuntimeTypeHandle_GetConstraints", NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_GetConstraints"
             "RuntimeTypeHandle_GetDeclaringTypeHandle",
             NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_GetDeclaringTypeHandle"
+            "RuntimeTypeHandle_GetDeclaringTypeHandleForGenericVariable",
+            NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_GetDeclaringTypeHandleForGenericVariable"
             "RuntimeTypeHandle_GetFields", NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_GetFields"
             "RuntimeTypeHandle_GetInstantiation", NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_GetInstantiation"
             "RuntimeTypeHandle_Instantiate", NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_Instantiate"

--- a/WoofWare.PawPrint/Native/NativeRuntimeType.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeType.fs
@@ -2516,6 +2516,81 @@ module NativeRuntimeType =
                 IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt returnSource) ctx.Thread state
 
             (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+        | "RuntimeTypeHandle_GetDeclaringTypeHandleForGenericVariable",
+          "System.Private.CoreLib",
+          "System",
+          "RuntimeTypeHandle",
+          "GetDeclaringTypeHandleForGenericVariable",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr) ->
+            let operation = "RuntimeTypeHandle.GetDeclaringTypeHandleForGenericVariable"
+
+            if instruction.Arguments.Length <> 1 then
+                failwith $"%s{operation}: expected one native argument, got %d{instruction.Arguments.Length}"
+
+            let typeHandleArg = instruction.Arguments.[0] |> EvalStackValue.ofCliType
+
+            let target =
+                NativeCall.runtimeTypeHandleTargetOfEvalStackValue operation typeHandleArg
+
+            // The managed wrapper RuntimeTypeHandle.GetDeclaringType only routes here when
+            // typeHandle.IsTypeDesc and the CorElementType is ELEMENT_TYPE_VAR/MVAR — i.e.
+            // exactly when the underlying target is a generic parameter. Mirror CoreCLR's
+            // `_ASSERTE(typeHandle.IsGenericVariable())` and fail loudly on any other
+            // shape rather than silently returning a wrong answer.
+            let declaringTarget, state =
+                match target with
+                | RuntimeTypeHandleTarget.GenericParameter (declaringType, _) ->
+                    // The owning type of a type-generic parameter is always generic
+                    // (the parameter could not exist otherwise), so the declaring
+                    // RuntimeType is the OpenGenericTypeDefinition. The type-handle
+                    // registry keys structurally, so this is reference-equal to the
+                    // RuntimeType allocated for `typeof(T<>)`.
+                    RuntimeTypeHandleTarget.OpenGenericTypeDefinition declaringType, state
+                | RuntimeTypeHandleTarget.MethodGenericParameter (declaringType, _, _) ->
+                    // CoreCLR returns the owning method's MethodTable, which corresponds
+                    // to the canonical (open) type that declares the method. For non-
+                    // generic declaring types we must fall back to a Closed handle: an
+                    // OpenGenericTypeDefinition target would incorrectly report
+                    // IsGenericType=true. This mirrors `declaringRuntimeType` above.
+                    let assembly =
+                        state.LoadedAssembly declaringType.Assembly
+                        |> Option.defaultWith (fun () ->
+                            failwith
+                                $"%s{operation}: assembly for method-generic-parameter declaring type is not loaded: %s{declaringType.AssemblyFullName}"
+                        )
+
+                    let typeInfo = assembly.TypeDefs.[declaringType.TypeDefinition.Get]
+
+                    if typeInfo.Generics.IsEmpty then
+                        let stk =
+                            DumpedAssembly.signatureTypeKind ctx.BaseClassTypes state._LoadedAssemblies typeInfo
+
+                        let state, typeHandle =
+                            IlMachineState.concretizeType
+                                ctx.LoggerFactory
+                                ctx.BaseClassTypes
+                                state
+                                typeInfo.Assembly
+                                ImmutableArray.Empty
+                                ImmutableArray.Empty
+                                (TypeDefn.FromDefinition (typeInfo.Identity, stk))
+
+                        RuntimeTypeHandleTarget.Closed typeHandle, state
+                    else
+                        RuntimeTypeHandleTarget.OpenGenericTypeDefinition declaringType, state
+                | RuntimeTypeHandleTarget.Closed _
+                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
+                    failwith
+                        $"%s{operation}: BCL contract violation: QCall reached for non-generic-variable target %O{target}; the managed wrapper should have routed this to RuntimeTypeHandle_GetDeclaringTypeHandle"
+
+            let state =
+                IlMachineState.pushToEvalStack'
+                    (EvalStackValue.NativeInt (NativeIntSource.TypeHandlePtr declaringTarget))
+                    ctx.Thread
+                    state
+
+            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
         | "ModuleHandle_ResolveType",
           "System.Private.CoreLib",
           "System",


### PR DESCRIPTION
The managed RuntimeTypeHandle.GetDeclaringType wrapper routes generic- variable handles (TypeDesc with ELEMENT_TYPE_VAR / ELEMENT_TYPE_MVAR) through this QCall instead of GetDeclaringTypeHandle. Returning the owning RuntimeTypeHandleTarget unblocks Type.DeclaringType for parameters obtained via typeof(T<>).GetGenericArguments().

For type-generic parameters this is always OpenGenericTypeDefinition; for method-generic parameters we mirror the existing declaringRuntimeType helper, falling back to a Closed handle when the declaring type itself is non-generic so that IsGenericType remains false.

The full RuntimeTypeHandleTypeParameterDeclaringType.cs end-to-end test remains in `unimplemented` because GetRuntimeTypeFromHandle now reaches ldflda on MethodTableAuxiliaryData::ExposedClassObjectRaw with an OpenGenericTypeDefinition target, which the projection model only supports for Closed handles today.