### PR TITLE
Handle MemberReference tokens in ldftn (and fix MethodSpec generic-arg substitution)

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -42,7 +42,7 @@ module TestPureCases =
             "RuntimeTypeHandleGetInstantiationOpenGeneric.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringMethodForGenericParameter
             "InitializeArrayBoxedFieldHandle.cs" // past String::FastAllocateString(MethodTable*, nint); now blocked by unimplemented MethodTable field projection for ParentMethodTable
             "MethodReflectionProbe.cs" // past AssemblyNative_IsApplyUpdateSupported QCall (MetadataUpdater.IsSupported now returns false during static init); now blocked by unimplemented InternalCall RuntimeMethodHandle::GetStubIfNeededInternal during MethodInfo materialisation
-            "ArraySortHelperDefaultInt.cs" // past Interlocked.Exchange(ref bool, bool) (covered by InterlockedExchangeBool.cs); now blocked by Ldftn against a MemberReference token (executeLdftn only handles MethodDef/MethodSpec)
+            "ArraySortHelperDefaultInt.cs" // past Ldftn against MemberReference (covered by LdftnCrossAssembly.cs); now blocked by unimplemented QCall Environment_FailFast
         ]
         |> Set.ofList
 

--- a/WoofWare.PawPrint.Test/sourcesPure/CallCrossAssemblyMethodSpecCallerGeneric.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/CallCrossAssemblyMethodSpecCallerGeneric.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+
+// Direct-call counterpart to LdftnCrossAssemblyMethodSpecCallerGeneric.cs.
+// Exercises the same MethodSpec(MemberReference) shape (caller's class generic
+// used as a method-generic argument on a constructed BCL generic type) but via
+// `call` rather than `ldftn`, to catch the equivalent re-substitution bug in
+// `UnaryMetadataCallOps.executeCall`.
+
+class Program
+{
+    static int Main(string[] args)
+    {
+        return new C<int, string>().Run() ? 0 : 1;
+    }
+}
+
+class C<A, B>
+{
+    public bool Run()
+    {
+        var list = new List<int> { 1, 2, 3 };
+        // List<int>::ConvertAll<B> — MethodSpec(MemberReference), target type
+        // generics [int], method generics [B] (caller's class generic 1).
+        var converted = list.ConvertAll<B>(_ => default!);
+        return converted.Count == 3;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/LdftnCrossAssembly.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/LdftnCrossAssembly.cs
@@ -1,0 +1,18 @@
+using System;
+
+// Exercises `ldftn` against a method defined in another assembly (System.Private.CoreLib).
+// In-assembly `ldftn` targets resolve to MethodDef tokens, but a delegate constructed
+// against a BCL method like `Math.Max` produces a MemberReference token, which is the
+// case `UnaryMetadataTokenOps.executeLdftn` must also handle.
+
+class Program
+{
+    static int Main(string[] args)
+    {
+        Func<int, int, int> max = Math.Max;
+        if (max is null) return 1;
+        if (max(2, 5) != 5) return 2;
+        if (max(-3, -10) != -3) return 3;
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/LdftnCrossAssemblyMethodSpecCallerGeneric.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/LdftnCrossAssemblyMethodSpecCallerGeneric.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+
+// Codex flagged a potential bug in MethodSpec(MemberReference) ldftn handling: if
+// the spec's method-generic args reference the caller's class generic (e.g.
+// `class C<A,B>` calling `Other<X>.Generic<B>`), the path passes spec.Signature
+// raw to concretizeMethodForExecution alongside `extractedTypeArgs` (the
+// target type's generics), which then re-substitutes the spec args against
+// the wrong context. This test exercises that exact shape: a generic class
+// captures a delegate over a BCL generic method on a generic target type,
+// instantiated with its own class type parameter.
+
+class Program
+{
+    static int Main(string[] args)
+    {
+        return new C<int, string>().Run() ? 0 : 1;
+    }
+}
+
+class C<A, B>
+{
+    public bool Run()
+    {
+        // List<int>.ConvertAll<TOutput> is a generic method on a constructed
+        // generic type (List<int>). Taking the address with B as the method
+        // type argument produces MethodSpec(MemberReference) where:
+        //   - extractedTypeArgs = [int]  (List<int>'s generics)
+        //   - spec.Signature   = [B]     (referring to caller's class generic 1)
+        // If concretizeMethodForExecution re-substitutes spec.Signature using
+        // extractedTypeArgs as typeGenerics context, GenericTypeParameter 1
+        // would index out of bounds in [int].
+        var list = new List<int> { 1, 2, 3 };
+        Func<Converter<int, B>, List<B>> f = list.ConvertAll<B>;
+        var converted = f(_ => default!);
+        return converted.Count == 3;
+    }
+}

--- a/WoofWare.PawPrint/ExecutionConcretization.fs
+++ b/WoofWare.PawPrint/ExecutionConcretization.fs
@@ -95,6 +95,54 @@ module ExecutionConcretization =
             concretizedMethodGenerics
             state
 
+    /// Resolve the target method's declaring-type generics from the IL metadata, falling back to
+    /// the current frame when none were supplied. Returned handles are already concretized.
+    let private resolveTargetTypeGenerics
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (thread : ThreadId)
+        (typeArgsFromMetadata : TypeDefn ImmutableArray option)
+        (state : IlMachineState)
+        : ImmutableArray<ConcreteTypeHandle> * IlMachineState
+        =
+        match typeArgsFromMetadata with
+        | Some args when not args.IsEmpty ->
+            // We have concrete type arguments from the IL metadata
+            // Need to concretize them to ConcreteTypeHandle first
+            let handles = ImmutableArray.CreateBuilder args.Length
+            let mutable state = state
+
+            for i = 0 to args.Length - 1 do
+                let ctx =
+                    {
+                        TypeConcretization.ConcretizationContext.ConcreteTypes = state.ConcreteTypes
+                        TypeConcretization.ConcretizationContext.LoadedAssemblies = state._LoadedAssemblies
+                        TypeConcretization.ConcretizationContext.BaseTypes = baseClassTypes
+                    }
+
+                let handle, newCtx =
+                    TypeConcretization.concretizeType
+                        ctx
+                        (IlMachineState.loader loggerFactory state)
+                        (state.ActiveAssembly thread).Name
+                        ImmutableArray.Empty // No type generics for the concretization context
+                        ImmutableArray.Empty // No method generics for the concretization context
+                        args.[i]
+
+                handles.Add handle
+
+                state <-
+                    { state with
+                        ConcreteTypes = newCtx.ConcreteTypes
+                        _LoadedAssemblies = newCtx.LoadedAssemblies
+                    }
+
+            handles.ToImmutable (), state
+        | _ ->
+            // Fall back to current execution context
+            let currentMethod = state.ThreadState.[thread].MethodState.ExecutingMethod
+            currentMethod.DeclaringType.Generics, state
+
     /// Returns also the declaring type.
     let concretizeMethodForExecution
         (loggerFactory : ILoggerFactory)
@@ -108,47 +156,8 @@ module ExecutionConcretization =
           WoofWare.PawPrint.MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle> *
           ConcreteTypeHandle
         =
-        // Use type generics from metadata if available, otherwise fall back to current execution context
-        let typeGenerics =
-            match typeArgsFromMetadata with
-            | Some args when not args.IsEmpty ->
-                // We have concrete type arguments from the IL metadata
-                // Need to concretize them to ConcreteTypeHandle first
-                let handles = ImmutableArray.CreateBuilder args.Length
-                let mutable state = state
-
-                for i = 0 to args.Length - 1 do
-                    let ctx =
-                        {
-                            TypeConcretization.ConcretizationContext.ConcreteTypes = state.ConcreteTypes
-                            TypeConcretization.ConcretizationContext.LoadedAssemblies = state._LoadedAssemblies
-                            TypeConcretization.ConcretizationContext.BaseTypes = baseClassTypes
-                        }
-
-                    let handle, newCtx =
-                        TypeConcretization.concretizeType
-                            ctx
-                            (IlMachineState.loader loggerFactory state)
-                            (state.ActiveAssembly thread).Name
-                            ImmutableArray.Empty // No type generics for the concretization context
-                            ImmutableArray.Empty // No method generics for the concretization context
-                            args.[i]
-
-                    handles.Add handle
-
-                    state <-
-                        { state with
-                            ConcreteTypes = newCtx.ConcreteTypes
-                            _LoadedAssemblies = newCtx.LoadedAssemblies
-                        }
-
-                handles.ToImmutable (), state
-            | _ ->
-                // Fall back to current execution context
-                let currentMethod = state.ThreadState.[thread].MethodState.ExecutingMethod
-                currentMethod.DeclaringType.Generics, state
-
-        let typeGenerics, state = typeGenerics
+        let typeGenerics, state =
+            resolveTargetTypeGenerics loggerFactory baseClassTypes thread typeArgsFromMetadata state
 
         let callingAssembly = (state.ActiveAssembly thread).Name
         let currentMethod = state.ThreadState.[thread].MethodState.ExecutingMethod
@@ -162,6 +171,28 @@ module ExecutionConcretization =
             callingAssembly
             currentMethod.Generics
             state
+
+    /// Variant of `concretizeMethodForExecution` for callers that have already concretized the
+    /// method's generic args against the current frame's context (e.g. MethodSpec dispatch where
+    /// `spec.Signature` has been substituted to pick the right MemberReference overload). Avoids
+    /// re-substituting those args against the target type's generics, which would be the wrong
+    /// context whenever `spec.Signature` references the caller's class or method generics.
+    let concretizeMethodForExecutionWithConcreteMethodGenerics
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (thread : ThreadId)
+        (methodToCall : WoofWare.PawPrint.MethodInfo<'ty, GenericParamFromMetadata, TypeDefn>)
+        (methodGenerics : ImmutableArray<ConcreteTypeHandle>)
+        (typeArgsFromMetadata : TypeDefn ImmutableArray option)
+        (state : IlMachineState)
+        : IlMachineState *
+          WoofWare.PawPrint.MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle> *
+          ConcreteTypeHandle
+        =
+        let typeGenerics, state =
+            resolveTargetTypeGenerics loggerFactory baseClassTypes thread typeArgsFromMetadata state
+
+        concretizeMethodWithAllGenerics loggerFactory baseClassTypes typeGenerics methodToCall methodGenerics state
 
     let concretizeFieldForExecution
         (loggerFactory : ILoggerFactory)

--- a/WoofWare.PawPrint/UnaryMetadataCallOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataCallOps.fs
@@ -15,7 +15,12 @@ module internal UnaryMetadataCallOps =
         let currentMethod = ctx.CurrentMethod
         let thread = ctx.Thread
 
-        let state, methodToCall, methodGenerics, typeArgsFromMetadata =
+        // For MethodSpec(MemberReference) the spec's method-generic args are caller-relative
+        // and have already been substituted against the current frame to drive overload
+        // resolution; we surface them as `preConcretizedMethodGenerics` so the concretization
+        // step below uses them directly rather than re-substituting against the (target type's)
+        // generics, which would be the wrong context.
+        let state, methodToCall, methodGenerics, typeArgsFromMetadata, preConcretizedMethodGenerics =
             match metadataToken with
             | MetadataToken.MethodSpecification h ->
                 let spec = activeAssy.MethodSpecs.[h]
@@ -44,7 +49,7 @@ module internal UnaryMetadataCallOps =
                         activeAssy.Methods.[token]
                         |> MethodInfo.mapTypeGenerics (fun (par, _) -> TypeDefn.GenericTypeParameter par.SequenceNumber)
 
-                    state, method, Some spec.Signature, None
+                    state, method, Some spec.Signature, None, None
                 | MetadataToken.MemberReference ref ->
                     let state, _, method, extractedTypeArgs =
                         IlMachineState.resolveMember
@@ -58,7 +63,7 @@ module internal UnaryMetadataCallOps =
 
                     match method with
                     | Choice2Of2 _field -> failwith "tried to Call a field"
-                    | Choice1Of2 method -> state, method, Some spec.Signature, Some extractedTypeArgs
+                    | Choice1Of2 method -> state, method, None, Some extractedTypeArgs, Some methodGenerics
                 | k -> failwith $"Unrecognised kind: %O{k}"
             | MetadataToken.MemberReference h ->
                 let state, _, method, extractedTypeArgs =
@@ -73,13 +78,13 @@ module internal UnaryMetadataCallOps =
 
                 match method with
                 | Choice2Of2 _field -> failwith "tried to Call a field"
-                | Choice1Of2 method -> state, method, None, Some extractedTypeArgs
+                | Choice1Of2 method -> state, method, None, Some extractedTypeArgs, None
 
             | MetadataToken.MethodDef defn ->
                 match activeAssy.Methods.TryGetValue defn with
                 | true, method ->
                     let method = method |> MethodInfo.mapTypeGenerics (fun _ -> failwith "not generic")
-                    state, method, None, None
+                    state, method, None, None, None
                 | false, _ -> failwith $"could not find method in {activeAssy.Name}"
             | k -> failwith $"Unrecognised kind: %O{k}"
 
@@ -129,14 +134,25 @@ module internal UnaryMetadataCallOps =
                     )
 
         let state, concretizedMethod, declaringTypeHandle =
-            ExecutionConcretization.concretizeMethodForExecution
-                loggerFactory
-                baseClassTypes
-                thread
-                methodToCall
-                methodGenerics
-                typeArgsFromMetadata
-                state
+            match preConcretizedMethodGenerics with
+            | Some concrete ->
+                ExecutionConcretization.concretizeMethodForExecutionWithConcreteMethodGenerics
+                    loggerFactory
+                    baseClassTypes
+                    thread
+                    methodToCall
+                    concrete
+                    typeArgsFromMetadata
+                    state
+            | None ->
+                ExecutionConcretization.concretizeMethodForExecution
+                    loggerFactory
+                    baseClassTypes
+                    thread
+                    methodToCall
+                    methodGenerics
+                    typeArgsFromMetadata
+                    state
 
         let state, concretizedMethod, declaringTypeHandle =
             match pendingConstrained with
@@ -232,7 +248,12 @@ module internal UnaryMetadataCallOps =
 
 
         // TODO: this is presumably super incomplete
-        let state, methodToCall, methodGenerics, typeArgsFromMetadata =
+        // For MethodSpec(MemberReference) the spec's method-generic args are caller-relative
+        // and already concretized against the current frame; we surface them as
+        // `preConcretizedMethodGenerics` so the concretization step uses them directly rather
+        // than re-substituting against the target type's generics, which would be the wrong
+        // context whenever `spec.Signature` references the caller's class or method generics.
+        let state, methodToCall, methodGenerics, typeArgsFromMetadata, preConcretizedMethodGenerics =
             match metadataToken with
             | MetadataToken.MethodSpecification h ->
                 let spec = activeAssy.MethodSpecs.[h]
@@ -261,7 +282,7 @@ module internal UnaryMetadataCallOps =
                         activeAssy.Methods.[token]
                         |> MethodInfo.mapTypeGenerics (fun (p, _) -> spec.Signature.[p.SequenceNumber])
 
-                    state, method, Some spec.Signature, None
+                    state, method, Some spec.Signature, None, None
                 | MetadataToken.MemberReference ref ->
                     let state, _, method, extractedTypeArgs =
                         IlMachineState.resolveMember
@@ -275,7 +296,7 @@ module internal UnaryMetadataCallOps =
 
                     match method with
                     | Choice2Of2 _field -> failwith "tried to Callvirt a field"
-                    | Choice1Of2 method -> state, method, Some spec.Signature, Some extractedTypeArgs
+                    | Choice1Of2 method -> state, method, None, Some extractedTypeArgs, Some methodGenerics
                 | k -> failwith $"Unrecognised kind: %O{k}"
             | MetadataToken.MemberReference h ->
                 let state, _, method, extractedTypeArgs =
@@ -290,25 +311,36 @@ module internal UnaryMetadataCallOps =
 
                 match method with
                 | Choice2Of2 _field -> failwith "tried to Callvirt a field"
-                | Choice1Of2 method -> state, method, None, Some extractedTypeArgs
+                | Choice1Of2 method -> state, method, None, Some extractedTypeArgs, None
 
             | MetadataToken.MethodDef defn ->
                 match activeAssy.Methods.TryGetValue defn with
                 | true, method ->
                     let method = method |> MethodInfo.mapTypeGenerics (fun _ -> failwith "not generic")
-                    state, method, None, None
+                    state, method, None, None, None
                 | false, _ -> failwith $"could not find method in {activeAssy.Name}"
             | k -> failwith $"Unrecognised kind: %O{k}"
 
         let state, concretizedMethod, declaringTypeHandle =
-            ExecutionConcretization.concretizeMethodForExecution
-                loggerFactory
-                baseClassTypes
-                thread
-                methodToCall
-                methodGenerics
-                typeArgsFromMetadata
-                state
+            match preConcretizedMethodGenerics with
+            | Some concrete ->
+                ExecutionConcretization.concretizeMethodForExecutionWithConcreteMethodGenerics
+                    loggerFactory
+                    baseClassTypes
+                    thread
+                    methodToCall
+                    concrete
+                    typeArgsFromMetadata
+                    state
+            | None ->
+                ExecutionConcretization.concretizeMethodForExecution
+                    loggerFactory
+                    baseClassTypes
+                    thread
+                    methodToCall
+                    methodGenerics
+                    typeArgsFromMetadata
+                    state
 
         // Capture the pending `constrained.` prefix up front and clear it from the current
         // frame before attempting class init. This ensures that if the class initializer

--- a/WoofWare.PawPrint/UnaryMetadataTokenOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataTokenOps.fs
@@ -12,17 +12,38 @@ module internal UnaryMetadataTokenOps =
         let baseClassTypes = ctx.BaseClassTypes
         let activeAssy = ctx.ActiveAssembly
         let metadataToken = ctx.MetadataToken
+        let currentMethod = ctx.CurrentMethod
         let thread = ctx.Thread
         let logger = ctx.Logger
 
-        let method, methodGenerics =
+        // Resolution mirrors `UnaryMetadataCallOps.executeCall`: in-assembly methods arrive as
+        // MethodDef (optionally wrapped in a MethodSpec for generic methods), cross-assembly
+        // methods arrive as MemberReference (optionally MethodSpec-wrapped). MemberReference
+        // resolution must thread the extracted declaring-type generics back to
+        // `concretizeMethodForExecution`, otherwise generic types defined in another assembly
+        // would lose their instantiation when projected onto the eval-stack function pointer.
+        let state, method, methodGenerics, typeArgsFromMetadata =
             match metadataToken with
             | MetadataToken.MethodDef handle ->
                 let method =
                     activeAssy.Methods.[handle]
                     |> MethodInfo.mapTypeGenerics (fun (par, _) -> TypeDefn.GenericTypeParameter par.SequenceNumber)
 
-                method, None
+                state, method, None, None
+            | MetadataToken.MemberReference h ->
+                let state, _, method, extractedTypeArgs =
+                    IlMachineState.resolveMember
+                        loggerFactory
+                        baseClassTypes
+                        thread
+                        activeAssy
+                        ImmutableArray.Empty
+                        h
+                        state
+
+                match method with
+                | Choice2Of2 _field -> failwith "tried to Ldftn a field"
+                | Choice1Of2 method -> state, method, None, Some extractedTypeArgs
             | MetadataToken.MethodSpecification h ->
                 let spec = activeAssy.MethodSpecs.[h]
 
@@ -32,8 +53,43 @@ module internal UnaryMetadataTokenOps =
                         activeAssy.Methods.[token]
                         |> MethodInfo.mapTypeGenerics (fun (par, _) -> TypeDefn.GenericTypeParameter par.SequenceNumber)
 
-                    method, Some spec.Signature
-                | k -> failwith $"Unrecognised MethodSpecification kind: %O{k}"
+                    state, method, Some spec.Signature, None
+                | MetadataToken.MemberReference ref ->
+                    // Concretize the spec's generic method args against the current frame's
+                    // generic context so `resolveMember` can pick the right overload — the
+                    // member signature may reference these method type parameters by index.
+                    let state, methodGenerics =
+                        ((state, []), spec.Signature)
+                        ||> Seq.fold (fun (state, acc) typeDefn ->
+                            let state, concreteType =
+                                IlMachineState.concretizeType
+                                    loggerFactory
+                                    baseClassTypes
+                                    state
+                                    activeAssy.Name
+                                    currentMethod.DeclaringType.Generics
+                                    currentMethod.Generics
+                                    typeDefn
+
+                            state, concreteType :: acc
+                        )
+
+                    let methodGenerics = List.rev methodGenerics |> ImmutableArray.CreateRange
+
+                    let state, _, method, extractedTypeArgs =
+                        IlMachineState.resolveMember
+                            loggerFactory
+                            baseClassTypes
+                            thread
+                            activeAssy
+                            methodGenerics
+                            ref
+                            state
+
+                    match method with
+                    | Choice2Of2 _field -> failwith "tried to Ldftn a field"
+                    | Choice1Of2 method -> state, method, Some spec.Signature, Some extractedTypeArgs
+                | k -> failwith $"Unrecognised MethodSpecification kind for Ldftn: %O{k}"
             | t -> failwith $"Unexpectedly asked to Ldftn a non-method: {t}"
 
         let state, concretizedMethod, _declaringTypeHandle =
@@ -43,7 +99,7 @@ module internal UnaryMetadataTokenOps =
                 thread
                 method
                 methodGenerics
-                None
+                typeArgsFromMetadata
                 state
 
         logger.LogDebug (

--- a/WoofWare.PawPrint/UnaryMetadataTokenOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataTokenOps.fs
@@ -19,17 +19,31 @@ module internal UnaryMetadataTokenOps =
         // Resolution mirrors `UnaryMetadataCallOps.executeCall`: in-assembly methods arrive as
         // MethodDef (optionally wrapped in a MethodSpec for generic methods), cross-assembly
         // methods arrive as MemberReference (optionally MethodSpec-wrapped). MemberReference
-        // resolution must thread the extracted declaring-type generics back to
-        // `concretizeMethodForExecution`, otherwise generic types defined in another assembly
-        // would lose their instantiation when projected onto the eval-stack function pointer.
-        let state, method, methodGenerics, typeArgsFromMetadata =
+        // resolution must thread the extracted declaring-type generics back to the concretization
+        // step, otherwise generic types defined in another assembly would lose their instantiation
+        // when projected onto the eval-stack function pointer. For the MethodSpec(MemberReference)
+        // case we additionally bypass the default re-substitution path: the spec's method-generic
+        // args are caller-relative and have already been resolved against the current frame, so
+        // we hand the concrete handles directly to the concretization step rather than letting it
+        // re-substitute them against the (target type's) generics.
+        let state, concretizedMethod, method =
             match metadataToken with
             | MetadataToken.MethodDef handle ->
                 let method =
                     activeAssy.Methods.[handle]
                     |> MethodInfo.mapTypeGenerics (fun (par, _) -> TypeDefn.GenericTypeParameter par.SequenceNumber)
 
-                state, method, None, None
+                let state, concretized, _ =
+                    ExecutionConcretization.concretizeMethodForExecution
+                        loggerFactory
+                        baseClassTypes
+                        thread
+                        method
+                        None
+                        None
+                        state
+
+                state, concretized, method
             | MetadataToken.MemberReference h ->
                 let state, _, method, extractedTypeArgs =
                     IlMachineState.resolveMember
@@ -43,7 +57,18 @@ module internal UnaryMetadataTokenOps =
 
                 match method with
                 | Choice2Of2 _field -> failwith "tried to Ldftn a field"
-                | Choice1Of2 method -> state, method, None, Some extractedTypeArgs
+                | Choice1Of2 method ->
+                    let state, concretized, _ =
+                        ExecutionConcretization.concretizeMethodForExecution
+                            loggerFactory
+                            baseClassTypes
+                            thread
+                            method
+                            None
+                            (Some extractedTypeArgs)
+                            state
+
+                    state, concretized, method
             | MetadataToken.MethodSpecification h ->
                 let spec = activeAssy.MethodSpecs.[h]
 
@@ -53,7 +78,17 @@ module internal UnaryMetadataTokenOps =
                         activeAssy.Methods.[token]
                         |> MethodInfo.mapTypeGenerics (fun (par, _) -> TypeDefn.GenericTypeParameter par.SequenceNumber)
 
-                    state, method, Some spec.Signature, None
+                    let state, concretized, _ =
+                        ExecutionConcretization.concretizeMethodForExecution
+                            loggerFactory
+                            baseClassTypes
+                            thread
+                            method
+                            (Some spec.Signature)
+                            None
+                            state
+
+                    state, concretized, method
                 | MetadataToken.MemberReference ref ->
                     // Concretize the spec's generic method args against the current frame's
                     // generic context so `resolveMember` can pick the right overload — the
@@ -88,19 +123,20 @@ module internal UnaryMetadataTokenOps =
 
                     match method with
                     | Choice2Of2 _field -> failwith "tried to Ldftn a field"
-                    | Choice1Of2 method -> state, method, Some spec.Signature, Some extractedTypeArgs
+                    | Choice1Of2 method ->
+                        let state, concretized, _ =
+                            ExecutionConcretization.concretizeMethodForExecutionWithConcreteMethodGenerics
+                                loggerFactory
+                                baseClassTypes
+                                thread
+                                method
+                                methodGenerics
+                                (Some extractedTypeArgs)
+                                state
+
+                        state, concretized, method
                 | k -> failwith $"Unrecognised MethodSpecification kind for Ldftn: %O{k}"
             | t -> failwith $"Unexpectedly asked to Ldftn a non-method: {t}"
-
-        let state, concretizedMethod, _declaringTypeHandle =
-            ExecutionConcretization.concretizeMethodForExecution
-                loggerFactory
-                baseClassTypes
-                thread
-                method
-                methodGenerics
-                typeArgsFromMetadata
-                state
 
         logger.LogDebug (
             "Pushed pointer to function {LdFtnAssembly}.{LdFtnType}.{LdFtnMethodName}",


### PR DESCRIPTION
## Summary
- Extend `executeLdftn` to dispatch `MetadataToken.MemberReference` and `MetadataToken.MethodSpecification(MemberReference)` so cross-assembly delegate construction (e.g. `Func<int,int,int> max = Math.Max;`) no longer fails with \`Unexpectedly asked to Ldftn a non-method\`. Resolution mirrors `UnaryMetadataCallOps.executeCall` and threads the extracted declaring-type generics through to `concretizeMethodForExecution`.
- While verifying that fix, `codex review` flagged a P2 latent bug shared by `executeCall`, `executeCallvirt`, and the new `executeLdftn` paths: `concretizeMethodForExecution` re-substitutes the spec's method-generic args against the *target type's* generics, but those args are caller-relative. Reaching the bug is straightforward: `class C<A,B> { ... List<int>::ConvertAll<B>(...) }` indexes out of bounds in `[int]` when the spec encodes `B` as `GenericTypeParameter 1`. Added `concretizeMethodForExecutionWithConcreteMethodGenerics` that takes the already-substituted handles directly and routed all three call sites to it. Includes regression tests `Call*` and `Ldftn*CrossAssemblyMethodSpecCallerGeneric.cs`.
- Removed `ArraySortHelperDefaultInt.cs` from the unimplemented set briefly to confirm it now reaches the next blocker (\`Environment_FailFast\` QCall) and updated its annotation.

## Test plan
- [x] `nix develop -c dotnet build WoofWare.PawPrint/WoofWare.PawPrint.fsproj`
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --filter "Name~CrossAssembly"` — 16 passed including the 3 new regression cases
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 680 passed (was 678 + 2 new tests; LdftnCrossAssembly already added in earlier commit + 2 MethodSpec callers)
- [x] `nix develop -c dotnet fantomas .`
- [x] `codex review --base main` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)