### PR TITLE
Implement RuntimeMethodHandle::GetStubIfNeededInternal fast path

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -43,7 +43,6 @@ module TestPureCases =
             "IsAssignableToBasic.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringTypeHandle
             "RuntimeTypeHandleGetInstantiationOpenGeneric.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringMethodForGenericParameter
             "InitializeArrayBoxedFieldHandle.cs" // past String::FastAllocateString(MethodTable*, nint); now blocked by unimplemented MethodTable field projection for ParentMethodTable
-            "MethodReflectionProbe.cs" // past AssemblyNative_IsApplyUpdateSupported QCall (MetadataUpdater.IsSupported now returns false during static init); now blocked by unimplemented InternalCall RuntimeMethodHandle::GetStubIfNeededInternal during MethodInfo materialisation
             "ArraySortHelperDefaultInt.cs" // past Ldftn against MemberReference (covered by LdftnCrossAssembly.cs); now blocked by unimplemented QCall Environment_FailFast
         ]
         |> Set.ofList

--- a/WoofWare.PawPrint/MethodHandleRegistry.fs
+++ b/WoofWare.PawPrint/MethodHandleRegistry.fs
@@ -167,6 +167,19 @@ module MethodHandleRegistry =
 
         buildRuntimeMethodHandleInternal baseClassTypes allConcreteTypes zero
 
+    /// Build a `RuntimeMethodHandleInternal` value type whose `m_handle` field carries the given
+    /// registry id. Callers must ensure `id` was previously allocated (e.g. by
+    /// `getOrAllocateInternalHandle`); this helper performs no validation, so a stale id will
+    /// yield a struct that resolves to `None` from `resolveMethodFromId`.
+    let internalHandleFromId
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (allConcreteTypes : AllConcreteTypes)
+        (id : int64)
+        : CliValueType
+        =
+        let mHandle = CliType.RuntimePointer (CliRuntimePointer.MethodRegistryHandle id)
+        buildRuntimeMethodHandleInternal baseClassTypes allConcreteTypes mHandle
+
     /// Resolve a `RuntimeMethodHandleInternal` registry id back to its underlying `MethodHandle`,
     /// or return `None` if the id is unknown (including the zero/null id).
     let resolveMethodFromId (id : int64) (reg : MethodHandleRegistry) : MethodHandle option =

--- a/WoofWare.PawPrint/MethodHandleRegistry.fs
+++ b/WoofWare.PawPrint/MethodHandleRegistry.fs
@@ -168,15 +168,21 @@ module MethodHandleRegistry =
         buildRuntimeMethodHandleInternal baseClassTypes allConcreteTypes zero
 
     /// Build a `RuntimeMethodHandleInternal` value type whose `m_handle` field carries the given
-    /// registry id. Callers must ensure `id` was previously allocated (e.g. by
-    /// `getOrAllocateInternalHandle`); this helper performs no validation, so a stale id will
-    /// yield a struct that resolves to `None` from `resolveMethodFromId`.
+    /// registry id. Rejects the zero id (which is the BCL's null sentinel and must be constructed
+    /// via `zeroInternalHandle` so the resulting struct's `IsNullHandle()` check sees `IntPtr.Zero`
+    /// rather than a non-null `MethodRegistryHandle 0L`). The id is otherwise assumed live: a
+    /// non-zero id that was never allocated will yield a struct that resolves to `None` from
+    /// `resolveMethodFromId`.
     let internalHandleFromId
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (allConcreteTypes : AllConcreteTypes)
         (id : int64)
         : CliValueType
         =
+        if id = 0L then
+            failwith
+                "MethodHandleRegistry.internalHandleFromId: refusing to wrap zero id as a live RuntimeMethodHandleInternal; use zeroInternalHandle for the null sentinel"
+
         let mHandle = CliType.RuntimePointer (CliRuntimePointer.MethodRegistryHandle id)
         buildRuntimeMethodHandleInternal baseClassTypes allConcreteTypes mHandle
 

--- a/WoofWare.PawPrint/Native/NativeRuntimeMethodHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeMethodHandle.fs
@@ -106,4 +106,116 @@ module NativeRuntimeMethodHandle =
                     state
 
             (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+        | "System.Private.CoreLib",
+          "System",
+          "RuntimeMethodHandle",
+          "GetStubIfNeededInternal",
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System",
+                                              "RuntimeMethodHandleInternal",
+                                              handleGenerics)
+            ConcreteType state.ConcreteTypes ("System.Private.CoreLib", "System", "RuntimeType", runtimeTypeGenerics) ],
+          MethodReturnType.Returns (ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                                                      "System",
+                                                                      "RuntimeMethodHandleInternal",
+                                                                      retGenerics)) when
+            handleGenerics.IsEmpty && runtimeTypeGenerics.IsEmpty && retGenerics.IsEmpty
+            ->
+            // CoreCLR runtimehandles.cpp:1886-1911. Fast path that returns the same MethodDesc*
+            // when no instantiating/unboxing stub is needed. Returning NULL hands off to the slow
+            // QCall RuntimeMethodHandle_GetStubIfNeededSlow, which materialises an
+            // InstantiatedMethodDesc via FindOrCreateAssociatedMethodDescForReflection.
+            //
+            // CoreCLR predicate (skipping the IsAsyncVariantMethod short-circuit since async
+            // variants aren't yet modelled in PawPrint):
+            //   pMethod->HasMethodInstantiation()
+            //   || (!instType.IsValueType()
+            //       && (!instType.HasInstantiation() || instType.IsGenericTypeDefinition()))
+            let operation = "RuntimeMethodHandle.GetStubIfNeededInternal"
+
+            let methodInfo =
+                resolveMethodInfoFromHandleArg operation state instruction.Arguments.[0]
+
+            let methodHandleId =
+                NativeCall.methodHandleIdOfRuntimeMethodHandleInternal operation instruction.Arguments.[0]
+                |> Option.defaultWith (fun () -> failwith $"%s{operation}: null RuntimeMethodHandleInternal")
+
+            let hasMethodInstantiation = not methodInfo.Generics.IsEmpty
+
+            let state = IlMachineState.loadArgument ctx.Thread 1 state
+            let runtimeTypeRef, state = IlMachineState.popEvalStack ctx.Thread state
+
+            let target =
+                NativeCall.runtimeTypeHandleTargetOfRuntimeTypeRef operation state runtimeTypeRef
+
+            let returnsOriginalHandle =
+                if hasMethodInstantiation then
+                    true
+                else
+                    match target with
+                    | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
+                        // An open generic type definition has HasInstantiation = true and
+                        // IsGenericTypeDefinition = true, so the inner disjunction is true; the
+                        // overall predicate reduces to !IsValueType. (Roslyn does emit value-typed
+                        // generic definitions, e.g. Nullable<>, so we cannot assume false here.)
+                        let assembly =
+                            state.LoadedAssembly identity.Assembly
+                            |> Option.defaultWith (fun () ->
+                                failwith
+                                    $"%s{operation}: assembly for open generic type definition is not loaded: %s{identity.AssemblyFullName}"
+                            )
+
+                        let typeInfo = assembly.TypeDefs.[identity.TypeDefinition.Get]
+
+                        not (DumpedAssembly.isValueType ctx.BaseClassTypes state._LoadedAssemblies typeInfo)
+                    | RuntimeTypeHandleTarget.Closed handle ->
+                        // A `Closed` handle is a fully-bound type. IsGenericTypeDefinition is
+                        // therefore false; HasInstantiation matches whether the concrete type has
+                        // generic arguments. Structural shapes (array/byref/pointer/fnptr) have no
+                        // nominal definition and are reference-shaped from this predicate's
+                        // perspective: !IsValueType && (!HasInstantiation || false) = true.
+                        match handle with
+                        | ConcreteTypeHandle.Concrete _ ->
+                            match AllConcreteTypes.lookup handle state.ConcreteTypes with
+                            | None ->
+                                failwith
+                                    $"%s{operation}: closed RuntimeTypeHandle %O{handle} not found in ConcreteTypes"
+                            | Some concreteType ->
+                                let assembly =
+                                    state.LoadedAssembly concreteType.Assembly
+                                    |> Option.defaultWith (fun () ->
+                                        failwith
+                                            $"%s{operation}: assembly %s{concreteType.Assembly.FullName} for closed RuntimeTypeHandle is not loaded"
+                                    )
+
+                                let typeInfo = assembly.TypeDefs.[concreteType.Definition.Get]
+
+                                let isValueType =
+                                    DumpedAssembly.isValueType ctx.BaseClassTypes state._LoadedAssemblies typeInfo
+
+                                let hasInstantiation = not concreteType.Generics.IsEmpty
+
+                                not isValueType && not hasInstantiation
+                        | ConcreteTypeHandle.Byref _
+                        | ConcreteTypeHandle.Pointer _
+                        | ConcreteTypeHandle.FunctionPointer _
+                        | ConcreteTypeHandle.OneDimArrayZero _
+                        | ConcreteTypeHandle.Array _ -> true
+                    | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
+                        failwith
+                            $"%s{operation}: TODO: not implemented for type-generic parameter #%i{position} of %O{declaringType.TypeDefinition.Get}; reflecting MethodInfo through a TypeVar declaring type is uncommon and would need IsValueType modelling against the parameter's struct constraint"
+                    | RuntimeTypeHandleTarget.MethodGenericParameter (declaringType, declaringMethod, position) ->
+                        failwith
+                            $"%s{operation}: TODO: not implemented for method-generic parameter #%i{position} of method %O{declaringMethod.Get} on %O{declaringType.TypeDefinition.Get}"
+
+            let returnValue =
+                if returnsOriginalHandle then
+                    MethodHandleRegistry.internalHandleFromId ctx.BaseClassTypes state.ConcreteTypes methodHandleId
+                else
+                    MethodHandleRegistry.zeroInternalHandle ctx.BaseClassTypes state.ConcreteTypes
+
+            let state =
+                IlMachineState.pushToEvalStack (CliType.ValueType returnValue) ctx.Thread state
+
+            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
         | _ -> None


### PR DESCRIPTION
## Summary

- Models the CoreCLR fast path at `runtimehandles.cpp:1886-1911` as a new arm in `NativeRuntimeMethodHandle.tryExecute`. The predicate (sans the not-yet-modelled `IsAsyncVariantMethod` short-circuit) returns the original `RuntimeMethodHandleInternal` when no instantiating/unboxing stub is needed, and a zero handle otherwise — at which point the BCL routes through the slow QCall `RuntimeMethodHandle_GetStubIfNeededSlow` (still unimplemented).
- Adds `MethodHandleRegistry.internalHandleFromId` to rebuild a `RuntimeMethodHandleInternal` from an existing registry id (sibling of the existing `zeroInternalHandle` / `getOrAllocateInternalHandle`).
- Removes `MethodReflectionProbe.cs` from `unimplemented`; the test now passes end-to-end.

`GenericParameter` / `MethodGenericParameter` targets `failwith` with TODOs — reflection through a TypeVar declaring type is rare and would need `IsValueType` modelling against the parameter's struct constraint.

## Test plan

- [x] `nix develop -c dotnet test --filter "Name~MethodReflectionProbe"` passes
- [x] Full suite: 683 / 683 passing
- [x] `codex review --base main` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)