### PR TITLE
Implement RuntimeMethodHandle::GetAttributes InternalCall

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -42,7 +42,7 @@ module TestPureCases =
             "RuntimeTypeHandleGetInstantiationOpenGeneric.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringMethodForGenericParameter
             "InitializeArrayBoxedFieldHandle.cs" // past String::FastAllocateString(MethodTable*, nint); now blocked by unimplemented MethodTable field projection for ParentMethodTable
             "RuntimeTypeHandleTypeParameterDeclaringType.cs" // past RuntimeTypeHandle::GetDeclaringTypeHandleForGenericVariable QCall (now returns the open-generic declaring-type handle); blocked next by ldflda on MethodTableAuxiliaryData::ExposedClassObjectRaw for OpenGenericTypeDefinition targets (tryProjectAuxiliaryDataFieldAddress only handles Closed)
-            "MethodReflectionProbe.cs" // past RuntimeMethodHandle::GetUtf8NameInternal (RuntimeType.GetMethodCandidates can now read each candidate's name); now blocked by unimplemented InternalCall RuntimeMethodHandle::GetAttributes (used by the candidate filter to inspect each method's MethodAttributes)
+            "MethodReflectionProbe.cs" // past RuntimeMethodHandle::GetAttributes (RuntimeType.GetMethodCandidates can now read each candidate's MethodAttributes); now blocked by unimplemented QCall AssemblyNative_IsApplyUpdateSupported reached during MetadataUpdater static init
             "ArraySortHelperDefaultInt.cs" // past EventPipeInternal_* QCall stubs during EventSource static init; now blocked by unimplemented InternalCall String::.ctor(ReadOnlySpan<char>)
         ]
         |> Set.ofList

--- a/WoofWare.PawPrint/Native/NativeRuntimeMethodHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeMethodHandle.fs
@@ -2,6 +2,41 @@ namespace WoofWare.PawPrint
 
 [<RequireQualifiedAccess>]
 module NativeRuntimeMethodHandle =
+    let private resolveMethodInfoFromHandleArg
+        (operation : string)
+        (state : IlMachineState)
+        (arg : CliType)
+        : MethodInfo<GenericParamFromMetadata, GenericParamFromMetadata, TypeDefn>
+        =
+        // CoreCLR's RuntimeMethodHandle FCalls dereference the MethodDesc* directly and
+        // assert non-null; PawPrint's existing callers never yield a null handle, so we
+        // surface a contract violation rather than silently producing a default value.
+        let methodHandleId =
+            NativeCall.methodHandleIdOfRuntimeMethodHandleInternal operation arg
+            |> Option.defaultWith (fun () -> failwith $"%s{operation}: null RuntimeMethodHandleInternal")
+
+        let methodHandle =
+            MethodHandleRegistry.resolveMethodFromId methodHandleId state.MethodHandles
+            |> Option.defaultWith (fun () ->
+                failwith $"%s{operation}: registry id %d{methodHandleId} did not resolve to a known MethodHandle"
+            )
+
+        let assemblyFullName = methodHandle.GetAssemblyFullName ()
+
+        let assembly =
+            state.LoadedAssembly' assemblyFullName
+            |> Option.defaultWith (fun () -> failwith $"%s{operation}: assembly %s{assemblyFullName} is not loaded")
+
+        let methodDefHandle = methodHandle.GetMethodDefinitionHandle().Get
+
+        let mutable methodInfo =
+            Unchecked.defaultof<MethodInfo<GenericParamFromMetadata, GenericParamFromMetadata, TypeDefn>>
+
+        if not (assembly.Methods.TryGetValue (methodDefHandle, &methodInfo)) then
+            failwith $"%s{operation}: MethodDef %O{methodDefHandle} not found in assembly %s{assemblyFullName}"
+
+        methodInfo
+
     let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
@@ -31,42 +66,44 @@ module NativeRuntimeMethodHandle =
             // managed strlen path then walks the array as expected.
             let operation = "RuntimeMethodHandle.GetUtf8NameInternal"
 
-            let methodHandleId =
-                NativeCall.methodHandleIdOfRuntimeMethodHandleInternal operation instruction.Arguments.[0]
-                |> Option.defaultWith (fun () ->
-                    // CoreCLR's GetUtf8NameInternal is an FCall that dereferences the
-                    // MethodDesc* directly; the managed wrapper would surface a null
-                    // result as BadImageFormatException. None of PawPrint's current
-                    // callers (the introduced-method iterator) yield a null handle, so
-                    // reaching here would indicate a contract violation upstream.
-                    failwith $"%s{operation}: null RuntimeMethodHandleInternal"
-                )
-
-            let methodHandle =
-                MethodHandleRegistry.resolveMethodFromId methodHandleId state.MethodHandles
-                |> Option.defaultWith (fun () ->
-                    failwith $"%s{operation}: registry id %d{methodHandleId} did not resolve to a known MethodHandle"
-                )
-
-            let assemblyFullName = methodHandle.GetAssemblyFullName ()
-
-            let assembly =
-                state.LoadedAssembly' assemblyFullName
-                |> Option.defaultWith (fun () -> failwith $"%s{operation}: assembly %s{assemblyFullName} is not loaded")
-
-            let methodDefHandle = methodHandle.GetMethodDefinitionHandle().Get
-
-            let mutable methodInfo =
-                Unchecked.defaultof<MethodInfo<GenericParamFromMetadata, GenericParamFromMetadata, TypeDefn>>
-
-            if not (assembly.Methods.TryGetValue (methodDefHandle, &methodInfo)) then
-                failwith $"%s{operation}: MethodDef %O{methodDefHandle} not found in assembly %s{assemblyFullName}"
+            let methodInfo =
+                resolveMethodInfoFromHandleArg operation state instruction.Arguments.[0]
 
             let namePtr, state =
                 NativeCall.allocateNullTerminatedUtf8 ctx.BaseClassTypes methodInfo.Name state
 
             let state =
                 IlMachineState.pushToEvalStack' (EvalStackValue.ManagedPointer namePtr) ctx.Thread state
+
+            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+        | "System.Private.CoreLib",
+          "System",
+          "RuntimeMethodHandle",
+          "GetAttributes",
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System",
+                                              "RuntimeMethodHandleInternal",
+                                              generics) ],
+          MethodReturnType.Returns (ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                                                      "System.Reflection",
+                                                                      "MethodAttributes",
+                                                                      retGenerics)) when
+            generics.IsEmpty && retGenerics.IsEmpty
+            ->
+            // CoreCLR (runtimehandles.cpp): asserts non-null and returns
+            // (INT32)pMethod->GetAttrs(). The managed wrapper exposes this as the
+            // MethodAttributes flags backing MethodBase.Attributes / RuntimeMethodInfo's
+            // candidate filter.
+            let operation = "RuntimeMethodHandle.GetAttributes"
+
+            let methodInfo =
+                resolveMethodInfoFromHandleArg operation state instruction.Arguments.[0]
+
+            let state =
+                IlMachineState.pushToEvalStack
+                    (CliType.Numeric (CliNumericType.Int32 (int32 methodInfo.MethodAttributes)))
+                    ctx.Thread
+                    state
 
             (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
         | _ -> None


### PR DESCRIPTION
CoreCLR's FCall returns (INT32)pMethod->GetAttrs(); mirror that by resolving the method-handle registry id back to a MethodInfo and pushing its MethodAttributes as Int32. Asserts non-null to match CoreCLR (runtimehandles.cpp:1322).

Extract resolveMethodInfoFromHandleArg so GetUtf8NameInternal and GetAttributes share the registry/assembly/method-def lookup.

MethodReflectionProbe.cs now advances past the candidate-filter step and is blocked on QCall AssemblyNative_IsApplyUpdateSupported (via MetadataUpdater static init); the unimplemented-list comment is updated accordingly.