### PR TITLE
Plumb FieldMarshalDescriptor through FieldInfo and CliField

### DIFF
--- a/WoofWare.PawPrint.Domain/FieldInfo.fs
+++ b/WoofWare.PawPrint.Domain/FieldInfo.fs
@@ -2,6 +2,22 @@ namespace WoofWare.PawPrint
 
 open System.Reflection
 open System.Reflection.Metadata
+open System.Runtime.InteropServices
+
+/// Parsed form of a field's marshalling descriptor (ECMA-335 §II.23.4).
+/// Only the cases load-bearing for the interpreter today are decoded structurally; everything
+/// else is stashed in `Other` so callers can reject explicitly rather than silently treating a
+/// field as having no descriptor.
+type FieldMarshalDescriptor =
+    /// `[MarshalAs(UnmanagedType.ByValTStr, SizeConst = N)]`. Inline fixed-size character array
+    /// whose unmanaged byte size depends on the declaring type's CharSet.
+    | ByValTStr of sizeConst : int
+    /// `[MarshalAs(UnmanagedType.ByValArray, SizeConst = N, ArraySubType = elementType)]`.
+    /// Inline fixed-size array; the element `UnmanagedType` is absent when the descriptor blob
+    /// stops after the size constant.
+    | ByValArray of sizeConst : int * elementType : UnmanagedType option
+    /// Any other `UnmanagedType`. Preserved verbatim so callers can decide case-by-case.
+    | Other of UnmanagedType
 
 /// <summary>
 /// Represents detailed information about a field in a .NET assembly.
@@ -40,6 +56,11 @@ type FieldInfo<'typeGeneric, 'fieldGeneric> =
         /// The Relative Virtual Address for fields with the HasFieldRVA attribute.
         /// This points to the raw data in the PE image for fields used in array initialization, etc.
         RelativeVirtualAddress : int option
+
+        /// Parsed `[MarshalAs(...)]` descriptor for fields with the HasFieldMarshal attribute, or
+        /// `None` if the field has no marshalling descriptor. Drives unmanaged-size computation
+        /// for `Marshal.SizeOf` and structure marshalling.
+        MarshallingDescriptor : FieldMarshalDescriptor option
     }
 
     member this.HasFieldRVA = this.Attributes.HasFlag FieldAttributes.HasFieldRVA
@@ -47,6 +68,45 @@ type FieldInfo<'typeGeneric, 'fieldGeneric> =
 
     override this.ToString () : string =
         $"%s{this.DeclaringType.Assembly.Name}.{this.DeclaringType.Name}.%s{this.Name}"
+
+[<RequireQualifiedAccess>]
+module FieldMarshalDescriptor =
+    /// Decode a field-marshal descriptor blob (ECMA-335 §II.23.4) into the structured form we
+    /// need for sizing computations. Returns `None` if the blob is empty (which is invalid per
+    /// the spec, but we tolerate it). Any unexpected trailing bytes are ignored — we only read
+    /// the fields the standard says are present for the leading `NATIVE_TYPE`.
+    let parse (mr : MetadataReader) (handle : BlobHandle) : FieldMarshalDescriptor option =
+        let mutable reader = mr.GetBlobReader handle
+
+        if reader.RemainingBytes = 0 then
+            None
+        else
+            let nativeType : UnmanagedType =
+                LanguagePrimitives.EnumOfValue (int32 (reader.ReadByte ()))
+
+            match nativeType with
+            | UnmanagedType.ByValTStr ->
+                if reader.RemainingBytes = 0 then
+                    Some (Other nativeType)
+                else
+                    let sizeConst = reader.ReadCompressedInteger ()
+                    Some (ByValTStr sizeConst)
+            | UnmanagedType.ByValArray ->
+                let sizeConst =
+                    if reader.RemainingBytes = 0 then
+                        0
+                    else
+                        reader.ReadCompressedInteger ()
+
+                let elementType =
+                    if reader.RemainingBytes = 0 then
+                        None
+                    else
+                        let raw = int32 (reader.ReadByte ())
+                        Some (LanguagePrimitives.EnumOfValue raw : UnmanagedType)
+
+                Some (ByValArray (sizeConst, elementType))
+            | other -> Some (Other other)
 
 [<RequireQualifiedAccess>]
 module FieldInfo =
@@ -81,6 +141,12 @@ module FieldInfo =
             let v = def.GetRelativeVirtualAddress ()
             if v = 0 then None else Some v
 
+        let marshallingDescriptor =
+            if def.Attributes.HasFlag FieldAttributes.HasFieldMarshal then
+                FieldMarshalDescriptor.parse mr (def.GetMarshallingDescriptor ())
+            else
+                None
+
         {
             Name = name
             Signature = fieldSig
@@ -89,6 +155,7 @@ module FieldInfo =
             Attributes = def.Attributes
             Offset = offset
             RelativeVirtualAddress = rva
+            MarshallingDescriptor = marshallingDescriptor
         }
 
     let mapTypeGenerics<'a, 'b, 'field> (f : int -> 'a -> 'b) (input : FieldInfo<'a, 'field>) : FieldInfo<'b, 'field> =
@@ -102,4 +169,5 @@ module FieldInfo =
             Attributes = input.Attributes
             Offset = input.Offset
             RelativeVirtualAddress = input.RelativeVirtualAddress
+            MarshallingDescriptor = input.MarshallingDescriptor
         }

--- a/WoofWare.PawPrint.Test/TestCliTypeBytes.fs
+++ b/WoofWare.PawPrint.Test/TestCliTypeBytes.fs
@@ -65,6 +65,7 @@ module TestCliTypeBytes =
             Contents = contents
             Offset = offset
             Type = fieldType
+            MarshallingDescriptor = None
         }
 
     let private genPrimitiveNumeric : Gen<CliNumericType> =

--- a/WoofWare.PawPrint.Test/TestCliValueTypeCoerceFrom.fs
+++ b/WoofWare.PawPrint.Test/TestCliValueTypeCoerceFrom.fs
@@ -62,6 +62,7 @@ module TestCliValueTypeCoerceFrom =
                     Contents = CliType.Numeric (CliNumericType.Int32 7)
                     Offset = None
                     Type = int32Handle
+                    MarshallingDescriptor = None
                 }
             ]
             |> CliValueType.OfFields bct allCt declaredHandle Layout.Default
@@ -85,6 +86,7 @@ module TestCliValueTypeCoerceFrom =
                 Contents = CliType.Numeric (CliNumericType.Int32 0)
                 Offset = Some 0
                 Type = int32Handle
+                MarshallingDescriptor = None
             }
 
         let b : CliField =
@@ -94,6 +96,7 @@ module TestCliValueTypeCoerceFrom =
                 Contents = CliType.Numeric (CliNumericType.Int64 (Int64Source.Verbatim 0L))
                 Offset = Some 0
                 Type = int64Handle
+                MarshallingDescriptor = None
             }
 
         let layout : Layout = Layout.Custom (size = 8, packingSize = 0)

--- a/WoofWare.PawPrint.Test/TestEvalStackPrimitiveLikeBoundary.fs
+++ b/WoofWare.PawPrint.Test/TestEvalStackPrimitiveLikeBoundary.fs
@@ -52,6 +52,7 @@ module TestEvalStackPrimitiveLikeBoundary =
             Contents = contents
             Offset = None
             Type = declared
+            MarshallingDescriptor = None
         }
         |> List.singleton
         |> CliValueType.OfFields bct allCt declared Layout.Default

--- a/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
+++ b/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
@@ -184,6 +184,7 @@ public interface IOpenInterface<T>
                     Contents = CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim bits))
                     Offset = valueField.Offset
                     Type = intPtrHandle
+                    MarshallingDescriptor = None
                 }
             ]
             |> CliValueType.OfFields bct state.ConcreteTypes intPtrHandle Layout.Default
@@ -213,6 +214,7 @@ public interface IOpenInterface<T>
                     Contents = CliType.ObjectRef (Some objectAddr)
                     Offset = Some 0
                     Type = objectHandle
+                    MarshallingDescriptor = None
                 }
             ]
             |> CliValueType.OfFields bct state.ConcreteTypes declared (Layout.Custom (size = 8, packingSize = 0))
@@ -231,6 +233,7 @@ public interface IOpenInterface<T>
                 Contents = CliType.RuntimePointer (CliRuntimePointer.MethodTablePtr intHandle)
                 Offset = Some 0
                 Type = intPtrHandle
+                MarshallingDescriptor = None
             }
         ]
         |> CliValueType.OfFields bct state.ConcreteTypes declared (Layout.Custom (size = 8, packingSize = 0))
@@ -265,6 +268,7 @@ public interface IOpenInterface<T>
                     Contents = CliType.ObjectRef (Some storedAddr)
                     Offset = Some 0
                     Type = objectHandle
+                    MarshallingDescriptor = None
                 }
             ]
             |> CliValueType.OfFields bct state.ConcreteTypes objectHandle (Layout.Custom (size = 8, packingSize = 0))
@@ -3024,6 +3028,7 @@ public unsafe struct PointerWrapper
                     Contents = CliType.Numeric (CliNumericType.Int32 0x11111111)
                     Offset = Some 0
                     Type = int32Handle
+                    MarshallingDescriptor = None
                 }
                 {
                     Id = FieldId.named "B"
@@ -3031,6 +3036,7 @@ public unsafe struct PointerWrapper
                     Contents = CliType.Numeric (CliNumericType.Int16 0x1111s)
                     Offset = Some 2
                     Type = int16Handle
+                    MarshallingDescriptor = None
                 }
             ]
             |> CliValueType.OfFields bct state.ConcreteTypes objectHandle (Layout.Custom (size = 4, packingSize = 0))

--- a/WoofWare.PawPrint/CliType.fs
+++ b/WoofWare.PawPrint/CliType.fs
@@ -352,6 +352,10 @@ and CliField =
         /// "None" for "no explicit offset specified"; we expect most offsets to be None.
         Offset : int option
         Type : ConcreteTypeHandle
+        /// Parsed `[MarshalAs(...)]` descriptor for this field, or `None` if absent. Carried
+        /// on the field itself so that unmanaged-size computation can consult it without
+        /// re-walking the underlying `FieldInfo`.
+        MarshallingDescriptor : FieldMarshalDescriptor option
     }
 
 and CliConcreteField =
@@ -366,6 +370,7 @@ and CliConcreteField =
             EditedAtTime : uint64
             Id : FieldId
             Type : ConcreteTypeHandle
+            MarshallingDescriptor : FieldMarshalDescriptor option
         }
 
     static member ToCliField (this : CliConcreteField) : CliField =
@@ -375,6 +380,7 @@ and CliConcreteField =
             Id = this.Id
             Name = this.Name
             Type = this.Type
+            MarshallingDescriptor = this.MarshallingDescriptor
         }
 
 /// Field-backed storage preserves named field provenance. The preserved bytes are the full
@@ -503,6 +509,7 @@ and CliValueType =
                             ConfiguredOffset = field.Offset
                             EditedAtTime = 0UL
                             Type = field.Type
+                            MarshallingDescriptor = field.MarshallingDescriptor
                         }
 
                     alignedOffset + size.Size, concreteField :: acc
@@ -526,6 +533,7 @@ and CliValueType =
                     ConfiguredOffset = field.Offset
                     EditedAtTime = 0UL
                     Type = field.Type
+                    MarshallingDescriptor = field.MarshallingDescriptor
                 }
             )
 
@@ -1298,6 +1306,7 @@ module CliType =
                     )
                 Offset = None
                 Type = intPtrHandle
+                MarshallingDescriptor = valueField.MarshallingDescriptor
             }
             |> List.singleton
             |> CliValueType.OfFields corelib concreteTypes intPtrHandle Layout.Default
@@ -1321,6 +1330,7 @@ module CliType =
                     )
                 Offset = None
                 Type = uintPtrHandle
+                MarshallingDescriptor = valueField.MarshallingDescriptor
             }
             |> List.singleton
             |> CliValueType.OfFields corelib concreteTypes uintPtrHandle Layout.Default
@@ -1496,6 +1506,7 @@ module CliType =
                         Contents = fieldZero
                         Offset = field.Offset
                         Type = fieldHandle
+                        MarshallingDescriptor = field.MarshallingDescriptor
                     }
                 )
                 |> CliValueType.OfFields corelib currentConcreteTypes handle typeDef.Layout

--- a/WoofWare.PawPrint/FieldIdentity.fs
+++ b/WoofWare.PawPrint/FieldIdentity.fs
@@ -18,6 +18,7 @@ module FieldIdentity =
             Contents = contents
             Offset = field.Offset
             Type = fieldTypeHandle
+            MarshallingDescriptor = field.MarshallingDescriptor
         }
 
     let private requiredOwnFieldMatching

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -421,6 +421,7 @@ module IlMachineRuntimeMetadata =
                         Contents = zero
                         Offset = field.Offset
                         Type = fieldTypeHandle
+                        MarshallingDescriptor = field.MarshallingDescriptor
                     }
 
                 state, cliField :: fields

--- a/WoofWare.PawPrint/UnaryMetadataCallOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataCallOps.fs
@@ -512,6 +512,7 @@ module internal UnaryMetadataCallOps =
                                                 Contents = coerced
                                                 Offset = field.Offset
                                                 Type = fieldTypeHandle
+                                                MarshallingDescriptor = field.MarshallingDescriptor
                                             }
 
                                         state, cliField :: acc

--- a/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
@@ -420,6 +420,7 @@ module internal UnaryMetadataObjectOps =
                                                 Contents = coerced
                                                 Offset = field.Offset
                                                 Type = fieldTypeHandle
+                                                MarshallingDescriptor = field.MarshallingDescriptor
                                             }
 
                                         state, cliField :: acc
@@ -477,6 +478,7 @@ module internal UnaryMetadataObjectOps =
                                         Contents = coerced
                                         Offset = field.Offset
                                         Type = fieldTypeHandle
+                                        MarshallingDescriptor = field.MarshallingDescriptor
                                     }
 
                                 state, cliField :: acc


### PR DESCRIPTION
## Summary

- Read each field's `[MarshalAs(...)]` descriptor from the metadata blob into a new `FieldMarshalDescriptor` DU on `FieldInfo`, and propagate it through `CliField` / `CliConcreteField`.
- No behaviour change. This is Stage 1 of a three-stage plan to teach `MarshalNative_SizeOfHelper` how to size structs whose object-ref fields carry `ByValTStr` or `ByValArray` overrides — currently the source of the `AdvancedStructLayout.cs` blocker.
- Subsequent stages will (2) capture `CharSet` on `CliValueType.Layout` and (3) actually consume the descriptor in `marshalSizeOf`.

## Test plan

- [x] `nix develop -c dotnet build WoofWare.PawPrint.slnx` — clean, 0 warnings.
- [x] `nix develop -c dotnet test ... --filter "FullyQualifiedName~CliValueType|CliTypeBytes|MethodTableProjection|EvalStackPrimitiveLikeBoundary|Marshal"` — 124/124 passing.
- [x] `codex review --base main` returned no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)