### PR TITLE
Implement EventPipeInternal_* QCall stubs

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -21,7 +21,6 @@ module TestPureCases =
             "LdtokenField.cs" // TODO: read through `ReinterpretAs` as non-primitive type .VolatileObject
             "GenericEdgeCases.cs" // blocked after BitOperations.Log2 by unimplemented JIT intrinsic System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned (reached via int.ToString -> Number.UInt32ToDecStr)
             "CrossAssemblyTypes.cs" // past MethodTable::ParentMethodTable projection; now blocked by unimplemented QCall EventPipeInternal_CreateProvider during static init of System.Diagnostics.Tracing.EventPipeInternal
-
             "InterfaceDispatch.cs" // past MetadataImport::GetCustomAttributeProps; now blocked by unimplemented InternalCall MetadataImport::GetParentToken
             "NullDereferenceTest.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
             "CastClassInvalid.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
@@ -36,7 +35,6 @@ module TestPureCases =
             "MakeGenericTypeStructConstraint.cs" // past MetadataImport::GetSigOfMethodDef; now blocked by unimplemented QCall ModuleHandle::ResolveMethod during ArgumentException ctor → ResourceManager init
             "MakeGenericTypeClassConstraint.cs" // past MetadataImport::GetSigOfMethodDef; now blocked by unimplemented QCall ModuleHandle::ResolveMethod during ArgumentException ctor → ResourceManager init
             "MakeGenericTypeNewConstraint.cs" // past MetadataImport::GetSigOfMethodDef; now blocked by unimplemented QCall ModuleHandle::ResolveMethod during ArgumentException ctor → ResourceManager init
-            "ArraySortHelperDefaultInt.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringTypeHandle
             "EnumSemantics.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringTypeHandle
             "GetDeclaringTypeNestedGeneric.cs" // past MethodTable::AuxiliaryData projection for OpenGenericTypeDefinition; now blocked by ldflda through synthetic MethodTableAuxiliaryData::ExposedClassObjectRaw field address (same blocker as GetElementTypeBasic.cs)
             "IsAssignableToBasic.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringTypeHandle
@@ -45,6 +43,7 @@ module TestPureCases =
             "InitializeArrayBoxedFieldHandle.cs" // past String::FastAllocateString(MethodTable*, nint); now blocked by unimplemented MethodTable field projection for ParentMethodTable
             "RuntimeTypeHandleTypeParameterDeclaringType.cs" // past TypeHandle.GetCorElementType for generic parameter handles (now returns ELEMENT_TYPE_VAR/MVAR); blocked next by unimplemented QCall RuntimeTypeHandle::GetDeclaringTypeHandleForGenericVariable
             "MethodReflectionProbe.cs" // past RuntimeMethodHandle::GetUtf8NameInternal (RuntimeType.GetMethodCandidates can now read each candidate's name); now blocked by unimplemented InternalCall RuntimeMethodHandle::GetAttributes (used by the candidate filter to inspect each method's MethodAttributes)
+            "ArraySortHelperDefaultInt.cs" // past EventPipeInternal_* QCall stubs during EventSource static init; now blocked by unimplemented InternalCall String::.ctor(ReadOnlySpan<char>)
         ]
         |> Set.ofList
 

--- a/WoofWare.PawPrint/CliNumericType.fs
+++ b/WoofWare.PawPrint/CliNumericType.fs
@@ -196,6 +196,8 @@ type CliNumericType =
             | NativeIntSource.MethodTableAuxiliaryDataPtr _ ->
                 failwith "refusing to express MethodTableAuxiliaryDataPtr as bytes"
             | NativeIntSource.GcHandlePtr _ -> failwith "refusing to express GcHandlePtr as bytes"
+            | NativeIntSource.EventPipeProviderPtr _ -> failwith "refusing to express EventPipeProviderPtr as bytes"
+            | NativeIntSource.EventPipeEventPtr _ -> failwith "refusing to express EventPipeEventPtr as bytes"
             | NativeIntSource.AssemblyHandle _ -> failwith "refusing to express AssemblyHandle as bytes"
             | NativeIntSource.ModuleHandle _ -> failwith "refusing to express ModuleHandle as bytes"
             | NativeIntSource.MetadataImportHandle _ -> failwith "refusing to express MetadataImportHandle as bytes"

--- a/WoofWare.PawPrint/CliType.fs
+++ b/WoofWare.PawPrint/CliType.fs
@@ -64,6 +64,8 @@ module private ByteAddressabilityClassifier =
         | NativeIntSource.ModuleHandle _
         | NativeIntSource.MetadataImportHandle _
         | NativeIntSource.GcHandlePtr _
+        | NativeIntSource.EventPipeProviderPtr _
+        | NativeIntSource.EventPipeEventPtr _
         | NativeIntSource.SyntheticCrossArrayOffset _ ->
             CliByteAddressability.Rejected (CliByteAddressabilityRejection.NativeIntSourceNotByteAddressable source)
 
@@ -1416,42 +1418,38 @@ module CliType =
                 elif TypeInfo.NominallyEqual typeDef corelib.Array then
                     // Arrays are reference types
                     CliType.ObjectRef None, concreteTypes
-                else if
 
-                    // Not a known primitive, now check for cycles
-                    Set.contains handle visited
-                then
-                    // We're in a cycle - return a default zero value for the type
-                    // Value types can't be self-referential unless they are specifically known to the
-                    // runtime - for example, System.Byte is a value type with a single field,
-                    // of type System.Byte.
-                    // Since we check for (nominal) equality against all such types in the first branch,
-                    // this code path is only hit with reference types.
-                    CliType.ObjectRef None, concreteTypes
-                else
-                    let visited = Set.add handle visited
-                    // Not a known primitive, check if it's a value type or reference type
-                    determineZeroForCustomType concreteTypes assemblies corelib handle concreteType typeDef visited
-            else if
-
-                // Not from corelib or has generics
-                concreteType.Assembly.FullName = corelib.Corelib.Name.FullName
-                && TypeInfo.NominallyEqual typeDef corelib.Array
-                && concreteType.Generics.Length = 1
-            then
-                // This is an array type, so null is appropriate
-                CliType.ObjectRef None, concreteTypes
-            else if
-
-                // Custom type - now check for cycles
-                Set.contains handle visited
-            then
-                // We're in a cycle - return a default zero value for the type.
+                // Not a known primitive, now check for cycles
+                // We're in a cycle - return a default zero value for the type
                 // Value types can't be self-referential unless they are specifically known to the
                 // runtime - for example, System.Byte is a value type with a single field,
                 // of type System.Byte.
                 // Since we check for (nominal) equality against all such types in the first branch,
                 // this code path is only hit with reference types.
+                else if Set.contains handle visited then
+                    CliType.ObjectRef None, concreteTypes
+                else
+                    let visited = Set.add handle visited
+                    // Not a known primitive, check if it's a value type or reference type
+                    determineZeroForCustomType concreteTypes assemblies corelib handle concreteType typeDef visited
+
+            // Not from corelib or has generics
+            // This is an array type, so null is appropriate
+            else if
+                concreteType.Assembly.FullName = corelib.Corelib.Name.FullName
+                && TypeInfo.NominallyEqual typeDef corelib.Array
+                && concreteType.Generics.Length = 1
+            then
+                CliType.ObjectRef None, concreteTypes
+
+            // Custom type - now check for cycles
+            // We're in a cycle - return a default zero value for the type.
+            // Value types can't be self-referential unless they are specifically known to the
+            // runtime - for example, System.Byte is a value type with a single field,
+            // of type System.Byte.
+            // Since we check for (nominal) equality against all such types in the first branch,
+            // this code path is only hit with reference types.
+            else if Set.contains handle visited then
                 CliType.ObjectRef None, concreteTypes
             else
                 let visited = Set.add handle visited

--- a/WoofWare.PawPrint/EvalStack.fs
+++ b/WoofWare.PawPrint/EvalStack.fs
@@ -49,6 +49,10 @@ module EvalStackValue =
             failwith $"%s{operation}: refusing to convert RuntimeMethodHandle pointer %d{handle} to an integer"
         | NativeIntSource.GcHandlePtr handle ->
             failwith $"%s{operation}: refusing to convert GC handle pointer %O{handle} to an integer"
+        | NativeIntSource.EventPipeProviderPtr id ->
+            failwith $"%s{operation}: refusing to convert EventPipe provider handle #%d{id} to an integer"
+        | NativeIntSource.EventPipeEventPtr id ->
+            failwith $"%s{operation}: refusing to convert EventPipe event handle #%d{id} to an integer"
         | NativeIntSource.AssemblyHandle assemblyName ->
             failwith $"%s{operation}: refusing to convert assembly handle %s{assemblyName} to an integer"
         | NativeIntSource.ModuleHandle moduleName ->
@@ -218,6 +222,10 @@ module EvalStackValue =
                     $"Conv_U: refusing to convert MethodTableAuxiliaryData pointer %O{typeHandle} to unsigned native int"
             | NativeIntSource.GcHandlePtr handle ->
                 failwith $"Conv_U: refusing to convert GC handle pointer %O{handle} to unsigned native int"
+            | NativeIntSource.EventPipeProviderPtr id ->
+                failwith $"Conv_U: refusing to convert EventPipe provider handle #%d{id} to unsigned native int"
+            | NativeIntSource.EventPipeEventPtr id ->
+                failwith $"Conv_U: refusing to convert EventPipe event handle #%d{id} to unsigned native int"
             | NativeIntSource.AssemblyHandle assemblyName ->
                 failwith $"Conv_U: refusing to convert assembly handle %s{assemblyName} to unsigned native int"
             | NativeIntSource.ModuleHandle moduleName ->
@@ -498,6 +506,10 @@ module EvalStackValue =
                     | NativeIntSource.MethodTablePtr f -> failwith $"TODO: {f}"
                     | NativeIntSource.MethodTableAuxiliaryDataPtr f -> failwith $"TODO: {f}"
                     | NativeIntSource.GcHandlePtr f -> failwith $"TODO: {f}"
+                    | NativeIntSource.EventPipeProviderPtr id ->
+                        failwith $"refusing to coerce EventPipe provider handle #%d{id} to int64"
+                    | NativeIntSource.EventPipeEventPtr id ->
+                        failwith $"refusing to coerce EventPipe event handle #%d{id} to int64"
                     | NativeIntSource.AssemblyHandle f -> failwith $"TODO: {f}"
                     | NativeIntSource.ModuleHandle f -> failwith $"TODO: {f}"
                     | NativeIntSource.MetadataImportHandle f ->
@@ -594,6 +606,10 @@ module EvalStackValue =
                     failwith "refusing to interpret method handle ID as an object ref"
                 | NativeIntSource.FieldHandlePtr _ -> failwith "refusing to interpret field handle ID as an object ref"
                 | NativeIntSource.GcHandlePtr _ -> failwith "refusing to interpret GC handle ID as an object ref"
+                | NativeIntSource.EventPipeProviderPtr _ ->
+                    failwith "refusing to interpret EventPipe provider handle as an object ref"
+                | NativeIntSource.EventPipeEventPtr _ ->
+                    failwith "refusing to interpret EventPipe event handle as an object ref"
                 | NativeIntSource.AssemblyHandle _ -> failwith "refusing to interpret assembly handle as an object ref"
                 | NativeIntSource.ModuleHandle _ -> failwith "refusing to interpret module handle as an object ref"
                 | NativeIntSource.MetadataImportHandle _ ->
@@ -641,6 +657,12 @@ module EvalStackValue =
                 | NativeIntSource.MethodHandlePtr ptr ->
                     CliType.RuntimePointer (CliRuntimePointer.MethodRegistryHandle ptr)
                 | NativeIntSource.GcHandlePtr addr -> CliType.RuntimePointer (CliRuntimePointer.GcHandlePtr addr)
+                | NativeIntSource.EventPipeProviderPtr id ->
+                    failwith
+                        $"refusing to coerce EventPipe provider handle #%d{id} to runtime pointer: tracing handles are opaque, not addresses"
+                | NativeIntSource.EventPipeEventPtr id ->
+                    failwith
+                        $"refusing to coerce EventPipe event handle #%d{id} to runtime pointer: tracing handles are opaque, not addresses"
                 | NativeIntSource.AssemblyHandle _ -> failwith "todo: AssemblyHandle into CliType.RuntimePointer"
                 | NativeIntSource.ModuleHandle _ -> failwith "todo: ModuleHandle into CliType.RuntimePointer"
                 | NativeIntSource.MetadataImportHandle _ ->

--- a/WoofWare.PawPrint/EvalStackValueComparisons.fs
+++ b/WoofWare.PawPrint/EvalStackValueComparisons.fs
@@ -264,6 +264,8 @@ module EvalStackValueComparisons =
             | NativeIntSource.ModuleHandle f1, NativeIntSource.ModuleHandle f2 -> f1 = f2
             | NativeIntSource.MetadataImportHandle f1, NativeIntSource.MetadataImportHandle f2 -> f1 = f2
             | NativeIntSource.GcHandlePtr f1, NativeIntSource.GcHandlePtr f2 -> f1 = f2
+            | NativeIntSource.EventPipeProviderPtr f1, NativeIntSource.EventPipeProviderPtr f2 -> f1 = f2
+            | NativeIntSource.EventPipeEventPtr f1, NativeIntSource.EventPipeEventPtr f2 -> f1 = f2
             | NativeIntSource.Verbatim f1, NativeIntSource.Verbatim f2 -> f1 = f2
             | NativeIntSource.SyntheticCrossArrayOffset _, NativeIntSource.SyntheticCrossArrayOffset _
             | NativeIntSource.Verbatim _, NativeIntSource.SyntheticCrossArrayOffset _
@@ -330,7 +332,11 @@ module EvalStackValueComparisons =
             | NativeIntSource.MetadataImportHandle _, _
             | _, NativeIntSource.MetadataImportHandle _
             | NativeIntSource.GcHandlePtr _, _
-            | _, NativeIntSource.GcHandlePtr _ -> false
+            | _, NativeIntSource.GcHandlePtr _
+            | NativeIntSource.EventPipeProviderPtr _, _
+            | _, NativeIntSource.EventPipeProviderPtr _
+            | NativeIntSource.EventPipeEventPtr _, _
+            | _, NativeIntSource.EventPipeEventPtr _ -> false
         | EvalStackValue.NativeInt var1, EvalStackValue.Int32 var2 -> failwith $"TODO (CEQ): nativeint vs int32"
         | EvalStackValue.NativeInt var1, EvalStackValue.ManagedPointer var2 ->
             ceq (EvalStackValue.NativeInt var1) (EvalStackValue.NativeInt (NativeIntSource.ManagedPointer var2))

--- a/WoofWare.PawPrint/IlMachineStateModel.fs
+++ b/WoofWare.PawPrint/IlMachineStateModel.fs
@@ -61,6 +61,12 @@ type IlMachineState =
         /// This is currently process-wide; model it per-thread when a guest
         /// depends on thread-local GetLastError or errno state.
         LastSystemError : int
+        /// Monotonic ID source for opaque EventPipe provider/event handles
+        /// minted by the `EventPipeInternal_*` QCalls. PawPrint never opens a
+        /// tracing session, so the IDs are not stored in any registry; they
+        /// only need to be unique and non-zero (the BCL treats handle 0 as
+        /// "create failed" and throws OOM).
+        NextEventPipeId : int64
     }
 
     member this.WithTypeBeginInit (thread : ThreadId) (ty : ConcreteTypeHandle) =

--- a/WoofWare.PawPrint/IlMachineThreadState.fs
+++ b/WoofWare.PawPrint/IlMachineThreadState.fs
@@ -307,6 +307,7 @@ module IlMachineThreadState =
                 NextManagedThreadId = 2
                 LastPInvokeError = 0
                 LastSystemError = 0
+                NextEventPipeId = 1L
             }
 
         state.WithLoadedAssembly assyName entryAssembly

--- a/WoofWare.PawPrint/Native/NativeEventPipe.fs
+++ b/WoofWare.PawPrint/Native/NativeEventPipe.fs
@@ -1,0 +1,311 @@
+namespace WoofWare.PawPrint
+
+[<RequireQualifiedAccess>]
+module NativeEventPipe =
+    /// Mint the next opaque EventPipe handle ID. PawPrint never opens a tracing session, so
+    /// these are not stored anywhere — they only need to be unique and non-zero (the BCL treats
+    /// IntPtr.Zero from `CreateProvider`/`DefineEvent` as "create failed" and throws OOM).
+    let private mintEventPipeId (state : IlMachineState) : int64 * IlMachineState =
+        let id = state.NextEventPipeId
+
+        let state =
+            { state with
+                NextEventPipeId = state.NextEventPipeId + 1L
+            }
+
+        id, state
+
+    /// Validate that an IntPtr argument is either a PawPrint-minted EventPipe provider handle
+    /// or null. Foreign IntPtr values from other registries (GCHandlePtr, TypeHandlePtr, ...)
+    /// fail loudly: that mirrors the real EventPipe contract that only handles minted by
+    /// `EventPipeInternal_CreateProvider` are valid here.
+    let private providerHandleOfArgument (operation : string) (argName : string) (arg : CliType) : int64 option =
+        match CliType.unwrapPrimitiveLikeDeep arg with
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.EventPipeProviderPtr id)) -> Some id
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim 0L)) -> None
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.ManagedPointer ManagedPointerSource.Null)) -> None
+        | other -> failwith $"%s{operation}: expected %s{argName} to be EventPipe provider handle, got %O{other}"
+
+    let private eventHandleOfArgument (operation : string) (argName : string) (arg : CliType) : int64 option =
+        match CliType.unwrapPrimitiveLikeDeep arg with
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.EventPipeEventPtr id)) -> Some id
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim 0L)) -> None
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.ManagedPointer ManagedPointerSource.Null)) -> None
+        | other -> failwith $"%s{operation}: expected %s{argName} to be EventPipe event handle, got %O{other}"
+
+    let private uint32Argument (operation : string) (argName : string) (arg : CliType) : uint32 =
+        match CliType.unwrapPrimitiveLikeDeep arg with
+        | CliType.Numeric (CliNumericType.Int32 i) -> uint32 i
+        | other -> failwith $"%s{operation}: expected %s{argName} to be UInt32 argument, got %O{other}"
+
+    let private pushIntPtrZero (thread : ThreadId) (state : IlMachineState) : ExecutionResult =
+        state
+        |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt (NativeIntSource.Verbatim 0L)) thread
+        |> Tuple.withRight WhatWeDid.Executed
+        |> ExecutionResult.Stepped
+
+    let private pushProviderHandle (id : int64) (thread : ThreadId) (state : IlMachineState) : ExecutionResult =
+        state
+        |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt (NativeIntSource.EventPipeProviderPtr id)) thread
+        |> Tuple.withRight WhatWeDid.Executed
+        |> ExecutionResult.Stepped
+
+    let private pushEventHandle (id : int64) (thread : ThreadId) (state : IlMachineState) : ExecutionResult =
+        state
+        |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt (NativeIntSource.EventPipeEventPtr id)) thread
+        |> Tuple.withRight WhatWeDid.Executed
+        |> ExecutionResult.Stepped
+
+    let private pushUInt64Zero (thread : ThreadId) (state : IlMachineState) : ExecutionResult =
+        // The CLI evaluation stack stores UInt64 in the same Int64 cell, two's-complement.
+        state
+        |> IlMachineState.pushToEvalStack' (EvalStackValue.Int64 (Int64Source.Verbatim 0L)) thread
+        |> Tuple.withRight WhatWeDid.Executed
+        |> ExecutionResult.Stepped
+
+    let private pushInt32 (value : int32) (thread : ThreadId) (state : IlMachineState) : ExecutionResult =
+        state
+        |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 value) thread
+        |> Tuple.withRight WhatWeDid.Executed
+        |> ExecutionResult.Stepped
+
+    let private justStep (state : IlMachineState) : ExecutionResult =
+        (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
+        let state = ctx.State
+        let instruction = ctx.Instruction
+
+        match
+            entryPoint,
+            ctx.TargetAssembly.Name.Name,
+            ctx.TargetType.Namespace,
+            ctx.TargetType.Name,
+            instruction.ExecutingMethod.Signature.ParameterTypes,
+            instruction.ExecutingMethod.Signature.ReturnType
+        with
+        | "EventPipeInternal_Enable",
+          "System.Private.CoreLib",
+          "System.Diagnostics.Tracing",
+          "EventPipeInternal",
+          [ ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.Char)
+            ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Diagnostics.Tracing",
+                                              "EventPipeSerializationFormat",
+                                              formatGenerics)
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt32
+            ConcretePointer _
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt32 ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt64) when
+            formatGenerics.IsEmpty
+            ->
+            // No tracing session is ever opened in PawPrint, so we always report a zero
+            // session ID. EventPipeEventDispatcher treats sessionID == 0 as "enable failed"
+            // and stops trying to drive the dispatcher loop, which is exactly the behaviour
+            // we want.
+            state |> pushUInt64Zero ctx.Thread |> Some
+
+        | "EventPipeInternal_Disable",
+          "System.Private.CoreLib",
+          "System.Diagnostics.Tracing",
+          "EventPipeInternal",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt64 ],
+          MethodReturnType.Void ->
+            // No session was ever enabled; ignore the supplied sessionID.
+            state |> justStep |> Some
+
+        | "EventPipeInternal_CreateProvider",
+          "System.Private.CoreLib",
+          "System.Diagnostics.Tracing",
+          "EventPipeInternal",
+          [ ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt16)
+            ConcreteFunctionPointer _
+            ConcretePointer (ConcreteVoid state.ConcreteTypes) ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr) ->
+            // The provider name (UTF-16, char* in CoreCLR but System.Char in metadata is U2),
+            // the unmanaged callback function pointer, and the callback context are all
+            // accepted but discarded: PawPrint never invokes the callback or filters by
+            // provider name. We just mint a fresh tagged handle so the BCL sees a non-zero
+            // IntPtr and proceeds.
+            let id, state = mintEventPipeId state
+            state |> pushProviderHandle id ctx.Thread |> Some
+
+        | "EventPipeInternal_DefineEvent",
+          "System.Private.CoreLib",
+          "System.Diagnostics.Tracing",
+          "EventPipeInternal",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt32
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.Int64
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt32
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt32
+            ConcretePointer (ConcreteVoid state.ConcreteTypes)
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt32 ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr) ->
+            let operation = "EventPipeInternal_DefineEvent"
+
+            // Validate that the supplied provider handle is one we minted. EventSource only
+            // calls DefineEvent with a handle returned from CreateProvider, so a foreign or
+            // null IntPtr here would indicate a real bug worth catching loudly.
+            match providerHandleOfArgument operation "provHandle" instruction.Arguments.[0] with
+            | None ->
+                failwith $"%s{operation}: provHandle was IntPtr.Zero, but DefineEvent requires a registered provider"
+            | Some _ -> ()
+
+            // eventID, keywords, eventVersion, level, metadata pointer and metadataLength are
+            // accepted but not retained: the metadata blob is the schema EventPipe would use
+            // to format payloads, and PawPrint does not emit payloads anywhere.
+            let id, state = mintEventPipeId state
+            state |> pushEventHandle id ctx.Thread |> Some
+
+        | "EventPipeInternal_GetProvider",
+          "System.Private.CoreLib",
+          "System.Diagnostics.Tracing",
+          "EventPipeInternal",
+          [ ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt16) ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr) ->
+            // Real EventPipe returns the handle of an already-registered provider with this
+            // name, or IntPtr.Zero if none. PawPrint does not retain provider registrations,
+            // so the truthful answer is "no provider matches" — return zero. EventSource
+            // treats this as "not yet registered" and falls through to CreateProvider.
+            state |> pushIntPtrZero ctx.Thread |> Some
+
+        | "EventPipeInternal_DeleteProvider",
+          "System.Private.CoreLib",
+          "System.Diagnostics.Tracing",
+          "EventPipeInternal",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr ],
+          MethodReturnType.Void ->
+            let operation = "EventPipeInternal_DeleteProvider"
+
+            // EventPipeEventProvider.Dispose calls DeleteProvider unconditionally, including
+            // when registration failed and `_provHandle` is still zero. Match the native
+            // contract by treating IntPtr.Zero as a no-op rather than a failure, but reject
+            // foreign tagged IntPtr values via providerHandleOfArgument's exhaustive check.
+            providerHandleOfArgument operation "provHandle" instruction.Arguments.[0]
+            |> ignore
+
+            state |> justStep |> Some
+
+        | "EventPipeInternal_EventActivityIdControl",
+          "System.Private.CoreLib",
+          "System.Diagnostics.Tracing",
+          "EventPipeInternal",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt32 ; ConcretePointer guidPtrHandle ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) when
+            (match guidPtrHandle with
+             | ConcreteType state.ConcreteTypes ("System.Private.CoreLib", "System", "Guid", guidGenerics) ->
+                 guidGenerics.IsEmpty
+             | _ -> false)
+            ->
+            // The C# wrapper takes `ref Guid`, but the LibraryImport source generator marshals
+            // ref-to-value-type to a raw `Guid*` for the QCall. The QCall returns int32: 0 on
+            // success, 1 on failure (null thread/pointer or unrecognised control code) — see
+            // coreclr/vm/eventpipeinternal.cpp.
+            //
+            // CoreCLR keeps a per-thread activity ID independently of any tracing session, so
+            // EventSource calls this entry point during normal `WriteEvent` flow even when no
+            // EventPipe session is enabled. We honour the read-only GET_ID code by writing
+            // Guid.Empty into *activityId — the value real CoreCLR would also produce when no
+            // SetCurrentThreadActivityId has run on this thread — and reject mutating control
+            // codes loudly until per-thread activity ID storage is added.
+            let operation = "EventPipeInternal_EventActivityIdControl"
+            let controlCode = uint32Argument operation "controlCode" instruction.Arguments.[0]
+
+            let activityIdPtr =
+                NativeCall.managedPointerOfPointerArgument operation "activityId" instruction.Arguments.[1]
+
+            match controlCode with
+            | 1u ->
+                // EP_ACTIVITY_CONTROL_GET_ID
+                let zeroGuid, state =
+                    IlMachineState.cliTypeZeroOfHandle state ctx.BaseClassTypes guidPtrHandle
+
+                let state = IlMachineState.writeManagedByref state activityIdPtr zeroGuid
+                state |> pushInt32 0 ctx.Thread |> Some
+            | 2u ->
+                failwith
+                    $"%s{operation}: TODO: EP_ACTIVITY_CONTROL_SET_ID requires per-thread activity ID tracking, which PawPrint does not yet implement"
+            | 3u ->
+                failwith
+                    $"%s{operation}: TODO: EP_ACTIVITY_CONTROL_CREATE_ID requires deterministic GUID generation, which PawPrint does not yet implement"
+            | 4u ->
+                failwith
+                    $"%s{operation}: TODO: EP_ACTIVITY_CONTROL_GET_SET_ID requires per-thread activity ID tracking, which PawPrint does not yet implement"
+            | 5u ->
+                failwith
+                    $"%s{operation}: TODO: EP_ACTIVITY_CONTROL_CREATE_SET_ID requires deterministic GUID generation and per-thread tracking, which PawPrint does not yet implement"
+            | unknown -> failwith $"%s{operation}: unknown EP_ACTIVITY_CONTROL_* code %u{unknown}"
+
+        | "EventPipeInternal_WriteEventData",
+          "System.Private.CoreLib",
+          "System.Diagnostics.Tracing",
+          "EventPipeInternal",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr
+            ConcretePointer _
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt32
+            ConcretePointer (ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                                               "System",
+                                                               "Guid",
+                                                               activityGuidGenerics))
+            ConcretePointer (ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                                               "System",
+                                                               "Guid",
+                                                               relatedGuidGenerics)) ],
+          MethodReturnType.Void when activityGuidGenerics.IsEmpty && relatedGuidGenerics.IsEmpty ->
+            let operation = "EventPipeInternal_WriteEventData"
+
+            // Validate that the event handle is one we issued. EventSource itself only ever
+            // calls this with a handle DefineEvent returned (or zero, if the event was
+            // disabled before the call), so a foreign IntPtr here would indicate a real bug
+            // worth catching loudly.
+            eventHandleOfArgument operation "eventHandle" instruction.Arguments.[0]
+            |> ignore
+
+            // No event delivery; data and activity IDs are intentionally ignored.
+            state |> justStep |> Some
+
+        // The four entry points below all carry `[return: MarshalAs(UnmanagedType.Bool)]` on
+        // their managed wrappers. The LibraryImport source generator emits the underlying
+        // QCall as returning int32 and the wrapper applies `cgt.un` to convert; matching on
+        // PrimitiveType.Boolean here would never fire. Push 0 (FALSE) for "no session" — that
+        // is the truthful answer because PawPrint never opens a tracing session.
+        | "EventPipeInternal_GetSessionInfo",
+          "System.Private.CoreLib",
+          "System.Diagnostics.Tracing",
+          "EventPipeInternal",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt64 ; ConcretePointer _ ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
+            // No session was ever opened, so reporting "no session info available" is correct.
+            // The pSessionInfo out-pointer is left untouched.
+            state |> pushInt32 0 ctx.Thread |> Some
+
+        | "EventPipeInternal_GetNextEvent",
+          "System.Private.CoreLib",
+          "System.Diagnostics.Tracing",
+          "EventPipeInternal",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt64 ; ConcretePointer _ ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
+            // No session is enabled, so there is never a next event to drain.
+            state |> pushInt32 0 ctx.Thread |> Some
+
+        | "EventPipeInternal_SignalSession",
+          "System.Private.CoreLib",
+          "System.Diagnostics.Tracing",
+          "EventPipeInternal",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt64 ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
+            // No session to signal; report failure.
+            state |> pushInt32 0 ctx.Thread |> Some
+
+        | "EventPipeInternal_WaitForSessionSignal",
+          "System.Private.CoreLib",
+          "System.Diagnostics.Tracing",
+          "EventPipeInternal",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt64
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32 ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
+            // No session to wait on; report failure immediately rather than blocking.
+            state |> pushInt32 0 ctx.Thread |> Some
+
+        | _ -> None

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -32,6 +32,20 @@ module NativeQCall =
             "ThreadNative_Join", NativeThreading.tryExecuteQCall "ThreadNative_Join"
             "DebugDebugger_IsManagedDebuggerAttached",
             NativeDebugger.tryExecuteQCall "DebugDebugger_IsManagedDebuggerAttached"
+            "EventPipeInternal_Enable", NativeEventPipe.tryExecuteQCall "EventPipeInternal_Enable"
+            "EventPipeInternal_Disable", NativeEventPipe.tryExecuteQCall "EventPipeInternal_Disable"
+            "EventPipeInternal_CreateProvider", NativeEventPipe.tryExecuteQCall "EventPipeInternal_CreateProvider"
+            "EventPipeInternal_DefineEvent", NativeEventPipe.tryExecuteQCall "EventPipeInternal_DefineEvent"
+            "EventPipeInternal_GetProvider", NativeEventPipe.tryExecuteQCall "EventPipeInternal_GetProvider"
+            "EventPipeInternal_DeleteProvider", NativeEventPipe.tryExecuteQCall "EventPipeInternal_DeleteProvider"
+            "EventPipeInternal_EventActivityIdControl",
+            NativeEventPipe.tryExecuteQCall "EventPipeInternal_EventActivityIdControl"
+            "EventPipeInternal_WriteEventData", NativeEventPipe.tryExecuteQCall "EventPipeInternal_WriteEventData"
+            "EventPipeInternal_GetSessionInfo", NativeEventPipe.tryExecuteQCall "EventPipeInternal_GetSessionInfo"
+            "EventPipeInternal_GetNextEvent", NativeEventPipe.tryExecuteQCall "EventPipeInternal_GetNextEvent"
+            "EventPipeInternal_SignalSession", NativeEventPipe.tryExecuteQCall "EventPipeInternal_SignalSession"
+            "EventPipeInternal_WaitForSessionSignal",
+            NativeEventPipe.tryExecuteQCall "EventPipeInternal_WaitForSessionSignal"
             "Signature_Init", NativeSignature.tryExecuteQCall "Signature_Init"
             "Array_CreateInstance", NativeArray.tryExecuteQCall "Array_CreateInstance"
             "Enum_GetValuesAndNames", NativeEnum.tryExecuteQCall "Enum_GetValuesAndNames"

--- a/WoofWare.PawPrint/NativeIntSource.fs
+++ b/WoofWare.PawPrint/NativeIntSource.fs
@@ -122,6 +122,16 @@ type NativeIntSource =
     | ModuleHandle of string
     | MetadataImportHandle of string
     | GcHandlePtr of GcHandleAddress
+    /// Opaque handle returned by `EventPipeInternal_CreateProvider` /
+    /// `EventPipeInternal_GetProvider`. PawPrint never opens a tracing
+    /// session, so the payload is just a monotonically increasing ID; the
+    /// tagged variant exists so a foreign IntPtr cannot be mistaken for a
+    /// PawPrint-minted EventPipe provider handle.
+    | EventPipeProviderPtr of int64
+    /// Opaque handle returned by `EventPipeInternal_DefineEvent`. Same role
+    /// as `EventPipeProviderPtr` but distinguished by tag so an event handle
+    /// cannot be passed where a provider handle is expected.
+    | EventPipeEventPtr of int64
     /// Returned by `Unsafe.ByteOffset` or managed-pointer subtraction for two byrefs into distinct byte-addressed
     /// storage containers.
     | SyntheticCrossArrayOffset of SyntheticCrossArrayOffset
@@ -141,6 +151,8 @@ type NativeIntSource =
         | NativeIntSource.ModuleHandle name -> $"<module %s{name}>"
         | NativeIntSource.MetadataImportHandle name -> $"<metadata import for %s{name}>"
         | NativeIntSource.GcHandlePtr handle -> $"<GC handle %O{handle}>"
+        | NativeIntSource.EventPipeProviderPtr id -> $"<EventPipe provider #%i{id}>"
+        | NativeIntSource.EventPipeEventPtr id -> $"<EventPipe event #%i{id}>"
         | NativeIntSource.SyntheticCrossArrayOffset _ -> "<synthetic cross-storage byte offset>"
 
     override this.Equals (other : obj) : bool =
@@ -161,6 +173,8 @@ type NativeIntSource =
             | NativeIntSource.ModuleHandle left, NativeIntSource.ModuleHandle right -> left = right
             | NativeIntSource.MetadataImportHandle left, NativeIntSource.MetadataImportHandle right -> left = right
             | NativeIntSource.GcHandlePtr left, NativeIntSource.GcHandlePtr right -> left = right
+            | NativeIntSource.EventPipeProviderPtr left, NativeIntSource.EventPipeProviderPtr right -> left = right
+            | NativeIntSource.EventPipeEventPtr left, NativeIntSource.EventPipeEventPtr right -> left = right
             | NativeIntSource.SyntheticCrossArrayOffset left, NativeIntSource.SyntheticCrossArrayOffset right ->
                 left = right
             | NativeIntSource.Verbatim _, _
@@ -175,6 +189,8 @@ type NativeIntSource =
             | NativeIntSource.ModuleHandle _, _
             | NativeIntSource.MetadataImportHandle _, _
             | NativeIntSource.GcHandlePtr _, _
+            | NativeIntSource.EventPipeProviderPtr _, _
+            | NativeIntSource.EventPipeEventPtr _, _
             | NativeIntSource.SyntheticCrossArrayOffset _, _ -> false
         | _ -> false
 
@@ -199,7 +215,9 @@ type NativeIntSource =
         | NativeIntSource.ModuleHandle name -> HashCode.Combine (9, name)
         | NativeIntSource.MetadataImportHandle name -> HashCode.Combine (10, name)
         | NativeIntSource.GcHandlePtr handle -> HashCode.Combine (11, handle)
-        | NativeIntSource.SyntheticCrossArrayOffset s -> HashCode.Combine (12, hash s)
+        | NativeIntSource.EventPipeProviderPtr id -> HashCode.Combine (12, id)
+        | NativeIntSource.EventPipeEventPtr id -> HashCode.Combine (13, id)
+        | NativeIntSource.SyntheticCrossArrayOffset s -> HashCode.Combine (14, hash s)
 
 [<RequireQualifiedAccess>]
 module NativeIntSource =
@@ -223,6 +241,8 @@ module NativeIntSource =
         | NativeIntSource.MethodTablePtr _
         | NativeIntSource.MethodTableAuxiliaryDataPtr _
         | NativeIntSource.GcHandlePtr _
+        | NativeIntSource.EventPipeProviderPtr _
+        | NativeIntSource.EventPipeEventPtr _
         | NativeIntSource.AssemblyHandle _
         | NativeIntSource.MetadataImportHandle _
         | NativeIntSource.ModuleHandle _ -> false
@@ -244,6 +264,8 @@ module NativeIntSource =
         | NativeIntSource.MethodTablePtr _
         | NativeIntSource.MethodTableAuxiliaryDataPtr _
         | NativeIntSource.GcHandlePtr _
+        | NativeIntSource.EventPipeProviderPtr _
+        | NativeIntSource.EventPipeEventPtr _
         | NativeIntSource.AssemblyHandle _
         | NativeIntSource.MetadataImportHandle _
         | NativeIntSource.ModuleHandle _ -> true

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -130,7 +130,9 @@ module NullaryIlOp =
             | EvalStackValue.NativeInt (NativeIntSource.GcHandlePtr _)
             | EvalStackValue.NativeInt (NativeIntSource.AssemblyHandle _)
             | EvalStackValue.NativeInt (NativeIntSource.ModuleHandle _)
-            | EvalStackValue.NativeInt (NativeIntSource.MetadataImportHandle _) ->
+            | EvalStackValue.NativeInt (NativeIntSource.MetadataImportHandle _)
+            | EvalStackValue.NativeInt (NativeIntSource.EventPipeProviderPtr _)
+            | EvalStackValue.NativeInt (NativeIntSource.EventPipeEventPtr _) ->
                 failwith $"Localloc: refusing to use pointer-like value %O{value} as a byte count"
             | EvalStackValue.ManagedPointer _
             | EvalStackValue.NullObjectRef
@@ -261,6 +263,9 @@ module NullaryIlOp =
                 failwith $"Neg: refusing to negate module handle %s{moduleName}"
             | NativeIntSource.MetadataImportHandle moduleName ->
                 failwith $"Neg: refusing to negate metadata import handle %s{moduleName}"
+            | NativeIntSource.EventPipeProviderPtr id ->
+                failwith $"Neg: refusing to negate EventPipe provider handle %d{id}"
+            | NativeIntSource.EventPipeEventPtr id -> failwith $"Neg: refusing to negate EventPipe event handle %d{id}"
         | EvalStackValue.Float value -> -value |> EvalStackValue.Float
         | EvalStackValue.ManagedPointer ptr -> failwith $"Neg: refusing to negate managed pointer %O{ptr}"
         | EvalStackValue.NullObjectRef -> failwith "Neg: refusing to negate null object reference"
@@ -445,6 +450,8 @@ module NullaryIlOp =
                 | NativeIntSource.AssemblyHandle _
                 | NativeIntSource.ModuleHandle _
                 | NativeIntSource.MetadataImportHandle _
+                | NativeIntSource.EventPipeProviderPtr _
+                | NativeIntSource.EventPipeEventPtr _
                 | NativeIntSource.ManagedPointer _ -> failwith "Refusing to treat a pointer as an array index"
                 | NativeIntSource.SyntheticCrossArrayOffset _ ->
                     failwith "Refusing to treat a synthetic cross-storage byte offset as an array index"
@@ -489,6 +496,8 @@ module NullaryIlOp =
                 | NativeIntSource.AssemblyHandle _
                 | NativeIntSource.ModuleHandle _
                 | NativeIntSource.MetadataImportHandle _
+                | NativeIntSource.EventPipeProviderPtr _
+                | NativeIntSource.EventPipeEventPtr _
                 | NativeIntSource.ManagedPointer _ -> failwith "Refusing to treat a pointer as an array index"
                 | NativeIntSource.SyntheticCrossArrayOffset _ ->
                     failwith "Refusing to treat a synthetic cross-storage byte offset as an array index"

--- a/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
+++ b/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
@@ -93,6 +93,7 @@
     <Compile Include="Native\NativeRuntimeAssembly.fs" />
     <Compile Include="Native\NativeThreading.fs" />
     <Compile Include="Native\NativeDebugger.fs" />
+    <Compile Include="Native\NativeEventPipe.fs" />
     <Compile Include="Native\NativeQCall.fs" />
     <Compile Include="Native\NativeType.fs" />
     <Compile Include="Native\NativeString.fs" />


### PR DESCRIPTION
Real EventPipe tracing is never enabled in PawPrint, so each entry point reports the truthful "no session" answer (zero session ID, empty activity GUID, false-equivalent int returns) and mints opaque tagged handles for CreateProvider/DefineEvent so EventSource can run its registration flow without diverging.