### PR TITLE
Plumb CharSet metadata through CliValueType

### DIFF
--- a/WoofWare.PawPrint.Domain/TypeInfo.fs
+++ b/WoofWare.PawPrint.Domain/TypeInfo.fs
@@ -6,7 +6,22 @@ open System.Collections.Immutable
 open System.Reflection
 open System.Reflection.Metadata
 open System.Reflection.PortableExecutable
+open System.Runtime.InteropServices
 open Microsoft.FSharp.Core
+
+[<RequireQualifiedAccess>]
+module CharSetMetadata =
+    /// Project a `TypeAttributes` value's `StringFormatMask` bits onto the marshalling
+    /// `CharSet` enum. Mirrors the CLR's StringFormat → CharSet mapping used when no
+    /// explicit `[StructLayout(CharSet=...)]` is provided: `CustomFormatClass` is rare and
+    /// has no direct `CharSet` analogue, so we surface it as `CharSet.None` (callers should
+    /// treat that as "unspecified" rather than as a real choice).
+    let ofTypeAttributes (attrs : TypeAttributes) : CharSet =
+        match attrs &&& TypeAttributes.StringFormatMask with
+        | TypeAttributes.AnsiClass -> CharSet.Ansi
+        | TypeAttributes.UnicodeClass -> CharSet.Unicode
+        | TypeAttributes.AutoClass -> CharSet.Auto
+        | _ -> CharSet.None
 
 [<RequireQualifiedAccess>]
 type BaseTypeInfo =

--- a/WoofWare.PawPrint.Test/TestCliTypeBytes.fs
+++ b/WoofWare.PawPrint.Test/TestCliTypeBytes.fs
@@ -3,6 +3,7 @@ namespace WoofWare.PawPrint.Test
 open System.Collections.Generic
 open System.Collections.Immutable
 open System.IO
+open System.Runtime.InteropServices
 open FsCheck
 open FsCheck.FSharp
 open FsUnitTyped
@@ -128,14 +129,14 @@ module TestCliTypeBytes =
         }
 
     let private rawSizedValueType (size : int) : CliType =
-        CliValueType.OfFields bct allCt declaredHandle (Layout.Custom (size = size, packingSize = 0)) []
+        CliValueType.OfFields bct allCt declaredHandle (Layout.Custom (size = size, packingSize = 0)) CharSet.Ansi []
         |> CliType.ValueType
 
     let private fieldBackedValueType (value : int32) : CliValueType =
         let field =
             cliField "Value" (CliType.Numeric (CliNumericType.Int32 value)) None int32Handle
 
-        CliValueType.OfFields bct allCt declaredHandle Layout.Default [ field ]
+        CliValueType.OfFields bct allCt declaredHandle Layout.Default CharSet.Ansi [ field ]
 
     let private explicitUnionValueType (asInt : int32) : CliValueType =
         let asIntField =
@@ -158,6 +159,7 @@ module TestCliTypeBytes =
             allCt
             declaredHandle
             (Layout.Custom (size = 4, packingSize = 0))
+            CharSet.Ansi
             [ asIntField ; byte0 ; byte1 ; byte2 ; byte3 ]
 
     let private paddedValueType () : CliValueType =
@@ -167,7 +169,7 @@ module TestCliTypeBytes =
         let intField =
             cliField "Int" (CliType.Numeric (CliNumericType.Int32 0)) None int32Handle
 
-        CliValueType.OfFields bct allCt declaredHandle Layout.Default [ byteField ; intField ]
+        CliValueType.OfFields bct allCt declaredHandle Layout.Default CharSet.Ansi [ byteField ; intField ]
 
     let private nestedUnionValueType () : CliValueType =
         let inner =
@@ -184,6 +186,7 @@ module TestCliTypeBytes =
             allCt
             declaredHandle
             (Layout.Custom (size = 8, packingSize = 0))
+            CharSet.Ansi
             [ inner ; asLong ; upper ]
 
     let private outerOverInnerPaddingValueType () : CliValueType =
@@ -193,13 +196,25 @@ module TestCliTypeBytes =
         let other =
             cliField "Other" (CliType.Numeric (CliNumericType.UInt8 0uy)) (Some 1) byteHandle
 
-        CliValueType.OfFields bct allCt declaredHandle (Layout.Custom (size = 8, packingSize = 0)) [ inner ; other ]
+        CliValueType.OfFields
+            bct
+            allCt
+            declaredHandle
+            (Layout.Custom (size = 8, packingSize = 0))
+            CharSet.Ansi
+            [ inner ; other ]
 
     let private trailingStorageValueType () : CliValueType =
         let prefix =
             cliField "Prefix" (CliType.Numeric (CliNumericType.Int32 0)) (Some 0) int32Handle
 
-        CliValueType.OfFields bct allCt declaredHandle (Layout.Custom (size = 8, packingSize = 0)) [ prefix ]
+        CliValueType.OfFields
+            bct
+            allCt
+            declaredHandle
+            (Layout.Custom (size = 8, packingSize = 0))
+            CharSet.Ansi
+            [ prefix ]
 
     let private explicitOverlapWithTailValueType () : CliValueType =
         let whole =
@@ -208,12 +223,18 @@ module TestCliTypeBytes =
         let low =
             cliField "Low" (CliType.Numeric (CliNumericType.Int32 0)) (Some 0) int32Handle
 
-        CliValueType.OfFields bct allCt declaredHandle (Layout.Custom (size = 8, packingSize = 0)) [ whole ; low ]
+        CliValueType.OfFields
+            bct
+            allCt
+            declaredHandle
+            (Layout.Custom (size = 8, packingSize = 0))
+            CharSet.Ansi
+            [ whole ; low ]
 
     let private fieldBackedBoolValueType () : CliType =
         let field = cliField "Flag" (CliType.Bool 0uy) None boolHandle
 
-        CliValueType.OfFields bct allCt declaredHandle Layout.Default [ field ]
+        CliValueType.OfFields bct allCt declaredHandle Layout.Default CharSet.Ansi [ field ]
         |> CliType.ValueType
 
     let private objectReferenceValueType () : CliValueType =
@@ -222,6 +243,7 @@ module TestCliTypeBytes =
             allCt
             declaredHandle
             (Layout.Custom (size = 8, packingSize = 0))
+            CharSet.Ansi
             [ cliField "Obj" (CliType.ObjectRef None) (Some 0) objectHandle ]
 
     let private runtimePointerValueType () : CliValueType =
@@ -230,6 +252,7 @@ module TestCliTypeBytes =
             allCt
             declaredHandle
             (Layout.Custom (size = 8, packingSize = 0))
+            CharSet.Ansi
             [
                 cliField
                     "Ptr"
@@ -244,6 +267,7 @@ module TestCliTypeBytes =
             allCt
             declaredHandle
             (Layout.Custom (size = 8, packingSize = 0))
+            CharSet.Ansi
             [
                 cliField
                     "Handle"
@@ -258,14 +282,20 @@ module TestCliTypeBytes =
         let innerField =
             cliField "Inner" (inner |> CliType.ValueType) (Some 0) inner.Declared
 
-        CliValueType.OfFields bct allCt declaredHandle (Layout.Custom (size = 8, packingSize = 0)) [ innerField ]
+        CliValueType.OfFields
+            bct
+            allCt
+            declaredHandle
+            (Layout.Custom (size = 8, packingSize = 0))
+            CharSet.Ansi
+            [ innerField ]
 
     let private nestedObjectReferenceValueType () : CliValueType =
         let inner =
             let innerValueType = objectReferenceValueType ()
             cliField "Inner" (innerValueType |> CliType.ValueType) (Some 0) innerValueType.Declared
 
-        CliValueType.OfFields bct allCt int64Handle (Layout.Custom (size = 8, packingSize = 0)) [ inner ]
+        CliValueType.OfFields bct allCt int64Handle (Layout.Custom (size = 8, packingSize = 0)) CharSet.Ansi [ inner ]
 
     let private objectAndRuntimePointerValueType () : CliValueType =
         CliValueType.OfFields
@@ -273,6 +303,7 @@ module TestCliTypeBytes =
             allCt
             declaredHandle
             (Layout.Custom (size = 16, packingSize = 0))
+            CharSet.Ansi
             [
                 cliField "Obj" (CliType.ObjectRef None) (Some 0) objectHandle
                 cliField

--- a/WoofWare.PawPrint.Test/TestCliValueTypeCoerceFrom.fs
+++ b/WoofWare.PawPrint.Test/TestCliValueTypeCoerceFrom.fs
@@ -4,6 +4,7 @@ open System.Collections.Generic
 open System.Collections.Immutable
 open System.IO
 open System.Reflection.Metadata.Ecma335
+open System.Runtime.InteropServices
 open FsUnitTyped
 open NUnit.Framework
 open WoofWare.PawPrint
@@ -65,7 +66,7 @@ module TestCliValueTypeCoerceFrom =
                     MarshallingDescriptor = None
                 }
             ]
-            |> CliValueType.OfFields bct allCt declaredHandle Layout.Default
+            |> CliValueType.OfFields bct allCt declaredHandle Layout.Default CharSet.Ansi
 
         let ex =
             Assert.Throws<System.Exception> (fun () ->
@@ -101,7 +102,7 @@ module TestCliValueTypeCoerceFrom =
 
         let layout : Layout = Layout.Custom (size = 8, packingSize = 0)
 
-        CliValueType.OfFields bct allCt declaredHandle layout [ a ; b ]
+        CliValueType.OfFields bct allCt declaredHandle layout CharSet.Ansi [ a ; b ]
 
     [<Test>]
     let ``CoerceFrom preserves overlap write order for explicit-layout unions`` () : unit =

--- a/WoofWare.PawPrint.Test/TestEvalStackPrimitiveLikeBoundary.fs
+++ b/WoofWare.PawPrint.Test/TestEvalStackPrimitiveLikeBoundary.fs
@@ -3,6 +3,7 @@ namespace WoofWare.PawPrint.Test
 open System.Collections.Generic
 open System.Collections.Immutable
 open System.IO
+open System.Runtime.InteropServices
 open FsUnitTyped
 open NUnit.Framework
 open WoofWare.PawPrint
@@ -55,7 +56,7 @@ module TestEvalStackPrimitiveLikeBoundary =
             MarshallingDescriptor = None
         }
         |> List.singleton
-        |> CliValueType.OfFields bct allCt declared Layout.Default
+        |> CliValueType.OfFields bct allCt declared Layout.Default CharSet.Ansi
 
     let private wrapSingleField
         (ti : TypeInfo<GenericParamFromMetadata, TypeDefn>)

--- a/WoofWare.PawPrint.Test/TestFieldHandleRegistry.fs
+++ b/WoofWare.PawPrint.Test/TestFieldHandleRegistry.fs
@@ -2,6 +2,7 @@ namespace WoofWare.PawPrint.Test
 
 open System.Collections.Immutable
 open System.IO
+open System.Runtime.InteropServices
 open FsUnitTyped
 open Microsoft.Extensions.Logging
 open NUnit.Framework
@@ -172,7 +173,7 @@ public class DerivedWithField : BaseWithField
 
         let contents =
             ([] : CliField list)
-            |> CliValueType.OfFields fixture.BaseClassTypes state.ConcreteTypes objectType Layout.Default
+            |> CliValueType.OfFields fixture.BaseClassTypes state.ConcreteTypes objectType Layout.Default CharSet.Ansi
 
         IlMachineState.allocateManagedObject objectType contents state
 
@@ -448,6 +449,7 @@ public class DerivedWithField : BaseWithField
             state.ConcreteTypes
             runtimeFieldHandleInternalType
             Layout.Default
+            CharSet.Ansi
         |> CliType.ValueType
 
     let private readNativeIntValueAtPointer

--- a/WoofWare.PawPrint.Test/TestManifestResources.fs
+++ b/WoofWare.PawPrint.Test/TestManifestResources.fs
@@ -7,6 +7,7 @@ open System.Reflection
 open System.Reflection.Metadata
 open System.Reflection.Metadata.Ecma335
 open System.Reflection.PortableExecutable
+open System.Runtime.InteropServices
 open FsUnitTyped
 open Microsoft.CodeAnalysis
 open NUnit.Framework
@@ -261,6 +262,7 @@ public static class Entry
                 state.ConcreteTypes
                 zeroSizeDeclaredType
                 (Layout.Custom (size = 0, packingSize = 0))
+                CharSet.Ansi
                 []
             |> CliType.ValueType
 

--- a/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
+++ b/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
@@ -4,6 +4,7 @@ open System.Collections.Generic
 open System.Collections.Immutable
 open System.IO
 open System.Reflection.Metadata
+open System.Runtime.InteropServices
 open FsCheck
 open FsCheck.FSharp
 open FsUnitTyped
@@ -187,7 +188,7 @@ public interface IOpenInterface<T>
                     MarshallingDescriptor = None
                 }
             ]
-            |> CliValueType.OfFields bct state.ConcreteTypes intPtrHandle Layout.Default
+            |> CliValueType.OfFields bct state.ConcreteTypes intPtrHandle Layout.Default CharSet.Ansi
 
         IlMachineState.allocateManagedObject intPtrHandle valueType state
 
@@ -195,7 +196,7 @@ public interface IOpenInterface<T>
         let objectHandle = handleFor bct.Object
 
         let objectValue =
-            CliValueType.OfFields bct state.ConcreteTypes objectHandle Layout.Default []
+            CliValueType.OfFields bct state.ConcreteTypes objectHandle Layout.Default CharSet.Ansi []
 
         IlMachineState.allocateManagedObject objectHandle objectValue state
 
@@ -217,7 +218,12 @@ public interface IOpenInterface<T>
                     MarshallingDescriptor = None
                 }
             ]
-            |> CliValueType.OfFields bct state.ConcreteTypes declared (Layout.Custom (size = 8, packingSize = 0))
+            |> CliValueType.OfFields
+                bct
+                state.ConcreteTypes
+                declared
+                (Layout.Custom (size = 8, packingSize = 0))
+                CharSet.Ansi
 
         valueType, state
 
@@ -236,7 +242,12 @@ public interface IOpenInterface<T>
                 MarshallingDescriptor = None
             }
         ]
-        |> CliValueType.OfFields bct state.ConcreteTypes declared (Layout.Custom (size = 8, packingSize = 0))
+        |> CliValueType.OfFields
+            bct
+            state.ConcreteTypes
+            declared
+            (Layout.Custom (size = 8, packingSize = 0))
+            CharSet.Ansi
 
     let private allocateObjectReferenceValue (state : IlMachineState) : ManagedHeapAddress * IlMachineState =
         let valueType, state = objectReferenceValueType state
@@ -271,7 +282,12 @@ public interface IOpenInterface<T>
                     MarshallingDescriptor = None
                 }
             ]
-            |> CliValueType.OfFields bct state.ConcreteTypes objectHandle (Layout.Custom (size = 8, packingSize = 0))
+            |> CliValueType.OfFields
+                bct
+                state.ConcreteTypes
+                objectHandle
+                (Layout.Custom (size = 8, packingSize = 0))
+                CharSet.Ansi
 
         let containerAddr, state =
             IlMachineState.allocateManagedObject objectHandle fields state
@@ -3039,7 +3055,12 @@ public unsafe struct PointerWrapper
                     MarshallingDescriptor = None
                 }
             ]
-            |> CliValueType.OfFields bct state.ConcreteTypes objectHandle (Layout.Custom (size = 4, packingSize = 0))
+            |> CliValueType.OfFields
+                bct
+                state.ConcreteTypes
+                objectHandle
+                (Layout.Custom (size = 4, packingSize = 0))
+                CharSet.Ansi
 
         let containerAddr, state =
             IlMachineState.allocateManagedObject objectHandle containerFields state

--- a/WoofWare.PawPrint.Test/TestNativeSignature.fs
+++ b/WoofWare.PawPrint.Test/TestNativeSignature.fs
@@ -263,7 +263,12 @@ public sealed class GenericFieldHost<T>
         let contents =
             fields
             |> List.rev
-            |> CliValueType.OfFields fixture.BaseClassTypes state.ConcreteTypes typeHandle typeInfo.Layout
+            |> CliValueType.OfFields
+                fixture.BaseClassTypes
+                state.ConcreteTypes
+                typeHandle
+                typeInfo.Layout
+                (CharSetMetadata.ofTypeAttributes typeInfo.TypeAttributes)
 
         IlMachineState.allocateManagedObject typeHandle contents state
 

--- a/WoofWare.PawPrint/CliType.fs
+++ b/WoofWare.PawPrint/CliType.fs
@@ -3,6 +3,7 @@ namespace WoofWare.PawPrint
 open System
 open System.Collections.Immutable
 open System.Reflection
+open System.Runtime.InteropServices
 open Checked
 
 type SizeofResult =
@@ -417,6 +418,11 @@ and CliValueType =
             _PrimitiveLikeKind : PrimitiveLikeKind option
             _Storage : CliValueTypeStorage
             Layout : Layout
+            /// Marshalling string-encoding hint, derived from the declaring type's
+            /// `TypeAttributes.StringFormatMask` (Ansi/Unicode/Auto). Stage 3 of the field-marshal
+            /// work consumes this to size `[MarshalAs(ByValTStr)]` fields; today it's plumbing
+            /// only and has no effect on runtime behaviour.
+            CharSet : CharSet
             /// We track dependency orderings between updates to overlapping fields with a monotonically increasing
             /// timestamp.
             NextTimestamp : uint64
@@ -794,6 +800,7 @@ and CliValueType =
         (allCt : AllConcreteTypes)
         (declared : ConcreteTypeHandle)
         (layout : Layout)
+        (charSet : CharSet)
         (f : CliField list)
         : CliValueType
         =
@@ -804,6 +811,7 @@ and CliValueType =
             _PrimitiveLikeKind = CliValueType.ClassifyPrimitiveLike bct allCt declared fields
             _Storage = CliValueType.StorageFromFields layout fields
             Layout = layout
+            CharSet = charSet
             NextTimestamp = 1UL
         }
 
@@ -824,6 +832,7 @@ and CliValueType =
             _PrimitiveLikeKind = source._PrimitiveLikeKind
             _Storage = CliValueType.StorageFromFields layout fields
             Layout = layout
+            CharSet = source.CharSet
             NextTimestamp = 1UL
         }
 
@@ -1016,6 +1025,7 @@ and CliValueType =
             _Declared = cvt._Declared
             _PrimitiveLikeKind = cvt._PrimitiveLikeKind
             Layout = cvt.Layout
+            CharSet = cvt.CharSet
             _Storage =
                 let updatedFields =
                     storage.Fields
@@ -1096,6 +1106,7 @@ and CliValueType =
                 _PrimitiveLikeKind = target._PrimitiveLikeKind
                 _Storage = CliValueTypeStorage.RawBytes (Array.copy sourceBytes)
                 Layout = target.Layout
+                CharSet = target.CharSet
                 NextTimestamp = source.NextTimestamp
             }
         | CliValueTypeStorage.Fields targetStorage, CliValueTypeStorage.Fields sourceStorage ->
@@ -1139,6 +1150,7 @@ and CliValueType =
                             PreservedBytes = Array.copy sourceStorage.PreservedBytes
                         }
                 Layout = target.Layout
+                CharSet = target.CharSet
                 NextTimestamp = source.NextTimestamp
             }
         | CliValueTypeStorage.RawBytes targetBytes, CliValueTypeStorage.Fields sourceStorage ->
@@ -1169,6 +1181,7 @@ and CliValueType =
                     _PrimitiveLikeKind = template._PrimitiveLikeKind
                     _Storage = CliValueTypeStorage.RawBytes (Array.copy bytes)
                     Layout = template.Layout
+                    CharSet = template.CharSet
                     NextTimestamp = template.NextTimestamp
                 }
             | CliValueTypeStorage.Fields storage ->
@@ -1217,6 +1230,7 @@ and CliValueType =
                                     PreservedBytes = Array.copy bytes
                                 }
                         Layout = template.Layout
+                        CharSet = template.CharSet
                         NextTimestamp = max 1UL (uint64 fields.Length)
                     }
 
@@ -1309,7 +1323,12 @@ module CliType =
                 MarshallingDescriptor = valueField.MarshallingDescriptor
             }
             |> List.singleton
-            |> CliValueType.OfFields corelib concreteTypes intPtrHandle Layout.Default
+            |> CliValueType.OfFields
+                corelib
+                concreteTypes
+                intPtrHandle
+                Layout.Default
+                (CharSetMetadata.ofTypeAttributes corelib.IntPtr.TypeAttributes)
             |> CliType.ValueType
         | PrimitiveType.UIntPtr ->
             let uintPtrHandle =
@@ -1333,7 +1352,12 @@ module CliType =
                 MarshallingDescriptor = valueField.MarshallingDescriptor
             }
             |> List.singleton
-            |> CliValueType.OfFields corelib concreteTypes uintPtrHandle Layout.Default
+            |> CliValueType.OfFields
+                corelib
+                concreteTypes
+                uintPtrHandle
+                Layout.Default
+                (CharSetMetadata.ofTypeAttributes corelib.UIntPtr.TypeAttributes)
             |> CliType.ValueType
         | PrimitiveType.Object -> CliType.ObjectRef None
 
@@ -1509,7 +1533,12 @@ module CliType =
                         MarshallingDescriptor = field.MarshallingDescriptor
                     }
                 )
-                |> CliValueType.OfFields corelib currentConcreteTypes handle typeDef.Layout
+                |> CliValueType.OfFields
+                    corelib
+                    currentConcreteTypes
+                    handle
+                    typeDef.Layout
+                    (CharSetMetadata.ofTypeAttributes typeDef.TypeAttributes)
 
             CliType.ValueType vt, currentConcreteTypes
         else

--- a/WoofWare.PawPrint/ExceptionDispatching.fs
+++ b/WoofWare.PawPrint/ExceptionDispatching.fs
@@ -838,7 +838,13 @@ module ExceptionDispatching =
             IlMachineState.collectAllInstanceFields loggerFactory baseClassTypes state exnHandle
 
         let fields =
-            CliValueType.OfFields baseClassTypes state.ConcreteTypes exnHandle exceptionTypeInfo.Layout allFields
+            CliValueType.OfFields
+                baseClassTypes
+                state.ConcreteTypes
+                exnHandle
+                exceptionTypeInfo.Layout
+                (CharSetMetadata.ofTypeAttributes exceptionTypeInfo.TypeAttributes)
+                allFields
 
         let addr, state = IlMachineState.allocateManagedObject exnHandle fields state
 

--- a/WoofWare.PawPrint/FieldHandleRegistry.fs
+++ b/WoofWare.PawPrint/FieldHandleRegistry.fs
@@ -95,6 +95,7 @@ module FieldHandleRegistry =
                 allConcreteTypes
                 (AllConcreteTypes.getRequiredNonGenericHandle allConcreteTypes baseClassTypes.RuntimeFieldHandle)
                 Layout.Default
+                (CharSetMetadata.ofTypeAttributes baseClassTypes.RuntimeFieldHandle.TypeAttributes)
             |> CliType.ValueType
 
         let handle =
@@ -132,6 +133,7 @@ module FieldHandleRegistry =
                 allConcreteTypes
                 (AllConcreteTypes.getRequiredNonGenericHandle allConcreteTypes baseClassTypes.RuntimeFieldHandleInternal)
                 Layout.Default
+                (CharSetMetadata.ofTypeAttributes baseClassTypes.RuntimeFieldHandleInternal.TypeAttributes)
             |> CliType.ValueType
 
         // https://github.com/dotnet/runtime/blob/1d1bf92fcf43aa6981804dc53c5174445069c9e4/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs#L1074
@@ -175,7 +177,12 @@ module FieldHandleRegistry =
                         failwith
                             $"RuntimeFieldInfoStub field %s{field.Name} was expected to be reference-shaped or int32, got %O{signature}"
             )
-            |> CliValueType.OfFields baseClassTypes allConcreteTypes runtimeFieldInfoStubHandle Layout.Default // explicitly sequential but no custom packing size
+            |> CliValueType.OfFields
+                baseClassTypes
+                allConcreteTypes
+                runtimeFieldInfoStubHandle
+                Layout.Default
+                (CharSetMetadata.ofTypeAttributes baseClassTypes.RuntimeFieldInfoStub.TypeAttributes) // explicitly sequential but no custom packing size
 
         let alloc, state = allocate runtimeFieldInfoStub allocState
 

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -504,7 +504,12 @@ module IlMachineRuntimeMetadata =
                     (CliType.Numeric (CliNumericType.Int32 contents.Length))
                     (AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes baseClassTypes.Int32)
             ]
-            |> CliValueType.OfFields baseClassTypes state.ConcreteTypes stringType Layout.Default
+            |> CliValueType.OfFields
+                baseClassTypes
+                state.ConcreteTypes
+                stringType
+                Layout.Default
+                (CharSetMetadata.ofTypeAttributes baseClassTypes.String.TypeAttributes)
 
         let addr, state = IlMachineThreadState.allocateManagedObject stringType fields state
 
@@ -625,7 +630,13 @@ module IlMachineRuntimeMetadata =
             collectAllInstanceFields loggerFactory baseClassTypes state threadTypeHandle
 
         let fields =
-            CliValueType.OfFields baseClassTypes state.ConcreteTypes threadTypeHandle threadTypeInfo.Layout allFields
+            CliValueType.OfFields
+                baseClassTypes
+                state.ConcreteTypes
+                threadTypeHandle
+                threadTypeInfo.Layout
+                (CharSetMetadata.ofTypeAttributes threadTypeInfo.TypeAttributes)
+                allFields
 
         let addr, state =
             IlMachineThreadState.allocateManagedObject threadTypeHandle fields state
@@ -749,7 +760,13 @@ module IlMachineRuntimeMetadata =
             collectAllInstanceFields loggerFactory baseClassTypes state tieHandle
 
         let fields =
-            CliValueType.OfFields baseClassTypes state.ConcreteTypes tieHandle tieTypeInfo.Layout allFields
+            CliValueType.OfFields
+                baseClassTypes
+                state.ConcreteTypes
+                tieHandle
+                tieTypeInfo.Layout
+                (CharSetMetadata.ofTypeAttributes tieTypeInfo.TypeAttributes)
+                allFields
 
         let addr, state = IlMachineThreadState.allocateManagedObject tieHandle fields state
 

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -213,7 +213,12 @@ module Intrinsics =
                             baseClassTypes.RuntimeType.Identity
                          |> Option.get)
                     |> List.singleton
-                    |> CliValueType.OfFields baseClassTypes state.ConcreteTypes runtimeTypeHandleHandle Layout.Default
+                    |> CliValueType.OfFields
+                        baseClassTypes
+                        state.ConcreteTypes
+                        runtimeTypeHandleHandle
+                        Layout.Default
+                        (CharSetMetadata.ofTypeAttributes baseClassTypes.RuntimeTypeHandle.TypeAttributes)
 
                 IlMachineState.pushToEvalStack (CliType.ValueType vt) currentThread state
                 |> IlMachineState.advanceProgramCounter currentThread

--- a/WoofWare.PawPrint/MethodHandleRegistry.fs
+++ b/WoofWare.PawPrint/MethodHandleRegistry.fs
@@ -91,6 +91,7 @@ module MethodHandleRegistry =
             allConcreteTypes
             (AllConcreteTypes.getRequiredNonGenericHandle allConcreteTypes baseClassTypes.RuntimeMethodHandleInternal)
             Layout.Default
+            (CharSetMetadata.ofTypeAttributes baseClassTypes.RuntimeMethodHandleInternal.TypeAttributes)
 
     /// Construct the `MethodHandle` that identifies an open method declared on `declaringType`.
     /// Callers in the introduced-method iterator path use this rather than going through
@@ -227,6 +228,7 @@ module MethodHandleRegistry =
                 allConcreteTypes
                 (AllConcreteTypes.getRequiredNonGenericHandle allConcreteTypes baseClassTypes.RuntimeMethodHandle)
                 Layout.Default
+                (CharSetMetadata.ofTypeAttributes baseClassTypes.RuntimeMethodHandle.TypeAttributes)
             |> CliType.ValueType
 
         let handle = makeMethodHandle allConcreteTypes method
@@ -300,7 +302,12 @@ module MethodHandleRegistry =
                 failwith "RuntimeMethodInfoStub did not contain the expected m_value field"
 
             fields
-            |> CliValueType.OfFields baseClassTypes allConcreteTypes runtimeMethodInfoStubHandle Layout.Default
+            |> CliValueType.OfFields
+                baseClassTypes
+                allConcreteTypes
+                runtimeMethodInfoStubHandle
+                Layout.Default
+                (CharSetMetadata.ofTypeAttributes baseClassTypes.RuntimeMethodInfoStub.TypeAttributes)
 
         let alloc, state = allocate runtimeMethodInfoStub allocState
 

--- a/WoofWare.PawPrint/Native/NativeMetadataImport.fs
+++ b/WoofWare.PawPrint/Native/NativeMetadataImport.fs
@@ -362,7 +362,12 @@ module NativeMetadataImport =
 
         let valueType =
             [ lengthField ; pointerField ]
-            |> CliValueType.OfFields baseClassTypes state.ConcreteTypes constArrayHandle typeInfo.Layout
+            |> CliValueType.OfFields
+                baseClassTypes
+                state.ConcreteTypes
+                constArrayHandle
+                typeInfo.Layout
+                (CharSetMetadata.ofTypeAttributes typeInfo.TypeAttributes)
             |> CliType.ValueType
 
         valueType, state

--- a/WoofWare.PawPrint/Native/NativeRuntimeType.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeType.fs
@@ -1111,7 +1111,13 @@ module NativeRuntimeType =
             IlMachineState.collectAllInstanceFields loggerFactory baseClassTypes state typeHandle
 
         let fields =
-            CliValueType.OfFields baseClassTypes state.ConcreteTypes typeHandle typeInfo.Layout allFields
+            CliValueType.OfFields
+                baseClassTypes
+                state.ConcreteTypes
+                typeHandle
+                typeInfo.Layout
+                (CharSetMetadata.ofTypeAttributes typeInfo.TypeAttributes)
+                allFields
 
         IlMachineState.allocateManagedObject typeHandle fields state
 

--- a/WoofWare.PawPrint/TypeHandleRegistry.fs
+++ b/WoofWare.PawPrint/TypeHandleRegistry.fs
@@ -66,7 +66,12 @@ module TypeHandleRegistry =
                     (CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.TypeHandlePtr def)))
                     (AllConcreteTypes.getRequiredNonGenericHandle allConcreteTypes corelib.IntPtr)
             ]
-            |> CliValueType.OfFields corelib allConcreteTypes runtimeTypeHandle Layout.Default
+            |> CliValueType.OfFields
+                corelib
+                allConcreteTypes
+                runtimeTypeHandle
+                Layout.Default
+                (CharSetMetadata.ofTypeAttributes corelib.RuntimeType.TypeAttributes)
 
         let alloc, state = allocate fields allocState
 

--- a/WoofWare.PawPrint/UnaryMetadataCallOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataCallOps.fs
@@ -519,7 +519,12 @@ module internal UnaryMetadataCallOps =
                                     )
 
                                 List.rev fieldValues
-                                |> CliValueType.OfFields baseClassTypes state.ConcreteTypes tHandle tDefn.Layout,
+                                |> CliValueType.OfFields
+                                    baseClassTypes
+                                    state.ConcreteTypes
+                                    tHandle
+                                    tDefn.Layout
+                                    (CharSetMetadata.ofTypeAttributes tDefn.TypeAttributes),
                                 state
 
                         let addr, state = IlMachineState.allocateManagedObject tHandle cvt state

--- a/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
@@ -261,7 +261,13 @@ module internal UnaryMetadataObjectOps =
             IlMachineState.collectAllInstanceFields loggerFactory baseClassTypes state declaringTypeHandle
 
         let fields =
-            CliValueType.OfFields baseClassTypes state.ConcreteTypes declaringTypeHandle ctorType.Layout allFields
+            CliValueType.OfFields
+                baseClassTypes
+                state.ConcreteTypes
+                declaringTypeHandle
+                ctorType.Layout
+                (CharSetMetadata.ofTypeAttributes ctorType.TypeAttributes)
+                allFields
 
         // Note: this is a bit unorthodox for value types, which *aren't* heap-allocated.
         // We'll perform their construction on the heap, though, to keep the interface
@@ -449,7 +455,8 @@ module internal UnaryMetadataObjectOps =
                                     baseClassTypes
                                     state.ConcreteTypes
                                     underlyingTypeHandle
-                                    underlyingDefn.Layout,
+                                    underlyingDefn.Layout
+                                    (CharSetMetadata.ofTypeAttributes underlyingDefn.TypeAttributes),
                                 state
 
                         let addr, state =
@@ -504,7 +511,12 @@ module internal UnaryMetadataObjectOps =
 
                         let cvt =
                             List.rev fieldValues
-                            |> CliValueType.OfFields baseClassTypes state.ConcreteTypes typeHandle defn.Layout
+                            |> CliValueType.OfFields
+                                baseClassTypes
+                                state.ConcreteTypes
+                                typeHandle
+                                defn.Layout
+                                (CharSetMetadata.ofTypeAttributes defn.TypeAttributes)
 
                         cvt, state
 

--- a/WoofWare.PawPrint/UnaryMetadataTokenOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataTokenOps.fs
@@ -123,7 +123,12 @@ module internal UnaryMetadataTokenOps =
                     (CliType.ObjectRef (Some alloc))
                     (AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes baseClassTypes.RuntimeType)
                 |> List.singleton
-                |> CliValueType.OfFields baseClassTypes state.ConcreteTypes runtimeTypeHandleHandle Layout.Default
+                |> CliValueType.OfFields
+                    baseClassTypes
+                    state.ConcreteTypes
+                    runtimeTypeHandleHandle
+                    Layout.Default
+                    (CharSetMetadata.ofTypeAttributes baseClassTypes.RuntimeTypeHandle.TypeAttributes)
 
             IlMachineState.pushToEvalStack (CliType.ValueType vt) thread state
 


### PR DESCRIPTION
## Summary
Stage 2 of the field-marshal-aware `Marshal.SizeOf` work (Stage 1 landed in #478).

- Adds a `CharSet` field on `CliValueType`, sourced from the declaring type's `TypeAttributes.StringFormatMask` via the new `CharSetMetadata.ofTypeAttributes` helper in `WoofWare.PawPrint.Domain`.
- Threads the new argument through `CliValueType.OfFields` and preserves the value across the existing reshape paths (`OfFieldsLike`, `WithFieldSetById`, `CoerceFrom` branches, `OfBytesLike` branches).
- Updates every production caller and every test caller; production sites pull the `CharSet` from the relevant `TypeInfo.TypeAttributes` (or, in `IntPtr`/`UIntPtr` zeroing in `CliType.zeroOfPrimitive`, from the corelib base classes); test fixtures pass `CharSet.Ansi` since they synthesise non-real types.
- Today the field is plumbing only; Stage 3 will consume it (alongside the existing `FieldMarshalDescriptor`) when sizing `[MarshalAs(ByValTStr)]` / `[MarshalAs(ByValArray)]` fields in `MarshalNative_SizeOfHelper`.

## Test plan
- [x] `nix develop -c dotnet build` — clean (0 warnings, 0 errors)
- [x] `nix develop -c dotnet test --no-build` — 672/672 passing
- [x] `nix develop -c dotnet fantomas .`
- [x] `codex review` — no findings