### PR TITLE
Refresh unimplemented test comments to reflect current blockers

### DIFF
--- a/WoofWare.PawPrint.Test/TestHarness.fs
+++ b/WoofWare.PawPrint.Test/TestHarness.fs
@@ -49,6 +49,8 @@ module MockEnv =
                             |> Tuple.withRight WhatWeDid.Executed
                             |> ExecutionResult.Stepped
                     TryGetEnvironmentVariable = tryGetEnvironmentVariable
+                    FailFast =
+                        fun thread message _errorSource state -> ExecutionResult.FailFast (state, thread, message)
                 }
         }
 

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -24,26 +24,41 @@ module TestPureCases =
             "RethrowStackTraceBoundary.cs" // stack trace rendering returns exit code 11 because frames lack parameter signatures (the test asserts presence of "RethrowStackTraceBoundary.Thrower(String value)")
             "RuntimeTypeHandleGetInstantiationOpenGeneric.cs" // still blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringMethodForGenericParameter
             "Threads.cs" // past pointer arithmetic over the generated Data field; now blocked by unimplemented PInvoke libSystem.Native!SystemNative_LowLevelMonitor_Create
-            // The remaining tests reach Environment.FailFast inside the BCL (now wired up as a QCall), where the test fixture's System_EnvironmentMock raises NotImplementedException for FailFast. They will unblock together once the test mock implements FailFast (e.g. by returning ExecutionResult.FailFast, as System_Environment.passThru does).
-            "ArraySortHelperDefaultInt.cs" // ResourceManager recursion escalates to Environment.FailFast; blocked at the test mock's unimplemented FailFast
-            "CastClassInvalid.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
-            "CastclassFailures.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
-            "ComplexTryCatch.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
-            "CrossAssemblyTypes.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
-            "EnumSemantics.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
-            "InitializeArrayBoxedFieldHandle.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
-            "InterfaceDispatch.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
-            "IsAssignableToBasic.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
-            "LdelemaArrayTypeMismatch.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
-            "MakeGenericTypeClassConstraint.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
-            "MakeGenericTypeNewConstraint.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
-            "MakeGenericTypeStructConstraint.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
-            "MetadataImportGetSigOfMethodDef.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
-            "NullDereferenceTest.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
-            "RuntimeTypeGetInterfacesEmpty.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
-            "RuntimeTypeGetInterfacesInherited.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
-            "ThrowingCctorProperties.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
-            "TypeDefCustomAttributeEnum.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
+            // The remaining tests share a symptom rather than a blocker: an upstream
+            // NullReferenceException is raised somewhere in the BCL while running the test,
+            // and when SR.GetResourceString tries to look up the "Arg_NullReferenceException"
+            // string to format the exception's message, the resource-loading path itself
+            // throws another NRE. SR's recursion guard detects the loop and calls
+            // Environment.FailFast(...). Real CoreCLR does not FailFast for these scenarios,
+            // so each entry indicates a genuine PawPrint defect upstream of the FailFast.
+            //   For RuntimeTypeGetInterfacesEmpty/Inherited the upstream NRE is reproducible
+            //   and traces to `Ldsfld System.String::Empty` returning null: that field is
+            //   marked `[Intrinsic]` in CoreLib and is populated by the CLR's EE startup
+            //   rather than by a static cctor, so PawPrint's `cliTypeZeroOf` fallback hands
+            //   out a zero-initialised reference (null) which then NREs in
+            //   `MemberInfoCache<T>.GetListByName` at `name.Length`.
+            // Other entries are likely upstream-NRE bugs of their own kind; they are grouped
+            // here only because they share the SR.GetResourceString recursion-guard failure
+            // mode once the test fixture wires FailFast as ExecutionResult.FailFast.
+            "ArraySortHelperDefaultInt.cs" // upstream NRE -> SR.GetResourceString recursion guard -> Environment.FailFast (see group comment above)
+            "CastClassInvalid.cs" // upstream NRE -> SR.GetResourceString recursion guard -> Environment.FailFast (see group comment above)
+            "CastclassFailures.cs" // upstream NRE -> SR.GetResourceString recursion guard -> Environment.FailFast (see group comment above)
+            "ComplexTryCatch.cs" // upstream NRE -> SR.GetResourceString recursion guard -> Environment.FailFast (see group comment above)
+            "CrossAssemblyTypes.cs" // upstream NRE -> SR.GetResourceString recursion guard -> Environment.FailFast (see group comment above)
+            "EnumSemantics.cs" // upstream NRE -> SR.GetResourceString recursion guard -> Environment.FailFast (see group comment above)
+            "InitializeArrayBoxedFieldHandle.cs" // upstream NRE -> SR.GetResourceString recursion guard -> Environment.FailFast (see group comment above)
+            "InterfaceDispatch.cs" // upstream NRE -> SR.GetResourceString recursion guard -> Environment.FailFast (see group comment above)
+            "IsAssignableToBasic.cs" // upstream NRE -> SR.GetResourceString recursion guard -> Environment.FailFast (see group comment above)
+            "LdelemaArrayTypeMismatch.cs" // upstream NRE -> SR.GetResourceString recursion guard -> Environment.FailFast (see group comment above)
+            "MakeGenericTypeClassConstraint.cs" // upstream NRE -> SR.GetResourceString recursion guard -> Environment.FailFast (see group comment above)
+            "MakeGenericTypeNewConstraint.cs" // upstream NRE -> SR.GetResourceString recursion guard -> Environment.FailFast (see group comment above)
+            "MakeGenericTypeStructConstraint.cs" // upstream NRE -> SR.GetResourceString recursion guard -> Environment.FailFast (see group comment above)
+            "MetadataImportGetSigOfMethodDef.cs" // upstream NRE -> SR.GetResourceString recursion guard -> Environment.FailFast (see group comment above)
+            "NullDereferenceTest.cs" // upstream NRE -> SR.GetResourceString recursion guard -> Environment.FailFast (see group comment above)
+            "RuntimeTypeGetInterfacesEmpty.cs" // upstream NRE in MemberInfoCache.GetListByName because `String::Empty` is uninitialised; SR.GetResourceString's recursion guard then FailFasts (see group comment above)
+            "RuntimeTypeGetInterfacesInherited.cs" // upstream NRE in MemberInfoCache.GetListByName because `String::Empty` is uninitialised; SR.GetResourceString's recursion guard then FailFasts (see group comment above)
+            "ThrowingCctorProperties.cs" // upstream NRE -> SR.GetResourceString recursion guard -> Environment.FailFast (see group comment above)
+            "TypeDefCustomAttributeEnum.cs" // upstream NRE -> SR.GetResourceString recursion guard -> Environment.FailFast (see group comment above)
         ]
         |> Set.ofList
 

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -17,33 +17,33 @@ module TestPureCases =
 
     let unimplemented =
         [
-            "AdvancedStructLayout.cs" // blocked after fixed-buffer pointer arithmetic by MarshalNative_SizeOfHelper for ByValTStr string marshalling
-            "LdtokenField.cs" // past Volatile.Write of an object reference; now blocked by unimplemented InternalCall System.Buffer::BulkMoveWithWriteBarrierInternal during reflection-cache update
-            "RuntimeFieldHandleGetUtf8Name.cs" // exercises RuntimeFieldHandle::GetUtf8NameInternal, RuntimeTypeHandle::GetInterfaces, and Volatile.Write of object refs successfully; now blocked at the next step by unimplemented InternalCall System.Buffer::BulkMoveWithWriteBarrierInternal
-            "RuntimeTypeGetInterfacesEmpty.cs" // past RuntimeTypeHandle::GetInterfaces QCall; now blocked by unimplemented QCall Environment_FailFast (same as ArraySortHelperDefaultInt.cs)
-            "RuntimeTypeGetInterfacesInherited.cs" // exercises the QCall's inherited-base + transitive-interface walk; same Environment_FailFast blocker as RuntimeTypeGetInterfacesEmpty.cs
-            "GenericEdgeCases.cs" // blocked after BitOperations.Log2 by unimplemented JIT intrinsic System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned (reached via int.ToString -> Number.UInt32ToDecStr)
-            "CrossAssemblyTypes.cs" // past MethodTable::ParentMethodTable projection; now blocked by unimplemented QCall EventPipeInternal_CreateProvider during static init of System.Diagnostics.Tracing.EventPipeInternal
-            "InterfaceDispatch.cs" // past MetadataImport::GetCustomAttributeProps; now blocked by unimplemented InternalCall MetadataImport::GetParentToken
-            "NullDereferenceTest.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
-            "CastClassInvalid.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
-            "CastclassFailures.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
-            "ComplexTryCatch.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
-            "TypeDefCustomAttributeEnum.cs" // past DependentHandle InternalCalls (ConditionalWeakTable static init); now blocked by unimplemented JIT intrinsic System.Threading.Interlocked.Exchange(&, System.Boolean)
-            "RethrowStackTraceBoundary.cs" // stack trace rendering lacks CLR inner-exception boundary and parameterised frames
-            "ThrowingCctorProperties.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
-            "Threads.cs" // blocked by pointer arithmetic over a generated Data field after Interlocked.CompareExchange
-            "MetadataImportGetSigOfMethodDef.cs" // exercises MetadataImport::GetSigOfMethodDef successfully; now blocked at the next step by unimplemented QCall RuntimeMethodHandle::IsCAVisibleFromDecoratedType
-            "LdelemaArrayTypeMismatch.cs" // ArrayTypeMismatchException is raised correctly, but its ctor walks past MetadataImport::GetCustomAttributeProps and now reaches unimplemented MetadataImport::GetParentToken while constructing the message
-            "MakeGenericTypeStructConstraint.cs" // past MetadataImport::GetSigOfMethodDef; now blocked by unimplemented QCall ModuleHandle::ResolveMethod during ArgumentException ctor → ResourceManager init
-            "MakeGenericTypeClassConstraint.cs" // past MetadataImport::GetSigOfMethodDef; now blocked by unimplemented QCall ModuleHandle::ResolveMethod during ArgumentException ctor → ResourceManager init
-            "MakeGenericTypeNewConstraint.cs" // past MetadataImport::GetSigOfMethodDef; now blocked by unimplemented QCall ModuleHandle::ResolveMethod during ArgumentException ctor → ResourceManager init
-            "EnumSemantics.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringTypeHandle
-            "GetDeclaringTypeNestedGeneric.cs" // past MethodTable::AuxiliaryData projection for OpenGenericTypeDefinition; now blocked by ldflda through synthetic MethodTableAuxiliaryData::ExposedClassObjectRaw field address (same blocker as GetElementTypeBasic.cs)
-            "IsAssignableToBasic.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringTypeHandle
-            "RuntimeTypeHandleGetInstantiationOpenGeneric.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringMethodForGenericParameter
-            "InitializeArrayBoxedFieldHandle.cs" // past String::FastAllocateString(MethodTable*, nint); now blocked by unimplemented MethodTable field projection for ParentMethodTable
-            "ArraySortHelperDefaultInt.cs" // past Environment_FailFast QCall (now wired up); now blocked downstream by ResourceManager hitting infinite recursion looking up 'Arg_NullReferenceException' in System.Private.CoreLib, which the BCL escalates to Environment.FailFast
+            "AdvancedStructLayout.cs" // past fixed-buffer pointer arithmetic and MarshalNative_SizeOfHelper; now blocked by unimplemented PInvoke libSystem.Native!SystemNative_Malloc
+            "LdtokenField.cs" // past Volatile.Write of an object reference; still blocked by unimplemented InternalCall System.Buffer::BulkMoveWithWriteBarrierInternal during reflection-cache update
+            "RuntimeFieldHandleGetUtf8Name.cs" // exercises RuntimeFieldHandle::GetUtf8NameInternal, RuntimeTypeHandle::GetInterfaces, and Volatile.Write of object refs; still blocked by unimplemented InternalCall System.Buffer::BulkMoveWithWriteBarrierInternal
+            "GenericEdgeCases.cs" // past BitOperations.Log2; still blocked by unimplemented JIT intrinsic System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned (reached via int.ToString -> Number.UInt32ToDecStr)
+            "RethrowStackTraceBoundary.cs" // stack trace rendering returns exit code 11 because frames lack parameter signatures (the test asserts presence of "RethrowStackTraceBoundary.Thrower(String value)")
+            "RuntimeTypeHandleGetInstantiationOpenGeneric.cs" // still blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringMethodForGenericParameter
+            "Threads.cs" // past pointer arithmetic over the generated Data field; now blocked by unimplemented PInvoke libSystem.Native!SystemNative_LowLevelMonitor_Create
+            // The remaining tests reach Environment.FailFast inside the BCL (now wired up as a QCall), where the test fixture's System_EnvironmentMock raises NotImplementedException for FailFast. They will unblock together once the test mock implements FailFast (e.g. by returning ExecutionResult.FailFast, as System_Environment.passThru does).
+            "ArraySortHelperDefaultInt.cs" // ResourceManager recursion escalates to Environment.FailFast; blocked at the test mock's unimplemented FailFast
+            "CastClassInvalid.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
+            "CastclassFailures.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
+            "ComplexTryCatch.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
+            "CrossAssemblyTypes.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
+            "EnumSemantics.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
+            "InitializeArrayBoxedFieldHandle.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
+            "InterfaceDispatch.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
+            "IsAssignableToBasic.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
+            "LdelemaArrayTypeMismatch.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
+            "MakeGenericTypeClassConstraint.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
+            "MakeGenericTypeNewConstraint.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
+            "MakeGenericTypeStructConstraint.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
+            "MetadataImportGetSigOfMethodDef.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
+            "NullDereferenceTest.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
+            "RuntimeTypeGetInterfacesEmpty.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
+            "RuntimeTypeGetInterfacesInherited.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
+            "ThrowingCctorProperties.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
+            "TypeDefCustomAttributeEnum.cs" // reaches Environment.FailFast in the BCL; blocked at the test mock's unimplemented FailFast
         ]
         |> Set.ofList
 


### PR DESCRIPTION
## Summary
- Refreshes the `unimplemented` set comments in `TestPureCases.fs` after re-running every entry against current `main`.
- 19 of the 26 entries had converged on a single symptom: PawPrint reaches `Environment.FailFast` inside the BCL. The previous comments treated this as the blocker, but real CoreCLR does **not** `FailFast` for these scenarios. The `FailFast` is `SR.InternalGetResourceString`'s recursion guard firing because the BCL is trying to format an `Arg_NullReferenceException` message while the resource-loading path itself NREs. Each entry therefore indicates a genuine PawPrint defect *upstream* of the `FailFast`.
- Wires the test fixture's `System_EnvironmentMock.FailFast` to `ExecutionResult.FailFast` so future investigations see the real BCL message (`"Encountered infinite recursion while looking up resource 'Arg_NullReferenceException' in System.Private.CoreLib. ..."`) rather than the mock's `NotImplementedException`. Strict diagnostic improvement; doesn't change which tests pass.
- For `RuntimeTypeGetInterfacesEmpty/Inherited`, the upstream NRE is now traced: PawPrint never initialises `System.String::Empty`. CoreLib marks that field `[Intrinsic]` and the CLR's EE startup populates it directly (there is no static cctor). PawPrint's `cliTypeZeroOf` fallback hands out a zero-initialised reference (null), so `Ldsfld String::Empty` from `MemberInfoCache<T>.Populate` returns null and the call into `GetListByName` NREs at `name.Length`.
- The other entries in the group are likely upstream-NRE bugs of their own kind; they are grouped here only because they share the recursion-guard failure mode.

## Test plan
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 685/685 passing locally (the entries in `unimplemented` are still skipped as expected; nothing newly passes or regresses).
- [x] `nix develop -c dotnet fantomas WoofWare.PawPrint.Test/TestPureCases.fs WoofWare.PawPrint.Test/TestHarness.fs` — formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)