### PR TITLE
Fast-path Volatile.Write<T> over object-reference storage

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -18,8 +18,8 @@ module TestPureCases =
     let unimplemented =
         [
             "AdvancedStructLayout.cs" // blocked after fixed-buffer pointer arithmetic by MarshalNative_SizeOfHelper for ByValTStr string marshalling
-            "LdtokenField.cs" // past RuntimeTypeHandle::GetInterfaces QCall; now blocked by unimplemented Volatile.Write of an object reference through ReinterpretAs over byte-unaddressable storage during reflection-cache update
-            "RuntimeFieldHandleGetUtf8Name.cs" // exercises RuntimeFieldHandle::GetUtf8NameInternal and RuntimeTypeHandle::GetInterfaces successfully; now blocked at the next step by unimplemented Volatile.Write of an object reference through ReinterpretAs over byte-unaddressable storage during reflection-cache update
+            "LdtokenField.cs" // past Volatile.Write of an object reference; now blocked by unimplemented InternalCall System.Buffer::BulkMoveWithWriteBarrierInternal during reflection-cache update
+            "RuntimeFieldHandleGetUtf8Name.cs" // exercises RuntimeFieldHandle::GetUtf8NameInternal, RuntimeTypeHandle::GetInterfaces, and Volatile.Write of object refs successfully; now blocked at the next step by unimplemented InternalCall System.Buffer::BulkMoveWithWriteBarrierInternal
             "RuntimeTypeGetInterfacesEmpty.cs" // past RuntimeTypeHandle::GetInterfaces QCall; now blocked by unimplemented QCall Environment_FailFast (same as ArraySortHelperDefaultInt.cs)
             "RuntimeTypeGetInterfacesInherited.cs" // exercises the QCall's inherited-base + transitive-interface walk; same Environment_FailFast blocker as RuntimeTypeGetInterfacesEmpty.cs
             "GenericEdgeCases.cs" // blocked after BitOperations.Log2 by unimplemented JIT intrinsic System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned (reached via int.ToString -> Number.UInt32ToDecStr)

--- a/WoofWare.PawPrint.Test/sourcesPure/VolatileWriteObject.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/VolatileWriteObject.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+
+class Holder
+{
+    public object Field;
+}
+
+class Program
+{
+    static int Main(string[] args)
+    {
+        Holder h = new Holder();
+        object initial = new object();
+        h.Field = initial;
+
+        object replacement = new object();
+        Volatile.Write(ref h.Field, replacement);
+
+        if (!ReferenceEquals(h.Field, replacement)) return 1;
+        if (ReferenceEquals(h.Field, initial)) return 2;
+
+        Volatile.Write(ref h.Field, null);
+        if (h.Field != null) return 3;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -1346,6 +1346,43 @@ module IlMachineManagedByref =
         let operation =
             $"write through `ReinterpretAs` as %s{reinterpretTy.Namespace}.%s{reinterpretTy.Name}"
 
+        // Object-reference single-field wrapper write fast path. CoreLib lowers
+        // `Volatile.Write<T>(ref T, T) where T : class?` to
+        // `Unsafe.As<T, VolatileObject>(ref location).Value = value`, which produces a
+        // byref over `CliType.ObjectRef` storage with a trailing `ReinterpretAs VolatileObject`
+        // and a `Field "Value"` projection. Bytewise reinterpret over an ObjectRef is
+        // meaningless because ObjectRef storage is not byte-addressable; mirror the
+        // affordance in `readReinterpretedByrefField` and treat the assignment to the
+        // wrapper's only field as a direct assignment to the storage.
+        let objectRefWrapperFastPath () : CliType option voption =
+            match storageValue, reinterpretProjs, byteOffset with
+            | CliType.ObjectRef _, [ ByrefProjection.Field field ], 0 ->
+                let reinterpretTemplate = zeroForConcreteType baseClassTypes state reinterpretTy
+                let fieldTemplate = CliType.getFieldById field reinterpretTemplate
+                let fieldOffset, fieldSize = CliType.getFieldLayoutById field reinterpretTemplate
+
+                match fieldTemplate with
+                | CliType.ObjectRef _ when
+                    fieldOffset = 0
+                    && fieldSize = CliType.sizeOf fieldTemplate
+                    && CliType.sizeOf reinterpretTemplate = CliType.sizeOf fieldTemplate
+                    ->
+                    match newValue with
+                    | CliType.ObjectRef _ ->
+                        if storageValue = newValue then
+                            ValueSome None
+                        else
+                            ValueSome (Some newValue)
+                    | other ->
+                        failwith
+                            $"%s{operation}: assigning non-object value %s{describeCliStorage state other} to object-reference field %O{field} of single-instance-field wrapper"
+                | _ -> ValueNone
+            | _ -> ValueNone
+
+        match objectRefWrapperFastPath () with
+        | ValueSome result -> result
+        | ValueNone ->
+
         let storageBytes = reinterpretStorageBytes state operation storageValue
         let reinterpretZero = zeroForConcreteType baseClassTypes state reinterpretTy
         let reinterpretSize = CliType.sizeOf reinterpretZero


### PR DESCRIPTION
## Summary
- CoreLib lowers `Volatile.Write<T>(ref T, T) where T : class?` to `Unsafe.As<T, VolatileObject>(ref location).Value = value`, where `VolatileObject` is a single-instance-field transparent wrapper around `object?`. The interpreter's reinterpret-write path tries to round-trip through bytes, which fails because `CliType.ObjectRef` is not byte-addressable.
- `readReinterpretedByrefField` already short-circuits this shape on the read side. This adds the symmetric write affordance: when storage is `CliType.ObjectRef`, byte offset is 0, and the reinterpret type is a single-instance-field wrapper of an ObjectRef at offset 0 sized to the storage, treat the assignment to the wrapper's field as a direct assignment to the storage.
- Adds a focused `VolatileWriteObject.cs` test exercising `Volatile.Write<T>` against a reference-typed field. Updates the unimplemented blocker comments for `LdtokenField.cs` and `RuntimeFieldHandleGetUtf8Name.cs`, which both advance past the Volatile-write step to a new shared blocker (`System.Buffer::BulkMoveWithWriteBarrierInternal` InternalCall).

## Test plan
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 683 passing, 0 failing.
- [x] New focused test `VolatileWriteObject.cs` passes.
- [x] `codex review --base main` — clean (no findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)