### PR TITLE
Support Span<IntPtr> over localloc for RuntimeTypeHandle::GetFields

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -18,7 +18,7 @@ module TestPureCases =
     let unimplemented =
         [
             "AdvancedStructLayout.cs" // blocked after fixed-buffer pointer arithmetic by MarshalNative_SizeOfHelper for ByValTStr string marshalling
-            "LdtokenField.cs" // TODO: read through `ReinterpretAs` as non-primitive type .VolatileObject
+            "LdtokenField.cs" // past RuntimeTypeHandle::GetFields (Span<IntPtr> pinned over localloc, FieldHandlePtr written through ReinterpretAs IntPtr); now blocked by unimplemented InternalCall RuntimeFieldHandle::GetUtf8NameInternal
             "GenericEdgeCases.cs" // blocked after BitOperations.Log2 by unimplemented JIT intrinsic System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned (reached via int.ToString -> Number.UInt32ToDecStr)
             "CrossAssemblyTypes.cs" // past MethodTable::ParentMethodTable projection; now blocked by unimplemented QCall EventPipeInternal_CreateProvider during static init of System.Diagnostics.Tracing.EventPipeInternal
             "InterfaceDispatch.cs" // past MetadataImport::GetCustomAttributeProps; now blocked by unimplemented InternalCall MetadataImport::GetParentToken

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -1106,6 +1106,17 @@ module IlMachineManagedByref =
         // stackalloc + stind through a NativeInt-wrapped pointer; see
         // NullaryIlOp.fs's `stind` dispatcher and `Localloc`, which pushes
         // `EvalStackValue.NativeInt (NativeIntSource.ManagedPointer ...)`).
+        // The same fast path also accepts a trailing byte view
+        // (`[ReinterpretAs ty]` / `[ReinterpretAs ty; ByteOffset n]`) when
+        // the value being written cannot be flattened to bytes; otherwise
+        // byte-view writes must continue to land in the `Bytes` overlay so
+        // that partial-cell semantics (`stind.i1` updating one byte of a
+        // wider cell, byte-by-byte initialisation of a stackalloc buffer)
+        // are preserved. The Span<IntPtr> pinning path that feeds
+        // RuntimeTypeHandle.GetFields produces a byte-view shape over
+        // localloc memory and writes `FieldHandlePtr`-tagged native ints
+        // through it; those are not byte-addressable, so the typed-cell
+        // path is the only one that can preserve them.
         // We restrict the fast path to writes that are observably equivalent
         // to byte scatter: the new value must replace at most one existing
         // cell that starts exactly at `byteOffset` and has the same size as
@@ -1114,8 +1125,25 @@ module IlMachineManagedByref =
         // partial-cell semantics (`stind.i1` updating one byte of an
         // existing `Int32`) and correctly throws on unmodelled byte views
         // of non-byte-addressable cells (e.g. tagged-pointer cells).
-        match src with
-        | ManagedPointerSource.Byref (ByrefRoot.LocalMemoryByte (thread, frame, block, byteOffset), []) ->
+        let localMemoryByteTarget =
+            match src with
+            | ManagedPointerSource.Byref (ByrefRoot.LocalMemoryByte (thread, frame, block, byteOffset), []) ->
+                ValueSome (thread, frame, block, byteOffset)
+            | ManagedPointerSource.Byref (ByrefRoot.LocalMemoryByte _, _) ->
+                match CliType.ByteAddressability newValue with
+                | CliByteAddressability.ByteAddressable ->
+                    // Byte-addressable byte-view writes follow the existing byte-scatter
+                    // path below to preserve the `Bytes` overlay representation.
+                    ValueNone
+                | CliByteAddressability.Rejected _ ->
+                    match splitTrailingByteView src with
+                    | ValueSome (ByrefRoot.LocalMemoryByte (thread, frame, block, rootByteOffset), [], byteOffset) ->
+                        ValueSome (thread, frame, block, rootByteOffset + byteOffset)
+                    | _ -> ValueNone
+            | _ -> ValueNone
+
+        match localMemoryByteTarget with
+        | ValueSome (thread, frame, block, byteOffset) ->
             let pool = IlMachineThreadState.getLocalMemoryPool thread frame state
             let destSize = CliType.sizeOf newValue
 
@@ -1126,7 +1154,7 @@ module IlMachineManagedByref =
             else
                 let bytes = CliType.ToBytes newValue
                 writeLocalMemoryBytesAt state thread frame block byteOffset bytes
-        | _ ->
+        | ValueNone ->
 
         // Field-precise byte-view write into a heap object: when the destination is a
         // typed instance field of matching size and shape, route the write through the
@@ -1155,7 +1183,7 @@ module IlMachineManagedByref =
         | ManagedPointerSource.Null -> failwith "TODO: throw NullReferenceException"
         | ManagedPointerSource.Byref (ByrefRoot.HeapValue addr, []) -> writeHeapValueBytes state addr 0 bytes
         | ManagedPointerSource.Byref (ByrefRoot.LocalMemoryByte _, []) ->
-            // Already handled by the typed-cell fast path above.
+            // Already handled by the LocalMemoryByte typed-cell fast path above.
             failwith "unreachable: bare LocalMemoryByte byref dispatched in fast path"
         | ManagedPointerSource.Byref (ByrefRoot.PeByteRange peByteRange, _) ->
             failwith
@@ -1167,6 +1195,11 @@ module IlMachineManagedByref =
         | ManagedPointerSource.Byref (outerRoot, outerProjs) ->
             match splitTrailingByteView src with
             | ValueSome (ByrefRoot.LocalMemoryByte (thread, frame, block, rootByteOffset), [], byteOffset) ->
+                // Byte-addressable byte-view writes through a localloc buffer
+                // intentionally fall through here (the typed-cell fast path
+                // above declines them so that the `Bytes` overlay
+                // representation is preserved for `stind.i1`-style partial
+                // updates).
                 writeLocalMemoryBytesAt state thread frame block (rootByteOffset + byteOffset) bytes
             | ValueSome (ByrefRoot.ArrayElement (arr, index), [], byteOffset) ->
                 writeArrayBytes state arr index byteOffset bytes

--- a/WoofWare.PawPrint/Native/NativeRuntimeType.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeType.fs
@@ -60,15 +60,34 @@ module NativeRuntimeType =
                 ByrefRoot.LocalMemoryByte (thread, frame, block, byteOffset + (index * nativeIntSize)),
                 []
             )
+        // Span<IntPtr> pinned over a `stackalloc IntPtr[N]` buffer: the Span(void*, int)
+        // constructor appends `ReinterpretAs IntPtr` to the localloc byte byref when
+        // storing it into `_reference`, and the LibraryImport stub for the QCall pulls
+        // that reference back out. The reinterpret is address-preserving, so striding
+        // by nativeIntSize bytes and preserving the projection keeps the typed view.
+        | ManagedPointerSource.Byref (ByrefRoot.LocalMemoryByte (thread, frame, block, byteOffset),
+                                      [ ByrefProjection.ReinterpretAs reinterpretTy as proj ]) ->
+            // The QCall signature mandates `Span<IntPtr>`; any other reinterpret type would mean
+            // the buffer was constructed from a different element type and `nativeIntSize` striding
+            // would be wrong, so surface the mismatch loudly rather than silently mis-striding.
+            if reinterpretTy.Namespace <> "System" || reinterpretTy.Name <> "IntPtr" then
+                failwith
+                    $"%s{operation}: expected IntPtr-reinterpret on localloc buffer, got %s{reinterpretTy.Namespace}.%s{reinterpretTy.Name} in %O{buffer}"
+
+            ManagedPointerSource.Byref (
+                ByrefRoot.LocalMemoryByte (thread, frame, block, byteOffset + (index * nativeIntSize)),
+                [ proj ]
+            )
         // The 1-arg overload of CreateInstanceForAnotherGenericParameter takes the
         // address of a single IntPtr local (`&typeHandle`), so element 0 *is* the
         // buffer itself. We cannot stride past it without escaping the local.
         | ManagedPointerSource.Byref (ByrefRoot.LocalVariable _, []) when index = 0 -> buffer
         | ManagedPointerSource.Byref (ByrefRoot.Argument _, []) when index = 0 -> buffer
-        // Buffers are currently reached through GetFields' stackalloc/array path,
-        // or through a single-IntPtr local taken by `&` for the 1-arg overload of
-        // CreateInstanceForAnotherGenericParameter. Other shapes should fail with
-        // their structure intact.
+        // Buffers are currently reached through GetFields' stackalloc/array path
+        // (either as a bare byte byref or with a trailing `ReinterpretAs IntPtr` when
+        // the buffer was wrapped in a Span<IntPtr>), or through a single-IntPtr local
+        // taken by `&` for the 1-arg overload of CreateInstanceForAnotherGenericParameter.
+        // Other shapes should fail with their structure intact.
         | _ -> failwith $"%s{operation}: unsupported IntPtr result buffer pointer shape %O{buffer}"
 
     let private writeFieldHandleElement


### PR DESCRIPTION
## Summary

Advances `LdtokenField.cs` past `RuntimeTypeHandle.GetFields`. The BCL marshals its `Span<IntPtr>` argument by pinning a `stackalloc IntPtr[64]` buffer, producing a byref shape (`LocalMemoryByte` root + trailing `ReinterpretAs IntPtr` projection) that two interpreter paths previously rejected.

- `NativeRuntimeType.nativeIntElementPointer` now strides through `LocalMemoryByte + [ReinterpretAs IntPtr]` while preserving the typed view; non-`IntPtr` reinterprets fail loudly rather than silently mis-stride.
- `IlMachineManagedByref.writeManagedByrefBytesOrTypedCell`'s `LocalMemoryByte` fast path now also accepts a trailing byte-view projection, but only when the value being written is *not* byte-addressable. The QCall writes `FieldHandlePtr`-tagged native ints, which refuse `CliType.ToBytes`; routing them through `writeRootValue` preserves provenance. Byte-addressable byte-view writes (`stind.i1` byte-scatter into a stackalloc) continue down the existing path, keeping `Local memory typed cell write evicts intersecting byte overlay` green.

`LdtokenField.cs` now blocks at `RuntimeFieldHandle::GetUtf8NameInternal`. Per `AGENTS.md` (one feature at a time), it stays in the `unimplemented` set with an updated comment describing the new boundary.

## Test plan

- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 676/676 pass
- [x] `codex review --base main` — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)