### PR TITLE
Implement Unsafe.CopyBlock / CopyBlockUnaligned JIT intrinsic

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -22,7 +22,6 @@ module TestPureCases =
             "RuntimeFieldHandleGetUtf8Name.cs" // exercises RuntimeFieldHandle::GetUtf8NameInternal, RuntimeTypeHandle::GetInterfaces, and Volatile.Write of object refs successfully; now blocked at the next step by unimplemented InternalCall System.Buffer::BulkMoveWithWriteBarrierInternal
             "RuntimeTypeGetInterfacesEmpty.cs" // past RuntimeTypeHandle::GetInterfaces QCall; now blocked by unimplemented QCall Environment_FailFast (same as ArraySortHelperDefaultInt.cs)
             "RuntimeTypeGetInterfacesInherited.cs" // exercises the QCall's inherited-base + transitive-interface walk; same Environment_FailFast blocker as RuntimeTypeGetInterfacesEmpty.cs
-            "GenericEdgeCases.cs" // blocked after BitOperations.Log2 by unimplemented JIT intrinsic System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned (reached via int.ToString -> Number.UInt32ToDecStr)
             "CrossAssemblyTypes.cs" // past MethodTable::ParentMethodTable projection; now blocked by unimplemented QCall EventPipeInternal_CreateProvider during static init of System.Diagnostics.Tracing.EventPipeInternal
             "InterfaceDispatch.cs" // past MetadataImport::GetCustomAttributeProps; now blocked by unimplemented InternalCall MetadataImport::GetParentToken
             "NullDereferenceTest.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
@@ -44,6 +43,7 @@ module TestPureCases =
             "RuntimeTypeHandleGetInstantiationOpenGeneric.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringMethodForGenericParameter
             "InitializeArrayBoxedFieldHandle.cs" // past String::FastAllocateString(MethodTable*, nint); now blocked by unimplemented MethodTable field projection for ParentMethodTable
             "ArraySortHelperDefaultInt.cs" // past Environment_FailFast QCall (now wired up); now blocked downstream by ResourceManager hitting infinite recursion looking up 'Arg_NullReferenceException' in System.Private.CoreLib, which the BCL escalates to Environment.FailFast
+            "GenericEdgeCases.cs" // past Unsafe.CopyBlockUnaligned JIT intrinsic; now blocked downstream by ResourceManager hitting infinite recursion looking up 'Arg_NullReferenceException' in System.Private.CoreLib, which the BCL escalates to Environment.FailFast (same blocker as ArraySortHelperDefaultInt.cs)
         ]
         |> Set.ofList
 

--- a/WoofWare.PawPrint/IntrinsicHelpers.fs
+++ b/WoofWare.PawPrint/IntrinsicHelpers.fs
@@ -1062,3 +1062,50 @@ module internal IntrinsicHelpers =
         state
         |> IlMachineState.pushToEvalStack (CliType.ofBool result) currentThread
         |> IlMachineState.advanceProgramCounter currentThread
+
+    let executeUnsafeCopyBlock
+        (baseClassTypes : BaseClassTypes<_>)
+        (currentThread : ThreadId)
+        (operation : string)
+        (state : IlMachineState)
+        : IlMachineState
+        =
+        // Stack order: destination (arg0) pushed first, source (arg1), byteCount (arg2) on top.
+        let byteCountArg, state = IlMachineState.popEvalStack currentThread state
+        let sourceArg, state = IlMachineState.popEvalStack currentThread state
+        let destArg, state = IlMachineState.popEvalStack currentThread state
+
+        let byteCount = byteCountOfStackValue operation byteCountArg
+
+        let state =
+            if byteCount = 0 then
+                state
+            else
+                let sourcePtr = managedPointerOfPointerArgument operation sourceArg
+                let destPtr = managedPointerOfPointerArgument operation destArg
+
+                match sourcePtr, destPtr with
+                | ManagedPointerSource.Null, _ -> failwith $"%s{operation}: refusing nonzero byte copy from null source"
+                | _, ManagedPointerSource.Null ->
+                    failwith $"%s{operation}: refusing nonzero byte copy to null destination"
+                | _ ->
+
+                let byteType = byteConcreteType operation baseClassTypes state
+                let mutable state = state
+
+                // cpblk is undefined for overlapping ranges (ECMA-335 III.3.30), so a
+                // forward byte-by-byte copy is per-spec correct here; we don't need the
+                // Memmove-style overlap handling that Buffer.Memmove offers callers.
+                for i = 0 to byteCount - 1 do
+                    let src =
+                        ManagedPointerByteView.addByteOffset baseClassTypes state byteType i sourcePtr
+
+                    let dest =
+                        ManagedPointerByteView.addByteOffset baseClassTypes state byteType i destPtr
+
+                    let value = IlMachineState.readManagedByrefBytesAs state src byteTemplate
+                    state <- IlMachineState.writeManagedByrefBytesOrTypedCell state dest value
+
+                state
+
+        state |> IlMachineState.advanceProgramCounter currentThread

--- a/WoofWare.PawPrint/IntrinsicHelpers.fsi
+++ b/WoofWare.PawPrint/IntrinsicHelpers.fsi
@@ -92,3 +92,13 @@ module internal IntrinsicHelpers =
         methodToCall : WoofWare.PawPrint.MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle> ->
         state : IlMachineState ->
             IlMachineState
+
+    /// Execute the `Unsafe.CopyBlock` / `Unsafe.CopyBlockUnaligned` JIT intrinsics, performing
+    /// a forward byte-by-byte copy between managed pointers (cpblk has undefined behaviour on
+    /// overlap per ECMA-335 III.3.30, so no overlap detection is performed).
+    val executeUnsafeCopyBlock :
+        baseClassTypes : BaseClassTypes<DumpedAssembly> ->
+        currentThread : ThreadId ->
+        operation : string ->
+        state : IlMachineState ->
+            IlMachineState

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -1309,6 +1309,20 @@ module Intrinsics =
                 let state = state |> IlMachineState.advanceProgramCounter currentThread
                 Some state
             | _ -> None
+        | "System.Private.CoreLib", "Unsafe", ("CopyBlock" | "CopyBlockUnaligned") ->
+            // https://github.com/dotnet/runtime/blob/108fa7856efcfd39bc991c2d849eabbf7ba5989c/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/Unsafe.cs#L313
+            // The CoreLib bodies throw PlatformNotSupportedException; the real JIT replaces
+            // these with `cpblk` (optionally prefixed by `unaligned.`). Both overloads accept
+            // the byref and pointer forms uniformly via managedPointerOfPointerArgument.
+            match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
+            | [ ConcreteByref (ConcretePrimitive state.ConcreteTypes PrimitiveType.Byte)
+                ConcreteByref (ConcretePrimitive state.ConcreteTypes PrimitiveType.Byte)
+                ConcreteUInt32 state.ConcreteTypes ],
+              MethodReturnType.Void
+            | [ ConcretePointer _ ; ConcretePointer _ ; ConcreteUInt32 state.ConcreteTypes ], MethodReturnType.Void ->
+                let operation = $"Unsafe.%s{methodToCall.Name}"
+                executeUnsafeCopyBlock baseClassTypes currentThread operation state |> Some
+            | _ -> None
         | "System.Private.CoreLib", "String", "op_Implicit" ->
             match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
             | [ par ], MethodReturnType.Returns ret ->


### PR DESCRIPTION
## Summary
- The CoreLib IL bodies of `Unsafe.CopyBlock` and `Unsafe.CopyBlockUnaligned` just throw `PlatformNotSupportedException`; the real CLR JIT replaces them with `cpblk` (optionally prefixed by `unaligned.`), so PawPrint must intercept them as intrinsics rather than executing the IL.
- Added a shared `IntrinsicHelpers.executeUnsafeCopyBlock` helper performing a forward byte-by-byte copy through the existing `ManagedPointerByteView` + byte-template read/write APIs. `cpblk` is undefined for overlapping ranges per ECMA-335 III.3.30, so forward copy is per-spec correct and we don't replicate Buffer.Memmove's overlap handling.
- Hooked dispatch in `Intrinsics.fs` for both `(void*, void*, uint32)` and `(ref byte, ref byte, uint32)` overloads of both methods.
- `GenericEdgeCases.cs` now progresses past `Number.UInt32ToDecStr` and reaches the same downstream ResourceManager → `Environment.FailFast` blocker as `ArraySortHelperDefaultInt.cs`; the unimplemented-list entry has been updated accordingly.

## Test plan
- [x] Full test suite passes (685/685)
- [x] Targeted `Name~Unsafe|Span|Number|ToString` filter passes (32/32)
- [x] `GenericEdgeCases.cs` no longer fails on the CopyBlockUnaligned TODO; now reaches the documented downstream blocker
- [x] `codex review --base main` raised no correctness concerns

🤖 Generated with [Claude Code](https://claude.com/claude-code)