### PR TITLE
Implement Marshal.SizeOf for [MarshalAs(...)] field descriptors

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/MarshalSizeOfByValTStr.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/MarshalSizeOfByValTStr.cs
@@ -1,0 +1,40 @@
+using System.Runtime.InteropServices;
+
+public class MarshalSizeOfByValTStrTest
+{
+    // Two structs that differ only in CharSet. Under correct ByValTStr sizing the Ansi
+    // variant uses 1 byte per char and the Unicode variant uses 2, so the *byte* size
+    // of the Name field differs. The fixed Id (4) and Value (8) fields surround it,
+    // and SizeConst=16 is chosen so neither size hits a packing boundary that would
+    // mask a per-char miscount.
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+    struct AnsiStruct
+    {
+        public int Id;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 16)]
+        public string Name;
+        public double Value;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    struct UnicodeStruct
+    {
+        public int Id;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 16)]
+        public string Name;
+        public double Value;
+    }
+
+    public static int Main(string[] argv)
+    {
+        int ansiSize = Marshal.SizeOf(typeof(AnsiStruct));
+        int unicodeSize = Marshal.SizeOf(typeof(UnicodeStruct));
+
+        // 4 (Id) + 16 * 1 (Name) padded to 8 + 8 (Value) = 32
+        if (ansiSize != 32) return 1;
+        // 4 (Id) + 16 * 2 (Name) padded to 8 + 8 (Value) = 48
+        if (unicodeSize != 48) return 2;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/MarshalSizeOfScalarMarshalAs.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/MarshalSizeOfScalarMarshalAs.cs
@@ -27,12 +27,24 @@ public class MarshalSizeOfScalarMarshalAsTest
         public int Other;
     }
 
+    // SysInt / SysUInt are pointer-sized scalar descriptors typically applied to IntPtr/UIntPtr
+    // fields. They should size as NATIVE_INT_SIZE.
+    [StructLayout(LayoutKind.Sequential)]
+    struct WithSysInt
+    {
+        [MarshalAs(UnmanagedType.SysInt)]
+        public System.IntPtr Handle;
+        public int Other;
+    }
+
     public static int Main(string[] argv)
     {
         // A: 4, B: 2 (offset 4), C: 1 (offset 6), tail-pad to alignment 4 -> 8.
         if (Marshal.SizeOf(typeof(ScalarMatching)) != 8) return 1;
         // Hr: 4, Other: 4 -> 8.
         if (Marshal.SizeOf(typeof(WithHresult)) != 8) return 2;
+        // Handle: 8, Other: 4 (offset 8), tail-pad to alignment 8 -> 16.
+        if (Marshal.SizeOf(typeof(WithSysInt)) != 16) return 3;
         return 0;
     }
 }

--- a/WoofWare.PawPrint.Test/sourcesPure/MarshalSizeOfScalarMarshalAs.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/MarshalSizeOfScalarMarshalAs.cs
@@ -1,0 +1,26 @@
+using System.Runtime.InteropServices;
+
+public class MarshalSizeOfScalarMarshalAsTest
+{
+    // [MarshalAs] with a scalar UnmanagedType is a perfectly normal annotation on a
+    // matching-width primitive field. The previous Marshal.SizeOf path silently ignored these
+    // descriptors and relied on the managed CLI size; the descriptor-aware path must continue
+    // to admit them rather than rejecting every non-ByVal descriptor.
+    [StructLayout(LayoutKind.Sequential)]
+    struct ScalarMatching
+    {
+        [MarshalAs(UnmanagedType.I4)]
+        public int A;
+        [MarshalAs(UnmanagedType.U2)]
+        public ushort B;
+        [MarshalAs(UnmanagedType.I1)]
+        public sbyte C;
+    }
+
+    public static int Main(string[] argv)
+    {
+        // A: 4, B: 2 (offset 4), C: 1 (offset 6), tail-pad to alignment 4 -> 8.
+        if (Marshal.SizeOf(typeof(ScalarMatching)) != 8) return 1;
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/MarshalSizeOfScalarMarshalAs.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/MarshalSizeOfScalarMarshalAs.cs
@@ -37,6 +37,24 @@ public class MarshalSizeOfScalarMarshalAsTest
         public int Other;
     }
 
+    [StructLayout(LayoutKind.Sequential)]
+    struct InnerStruct
+    {
+        public int A;
+        public int B;
+    }
+
+    // [MarshalAs(UnmanagedType.Struct)] on a value-type field marshals it inline using its
+    // own native layout. This is the default for value-type fields, so the descriptor is
+    // redundant but legal — and is common in BCL code.
+    [StructLayout(LayoutKind.Sequential)]
+    struct WithMarshaledStruct
+    {
+        public int Tag;
+        [MarshalAs(UnmanagedType.Struct)]
+        public InnerStruct Payload;
+    }
+
     public static int Main(string[] argv)
     {
         // A: 4, B: 2 (offset 4), C: 1 (offset 6), tail-pad to alignment 4 -> 8.
@@ -45,6 +63,8 @@ public class MarshalSizeOfScalarMarshalAsTest
         if (Marshal.SizeOf(typeof(WithHresult)) != 8) return 2;
         // Handle: 8, Other: 4 (offset 8), tail-pad to alignment 8 -> 16.
         if (Marshal.SizeOf(typeof(WithSysInt)) != 16) return 3;
+        // Tag: 4, Payload (8 bytes, alignment 4) -> 12.
+        if (Marshal.SizeOf(typeof(WithMarshaledStruct)) != 12) return 4;
         return 0;
     }
 }

--- a/WoofWare.PawPrint.Test/sourcesPure/MarshalSizeOfScalarMarshalAs.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/MarshalSizeOfScalarMarshalAs.cs
@@ -17,10 +17,22 @@ public class MarshalSizeOfScalarMarshalAsTest
         public sbyte C;
     }
 
+    // HRESULT is marshalled as a 4-byte integer just like UnmanagedType.I4. CoreCLR accepts
+    // it on `int`/`uint` fields, so we should too.
+    [StructLayout(LayoutKind.Sequential)]
+    struct WithHresult
+    {
+        [MarshalAs(UnmanagedType.Error)]
+        public int Hr;
+        public int Other;
+    }
+
     public static int Main(string[] argv)
     {
         // A: 4, B: 2 (offset 4), C: 1 (offset 6), tail-pad to alignment 4 -> 8.
         if (Marshal.SizeOf(typeof(ScalarMatching)) != 8) return 1;
+        // Hr: 4, Other: 4 -> 8.
+        if (Marshal.SizeOf(typeof(WithHresult)) != 8) return 2;
         return 0;
     }
 }

--- a/WoofWare.PawPrint/CliType.fs
+++ b/WoofWare.PawPrint/CliType.fs
@@ -178,6 +178,23 @@ type CliType =
         | CliType.Numeric _
         | CliType.RuntimePointer _ -> None
 
+    /// Compute the unmanaged size that `Marshal.SizeOf` would return for `t`. Returns `Error reason`
+    /// when the type contains a shape whose unmanaged layout we can't yet derive from the managed
+    /// representation alone (e.g. an object reference field with no `[MarshalAs]` descriptor, or a
+    /// `[MarshalAs]` variant we don't decode yet). Value types delegate to
+    /// `CliValueType.TryComputeMarshalSize`, which consumes per-field `FieldMarshalDescriptor` and
+    /// the declaring type's `CharSet` to size `[MarshalAs(ByValTStr)]` and `[MarshalAs(ByValArray)]`
+    /// fields correctly.
+    static member TryComputeMarshalSize (t : CliType) : Result<SizeofResult, string> =
+        match t with
+        | CliType.Numeric _
+        | CliType.RuntimePointer _ -> Result.Ok (CliType.SizeOf t)
+        | CliType.Bool _ -> Result.Error "System.Boolean marshals as a 4-byte BOOL by default, not a 1-byte CLI bool"
+        | CliType.Char _ ->
+            Result.Error "System.Char marshalling depends on CharSet and does not always match 2-byte CLI char"
+        | CliType.ObjectRef _ -> Result.Error "object references require managed-to-unmanaged marshalling"
+        | CliType.ValueType vt -> CliValueType.TryComputeMarshalSize vt
+
     static member ToBytes (t : CliType) : byte[] =
         match t with
         | CliType.Numeric n -> CliNumericType.ToBytes n
@@ -1013,6 +1030,194 @@ and CliValueType =
                 CliType.TryFindMarshalSizeDifference field.Contents
                 |> Option.map (fun reason -> $"field %s{field.Name}: %s{reason}")
             )
+
+    /// Bytes per character for the declaring type's `CharSet`, used to size
+    /// `[MarshalAs(ByValTStr)]` fields. `None` is treated as the runtime default (Ansi). `Auto`
+    /// is platform-dependent (Unicode on Windows, Ansi on Unix), so we reject it explicitly
+    /// rather than picking a host-dependent answer in a deterministic interpreter.
+    static member private CharSetByteSize (charSet : CharSet) : Result<int, string> =
+        match charSet with
+        | CharSet.None
+        | CharSet.Ansi -> Result.Ok 1
+        | CharSet.Unicode -> Result.Ok 2
+        | CharSet.Auto ->
+            Result.Error "CharSet.Auto is platform-dependent and not yet supported by marshalled-size computation"
+        | other -> Result.Error $"unrecognised CharSet %O{other}"
+
+    /// Unmanaged element size for an `UnmanagedType` used as a `[MarshalAs(ByValArray)]`
+    /// element type. Only the unambiguous fixed-width primitive cases are decoded; everything
+    /// else is rejected so the caller can decide whether a richer mapping is needed.
+    static member private MarshalSizeOfElement (elementType : UnmanagedType) : Result<SizeofResult, string> =
+        match elementType with
+        | UnmanagedType.I1
+        | UnmanagedType.U1 ->
+            Result.Ok
+                {
+                    Size = 1
+                    Alignment = 1
+                }
+        | UnmanagedType.I2
+        | UnmanagedType.U2 ->
+            Result.Ok
+                {
+                    Size = 2
+                    Alignment = 2
+                }
+        | UnmanagedType.I4
+        | UnmanagedType.U4
+        | UnmanagedType.R4 ->
+            Result.Ok
+                {
+                    Size = 4
+                    Alignment = 4
+                }
+        | UnmanagedType.I8
+        | UnmanagedType.U8
+        | UnmanagedType.R8 ->
+            Result.Ok
+                {
+                    Size = 8
+                    Alignment = 8
+                }
+        | other -> Result.Error $"ByValArray element type %O{other} is not yet supported"
+
+    /// Compute the unmanaged size of a single field, consulting `[MarshalAs(...)]` descriptors
+    /// and the declaring type's `CharSet`. Without a descriptor, falls back to the managed
+    /// layout size for byte-stable primitives, recurses into nested value types, and rejects
+    /// shapes (Bool/Char/ObjectRef) whose unmanaged size deviates from the managed one.
+    static member TryFieldMarshalSize
+        (charSet : CharSet)
+        (descriptor : FieldMarshalDescriptor option)
+        (contents : CliType)
+        : Result<SizeofResult, string>
+        =
+        match descriptor with
+        | Some (FieldMarshalDescriptor.ByValTStr sizeConst) ->
+            if sizeConst <= 0 then
+                Result.Error $"ByValTStr SizeConst=%d{sizeConst} is not positive"
+            else
+                CliValueType.CharSetByteSize charSet
+                |> Result.map (fun bpc ->
+                    {
+                        Size = sizeConst * bpc
+                        Alignment = bpc
+                    }
+                )
+        | Some (FieldMarshalDescriptor.ByValArray (sizeConst, Some elementType)) ->
+            if sizeConst <= 0 then
+                Result.Error $"ByValArray SizeConst=%d{sizeConst} is not positive"
+            else
+                CliValueType.MarshalSizeOfElement elementType
+                |> Result.map (fun elementSize ->
+                    {
+                        Size = sizeConst * elementSize.Size
+                        Alignment = elementSize.Alignment
+                    }
+                )
+        | Some (FieldMarshalDescriptor.ByValArray (_, None)) ->
+            Result.Error "ByValArray descriptor without an explicit element type is not supported"
+        | Some (FieldMarshalDescriptor.Other unmanagedType) ->
+            Result.Error
+                $"FieldMarshal descriptor %O{unmanagedType} is not yet supported by marshalled-size computation"
+        | None ->
+            match contents with
+            | CliType.Numeric _
+            | CliType.RuntimePointer _ -> Result.Ok (CliType.SizeOf contents)
+            | CliType.Bool _ ->
+                Result.Error "System.Boolean marshals as a 4-byte BOOL by default, not a 1-byte CLI bool"
+            | CliType.Char _ ->
+                Result.Error "System.Char marshalling depends on CharSet and does not always match 2-byte CLI char"
+            | CliType.ObjectRef _ -> Result.Error "object references require managed-to-unmanaged marshalling"
+            | CliType.ValueType vt -> CliValueType.TryComputeMarshalSize vt
+
+    /// Compute the unmanaged size of a value type as `Marshal.SizeOf` would. Lays fields out
+    /// using the declaring type's `Layout` (sequential or explicit) and packing, but with each
+    /// field sized via `TryFieldMarshalSize` so `[MarshalAs(ByValTStr/ByValArray)]` fields
+    /// contribute their unmanaged byte cost rather than the managed CLI size.
+    static member TryComputeMarshalSize (vt : CliValueType) : Result<SizeofResult, string> =
+        match vt._Storage with
+        | CliValueTypeStorage.RawBytes bytes ->
+            Result.Ok
+                {
+                    Size = bytes.Length
+                    Alignment = 1
+                }
+        | CliValueTypeStorage.Fields storage ->
+            let minimumSize, packingSize =
+                match vt.Layout with
+                | Layout.Custom (size = size ; packingSize = packing) ->
+                    size, if packing = 0 then DEFAULT_STRUCT_ALIGNMENT else packing
+                | Layout.Default -> 0, DEFAULT_STRUCT_ALIGNMENT
+
+            let computeFinal (currentEnd : int) (maxAlign : int) : SizeofResult =
+                let alignment = max maxAlign 1
+                let error = currentEnd % alignment
+
+                let totalSize =
+                    if error = 0 then
+                        currentEnd
+                    else
+                        currentEnd + (alignment - error)
+
+                {
+                    Size = max totalSize minimumSize
+                    Alignment = alignment
+                }
+
+            let seqFields, nonSeqFields =
+                storage.Fields |> List.partition (fun field -> field.ConfiguredOffset.IsNone)
+
+            match seqFields, nonSeqFields with
+            | [], [] ->
+                Result.Ok
+                    {
+                        Size = minimumSize
+                        Alignment = 1
+                    }
+            | _ :: _, [] ->
+                (Result.Ok (0, 0), seqFields)
+                ||> List.fold (fun acc field ->
+                    match acc with
+                    | Result.Error _ -> acc
+                    | Result.Ok (currentOffset, maxAlign) ->
+                        match
+                            CliValueType.TryFieldMarshalSize vt.CharSet field.MarshallingDescriptor field.Contents
+                        with
+                        | Result.Error reason -> Result.Error $"field %s{field.Name}: %s{reason}"
+                        | Result.Ok size ->
+                            let alignmentCap = min size.Alignment packingSize
+
+                            let alignedOffset =
+                                if alignmentCap = 0 then
+                                    currentOffset
+                                else
+                                    let err = currentOffset % alignmentCap
+
+                                    if err = 0 then
+                                        currentOffset
+                                    else
+                                        currentOffset + (alignmentCap - err)
+
+                            Result.Ok (alignedOffset + size.Size, max maxAlign alignmentCap)
+                )
+                |> Result.map (fun (off, align) -> computeFinal off align)
+            | [], _ :: _ ->
+                (Result.Ok (0, 0), nonSeqFields)
+                ||> List.fold (fun acc field ->
+                    match acc with
+                    | Result.Error _ -> acc
+                    | Result.Ok (maxEnd, maxAlign) ->
+                        match
+                            CliValueType.TryFieldMarshalSize vt.CharSet field.MarshallingDescriptor field.Contents
+                        with
+                        | Result.Error reason -> Result.Error $"field %s{field.Name}: %s{reason}"
+                        | Result.Ok size ->
+                            let alignmentCap = min size.Alignment packingSize
+                            let fieldEnd = field.Offset + size.Size
+                            Result.Ok (max maxEnd fieldEnd, max maxAlign alignmentCap)
+                )
+                |> Result.map (fun (off, align) -> computeFinal off align)
+            | _ :: _, _ :: _ -> Result.Error "unexpectedly mixed explicit and automatic field offsets"
 
     /// Sets the value of the specified field, *without* touching any overlapping fields.
     /// `DereferenceField` handles resolving conflicts between overlapping fields.

--- a/WoofWare.PawPrint/CliType.fs
+++ b/WoofWare.PawPrint/CliType.fs
@@ -184,8 +184,15 @@ type CliType =
     /// `[MarshalAs]` variant we don't decode yet). Value types delegate to
     /// `CliValueType.TryComputeMarshalSize`, which consumes per-field `FieldMarshalDescriptor` and
     /// the declaring type's `CharSet` to size `[MarshalAs(ByValTStr)]` and `[MarshalAs(ByValArray)]`
-    /// fields correctly.
-    static member TryComputeMarshalSize (t : CliType) : Result<SizeofResult, string> =
+    /// fields correctly. Type-system context is required so descriptors that depend on the
+    /// field's nominal type can be validated.
+    static member TryComputeMarshalSize
+        (concreteTypes : AllConcreteTypes)
+        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (corelib : BaseClassTypes<DumpedAssembly>)
+        (t : CliType)
+        : Result<SizeofResult, string>
+        =
         match t with
         | CliType.Numeric _
         | CliType.RuntimePointer _ -> Result.Ok (CliType.SizeOf t)
@@ -193,7 +200,7 @@ type CliType =
         | CliType.Char _ ->
             Result.Error "System.Char marshalling depends on CharSet and does not always match 2-byte CLI char"
         | CliType.ObjectRef _ -> Result.Error "object references require managed-to-unmanaged marshalling"
-        | CliType.ValueType vt -> CliValueType.TryComputeMarshalSize vt
+        | CliType.ValueType vt -> CliValueType.TryComputeMarshalSize concreteTypes assemblies corelib vt
 
     static member ToBytes (t : CliType) : byte[] =
         match t with
@@ -1092,57 +1099,96 @@ and CliValueType =
                 }
         | other -> Result.Error $"UnmanagedType %O{other} is not yet supported by marshalled-size computation"
 
+    /// True iff the given handle refers to a CLI array type. CoreCLR only accepts
+    /// `[MarshalAs(ByValArray)]` on array-typed fields, so we use this as the shape guard.
+    static member private IsArrayFieldType (handle : ConcreteTypeHandle) : bool =
+        match handle with
+        | ConcreteTypeHandle.OneDimArrayZero _
+        | ConcreteTypeHandle.Array _ -> true
+        | ConcreteTypeHandle.Concrete _
+        | ConcreteTypeHandle.Byref _
+        | ConcreteTypeHandle.Pointer _
+        | ConcreteTypeHandle.FunctionPointer _ -> false
+
+    /// True iff the given handle refers to `System.String`. CoreCLR only accepts
+    /// `[MarshalAs(ByValTStr)]` on string-typed fields, so we use this as the shape guard.
+    static member private IsStringFieldType
+        (concreteTypes : AllConcreteTypes)
+        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (corelib : BaseClassTypes<DumpedAssembly>)
+        (handle : ConcreteTypeHandle)
+        : bool
+        =
+        match handle with
+        | ConcreteTypeHandle.Concrete _ ->
+            match AllConcreteTypes.lookup handle concreteTypes with
+            | None -> false
+            | Some concreteType ->
+                if
+                    concreteType.Assembly.FullName = corelib.Corelib.Name.FullName
+                    && concreteType.Generics.IsEmpty
+                then
+                    let typeDef =
+                        assemblies.[concreteType.Assembly.FullName].TypeDefs.[concreteType.Definition.Get]
+
+                    TypeInfo.NominallyEqual typeDef corelib.String
+                else
+                    false
+        | ConcreteTypeHandle.OneDimArrayZero _
+        | ConcreteTypeHandle.Array _
+        | ConcreteTypeHandle.Byref _
+        | ConcreteTypeHandle.Pointer _
+        | ConcreteTypeHandle.FunctionPointer _ -> false
+
     /// Compute the unmanaged size of a single field, consulting `[MarshalAs(...)]` descriptors
     /// and the declaring type's `CharSet`. Without a descriptor, falls back to the managed
     /// layout size for byte-stable primitives, recurses into nested value types, and rejects
     /// shapes (Bool/Char/ObjectRef) whose unmanaged size deviates from the managed one.
+    /// The field's nominal `ConcreteTypeHandle` is consulted to validate `ByValTStr`/`ByValArray`
+    /// descriptors against the declared field shape (CoreCLR rejects mismatches).
     static member TryFieldMarshalSize
+        (concreteTypes : AllConcreteTypes)
+        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (corelib : BaseClassTypes<DumpedAssembly>)
         (charSet : CharSet)
         (descriptor : FieldMarshalDescriptor option)
+        (fieldType : ConcreteTypeHandle)
         (contents : CliType)
         : Result<SizeofResult, string>
         =
         match descriptor with
         | Some (FieldMarshalDescriptor.ByValTStr sizeConst) ->
-            // CoreCLR's `MarshalInfo` rejects ByValTStr unless the managed field is a
-            // `string`. We don't carry the field's nominal type here, but reference-typed
-            // fields are the only ones that can possibly satisfy that requirement, so reject
-            // anything non-reference (this catches the codex-flagged `[MarshalAs(ByValTStr)]
-            // int` case).
-            match contents with
-            | CliType.ObjectRef _ ->
-                if sizeConst <= 0 then
-                    Result.Error $"ByValTStr SizeConst=%d{sizeConst} is not positive"
-                else
-                    CliValueType.CharSetByteSize charSet
-                    |> Result.map (fun bpc ->
-                        {
-                            Size = sizeConst * bpc
-                            Alignment = bpc
-                        }
-                    )
-            | _ ->
-                Result.Error
-                    "[MarshalAs(UnmanagedType.ByValTStr)] is only valid on string fields, not value-type or primitive contents"
+            // CoreCLR's `MarshalInfo` rejects ByValTStr unless the managed field is
+            // `System.String`. Validate against the declared field type so non-string
+            // references (e.g. arbitrary class fields) don't silently get a string-buffer
+            // size.
+            if not (CliValueType.IsStringFieldType concreteTypes assemblies corelib fieldType) then
+                Result.Error "[MarshalAs(UnmanagedType.ByValTStr)] is only valid on System.String fields"
+            elif sizeConst <= 0 then
+                Result.Error $"ByValTStr SizeConst=%d{sizeConst} is not positive"
+            else
+                CliValueType.CharSetByteSize charSet
+                |> Result.map (fun bpc ->
+                    {
+                        Size = sizeConst * bpc
+                        Alignment = bpc
+                    }
+                )
         | Some (FieldMarshalDescriptor.ByValArray (sizeConst, Some elementType)) ->
-            // Likewise, ByValArray requires an array field; reject anything that isn't a
-            // reference at the CLI level.
-            match contents with
-            | CliType.ObjectRef _ ->
-                if sizeConst <= 0 then
-                    Result.Error $"ByValArray SizeConst=%d{sizeConst} is not positive"
-                else
-                    CliValueType.MarshalSizeOfScalar elementType
-                    |> Result.mapError (fun reason -> $"ByValArray element type: %s{reason}")
-                    |> Result.map (fun elementSize ->
-                        {
-                            Size = sizeConst * elementSize.Size
-                            Alignment = elementSize.Alignment
-                        }
-                    )
-            | _ ->
-                Result.Error
-                    "[MarshalAs(UnmanagedType.ByValArray)] is only valid on array fields, not value-type or primitive contents"
+            // Likewise, ByValArray requires an array-typed field; reject anything else.
+            if not (CliValueType.IsArrayFieldType fieldType) then
+                Result.Error "[MarshalAs(UnmanagedType.ByValArray)] is only valid on array-typed fields"
+            elif sizeConst <= 0 then
+                Result.Error $"ByValArray SizeConst=%d{sizeConst} is not positive"
+            else
+                CliValueType.MarshalSizeOfScalar elementType
+                |> Result.mapError (fun reason -> $"ByValArray element type: %s{reason}")
+                |> Result.map (fun elementSize ->
+                    {
+                        Size = sizeConst * elementSize.Size
+                        Alignment = elementSize.Alignment
+                    }
+                )
         | Some (FieldMarshalDescriptor.ByValArray (_, None)) ->
             Result.Error "ByValArray descriptor without an explicit element type is not supported"
         | Some (FieldMarshalDescriptor.Other UnmanagedType.Struct) ->
@@ -1151,7 +1197,7 @@ and CliValueType =
             // into `TryComputeMarshalSize` so nested marshalling annotations on the inner
             // struct's fields contribute correctly to the outer size.
             match contents with
-            | CliType.ValueType vt -> CliValueType.TryComputeMarshalSize vt
+            | CliType.ValueType vt -> CliValueType.TryComputeMarshalSize concreteTypes assemblies corelib vt
             | _ ->
                 Result.Error
                     "[MarshalAs(UnmanagedType.Struct)] is only valid on value-type fields, not reference or primitive contents"
@@ -1180,13 +1226,21 @@ and CliValueType =
             | CliType.Char _ ->
                 Result.Error "System.Char marshalling depends on CharSet and does not always match 2-byte CLI char"
             | CliType.ObjectRef _ -> Result.Error "object references require managed-to-unmanaged marshalling"
-            | CliType.ValueType vt -> CliValueType.TryComputeMarshalSize vt
+            | CliType.ValueType vt -> CliValueType.TryComputeMarshalSize concreteTypes assemblies corelib vt
 
     /// Compute the unmanaged size of a value type as `Marshal.SizeOf` would. Lays fields out
     /// using the declaring type's `Layout` (sequential or explicit) and packing, but with each
     /// field sized via `TryFieldMarshalSize` so `[MarshalAs(ByValTStr/ByValArray)]` fields
-    /// contribute their unmanaged byte cost rather than the managed CLI size.
-    static member TryComputeMarshalSize (vt : CliValueType) : Result<SizeofResult, string> =
+    /// contribute their unmanaged byte cost rather than the managed CLI size. Type-system
+    /// context is required so descriptors that depend on the field's nominal type (e.g.
+    /// `ByValTStr` requires `System.String`) can be validated.
+    static member TryComputeMarshalSize
+        (concreteTypes : AllConcreteTypes)
+        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (corelib : BaseClassTypes<DumpedAssembly>)
+        (vt : CliValueType)
+        : Result<SizeofResult, string>
+        =
         match vt._Storage with
         | CliValueTypeStorage.RawBytes bytes ->
             Result.Ok
@@ -1233,7 +1287,14 @@ and CliValueType =
                     | Result.Error _ -> acc
                     | Result.Ok (currentOffset, maxAlign) ->
                         match
-                            CliValueType.TryFieldMarshalSize vt.CharSet field.MarshallingDescriptor field.Contents
+                            CliValueType.TryFieldMarshalSize
+                                concreteTypes
+                                assemblies
+                                corelib
+                                vt.CharSet
+                                field.MarshallingDescriptor
+                                field.Type
+                                field.Contents
                         with
                         | Result.Error reason -> Result.Error $"field %s{field.Name}: %s{reason}"
                         | Result.Ok size ->
@@ -1260,7 +1321,14 @@ and CliValueType =
                     | Result.Error _ -> acc
                     | Result.Ok (maxEnd, maxAlign) ->
                         match
-                            CliValueType.TryFieldMarshalSize vt.CharSet field.MarshallingDescriptor field.Contents
+                            CliValueType.TryFieldMarshalSize
+                                concreteTypes
+                                assemblies
+                                corelib
+                                vt.CharSet
+                                field.MarshallingDescriptor
+                                field.Type
+                                field.Contents
                         with
                         | Result.Error reason -> Result.Error $"field %s{field.Name}: %s{reason}"
                         | Result.Ok size ->

--- a/WoofWare.PawPrint/CliType.fs
+++ b/WoofWare.PawPrint/CliType.fs
@@ -1083,6 +1083,13 @@ and CliValueType =
                     Size = 8
                     Alignment = 8
                 }
+        | UnmanagedType.SysInt
+        | UnmanagedType.SysUInt ->
+            Result.Ok
+                {
+                    Size = NATIVE_INT_SIZE
+                    Alignment = NATIVE_INT_SIZE
+                }
         | other -> Result.Error $"UnmanagedType %O{other} is not yet supported by marshalled-size computation"
 
     /// Compute the unmanaged size of a single field, consulting `[MarshalAs(...)]` descriptors

--- a/WoofWare.PawPrint/CliType.fs
+++ b/WoofWare.PawPrint/CliType.fs
@@ -1044,11 +1044,13 @@ and CliValueType =
             Result.Error "CharSet.Auto is platform-dependent and not yet supported by marshalled-size computation"
         | other -> Result.Error $"unrecognised CharSet %O{other}"
 
-    /// Unmanaged element size for an `UnmanagedType` used as a `[MarshalAs(ByValArray)]`
-    /// element type. Only the unambiguous fixed-width primitive cases are decoded; everything
-    /// else is rejected so the caller can decide whether a richer mapping is needed.
-    static member private MarshalSizeOfElement (elementType : UnmanagedType) : Result<SizeofResult, string> =
-        match elementType with
+    /// Unmanaged size of a fixed-width scalar `UnmanagedType`. Used both as the per-element
+    /// size for `[MarshalAs(ByValArray)]` and as the authoritative field size when a scalar
+    /// `UnmanagedType` is supplied directly via `[MarshalAs(...)]`. Only the unambiguous
+    /// fixed-width primitive cases are decoded; everything else is rejected so the caller can
+    /// decide whether a richer mapping is needed.
+    static member private MarshalSizeOfScalar (unmanagedType : UnmanagedType) : Result<SizeofResult, string> =
+        match unmanagedType with
         | UnmanagedType.I1
         | UnmanagedType.U1 ->
             Result.Ok
@@ -1079,7 +1081,7 @@ and CliValueType =
                     Size = 8
                     Alignment = 8
                 }
-        | other -> Result.Error $"ByValArray element type %O{other} is not yet supported"
+        | other -> Result.Error $"UnmanagedType %O{other} is not yet supported by marshalled-size computation"
 
     /// Compute the unmanaged size of a single field, consulting `[MarshalAs(...)]` descriptors
     /// and the declaring type's `CharSet`. Without a descriptor, falls back to the managed
@@ -1107,7 +1109,8 @@ and CliValueType =
             if sizeConst <= 0 then
                 Result.Error $"ByValArray SizeConst=%d{sizeConst} is not positive"
             else
-                CliValueType.MarshalSizeOfElement elementType
+                CliValueType.MarshalSizeOfScalar elementType
+                |> Result.mapError (fun reason -> $"ByValArray element type: %s{reason}")
                 |> Result.map (fun elementSize ->
                     {
                         Size = sizeConst * elementSize.Size
@@ -1117,8 +1120,12 @@ and CliValueType =
         | Some (FieldMarshalDescriptor.ByValArray (_, None)) ->
             Result.Error "ByValArray descriptor without an explicit element type is not supported"
         | Some (FieldMarshalDescriptor.Other unmanagedType) ->
-            Result.Error
-                $"FieldMarshal descriptor %O{unmanagedType} is not yet supported by marshalled-size computation"
+            // The descriptor is authoritative for the field's marshalled size: even if the
+            // managed contents are a wider/narrower primitive, the unmanaged layout follows
+            // the declared `UnmanagedType`. Fall through to the scalar-size table for the
+            // fixed-width primitive cases (`[MarshalAs(I4)]` etc.); other variants stay
+            // rejected until we add explicit support.
+            CliValueType.MarshalSizeOfScalar unmanagedType
         | None ->
             match contents with
             | CliType.Numeric _

--- a/WoofWare.PawPrint/CliType.fs
+++ b/WoofWare.PawPrint/CliType.fs
@@ -1045,10 +1045,11 @@ and CliValueType =
         | other -> Result.Error $"unrecognised CharSet %O{other}"
 
     /// Unmanaged size of a fixed-width scalar `UnmanagedType`. Used both as the per-element
-    /// size for `[MarshalAs(ByValArray)]` and as the authoritative field size when a scalar
-    /// `UnmanagedType` is supplied directly via `[MarshalAs(...)]`. Only the unambiguous
-    /// fixed-width primitive cases are decoded; everything else is rejected so the caller can
-    /// decide whether a richer mapping is needed.
+    /// size for `[MarshalAs(ByValArray)]` and as the basis for the compatibility check when a
+    /// scalar `UnmanagedType` is supplied directly via `[MarshalAs(...)]`. Only the
+    /// unambiguous fixed-width primitive cases are decoded; everything else is rejected so the
+    /// caller can decide whether a richer mapping is needed. `Error` (HRESULT) is included
+    /// because CoreCLR accepts it on `int`/`uint` fields and it has the same width as `I4`.
     static member private MarshalSizeOfScalar (unmanagedType : UnmanagedType) : Result<SizeofResult, string> =
         match unmanagedType with
         | UnmanagedType.I1
@@ -1067,7 +1068,8 @@ and CliValueType =
                 }
         | UnmanagedType.I4
         | UnmanagedType.U4
-        | UnmanagedType.R4 ->
+        | UnmanagedType.R4
+        | UnmanagedType.Error ->
             Result.Ok
                 {
                     Size = 4
@@ -1120,12 +1122,21 @@ and CliValueType =
         | Some (FieldMarshalDescriptor.ByValArray (_, None)) ->
             Result.Error "ByValArray descriptor without an explicit element type is not supported"
         | Some (FieldMarshalDescriptor.Other unmanagedType) ->
-            // The descriptor is authoritative for the field's marshalled size: even if the
-            // managed contents are a wider/narrower primitive, the unmanaged layout follows
-            // the declared `UnmanagedType`. Fall through to the scalar-size table for the
-            // fixed-width primitive cases (`[MarshalAs(I4)]` etc.); other variants stay
-            // rejected until we add explicit support.
+            // CoreCLR's `MarshalInfo` validates a scalar `[MarshalAs]` against the managed
+            // field type and rejects width-mismatched pairs (e.g. `[MarshalAs(I1)] int`).
+            // Mirror that: only accept scalar descriptors when their declared width matches
+            // the field's CLI byte width. Variants whose unmanaged width we don't yet know
+            // (`Bool`, `LPStr`, `Currency`, ...) propagate the scalar-size error verbatim.
             CliValueType.MarshalSizeOfScalar unmanagedType
+            |> Result.bind (fun descSize ->
+                let cliSize = CliType.SizeOf contents
+
+                if cliSize.Size <> descSize.Size then
+                    Result.Error
+                        $"[MarshalAs(%O{unmanagedType})] declares %d{descSize.Size}-byte unmanaged width but managed field has %d{cliSize.Size} bytes"
+                else
+                    Result.Ok descSize
+            )
         | None ->
             match contents with
             | CliType.Numeric _

--- a/WoofWare.PawPrint/CliType.fs
+++ b/WoofWare.PawPrint/CliType.fs
@@ -1128,6 +1128,16 @@ and CliValueType =
                 )
         | Some (FieldMarshalDescriptor.ByValArray (_, None)) ->
             Result.Error "ByValArray descriptor without an explicit element type is not supported"
+        | Some (FieldMarshalDescriptor.Other UnmanagedType.Struct) ->
+            // `[MarshalAs(UnmanagedType.Struct)]` on a value-type field instructs the
+            // marshaller to lay out that struct inline using its own native layout. Recurse
+            // into `TryComputeMarshalSize` so nested marshalling annotations on the inner
+            // struct's fields contribute correctly to the outer size.
+            match contents with
+            | CliType.ValueType vt -> CliValueType.TryComputeMarshalSize vt
+            | _ ->
+                Result.Error
+                    "[MarshalAs(UnmanagedType.Struct)] is only valid on value-type fields, not reference or primitive contents"
         | Some (FieldMarshalDescriptor.Other unmanagedType) ->
             // CoreCLR's `MarshalInfo` validates a scalar `[MarshalAs]` against the managed
             // field type and rejects width-mismatched pairs (e.g. `[MarshalAs(I1)] int`).

--- a/WoofWare.PawPrint/CliType.fs
+++ b/WoofWare.PawPrint/CliType.fs
@@ -1104,28 +1104,45 @@ and CliValueType =
         =
         match descriptor with
         | Some (FieldMarshalDescriptor.ByValTStr sizeConst) ->
-            if sizeConst <= 0 then
-                Result.Error $"ByValTStr SizeConst=%d{sizeConst} is not positive"
-            else
-                CliValueType.CharSetByteSize charSet
-                |> Result.map (fun bpc ->
-                    {
-                        Size = sizeConst * bpc
-                        Alignment = bpc
-                    }
-                )
+            // CoreCLR's `MarshalInfo` rejects ByValTStr unless the managed field is a
+            // `string`. We don't carry the field's nominal type here, but reference-typed
+            // fields are the only ones that can possibly satisfy that requirement, so reject
+            // anything non-reference (this catches the codex-flagged `[MarshalAs(ByValTStr)]
+            // int` case).
+            match contents with
+            | CliType.ObjectRef _ ->
+                if sizeConst <= 0 then
+                    Result.Error $"ByValTStr SizeConst=%d{sizeConst} is not positive"
+                else
+                    CliValueType.CharSetByteSize charSet
+                    |> Result.map (fun bpc ->
+                        {
+                            Size = sizeConst * bpc
+                            Alignment = bpc
+                        }
+                    )
+            | _ ->
+                Result.Error
+                    "[MarshalAs(UnmanagedType.ByValTStr)] is only valid on string fields, not value-type or primitive contents"
         | Some (FieldMarshalDescriptor.ByValArray (sizeConst, Some elementType)) ->
-            if sizeConst <= 0 then
-                Result.Error $"ByValArray SizeConst=%d{sizeConst} is not positive"
-            else
-                CliValueType.MarshalSizeOfScalar elementType
-                |> Result.mapError (fun reason -> $"ByValArray element type: %s{reason}")
-                |> Result.map (fun elementSize ->
-                    {
-                        Size = sizeConst * elementSize.Size
-                        Alignment = elementSize.Alignment
-                    }
-                )
+            // Likewise, ByValArray requires an array field; reject anything that isn't a
+            // reference at the CLI level.
+            match contents with
+            | CliType.ObjectRef _ ->
+                if sizeConst <= 0 then
+                    Result.Error $"ByValArray SizeConst=%d{sizeConst} is not positive"
+                else
+                    CliValueType.MarshalSizeOfScalar elementType
+                    |> Result.mapError (fun reason -> $"ByValArray element type: %s{reason}")
+                    |> Result.map (fun elementSize ->
+                        {
+                            Size = sizeConst * elementSize.Size
+                            Alignment = elementSize.Alignment
+                        }
+                    )
+            | _ ->
+                Result.Error
+                    "[MarshalAs(UnmanagedType.ByValArray)] is only valid on array fields, not value-type or primitive contents"
         | Some (FieldMarshalDescriptor.ByValArray (_, None)) ->
             Result.Error "ByValArray descriptor without an explicit element type is not supported"
         | Some (FieldMarshalDescriptor.Other UnmanagedType.Struct) ->

--- a/WoofWare.PawPrint/Native/NativeMarshal.fs
+++ b/WoofWare.PawPrint/Native/NativeMarshal.fs
@@ -107,16 +107,13 @@ module NativeMarshal =
                 | EvalStackValue.Int32 _ -> true
                 | other -> failwith $"%s{operation}: expected throwIfNotMarshalable as Int32, got %O{other}"
 
-            match CliType.TryFindMarshalSizeDifference zero with
-            | Some reason ->
+            match CliType.TryComputeMarshalSize zero with
+            | Result.Error reason ->
                 failwith
-                    $"%s{operation}: refusing to approximate unmanaged marshalled size with managed layout size because %s{reason} (throwIfNotMarshalable=%b{throwIfNotMarshalable})"
-            | None -> ()
+                    $"%s{operation}: refusing to compute unmanaged marshalled size because %s{reason} (throwIfNotMarshalable=%b{throwIfNotMarshalable})"
+            | Result.Ok size ->
+                let state =
+                    IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 size.Size)) ctx.Thread state
 
-            let size = CliType.sizeOf zero
-
-            let state =
-                IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 size)) ctx.Thread state
-
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+                (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeMarshal.fs
+++ b/WoofWare.PawPrint/Native/NativeMarshal.fs
@@ -107,7 +107,7 @@ module NativeMarshal =
                 | EvalStackValue.Int32 _ -> true
                 | other -> failwith $"%s{operation}: expected throwIfNotMarshalable as Int32, got %O{other}"
 
-            match CliType.TryComputeMarshalSize zero with
+            match CliType.TryComputeMarshalSize state.ConcreteTypes state._LoadedAssemblies ctx.BaseClassTypes zero with
             | Result.Error reason ->
                 failwith
                     $"%s{operation}: refusing to compute unmanaged marshalled size because %s{reason} (throwIfNotMarshalable=%b{throwIfNotMarshalable})"


### PR DESCRIPTION
## Summary

Stage 3 of the `Marshal.SizeOf` plumbing effort. Builds on
[#478](https://github.com/Smaug123/WoofWare.PawPrint/pull/478) (which plumbed `FieldMarshalDescriptor` through `CliField`) and [#480](https://github.com/Smaug123/WoofWare.PawPrint/pull/480) (which plumbed `CharSet` through `CliValueType`).

Teaches the `MarshalNative_SizeOfHelper` QCall to honour per-field `[MarshalAs(...)]` descriptors so the returned size matches what CoreCLR's `Marshal.SizeOf` would produce:

- `[MarshalAs(ByValTStr, SizeConst=N)]`: `N * 1` (Ansi/None) or `N * 2` (Unicode) bytes, validated against `System.String` fields only.
- `[MarshalAs(ByValArray, SizeConst=N, ArraySubType=...)]`: `N * sizeof(elementType)`, validated against array-typed fields only.
- `[MarshalAs(UnmanagedType.Struct)]` on a value-type field: recurses into the inner struct's native layout.
- Scalar `[MarshalAs]` variants on primitive fields: `I1/U1/I2/U2/I4/U4/R4/Error/I8/U8/R8/SysInt/SysUInt` are decoded; width is checked against the field's CLI byte size and mismatches are rejected (matching CoreCLR's `MarshalInfo` validation).

The type-system context (`AllConcreteTypes` / loaded assemblies / `BaseClassTypes`) is threaded into `CliType.TryComputeMarshalSize` so descriptor/field-shape validation can use the field's nominal `ConcreteTypeHandle` rather than just the CLI shape.

## Test plan

- [x] `nix develop -c dotnet test ... --filter "Name~MarshalSizeOf"` — three focused tests pass
- [x] `MarshalSizeOfByValTStr.cs` covers Ansi (32 bytes) vs Unicode (48 bytes) variants
- [x] `MarshalSizeOfScalarMarshalAs.cs` covers scalar `[MarshalAs]` regressions: matching-width primitive descriptors, `HRESULT`/`Error`, `SysInt` on `IntPtr`, and `[MarshalAs(UnmanagedType.Struct)]` on a value-type field
- [x] Sizes verified against real .NET 10 before encoding into the tests
- [x] `codex review --base main` came back clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)