### PR TITLE
Dispatch Interlocked.Exchange/CompareExchange for bool and char

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -42,7 +42,7 @@ module TestPureCases =
             "RuntimeTypeHandleGetInstantiationOpenGeneric.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringMethodForGenericParameter
             "InitializeArrayBoxedFieldHandle.cs" // past String::FastAllocateString(MethodTable*, nint); now blocked by unimplemented MethodTable field projection for ParentMethodTable
             "MethodReflectionProbe.cs" // past AssemblyNative_IsApplyUpdateSupported QCall (MetadataUpdater.IsSupported now returns false during static init); now blocked by unimplemented InternalCall RuntimeMethodHandle::GetStubIfNeededInternal during MethodInfo materialisation
-            "ArraySortHelperDefaultInt.cs" // past DependentHandle InternalCalls (ConditionalWeakTable static init); now blocked by unimplemented JIT intrinsic System.Threading.Interlocked.Exchange(&, System.Boolean)
+            "ArraySortHelperDefaultInt.cs" // past Interlocked.Exchange(ref bool, bool) (covered by InterlockedExchangeBool.cs); now blocked by Ldftn against a MemberReference token (executeLdftn only handles MethodDef/MethodSpec)
         ]
         |> Set.ofList
 

--- a/WoofWare.PawPrint.Test/sourcesPure/InterlockedExchangeBool.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/InterlockedExchangeBool.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading;
+
+class Program
+{
+    class Holder
+    {
+        public bool Flag = false;
+    }
+
+    static bool s_staticFlag = false;
+
+    static int Main(string[] args)
+    {
+        bool local = false;
+        if (Interlocked.Exchange(ref local, true) != false || local != true) return 1;
+        if (Interlocked.Exchange(ref local, false) != true || local != false) return 2;
+        if (Interlocked.Exchange(ref local, false) != false || local != false) return 3;
+        if (Interlocked.Exchange(ref local, true) != false || local != true) return 4;
+
+        Holder h = new Holder();
+        if (Interlocked.Exchange(ref h.Flag, true) != false || h.Flag != true) return 5;
+        if (Interlocked.Exchange(ref h.Flag, false) != true || h.Flag != false) return 6;
+
+        if (Interlocked.Exchange(ref s_staticFlag, true) != false || s_staticFlag != true) return 7;
+        if (Interlocked.Exchange(ref s_staticFlag, true) != true || s_staticFlag != true) return 8;
+
+        // CompareExchange(ref bool, bool, bool) rides the same scalar arm; verify it.
+        bool cas = false;
+        if (Interlocked.CompareExchange(ref cas, true, true) != false || cas != false) return 9;
+        if (Interlocked.CompareExchange(ref cas, true, false) != false || cas != true) return 10;
+        if (Interlocked.CompareExchange(ref cas, false, false) != true || cas != true) return 11;
+        if (Interlocked.CompareExchange(ref cas, false, true) != true || cas != false) return 12;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -53,8 +53,17 @@ module Intrinsics =
             | PrimitiveType.UIntPtr -> true
             | _ -> false
 
-        let isScalarIntegerPrimitive (primitive : PrimitiveType) : bool =
+        // CIL widens Boolean (1-byte zero-extending) and Char (2-byte zero-extending)
+        // to Int32 on the eval stack and `EvalStackValue.toCliTypeCoerced` already
+        // rewraps from Int32 back to `CliType.Bool` / `CliType.Char`, so for atomic
+        // Exchange / CompareExchange they behave identically to the scalar integers
+        // here. Naming the predicate after the eval-stack shape rather than the spec
+        // name "integer" keeps its contract truthful for the call sites that justify
+        // dispatching to `executeScalarIntegerExchange` / `executeScalarInteger`.
+        let isScalarIntegralLikePrimitive (primitive : PrimitiveType) : bool =
             match primitive with
+            | PrimitiveType.Boolean
+            | PrimitiveType.Char
             | PrimitiveType.SByte
             | PrimitiveType.Byte
             | PrimitiveType.Int16
@@ -750,7 +759,7 @@ module Intrinsics =
                 ConcretePrimitive state.ConcreteTypes valuePrimitive
                 ConcretePrimitive state.ConcreteTypes comparandPrimitive ],
               MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes returnPrimitive) when
-                isScalarIntegerPrimitive locationPrimitive
+                isScalarIntegralLikePrimitive locationPrimitive
                 && locationPrimitive = valuePrimitive
                 && locationPrimitive = comparandPrimitive
                 && locationPrimitive = returnPrimitive
@@ -886,7 +895,7 @@ module Intrinsics =
             | [ ConcreteByref (ConcretePrimitive state.ConcreteTypes locationPrimitive)
                 ConcretePrimitive state.ConcreteTypes valuePrimitive ],
               MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes returnPrimitive) when
-                isScalarIntegerPrimitive locationPrimitive
+                isScalarIntegralLikePrimitive locationPrimitive
                 && locationPrimitive = valuePrimitive
                 && locationPrimitive = returnPrimitive
                 ->


### PR DESCRIPTION
## Summary
- Broaden the Interlocked intrinsic classifier so `Exchange(ref bool, bool)` and `CompareExchange(ref bool, bool, bool)` (and the same for `char`) route through the existing scalar arm rather than failing as a missing JIT intrinsic. Boolean and Char share the Int32 zero-extending eval-stack shape with the existing integer primitives, and `EvalStackValue.toCliTypeCoerced` already rewraps `Int32 → CliType.Bool`/`CliType.Char`, so no other change is needed. The predicate is renamed to `isScalarIntegralLikePrimitive` to keep its contract truthful.
- Add `InterlockedExchangeBool.cs` covering Exchange + CompareExchange against locals, fields, statics, and same/distinct-comparand cases.
- `ArraySortHelperDefaultInt.cs` is past this blocker but hits an unrelated `Ldftn`-against-`MemberReference` path next; its `unimplemented` note is updated and it stays in the set pending a separate fix.

## Test plan
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --filter "Name~Interlocked"` — 7 passed
- [x] Full `dotnet test` — 677 passed, 0 failed
- [x] `codex review --base main` — no actionable findings