### PR TITLE
Implement RuntimeTypeHandle_GetInterfaces QCall

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -18,8 +18,10 @@ module TestPureCases =
     let unimplemented =
         [
             "AdvancedStructLayout.cs" // blocked after fixed-buffer pointer arithmetic by MarshalNative_SizeOfHelper for ByValTStr string marshalling
-            "LdtokenField.cs" // past RuntimeFieldHandle::GetUtf8NameInternal; now blocked by unimplemented QCall RuntimeTypeHandle_GetInterfaces during RuntimeType.GetField name lookup
-            "RuntimeFieldHandleGetUtf8Name.cs" // exercises RuntimeFieldHandle::GetUtf8NameInternal successfully; now blocked at the next step by unimplemented QCall RuntimeTypeHandle_GetInterfaces during RuntimeType.GetField name lookup
+            "LdtokenField.cs" // past RuntimeTypeHandle::GetInterfaces QCall; now blocked by unimplemented Volatile.Write of an object reference through ReinterpretAs over byte-unaddressable storage during reflection-cache update
+            "RuntimeFieldHandleGetUtf8Name.cs" // exercises RuntimeFieldHandle::GetUtf8NameInternal and RuntimeTypeHandle::GetInterfaces successfully; now blocked at the next step by unimplemented Volatile.Write of an object reference through ReinterpretAs over byte-unaddressable storage during reflection-cache update
+            "RuntimeTypeGetInterfacesEmpty.cs" // past RuntimeTypeHandle::GetInterfaces QCall; now blocked by unimplemented QCall Environment_FailFast (same as ArraySortHelperDefaultInt.cs)
+            "RuntimeTypeGetInterfacesInherited.cs" // exercises the QCall's inherited-base + transitive-interface walk; same Environment_FailFast blocker as RuntimeTypeGetInterfacesEmpty.cs
             "GenericEdgeCases.cs" // blocked after BitOperations.Log2 by unimplemented JIT intrinsic System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned (reached via int.ToString -> Number.UInt32ToDecStr)
             "CrossAssemblyTypes.cs" // past MethodTable::ParentMethodTable projection; now blocked by unimplemented QCall EventPipeInternal_CreateProvider during static init of System.Diagnostics.Tracing.EventPipeInternal
             "InterfaceDispatch.cs" // past MetadataImport::GetCustomAttributeProps; now blocked by unimplemented InternalCall MetadataImport::GetParentToken
@@ -39,7 +41,6 @@ module TestPureCases =
             "EnumSemantics.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringTypeHandle
             "GetDeclaringTypeNestedGeneric.cs" // past MethodTable::AuxiliaryData projection for OpenGenericTypeDefinition; now blocked by ldflda through synthetic MethodTableAuxiliaryData::ExposedClassObjectRaw field address (same blocker as GetElementTypeBasic.cs)
             "IsAssignableToBasic.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringTypeHandle
-            "RuntimeTypeGetInterfacesEmpty.cs" // past Span`1::get_Empty; now blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringTypeHandle
             "RuntimeTypeHandleGetInstantiationOpenGeneric.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringMethodForGenericParameter
             "InitializeArrayBoxedFieldHandle.cs" // past String::FastAllocateString(MethodTable*, nint); now blocked by unimplemented MethodTable field projection for ParentMethodTable
             "MethodReflectionProbe.cs" // past AssemblyNative_IsApplyUpdateSupported QCall (MetadataUpdater.IsSupported now returns false during static init); now blocked by unimplemented InternalCall RuntimeMethodHandle::GetStubIfNeededInternal during MethodInfo materialisation

--- a/WoofWare.PawPrint.Test/sourcesPure/RuntimeTypeGetInterfacesInherited.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/RuntimeTypeGetInterfacesInherited.cs
@@ -1,0 +1,20 @@
+namespace RuntimeTypeGetInterfacesInherited
+{
+    interface IBase { }
+
+    interface IDerived : IBase { }
+
+    class Foo : IDerived { }
+
+    class Bar : Foo { }
+
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            // Bar : Foo : IDerived : IBase, so Bar.GetInterfaces() should yield 2 entries.
+            int count = typeof(Bar).GetInterfaces().Length;
+            return count == 2 ? 0 : 1;
+        }
+    }
+}

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -24,6 +24,7 @@ module NativeQCall =
             NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_GetDeclaringTypeHandleForGenericVariable"
             "RuntimeTypeHandle_GetFields", NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_GetFields"
             "RuntimeTypeHandle_GetInstantiation", NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_GetInstantiation"
+            "RuntimeTypeHandle_GetInterfaces", NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_GetInterfaces"
             "RuntimeTypeHandle_Instantiate", NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_Instantiate"
             "ModuleHandle_ResolveType", NativeRuntimeType.tryExecuteQCall "ModuleHandle_ResolveType"
             "MethodTable_CanCompareBitsOrUseFastGetHashCode",

--- a/WoofWare.PawPrint/Native/NativeRuntimeType.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeType.fs
@@ -2860,6 +2860,179 @@ module NativeRuntimeType =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 result)) ctx.Thread state
 
             (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+        | "RuntimeTypeHandle_GetInterfaces",
+          "System.Private.CoreLib",
+          "System",
+          "RuntimeTypeHandle",
+          _,
+          [ ConcretePointer (ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                                               "System.Runtime.CompilerServices",
+                                                               "MethodTable",
+                                                               methodTableGenerics))
+            ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "ObjectHandleOnStack",
+                                              objectHandleGenerics) ],
+          MethodReturnType.Void when methodTableGenerics.IsEmpty && objectHandleGenerics.IsEmpty ->
+            // CoreCLR's RuntimeTypeHandle_GetInterfaces (runtimehandles.cpp:518) walks
+            // MethodTable::IterateInterfaceMap, allocates a fresh PTRARRAYREF of length
+            // pMT->GetNumInterfaces() with element type RuntimeType, populates each slot
+            // from `it.GetInterface(pMT)->GetManagedClassObject()`, and writes the array
+            // through the ObjectHandleOnStack. If ifaceCount == 0 the QCall returns
+            // without writing, leaving the caller's empty-array local intact (the managed
+            // wrapper RuntimeHandles.cs:559 initialises `result` to `[]`).
+            //
+            // The managed wrapper short-circuits TypeDesc cases (byref/pointer/generic
+            // parameter) by returning `[]` before reaching the QCall, so we expect a
+            // closed MethodTable here.
+            let operation = "RuntimeTypeHandle.GetInterfaces"
+
+            let typeHandleTarget =
+                NativeCall.runtimeTypeHandleTargetOfEvalStackValue
+                    operation
+                    (instruction.Arguments.[0] |> EvalStackValue.ofCliType)
+
+            let retArray =
+                NativeCall.objectHandleOnStackTarget operation state "result" instruction.Arguments.[1]
+
+            let typeHandle =
+                match typeHandleTarget with
+                | RuntimeTypeHandleTarget.Closed handle -> handle
+                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
+                    failwith
+                        $"TODO: %s{operation} for open generic type definition %O{identity}; CoreCLR walks the canonical type's interface map, but PawPrint's interface concretization expects closed type generics"
+                | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
+                    failwith
+                        $"%s{operation}: generic parameter #%i{position} of %O{declaringType.TypeDefinition.Get} reached the QCall; the managed wrapper short-circuits IsTypeDesc to `[]` before this point"
+                | RuntimeTypeHandleTarget.MethodGenericParameter (declaringType, declaringMethod, position) ->
+                    failwith
+                        $"%s{operation}: method generic parameter #%i{position} of method %O{declaringMethod.Get} on %O{declaringType.TypeDefinition.Get} reached the QCall; the managed wrapper short-circuits IsTypeDesc to `[]` before this point"
+
+            match typeHandle with
+            | ConcreteTypeHandle.OneDimArrayZero _
+            | ConcreteTypeHandle.Array _ ->
+                failwith
+                    $"TODO: %s{operation} for array type %O{typeHandle}; arrays expose runtime-provided interfaces (IList<T>, ICollection<T>, IEnumerable<T>, ...) that PawPrint does not yet synthesize"
+            | ConcreteTypeHandle.Byref _
+            | ConcreteTypeHandle.Pointer _
+            | ConcreteTypeHandle.FunctionPointer _ ->
+                failwith
+                    $"%s{operation}: byref/pointer/function-pointer handle %O{typeHandle} reached the QCall; the managed wrapper should have short-circuited IsTypeDesc to `[]`"
+            | ConcreteTypeHandle.Concrete _ ->
+
+            // CoreCLR's MethodTable interface map enumerates ALL implemented interfaces:
+            // the type's direct ImplementedInterfaces rows, every interface those interfaces
+            // transitively extend, and the same closure for every base class up the chain.
+            // Mirror that here so e.g. `class D : B` where `B : IDisposable` reports
+            // `IDisposable`, and a class implementing `IList<T>` also reports `ICollection<T>`,
+            // `IEnumerable<T>`, `IEnumerable`. Concretization always uses the *owning* type's
+            // generics: when walking B<int>'s interfaces we resolve under `[int]`, regardless
+            // of the derived class's own generic instantiation.
+            let rec collectInterfaces
+                (state : IlMachineState, seen : Set<ConcreteTypeHandle>, ordered : ConcreteTypeHandle list)
+                (current : ConcreteTypeHandle)
+                : IlMachineState * Set<ConcreteTypeHandle> * ConcreteTypeHandle list
+                =
+                let state, seen, ordered =
+                    match IlMachineState.tryGetConcreteTypeInfo state current with
+                    | None -> state, seen, ordered
+                    | Some (currentCt, currentTypeInfo) ->
+                        let currentAssy =
+                            state.LoadedAssembly' currentCt.Identity.AssemblyFullName
+                            |> Option.defaultWith (fun () ->
+                                failwith
+                                    $"%s{operation}: owning assembly %s{currentCt.Identity.AssemblyFullName} not loaded"
+                            )
+
+                        ((state, seen, ordered), currentTypeInfo.ImplementedInterfaces)
+                        ||> Seq.fold (fun (state, seen, ordered) impl ->
+                            let implAssy =
+                                state.LoadedAssembly impl.RelativeToAssembly |> Option.defaultValue currentAssy
+
+                            let state, implTypeDefn, implResolvedAssy =
+                                IlMachineState.resolveTypeMetadataToken
+                                    ctx.LoggerFactory
+                                    ctx.BaseClassTypes
+                                    state
+                                    implAssy
+                                    currentCt.Generics
+                                    impl.InterfaceHandle
+
+                            let state, implHandle =
+                                IlMachineState.concretizeType
+                                    ctx.LoggerFactory
+                                    ctx.BaseClassTypes
+                                    state
+                                    implResolvedAssy.Name
+                                    currentCt.Generics
+                                    ImmutableArray.Empty
+                                    implTypeDefn
+
+                            if Set.contains implHandle seen then
+                                state, seen, ordered
+                            else
+                                let seen = Set.add implHandle seen
+                                let ordered = implHandle :: ordered
+                                // Recurse into the interface's own transitive interface set.
+                                collectInterfaces (state, seen, ordered) implHandle
+                        )
+
+                // Walk up the base type chain.
+                let state, baseHandle =
+                    IlMachineState.resolveBaseConcreteType ctx.LoggerFactory ctx.BaseClassTypes state current
+
+                match baseHandle with
+                | None -> state, seen, ordered
+                | Some baseHandle -> collectInterfaces (state, seen, ordered) baseHandle
+
+            let state, _, interfaceHandlesReversed =
+                collectInterfaces (state, Set.empty, []) typeHandle
+
+            let interfaceHandles = List.rev interfaceHandlesReversed
+
+            if List.isEmpty interfaceHandles then
+                // Mirror CoreCLR: skip the allocation and leave the caller's `[]` local intact.
+                (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            else
+                let state, _, runtimeTypeElementHandle =
+                    concretizeNonGenericCorelibType ctx.LoggerFactory ctx.BaseClassTypes state "System" "RuntimeType"
+
+                let arrayAddr, state =
+                    IlMachineState.allocateArray
+                        (ConcreteTypeHandle.OneDimArrayZero runtimeTypeElementHandle)
+                        (fun () -> CliType.ObjectRef None)
+                        (List.length interfaceHandles)
+                        state
+
+                let state =
+                    ((state, 0), interfaceHandles)
+                    ||> List.fold (fun (state, index) ifaceHandle ->
+                        let runtimeTypeAddr, state =
+                            IlMachineState.getOrAllocateType
+                                ctx.LoggerFactory
+                                ctx.BaseClassTypes
+                                (RuntimeTypeHandleTarget.Closed ifaceHandle)
+                                state
+
+                        let state =
+                            IlMachineState.setArrayValue
+                                arrayAddr
+                                (CliType.ObjectRef (Some runtimeTypeAddr))
+                                index
+                                state
+
+                        state, index + 1
+                    )
+                    |> fst
+
+                let state =
+                    IlMachineState.writeManagedByrefWithBase
+                        ctx.BaseClassTypes
+                        state
+                        retArray
+                        (CliType.ObjectRef (Some arrayAddr))
+
+                (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
         | _ -> None
 
     let tryExecute (ctx : NativeCallContext) : ExecutionResult option =


### PR DESCRIPTION
## Summary
- Walk the type's full interface closure: directly-implemented interfaces, each interface's transitively-extended interfaces, and the same closure for every base class up the inheritance chain.
- Concretize each `InterfaceImplementation` token under its *owning* type's generics (mirroring `resolveImplementedInterface` and the recursive walk in `isConcreteTypeAssignableTo`), deduplicate by `ConcreteTypeHandle`, allocate a `RuntimeType[]`, and write it through the `ObjectHandleOnStack`.
- Empty interface sets short-circuit to leave the caller's `[]` initialiser intact, matching CoreCLR.
- Open generic / type-desc handles fail loudly: the managed wrapper short-circuits those paths to `[]` before reaching the QCall, so any survivor is a bug worth surfacing.

## Test plan
- [x] `nix develop -c dotnet test` — all 682 tests pass
- [x] New focused tests `RuntimeTypeGetInterfacesEmpty.cs` (already present) and `RuntimeTypeGetInterfacesInherited.cs` advance past the QCall; tracked in `unimplemented` until the next blocker (`Environment_FailFast`) is implemented.
- [x] `LdtokenField.cs` and `RuntimeFieldHandleGetUtf8Name.cs` advance through this QCall and now block on the next downstream issue (`Volatile.Write` of an object reference through `ReinterpretAs`).
- [x] `codex review --base main` — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)