### PR TITLE
Handle structural reference-type tokens in Box IL op

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -26,7 +26,7 @@ module TestPureCases =
             "CastClassInvalid.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
             "CastclassFailures.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
             "ComplexTryCatch.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
-            "TypeDefCustomAttributeEnum.cs" // past String..ctor(ReadOnlySpan<char>); now blocked at the Box IL op when concretizeType returns a structural ConcreteTypeHandle (AllConcreteTypes.lookup is None) during attribute decoding
+            "TypeDefCustomAttributeEnum.cs" // past Box of structural reference-type handle during attribute decoding; now blocked by unimplemented InternalCall System.Runtime.DependentHandle::InternalAlloc
             "RethrowStackTraceBoundary.cs" // stack trace rendering lacks CLR inner-exception boundary and parameterised frames
             "ThrowingCctorProperties.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
             "Threads.cs" // blocked by pointer arithmetic over a generated Data field after Interlocked.CompareExchange
@@ -42,7 +42,7 @@ module TestPureCases =
             "RuntimeTypeHandleGetInstantiationOpenGeneric.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringMethodForGenericParameter
             "InitializeArrayBoxedFieldHandle.cs" // past String::FastAllocateString(MethodTable*, nint); now blocked by unimplemented MethodTable field projection for ParentMethodTable
             "MethodReflectionProbe.cs" // past AssemblyNative_IsApplyUpdateSupported QCall (MetadataUpdater.IsSupported now returns false during static init); now blocked by unimplemented InternalCall RuntimeMethodHandle::GetStubIfNeededInternal during MethodInfo materialisation
-            "ArraySortHelperDefaultInt.cs" // past String..ctor(ReadOnlySpan<char>); now blocked at the Box IL op when concretizeType returns a structural ConcreteTypeHandle (AllConcreteTypes.lookup is None) during EventSource static init
+            "ArraySortHelperDefaultInt.cs" // past Box of structural reference-type handle (`box !T` with T bound to an szarray, in ConditionalWeakTable`2.Add); now blocked by unimplemented InternalCall System.Runtime.DependentHandle::InternalAlloc
         ]
         |> Set.ofList
 

--- a/WoofWare.PawPrint.Test/sourcesPure/BoxGenericArray.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/BoxGenericArray.cs
@@ -1,0 +1,33 @@
+using System;
+
+public class Program
+{
+    // The C# compiler emits `box !!T` here. When T is bound to a reference type
+    // (e.g. an szarray), the box token concretizes to a structural handle —
+    // OneDimArrayZero — that AllConcreteTypes.lookup rightly does not store.
+    // ECMA-335 III.4.1: box of a reference-type token is a no-op; the value
+    // already on the stack is left unchanged.
+    private static object BoxIt<T>(T value)
+    {
+        return (object)value;
+    }
+
+    public static int Main(string[] args)
+    {
+        int[] arr = { 1, 2, 3 };
+
+        object boxed = BoxIt<int[]>(arr);
+        if (!ReferenceEquals(boxed, arr)) return 1;
+
+        // Multi-dim array — box of ConcreteTypeHandle.Array.
+        int[,] mat = new int[2, 2];
+        object boxedMat = BoxIt<int[,]>(mat);
+        if (!ReferenceEquals(boxedMat, mat)) return 2;
+
+        // Sanity: boxing a value type still works through the same generic helper.
+        object boxedInt = BoxIt<int>(7);
+        if (boxedInt is not int i || i != 7) return 3;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
@@ -341,6 +341,24 @@ module internal UnaryMetadataObjectOps =
 
         let toBox, state = state |> IlMachineState.popEvalStack thread
 
+        // ECMA-335 III.4.1: structural reference-type tokens (szarrays and multi-dim arrays)
+        // make `box` a no-op — the value already on the stack is a reference. Byref and
+        // pointer tokens are unverifiable for `box`. FunctionPointer is similarly not boxable.
+        match typeHandle with
+        | ConcreteTypeHandle.OneDimArrayZero _
+        | ConcreteTypeHandle.Array _ ->
+            state
+            |> IlMachineState.pushToEvalStack' toBox thread
+            |> IlMachineState.advanceProgramCounter thread
+            |> Tuple.withRight WhatWeDid.Executed
+        | ConcreteTypeHandle.Byref _ ->
+            failwithf "Box: byref types cannot be boxed (unverifiable IL); typeHandle=%O" typeHandle
+        | ConcreteTypeHandle.Pointer _ ->
+            failwithf "Box: pointer types cannot be boxed (unverifiable IL); typeHandle=%O" typeHandle
+        | ConcreteTypeHandle.FunctionPointer _ ->
+            failwithf "TODO: Box of function pointer type not implemented; typeHandle=%O" typeHandle
+        | ConcreteTypeHandle.Concrete _ ->
+
         let targetType =
             AllConcreteTypes.lookup typeHandle state.ConcreteTypes |> Option.get
 


### PR DESCRIPTION
## Summary
- `box` of a reference-type token (per ECMA-335 III.4.1) is a no-op: the value on the stack is unchanged. The interpreter unconditionally called `AllConcreteTypes.lookup typeHandle |> Option.get`, which crashed when concretization returned a structural handle (`OneDimArrayZero` / `Array` / `Byref` / `Pointer` / `FunctionPointer` — these are deliberately not stored). This was reached by `box !T` in shared-generic `ConditionalWeakTable\`2.Add` when T was bound to an szarray, blocking `ArraySortHelperDefaultInt.cs` and `TypeDefCustomAttributeEnum.cs`.
- `executeBox` now dispatches on `typeHandle` before the lookup: array shapes pass the value through; byref/pointer (unverifiable for box) and function-pointer (currently unsupported) fail with explicit messages.
- Adds `BoxGenericArray.cs` regression covering `box !!T` for szarray, multi-dim array, and value type via the same generic helper.
- Updates unimplemented-list comments for the two affected tests; both now advance past box and stop at the same next blocker (unimplemented `System.Runtime.DependentHandle::InternalAlloc` InternalCall — separate work).

## Test plan
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 672 passed, 0 failed
- [x] New `BoxGenericArray.cs` test passes
- [x] `ArraySortHelperDefaultInt.cs` and `TypeDefCustomAttributeEnum.cs` advance past box (verified manually via the App; both now stop at `DependentHandle::InternalAlloc`)
- [x] Codex review: no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)