### PR TITLE
Implement Environment.FailFast QCall

### DIFF
--- a/WoofWare.PawPrint.App/DebuggerServer.fs
+++ b/WoofWare.PawPrint.App/DebuggerServer.fs
@@ -205,6 +205,13 @@ module DebuggerServer =
             writer.WriteString ("kind", "processExit")
             writer.WriteNumber ("thread", threadIdValue thread)
             writeOptionalInt writer "exitCode" (tryExitCode state thread)
+        | RunOutcome.FailFast (_state, thread, message) ->
+            writer.WriteString ("kind", "failFast")
+            writer.WriteNumber ("thread", threadIdValue thread)
+
+            match message with
+            | Some m -> writer.WriteString ("message", m)
+            | None -> writer.WriteNull "message"
         | RunOutcome.GuestUnhandledException (_, thread, exn) ->
             writer.WriteString ("kind", "guestUnhandledException")
             writer.WriteNumber ("thread", threadIdValue thread)
@@ -232,6 +239,7 @@ module DebuggerServer =
         | SessionState.Running (prepared, _) -> prepared.State
         | SessionState.Finished (RunOutcome.NormalExit (state, _), _)
         | SessionState.Finished (RunOutcome.ProcessExit (state, _), _)
+        | SessionState.Finished (RunOutcome.FailFast (state, _, _), _)
         | SessionState.Finished (RunOutcome.GuestUnhandledException (state, _, _), _) -> state
         | SessionState.Deadlocked (prepared, _, _) -> prepared.State
 
@@ -280,6 +288,7 @@ module DebuggerServer =
                 match outcome with
                 | RunOutcome.NormalExit _ -> "normal exit"
                 | RunOutcome.ProcessExit _ -> "process exit"
+                | RunOutcome.FailFast _ -> "fail fast"
                 | RunOutcome.GuestUnhandledException _ -> "guest unhandled exception"
 
             {

--- a/WoofWare.PawPrint.App/Program.fs
+++ b/WoofWare.PawPrint.App/Program.fs
@@ -96,6 +96,16 @@ module AppProgram =
             match Program.run loggerFactory (Some dllPath) fileStream dotnetRuntimes impls args with
             | RunOutcome.NormalExit (state, thread)
             | RunOutcome.ProcessExit (state, thread) -> exitCodeFromStack state thread
+            | RunOutcome.FailFast (_state, _thread, message) ->
+                // CoreCLR aborts the process via the same SIGABRT path as an unhandled
+                // exception, so we mirror those exit codes.
+                let msg = message |> Option.defaultValue "<no message>"
+                logger.LogCritical ("Guest called Environment.FailFast: {FailFastMessage}", msg)
+
+                if RuntimeInformation.IsOSPlatform OSPlatform.Windows then
+                    -532462766
+                else
+                    134
             | RunOutcome.GuestUnhandledException (state, _thread, exn) ->
                 let exceptionTypeName =
                     match state.ManagedHeap.NonArrayObjects |> Map.tryFind exn.ExceptionObject with

--- a/WoofWare.PawPrint.App/Program.fs
+++ b/WoofWare.PawPrint.App/Program.fs
@@ -97,13 +97,14 @@ module AppProgram =
             | RunOutcome.NormalExit (state, thread)
             | RunOutcome.ProcessExit (state, thread) -> exitCodeFromStack state thread
             | RunOutcome.FailFast (_state, _thread, message) ->
-                // CoreCLR aborts the process via the same SIGABRT path as an unhandled
-                // exception, so we mirror those exit codes.
+                // CoreCLR's Environment_FailFast calls HandleFatalError(COR_E_FAILFAST)
+                // and on Windows terminates with 0x80131623; on Unix it aborts via
+                // SIGABRT (exit code 128 + 6 = 134).
                 let msg = message |> Option.defaultValue "<no message>"
                 logger.LogCritical ("Guest called Environment.FailFast: {FailFastMessage}", msg)
 
                 if RuntimeInformation.IsOSPlatform OSPlatform.Windows then
-                    -532462766
+                    -2146232797
                 else
                     134
             | RunOutcome.GuestUnhandledException (state, _thread, exn) ->

--- a/WoofWare.PawPrint.Performance/Program.fs
+++ b/WoofWare.PawPrint.Performance/Program.fs
@@ -173,6 +173,9 @@ type StackHeavyProgramBenchmarks () =
             | EvalStackValue.Int32 exitCode :: _ -> exitCode
             | [] -> failwith "Expected PawPrint run to leave an int exit code, but the stack was empty"
             | head :: _ -> failwith $"Expected PawPrint run to leave an int exit code, but got %O{head}"
+        | RunOutcome.FailFast (_, _, message) ->
+            let m = message |> Option.defaultValue "<no message>"
+            failwith $"PawPrint guest called Environment.FailFast: %s{m}"
         | RunOutcome.GuestUnhandledException (_, _, exn) ->
             failwith $"PawPrint threw an unhandled guest exception: %O{exn.ExceptionObject}"
 

--- a/WoofWare.PawPrint.Test/CrossAssemblyHarness.fs
+++ b/WoofWare.PawPrint.Test/CrossAssemblyHarness.fs
@@ -102,6 +102,9 @@ module CrossAssemblyHarness =
                 match Program.run loggerFactory (Some entryPath) peImage dotnetRuntimeDirs nativeImpls [] with
                 | RunOutcome.GuestUnhandledException (_, _, exn) ->
                     failwith $"Guest threw unhandled exception: %O{exn.ExceptionObject}"
+                | RunOutcome.FailFast (_, _, message) ->
+                    let m = message |> Option.defaultValue "<no message>"
+                    failwith $"Guest called Environment.FailFast: %s{m}"
                 | RunOutcome.NormalExit (state, thread) -> state, thread
                 | RunOutcome.ProcessExit (state, thread) -> state, thread
 

--- a/WoofWare.PawPrint.Test/TestDebuggerState.fs
+++ b/WoofWare.PawPrint.Test/TestDebuggerState.fs
@@ -15,6 +15,9 @@ module TestDebuggerState =
             match outcome with
             | RunOutcome.NormalExit (state, thread)
             | RunOutcome.ProcessExit (state, thread) -> state, thread
+            | RunOutcome.FailFast (_, _, message) ->
+                let m = message |> Option.defaultValue "<no message>"
+                failwith $"PawPrint guest called Environment.FailFast: %s{m}"
             | RunOutcome.GuestUnhandledException (_, _, exn) ->
                 failwith $"PawPrint threw an unexpected guest exception: %O{exn.ExceptionObject}"
 

--- a/WoofWare.PawPrint.Test/TestHardwareIntrinsicsProfile.fs
+++ b/WoofWare.PawPrint.Test/TestHardwareIntrinsicsProfile.fs
@@ -15,6 +15,9 @@ module TestHardwareIntrinsicsProfile =
             match outcome with
             | RunOutcome.NormalExit (state, thread)
             | RunOutcome.ProcessExit (state, thread) -> state, thread
+            | RunOutcome.FailFast (_, _, message) ->
+                let m = message |> Option.defaultValue "<no message>"
+                failwith $"PawPrint guest called Environment.FailFast: %s{m}"
             | RunOutcome.GuestUnhandledException (_, _, exn) ->
                 failwith $"PawPrint threw an unexpected guest exception: %O{exn.ExceptionObject}"
 

--- a/WoofWare.PawPrint.Test/TestImpureCases.fs
+++ b/WoofWare.PawPrint.Test/TestImpureCases.fs
@@ -87,6 +87,9 @@ module TestImpureCases =
                 match Program.run loggerFactory (Some case.FileName) peImage dotnetRuntimes case.NativeImpls [] with
                 | RunOutcome.GuestUnhandledException (_, _, exn) ->
                     failwith $"Guest threw unhandled exception: %O{exn.ExceptionObject}"
+                | RunOutcome.FailFast (_, _, message) ->
+                    let m = message |> Option.defaultValue "<no message>"
+                    failwith $"Guest called Environment.FailFast: %s{m}"
                 | RunOutcome.NormalExit (state, thread) -> state, thread
                 | RunOutcome.ProcessExit (state, thread) -> state, thread
 

--- a/WoofWare.PawPrint.Test/TestProgramDebugger.fs
+++ b/WoofWare.PawPrint.Test/TestProgramDebugger.fs
@@ -22,6 +22,7 @@ module TestProgramDebugger =
     type private OutcomeSignature =
         | ExitCode of int
         | GuestUnhandledException
+        | FailFast of message : string option
 
     let private sourceForExitCode (exitCode : int) : string =
         $"""
@@ -77,6 +78,7 @@ class Program
             match state.ThreadState.[thread].MethodState.EvaluationStack.Values with
             | EvalStackValue.Int32 i :: _ -> OutcomeSignature.ExitCode i
             | other -> failwith $"Expected int32 exit stack, got %O{other}"
+        | RunOutcome.FailFast (_, _, message) -> OutcomeSignature.FailFast message
         | RunOutcome.GuestUnhandledException _ -> OutcomeSignature.GuestUnhandledException
 
     let private stepToCompletion

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -44,7 +44,7 @@ module TestPureCases =
             "RuntimeTypeHandleGetInstantiationOpenGeneric.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringMethodForGenericParameter
             "InitializeArrayBoxedFieldHandle.cs" // past String::FastAllocateString(MethodTable*, nint); now blocked by unimplemented MethodTable field projection for ParentMethodTable
             "MethodReflectionProbe.cs" // past AssemblyNative_IsApplyUpdateSupported QCall (MetadataUpdater.IsSupported now returns false during static init); now blocked by unimplemented InternalCall RuntimeMethodHandle::GetStubIfNeededInternal during MethodInfo materialisation
-            "ArraySortHelperDefaultInt.cs" // past Ldftn against MemberReference (covered by LdftnCrossAssembly.cs); now blocked by unimplemented QCall Environment_FailFast
+            "ArraySortHelperDefaultInt.cs" // past Environment_FailFast QCall (now wired up); now blocked downstream by ResourceManager hitting infinite recursion looking up 'Arg_NullReferenceException' in System.Private.CoreLib, which the BCL escalates to Environment.FailFast
         ]
         |> Set.ofList
 
@@ -196,6 +196,10 @@ module TestPureCases =
 
                     failwith
                         $"Real runtime threw unhandled %s{realExn.GetType().Name}, but PawPrint exited normally (code: %O{pawPrintExitCode})"
+                | _, RunOutcome.FailFast (_, _, message) ->
+                    let m = message |> Option.defaultValue "<no message>"
+
+                    failwith $"PawPrint guest called Environment.FailFast for %s{case.FileName}: %s{m}"
                 | _, RunOutcome.ProcessExit _ -> failwith "unreachable: normalised away above"
             )
 
@@ -272,6 +276,9 @@ class Program
                     | [] -> failwith "expected program to return an int, but it returned void"
                     | ret :: _ -> failwith $"expected program to return an int, but it returned %O{ret}"
                 | RunOutcome.ProcessExit _ -> failwith "expected normal exit, got process exit"
+                | RunOutcome.FailFast (_, _, message) ->
+                    let m = message |> Option.defaultValue "<no message>"
+                    failwith $"expected normal exit, got Environment.FailFast: %s{m}"
                 | RunOutcome.GuestUnhandledException (_, _, exn) ->
                     failwith $"guest threw unhandled exception: %O{exn.ExceptionObject}"
             )
@@ -330,6 +337,9 @@ class Program
                     | [] -> failwith "expected program to return an int, but it returned void"
                     | ret :: _ -> failwith $"expected program to return an int, but it returned %O{ret}"
                 | RunOutcome.ProcessExit _ -> failwith "expected normal exit, got process exit"
+                | RunOutcome.FailFast (_, _, message) ->
+                    let m = message |> Option.defaultValue "<no message>"
+                    failwith $"expected normal exit, got Environment.FailFast: %s{m}"
                 | RunOutcome.GuestUnhandledException (_, _, exn) ->
                     failwith $"guest threw unhandled exception: %O{exn.ExceptionObject}"
             )
@@ -371,8 +381,47 @@ class Program
                     | [] -> failwith "expected program to return an int, but it returned void"
                     | ret :: _ -> failwith $"expected program to return an int, but it returned %O{ret}"
                 | RunOutcome.ProcessExit _ -> failwith "expected normal exit, got process exit"
+                | RunOutcome.FailFast (_, _, message) ->
+                    let m = message |> Option.defaultValue "<no message>"
+                    failwith $"expected normal exit, got Environment.FailFast: %s{m}"
                 | RunOutcome.GuestUnhandledException (_, _, exn) ->
                     failwith $"guest threw unhandled exception: %O{exn.ExceptionObject}"
+            )
+
+    [<Test>]
+    let ``Environment.FailFast aborts execution`` () =
+        let source =
+            """
+using System;
+
+class Program
+{
+    static int Main(string[] args)
+    {
+        Environment.FailFast("boom");
+        return 0;
+    }
+}
+"""
+
+        let nativeImpls =
+            let empty = MockEnv.make ()
+
+            { empty with
+                System_Environment = System_Environment.passThru
+            }
+
+        runPawPrintSource
+            "EnvironmentFailFast.cs"
+            source
+            nativeImpls
+            (fun _image pawPrintResult ->
+                match pawPrintResult with
+                | RunOutcome.FailFast (_, _, message) -> message |> shouldEqual (Some "boom")
+                | RunOutcome.NormalExit _ -> failwith "expected FailFast, got normal exit"
+                | RunOutcome.ProcessExit _ -> failwith "expected FailFast, got process exit"
+                | RunOutcome.GuestUnhandledException (_, _, exn) ->
+                    failwith $"expected FailFast, got guest unhandled exception: %O{exn.ExceptionObject}"
             )
 
     [<TestCaseSource(nameof simpleCases)>]

--- a/WoofWare.PawPrint/AbstractMachine.fs
+++ b/WoofWare.PawPrint/AbstractMachine.fs
@@ -49,6 +49,7 @@ module AbstractMachine =
             match outcome with
             | ExecutionResult.Terminated (state, terminating) -> ExecutionResult.Terminated (state, terminating)
             | ExecutionResult.ProcessExit _ -> outcome
+            | ExecutionResult.FailFast _ -> outcome
             | ExecutionResult.UnhandledException _ -> outcome
             | ExecutionResult.Stepped (state, WhatWeDid.SuspendedForClassInit) ->
                 // A cctor was pushed; the native frame must stay on the stack so the dispatch loop

--- a/WoofWare.PawPrint/ExternImplementations/System.Environment.fs
+++ b/WoofWare.PawPrint/ExternImplementations/System.Environment.fs
@@ -12,6 +12,12 @@ type ISystem_Environment =
     /// The expected side effect is to terminate execution.
     abstract _Exit : ThreadId -> IlMachineState -> ExecutionResult
 
+    /// Environment.FailFast lowering. The expected side effect is to abort execution
+    /// (`ExecutionResult.FailFast`). `message` and `errorSource` are the guest-supplied
+    /// diagnostic strings (each may be absent if the guest passed a null pointer).
+    abstract FailFast :
+        ThreadId -> message : string option -> errorSource : string option -> IlMachineState -> ExecutionResult
+
 [<RequireQualifiedAccess>]
 module System_Environment =
     let passThru : ISystem_Environment =
@@ -42,6 +48,13 @@ module System_Environment =
                 // it as the final exit code, then tear the whole process down.
                 let state = state |> IlMachineState.loadArgument currentThread 0
                 ExecutionResult.ProcessExit (state, currentThread)
+
+            member _.FailFast currentThread message _errorSource state =
+                // FailFast aborts the process. We don't load the StackCrawlMark / exception
+                // / errorSource arguments onto the eval stack because the caller never
+                // returns — the run-loop converts ExecutionResult.FailFast directly to
+                // RunOutcome.FailFast for the host to surface.
+                ExecutionResult.FailFast (state, currentThread, message)
         }
 
 type ISystem_Environment_Env =

--- a/WoofWare.PawPrint/IlMachineStateModel.fs
+++ b/WoofWare.PawPrint/IlMachineStateModel.fs
@@ -199,6 +199,13 @@ type ExecutionResult =
     /// guest execution (e.g. finalizers, AppDomain-unload hooks), this constructor will
     /// need to return the thread to a consistent state first.
     | ProcessExit of IlMachineState * exitingThread : ThreadId
+    /// Environment.FailFast was called on `abortingThread`. Like ProcessExit, the process
+    /// terminates immediately; unlike ProcessExit, this represents an abort (no exit code
+    /// on the stack, no clean-shutdown semantics). `message` is the guest-supplied diagnostic
+    /// string (if any). Distinct from ProcessExit so test harnesses can assert the difference,
+    /// and so callers can surface the abort to the host (logs, non-zero exit) rather than
+    /// reporting a clean exit.
+    | FailFast of IlMachineState * abortingThread : ThreadId * message : string option
     | Stepped of IlMachineState * WhatWeDid
     | UnhandledException of
         IlMachineState *
@@ -228,6 +235,11 @@ type RunOutcome =
     /// code. Distinct from `NormalExit` so the pre-main cctor pump can bail rather
     /// than silently continuing into `Main` after the guest already asked to die.
     | ProcessExit of IlMachineState * exitingThread : ThreadId
+    /// A thread called `Environment.FailFast`. The process aborts immediately; the
+    /// abort message (if any) is surfaced for diagnostics. Distinct from ProcessExit
+    /// because FailFast is semantically an abort, not a clean exit — finalizers do not
+    /// run on real CoreCLR, and the host typically reports a non-zero/abort exit.
+    | FailFast of IlMachineState * abortingThread : ThreadId * message : string option
     | GuestUnhandledException of
         IlMachineState *
         terminatingThread : ThreadId *

--- a/WoofWare.PawPrint/Native/NativeEnvironment.fs
+++ b/WoofWare.PawPrint/Native/NativeEnvironment.fs
@@ -56,38 +56,50 @@ module NativeEnvironment =
           MethodReturnType.Void ->
             let env = ISystem_Environment_Env.get ctx.Implementations
             env._Exit ctx.Thread state |> Some
-        | "System.Private.CoreLib",
-          "System",
-          "Environment",
-          "<FailFast>g____PInvoke|11_0",
-          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
-                                              "System.Runtime.CompilerServices",
-                                              "StackCrawlMarkHandle",
-                                              stackMarkGenerics)
-            ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt16)
-            ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
-                                              "System.Runtime.CompilerServices",
-                                              "ObjectHandleOnStack",
-                                              objHandleGenerics)
-            ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt16) ],
-          MethodReturnType.Void when stackMarkGenerics.IsEmpty && objHandleGenerics.IsEmpty ->
+        | "System.Private.CoreLib", "System", "Environment", _, _, _ when
+            NativeCall.tryQCallEntryPoint ctx = Some "Environment_FailFast"
+            ->
             // QCall lowering of Environment.FailFast(string?, Exception?, string?). The
-            // StackCrawlMarkHandle and ObjectHandleOnStack args are diagnostic-only on the
-            // native side (used by CoreCLR to walk the managed stack and capture the
-            // exception object); PawPrint surfaces FailFast as an abort outcome and does
-            // not yet inspect either, so they're ignored here. `message` and `errorSource`
-            // are UTF-16 char* pointers (possibly null).
+            // C# source uses LibraryImport with non-blittable string args, so Roslyn
+            // emits a marshalling stub whose synthesized name (e.g.
+            // `<FailFast>g____PInvoke|N_M`) carries source-generator counters and is
+            // not stable across runtime/source-generator versions. Match on the QCall
+            // entry-point name (`Environment_FailFast`) instead, then verify the
+            // signature shape before reading args.
+            //
+            // The StackCrawlMarkHandle and ObjectHandleOnStack args are diagnostic-only
+            // on the native side (used by CoreCLR to walk the managed stack and capture
+            // the exception object); PawPrint surfaces FailFast as an abort outcome and
+            // does not yet inspect either, so they're ignored here. `message` and
+            // `errorSource` are UTF-16 char* pointers (possibly null).
             let operation = "Environment_FailFast"
 
-            if instruction.Arguments.Length <> 4 then
+            match
+                instruction.ExecutingMethod.Signature.ParameterTypes, instruction.ExecutingMethod.Signature.ReturnType
+            with
+            | [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                                  "System.Runtime.CompilerServices",
+                                                  "StackCrawlMarkHandle",
+                                                  stackMarkGenerics)
+                ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt16)
+                ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                                  "System.Runtime.CompilerServices",
+                                                  "ObjectHandleOnStack",
+                                                  objHandleGenerics)
+                ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt16) ],
+              MethodReturnType.Void when stackMarkGenerics.IsEmpty && objHandleGenerics.IsEmpty ->
+                if instruction.Arguments.Length <> 4 then
+                    failwith
+                        $"%s{operation}: expected four native arguments after matching signature, got %d{instruction.Arguments.Length}"
+
+                let message = tryReadOptionalUtf16 operation "message" ctx instruction.Arguments.[1]
+
+                let errorSource =
+                    tryReadOptionalUtf16 operation "errorSource" ctx instruction.Arguments.[3]
+
+                let env = ISystem_Environment_Env.get ctx.Implementations
+                env.FailFast ctx.Thread message errorSource state |> Some
+            | paramTypes, returnType ->
                 failwith
-                    $"%s{operation}: expected four native arguments after matching signature, got %d{instruction.Arguments.Length}"
-
-            let message = tryReadOptionalUtf16 operation "message" ctx instruction.Arguments.[1]
-
-            let errorSource =
-                tryReadOptionalUtf16 operation "errorSource" ctx instruction.Arguments.[3]
-
-            let env = ISystem_Environment_Env.get ctx.Implementations
-            env.FailFast ctx.Thread message errorSource state |> Some
+                    $"%s{operation}: matched QCall entry point but signature unexpected: params=%A{paramTypes}, return=%A{returnType}"
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeEnvironment.fs
+++ b/WoofWare.PawPrint/Native/NativeEnvironment.fs
@@ -4,6 +4,22 @@ open WoofWare.PawPrint.ExternImplementations
 
 [<RequireQualifiedAccess>]
 module NativeEnvironment =
+    /// Read a UTF-16 char* argument, returning None for a null pointer and Some <string> otherwise.
+    let private tryReadOptionalUtf16
+        (operation : string)
+        (argName : string)
+        (ctx : NativeCallContext)
+        (arg : CliType)
+        : string option
+        =
+        let ptr = NativeCall.managedPointerOfPointerArgument operation argName arg
+
+        match ptr with
+        | ManagedPointerSource.Null -> None
+        | _ ->
+            NativeCall.readNullTerminatedUtf16 operation ctx.BaseClassTypes ctx.State ptr
+            |> Some
+
     let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
@@ -40,4 +56,38 @@ module NativeEnvironment =
           MethodReturnType.Void ->
             let env = ISystem_Environment_Env.get ctx.Implementations
             env._Exit ctx.Thread state |> Some
+        | "System.Private.CoreLib",
+          "System",
+          "Environment",
+          "<FailFast>g____PInvoke|11_0",
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "StackCrawlMarkHandle",
+                                              stackMarkGenerics)
+            ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt16)
+            ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "ObjectHandleOnStack",
+                                              objHandleGenerics)
+            ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt16) ],
+          MethodReturnType.Void when stackMarkGenerics.IsEmpty && objHandleGenerics.IsEmpty ->
+            // QCall lowering of Environment.FailFast(string?, Exception?, string?). The
+            // StackCrawlMarkHandle and ObjectHandleOnStack args are diagnostic-only on the
+            // native side (used by CoreCLR to walk the managed stack and capture the
+            // exception object); PawPrint surfaces FailFast as an abort outcome and does
+            // not yet inspect either, so they're ignored here. `message` and `errorSource`
+            // are UTF-16 char* pointers (possibly null).
+            let operation = "Environment_FailFast"
+
+            if instruction.Arguments.Length <> 4 then
+                failwith
+                    $"%s{operation}: expected four native arguments after matching signature, got %d{instruction.Arguments.Length}"
+
+            let message = tryReadOptionalUtf16 operation "message" ctx instruction.Arguments.[1]
+
+            let errorSource =
+                tryReadOptionalUtf16 operation "errorSource" ctx instruction.Arguments.[3]
+
+            let env = ISystem_Environment_Env.get ctx.Implementations
+            env.FailFast ctx.Thread message errorSource state |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -143,6 +143,8 @@ module Program =
                     )
             | ExecutionResult.ProcessExit (state, exitingThread) ->
                 ProgramStepOutcome.Completed (RunOutcome.ProcessExit (state, exitingThread))
+            | ExecutionResult.FailFast (state, abortingThread, message) ->
+                ProgramStepOutcome.Completed (RunOutcome.FailFast (state, abortingThread, message))
             | ExecutionResult.UnhandledException (state, terminatingThread, exn) ->
                 ProgramStepOutcome.Completed (RunOutcome.GuestUnhandledException (state, terminatingThread, exn))
             | ExecutionResult.Stepped (state, whatWeDid) ->
@@ -420,6 +422,10 @@ module Program =
         | RunOutcome.ProcessExit _ as outcome ->
             // A worker started during cctor pumping called Environment.Exit; the process
             // has torn down. Propagate rather than pressing on into Main.
+            ProgramStartResult.CompletedBeforeMain outcome
+        | RunOutcome.FailFast _ as outcome ->
+            // A worker started during cctor pumping called Environment.FailFast; the
+            // process has aborted. Propagate rather than pressing on into Main.
             ProgramStartResult.CompletedBeforeMain outcome
         | RunOutcome.NormalExit (state, _) ->
 


### PR DESCRIPTION
## Summary
- Implement the `Environment_FailFast` QCall by adding a new `ISystem_Environment.FailFast` hook and dispatching it from `NativeEnvironment.tryExecute`. The hook is keyed on the stable QCall entry-point name rather than the Roslyn-synthesized P/Invoke stub.
- Introduce a distinct abort outcome (`ExecutionResult.FailFast` → `RunOutcome.FailFast`) so test harnesses and hosts can tell an abort apart from a clean `ProcessExit`. The pre-main cctor pump bails on FailFast just like ProcessExit; the App surfaces the message and the platform-appropriate exit code (`COR_E_FAILFAST = 0x80131623` on Windows, `SIGABRT = 134` on Unix).
- `ArraySortHelperDefaultInt.cs` moves past this blocker but now stops at a different downstream issue (ResourceManager infinite recursion on `Arg_NullReferenceException`); the `unimplemented` annotation is updated to reflect that.

## Test plan
- [x] `dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 683/683 pass
- [x] New regression test `Environment.FailFast aborts execution` exercises the happy path with a guest-supplied message
- [x] `codex review --base main` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)