### PR TITLE
Implement RuntimeFieldHandle::GetUtf8NameInternal

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -18,7 +18,8 @@ module TestPureCases =
     let unimplemented =
         [
             "AdvancedStructLayout.cs" // blocked after fixed-buffer pointer arithmetic by MarshalNative_SizeOfHelper for ByValTStr string marshalling
-            "LdtokenField.cs" // past RuntimeTypeHandle::GetFields (Span<IntPtr> pinned over localloc, FieldHandlePtr written through ReinterpretAs IntPtr); now blocked by unimplemented InternalCall RuntimeFieldHandle::GetUtf8NameInternal
+            "LdtokenField.cs" // past RuntimeFieldHandle::GetUtf8NameInternal; now blocked by unimplemented QCall RuntimeTypeHandle_GetInterfaces during RuntimeType.GetField name lookup
+            "RuntimeFieldHandleGetUtf8Name.cs" // exercises RuntimeFieldHandle::GetUtf8NameInternal successfully; now blocked at the next step by unimplemented QCall RuntimeTypeHandle_GetInterfaces during RuntimeType.GetField name lookup
             "GenericEdgeCases.cs" // blocked after BitOperations.Log2 by unimplemented JIT intrinsic System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned (reached via int.ToString -> Number.UInt32ToDecStr)
             "CrossAssemblyTypes.cs" // past MethodTable::ParentMethodTable projection; now blocked by unimplemented QCall EventPipeInternal_CreateProvider during static init of System.Diagnostics.Tracing.EventPipeInternal
             "InterfaceDispatch.cs" // past MetadataImport::GetCustomAttributeProps; now blocked by unimplemented InternalCall MetadataImport::GetParentToken

--- a/WoofWare.PawPrint.Test/sourcesPure/RuntimeFieldHandleGetUtf8Name.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/RuntimeFieldHandleGetUtf8Name.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+
+class Program
+{
+    public static int FieldA;
+    public static int FieldB;
+
+    static int Main(string[] args)
+    {
+        FieldInfo fi = typeof(Program).GetField("FieldA");
+        if (fi == null) return 1;
+        if (fi.Name != "FieldA") return 2;
+
+        FieldInfo fi2 = typeof(Program).GetField("FieldB");
+        if (fi2 == null) return 3;
+        if (fi2.Name != "FieldB") return 4;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/Native/NativeRuntimeFieldHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeFieldHandle.fs
@@ -74,6 +74,37 @@ module NativeRuntimeFieldHandle =
         | "System.Private.CoreLib",
           "System",
           "RuntimeFieldHandle",
+          "GetUtf8NameInternal",
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib", "System", "RuntimeFieldHandleInternal", generics) ],
+          MethodReturnType.Returns (ConcretePointer (ConcreteVoid state.ConcreteTypes)) when generics.IsEmpty ->
+            // CoreCLR's RuntimeFieldHandle::GetUtf8NameInternal (runtimehandles.cpp:2167)
+            // is an FCall that dereferences a FieldDesc* and reads the field's UTF-8 name
+            // from the metadata string heap. The managed wrapper RuntimeFieldHandle.GetUtf8Name
+            // (RuntimeHandles.cs:1501) wraps the result in MdUtf8String, which strlens the
+            // pointer to discover the byte length. PawPrint materialises the field's metadata
+            // name as a freshly-allocated null-terminated UTF-8 byte[] and returns a byref to
+            // it; the managed strlen path then walks the array as expected. Mirrors the
+            // RuntimeMethodHandle.GetUtf8NameInternal handler.
+            let operation = "RuntimeFieldHandle.GetUtf8NameInternal"
+
+            let fieldHandle =
+                // FCall asserts non-null; surface a null handle loudly here, matching the
+                // sibling RuntimeFieldHandle.GetAttributes precedent below.
+                fieldHandleOfRuntimeFieldHandleInternal operation state instruction.Arguments.[0]
+                |> Option.defaultWith (fun () -> failwith $"%s{operation}: null field handle")
+
+            let _, fieldInfo = getFieldForFieldHandle operation fieldHandle state
+
+            let namePtr, state =
+                NativeCall.allocateNullTerminatedUtf8 ctx.BaseClassTypes fieldInfo.Name state
+
+            let state =
+                IlMachineState.pushToEvalStack' (EvalStackValue.ManagedPointer namePtr) ctx.Thread state
+
+            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+        | "System.Private.CoreLib",
+          "System",
+          "RuntimeFieldHandle",
           "GetAttributes",
           [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib", "System", "RuntimeFieldHandleInternal", generics) ],
           MethodReturnType.Returns (ConcreteType state.ConcreteTypes ("System.Private.CoreLib",


### PR DESCRIPTION
## Summary

CoreCLR's FCall (`runtimehandles.cpp:2167`) dereferences a `FieldDesc*` and returns the field's UTF-8 name pointer into module metadata; the managed wrapper `RuntimeFieldHandle.GetUtf8Name` wraps it in `MdUtf8String` and `strlen`s the buffer.

WoofWare.PawPrint already has every helper (`fieldHandleOfRuntimeFieldHandleInternal`, `getFieldForFieldHandle`, `NativeCall.allocateNullTerminatedUtf8`) and an analogous `RuntimeMethodHandle::GetUtf8NameInternal` handler. This PR adds the sibling arm to `NativeRuntimeFieldHandle.tryExecute` that materialises the field's name as a freshly-allocated null-terminated UTF-8 byte[] and pushes a byref to it.

A null `RuntimeFieldHandleInternal` `failwith`s loudly (matching the sibling `RuntimeFieldHandle.GetAttributes` precedent) — stricter than CoreCLR's FCall (asserts non-null) and stricter than the managed wrapper (throws `BadImageFormatException`); easy to soften if a real call site benefits.

Adds focused test `RuntimeFieldHandleGetUtf8Name.cs` exercising `typeof(C).GetField(\"F\").Name`. The test progresses past `GetUtf8NameInternal` and now blocks at the next boundary, `RuntimeTypeHandle_GetInterfaces` (called from `RuntimeType.GetField` during member walking); it stays in the `unimplemented` set with a comment recording the new boundary. The same boundary is the new blocker for `LdtokenField.cs`, whose comment is updated accordingly.

## Test plan

- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 678/678 pass
- [x] `codex review --base main` — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)