### PR TITLE
Thread BaseClassTypes through readManagedByref; drop primitive-name template

### DIFF
--- a/WoofWare.PawPrint.Test/TestFieldHandleRegistry.fs
+++ b/WoofWare.PawPrint.Test/TestFieldHandleRegistry.fs
@@ -453,6 +453,7 @@ public class DerivedWithField : BaseWithField
         |> CliType.ValueType
 
     let private readNativeIntValueAtPointer
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (state : IlMachineState)
         (index : int)
         (ptr : ManagedPointerSource)
@@ -473,7 +474,7 @@ public class DerivedWithField : BaseWithField
             | _ when index = 0 -> ptr
             | _ -> failwith $"Expected native int buffer pointer, got %O{ptr}"
 
-        IlMachineState.readManagedByref state ptr
+        IlMachineState.readManagedByref baseClassTypes state ptr
 
     let private invokeRuntimeTypeHandleGetFields
         (fixture : FieldHandleFixture)
@@ -588,7 +589,7 @@ public class DerivedWithField : BaseWithField
 
         let fieldHandleValues =
             [ 0 .. valuesToRead - 1 ]
-            |> List.map (fun index -> readNativeIntValueAtPointer state index resultBuffer)
+            |> List.map (fun index -> readNativeIntValueAtPointer fixture.BaseClassTypes state index resultBuffer)
 
         success, count, fieldHandleValues, state
 

--- a/WoofWare.PawPrint.Test/TestManifestResources.fs
+++ b/WoofWare.PawPrint.Test/TestManifestResources.fs
@@ -233,8 +233,16 @@ public static class Entry
 
         ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arrayAddr, 0), []), state
 
-    let private readUInt32Out (state : IlMachineState) (ptr : ManagedPointerSource) : uint32 =
-        match IlMachineState.readManagedByref state ptr |> CliType.unwrapPrimitiveLikeDeep with
+    let private readUInt32Out
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (ptr : ManagedPointerSource)
+        : uint32
+        =
+        match
+            IlMachineState.readManagedByref baseClassTypes state ptr
+            |> CliType.unwrapPrimitiveLikeDeep
+        with
         | CliType.Numeric (CliNumericType.Int32 value) -> uint32 value
         | other -> failwith $"expected UInt32 out value, got %O{other}"
 
@@ -308,7 +316,7 @@ public static class Entry
             | None -> failwith "AssemblyNative_GetResource QCall did not match"
 
         let returnValue, state = IlMachineState.popEvalStack prepared.EntryThread state
-        state, readUInt32Out state lengthOut, returnValue
+        state, readUInt32Out baseClassTypes state lengthOut, returnValue
 
     let private invokeAssemblyNativeGetResourceForAssembly
         (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)

--- a/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
+++ b/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
@@ -1904,7 +1904,7 @@ public unsafe struct PointerWrapper
         let updated = CliType.Numeric (CliNumericType.Float32 0.0f)
         let state = IlMachineState.writeManagedByref state ptr updated
 
-        IlMachineState.readManagedByref state ptr |> shouldEqual updated
+        IlMachineState.readManagedByref bct state ptr |> shouldEqual updated
 
     [<Test>]
     let ``Local memory typed cell write evicts intersecting byte overlay`` () : unit =
@@ -2056,7 +2056,7 @@ public unsafe struct PointerWrapper
 
         let stateAfter = IlMachineState.writeManagedByref state ptr handle
 
-        IlMachineState.readManagedByref stateAfter ptr |> shouldEqual handle
+        IlMachineState.readManagedByref bct stateAfter ptr |> shouldEqual handle
 
     [<Test>]
     let ``Typed write into the middle of an existing cell fails visibly`` () : unit =
@@ -2117,7 +2117,7 @@ public unsafe struct PointerWrapper
 
         let stateAfter = IlMachineState.writeManagedByrefBytesOrTypedCell state ptr handle
 
-        IlMachineState.readManagedByref stateAfter ptr |> shouldEqual handle
+        IlMachineState.readManagedByref bct stateAfter ptr |> shouldEqual handle
 
     [<Test>]
     let ``Stind-shaped store of tagged native-int over an identical-shape cell still preserves provenance`` () : unit =
@@ -2144,7 +2144,7 @@ public unsafe struct PointerWrapper
         let state = IlMachineState.writeManagedByrefBytesOrTypedCell state ptr firstHandle
         let state = IlMachineState.writeManagedByrefBytesOrTypedCell state ptr secondHandle
 
-        IlMachineState.readManagedByref state ptr |> shouldEqual secondHandle
+        IlMachineState.readManagedByref bct state ptr |> shouldEqual secondHandle
 
     [<Test>]
     let ``Stind-shaped partial overwrite of a tagged native-int cell refuses to silently lose provenance`` () : unit =
@@ -2173,7 +2173,7 @@ public unsafe struct PointerWrapper
         |> ignore
 
         // The original tagged cell should still be intact.
-        IlMachineState.readManagedByref state ptr |> shouldEqual handle
+        IlMachineState.readManagedByref bct state ptr |> shouldEqual handle
 
     [<Test>]
     let ``Stind_I through bare local-memory byte view reports provenance preservation failure`` () : unit =
@@ -2211,7 +2211,7 @@ public unsafe struct PointerWrapper
 
         ex.Message |> shouldContainText "<field ID 1234>"
 
-        IlMachineState.readManagedByref state ptr
+        IlMachineState.readManagedByref bct state ptr
         |> shouldEqual (CliType.Numeric (CliNumericType.Int32 0x11223344))
 
     [<Test>]
@@ -2256,7 +2256,7 @@ public unsafe struct PointerWrapper
         // Reading the Int32 cell should reflect the byte overlay: the second
         // little-endian byte of 0x11223344 (0x33) becomes 0xAA, giving
         // 0x1122AA44.
-        match IlMachineState.readManagedByref state ptr with
+        match IlMachineState.readManagedByref bct state ptr with
         | CliType.Numeric (CliNumericType.Int32 v) -> v |> shouldEqual 0x1122AA44
         | other -> failwith $"Expected Int32, got %O{other}"
 
@@ -2281,7 +2281,7 @@ public unsafe struct PointerWrapper
 
         let stateAfter = IlMachineState.writeManagedByrefBytesOrTypedCell state ptr zero
 
-        IlMachineState.readManagedByref stateAfter ptr |> shouldEqual zero
+        IlMachineState.readManagedByref bct stateAfter ptr |> shouldEqual zero
 
     [<Test>]
     let ``Stind-shaped overwrite of a tagged cell with a byte-renderable value succeeds`` () : unit =
@@ -2308,7 +2308,7 @@ public unsafe struct PointerWrapper
 
         let state = IlMachineState.writeManagedByrefBytesOrTypedCell state ptr verbatim
 
-        IlMachineState.readManagedByref state ptr |> shouldEqual verbatim
+        IlMachineState.readManagedByref bct state ptr |> shouldEqual verbatim
 
     [<Test>]
     let ``Stind_I1 via EvalStackValue.ManagedPointer over local-memory Int32 cell scatters one byte`` () : unit =
@@ -2417,7 +2417,7 @@ public unsafe struct PointerWrapper
             | ExecutionResult.Stepped (state, WhatWeDid.Executed) -> state
             | other -> failwith $"Expected Stind_I to step, got %O{other}"
 
-        IlMachineState.readManagedByref state ptr
+        IlMachineState.readManagedByref bct state ptr
         |> shouldEqual (CliType.Numeric (CliNumericType.NativeInt secondHandle))
 
     [<Test>]
@@ -2470,7 +2470,7 @@ public unsafe struct PointerWrapper
                 | ExecutionResult.Stepped (state, WhatWeDid.Executed) -> state
                 | other -> failwith $"Expected Stind_I to step, got %O{other}"
 
-            IlMachineState.readManagedByref state ptr
+            IlMachineState.readManagedByref bct state ptr
             |> shouldEqual (CliType.Numeric (CliNumericType.NativeInt source))
 
         Check.One (
@@ -2522,7 +2522,7 @@ public unsafe struct PointerWrapper
                 | ExecutionResult.Stepped (state, WhatWeDid.Executed) -> state
                 | other -> failwith $"Expected Stind_I8 to step, got %O{other}"
 
-            IlMachineState.readManagedByref state ptr
+            IlMachineState.readManagedByref bct state ptr
             |> shouldEqual (CliType.Numeric (CliNumericType.Int64 source))
 
         Check.One (rawDataPropertyConfig.WithMaxTest 500, Prop.forAll (Arb.fromGen genTaggedInt64StindCase) property)
@@ -3003,10 +3003,10 @@ public unsafe struct PointerWrapper
         //   3. `Unsafe.As<byte, object>(ref byteN)`, appending `ReinterpretAs object`.
         // After `appendProjection` collapses the chained reinterpret, the projection list is
         // `[ReinterpretAs object]` (or `[ReinterpretAs object; ByteOffset N]` for non-zero N).
-        // `readManagedByref` must drive `readManagedByrefBytesAs` with an `ObjectRef None`
-        // template via the `Object` arm of `zeroForReinterpretTemplate`, which then dispatches
-        // through field-precise read and recovers the original reference. Without the `Object`
-        // arm this fails with "struct/object byte views are not modelled".
+        // `readManagedByref` must drive `readManagedByrefBytesAs` with the concrete type's
+        // zero-value template (an `ObjectRef None` for `Object`), which then dispatches through
+        // field-precise read and recovers the original reference. Without that, the read falls
+        // through to a generic byte view and fails with "struct/object byte views are not modelled".
         let state = state ()
         let storedAddr, containerAddr, state = allocateReferenceObjectWithRefField state
         let objectType = concreteTypeFor bct.Object
@@ -3016,7 +3016,7 @@ public unsafe struct PointerWrapper
             |> ManagedPointerSource.appendProjection (ByrefProjection.ByteOffset 0)
             |> ManagedPointerSource.appendProjection (ByrefProjection.ReinterpretAs objectType)
 
-        IlMachineState.readManagedByref state ptr
+        IlMachineState.readManagedByref bct state ptr
         |> shouldEqual (CliType.ObjectRef (Some storedAddr))
 
     [<Test>]

--- a/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
+++ b/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
@@ -2485,6 +2485,43 @@ public unsafe struct PointerWrapper
         observedDestinations.Count |> shouldEqual 3
 
     [<Test>]
+    let ``readManagedByref through ReinterpretAs IntPtr preserves tagged native-int provenance`` () : unit =
+        // Regression: when the byref carries a trailing `ReinterpretAs IntPtr`
+        // projection (the shape produced by the `Span<IntPtr>(void*, int)`
+        // constructor over a `stackalloc` buffer) and the storage cell holds a
+        // tagged `NativeIntSource` (e.g. `TypeHandlePtr` written by
+        // `Stind_I`), `readManagedByref` must return the bare native-int cell
+        // with its provenance intact. The byte-view fallback in
+        // `readLocalMemoryBytesAs` cannot serialise tagged sources, so the
+        // fast path that returns the existing typed cell is load-bearing for
+        // the `RuntimeTypeHandle.Instantiate` / `ModuleHandle.ResolveType`
+        // QCalls that walk such buffers.
+        let _, loggerFactory = LoggerFactory.makeTest ()
+
+        let state, thread =
+            stateWithSingleInstruction loggerFactory (IlOp.Nullary NullaryIlOp.Nop)
+
+        let bareLocallocPtr, state =
+            IlMachineState.allocateLocalMemory thread LocalMemoryInitialization.ZeroInitialized 8 state
+
+        let taggedHandle =
+            CliType.Numeric (
+                CliNumericType.NativeInt (
+                    NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed (handleFor bct.Int32))
+                )
+            )
+
+        let state = IlMachineState.writeManagedByref state bareLocallocPtr taggedHandle
+
+        let reinterpretedPtr =
+            bareLocallocPtr
+            |> ManagedPointerSource.appendProjection (ByrefProjection.ReinterpretAs (concreteTypeFor bct.IntPtr))
+
+        IlMachineState.readManagedByref bct state reinterpretedPtr
+        |> CliType.unwrapPrimitiveLikeDeep
+        |> shouldEqual taggedHandle
+
+    [<Test>]
     let ``Stind_I8 preserves tagged int64 provenance for exact-width typed destinations`` () : unit =
         let observedSources = HashSet<Int64Source> ()
         let observedDestinations = HashSet<TaggedInt64Destination> ()

--- a/WoofWare.PawPrint.Test/TestNativeEnum.fs
+++ b/WoofWare.PawPrint.Test/TestNativeEnum.fs
@@ -245,8 +245,13 @@ public static class Entry
 
         ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arrayAddr, 0), []), state
 
-    let private readObjectOut (state : IlMachineState) (ptr : ManagedPointerSource) : ManagedHeapAddress option =
-        match IlMachineState.readManagedByref state ptr with
+    let private readObjectOut
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (ptr : ManagedPointerSource)
+        : ManagedHeapAddress option
+        =
+        match IlMachineState.readManagedByref baseClassTypes state ptr with
         | CliType.ObjectRef maybeAddr -> maybeAddr
         | other -> failwith $"expected ObjectHandleOnStack target to contain object ref, got %O{other}"
 
@@ -314,10 +319,10 @@ public static class Entry
             | None -> failwith "Enum_GetValuesAndNames QCall did not match"
 
         let valuesArray =
-            readObjectOut state valuesOut
+            readObjectOut baseClassTypes state valuesOut
             |> Option.defaultWith (fun () -> failwith "Enum_GetValuesAndNames left values out handle null")
 
-        let namesArray = readObjectOut state namesOut
+        let namesArray = readObjectOut baseClassTypes state namesOut
 
         {
             State = state

--- a/WoofWare.PawPrint.Test/TestNativeMetadataImport.fs
+++ b/WoofWare.PawPrint.Test/TestNativeMetadataImport.fs
@@ -298,8 +298,16 @@ public class TypesWithMembers
         =
         allocateInt32Buffer fixture 1 value state
 
-    let private readInt32Out (state : IlMachineState) (ptr : ManagedPointerSource) : int32 =
-        match IlMachineState.readManagedByref state ptr |> CliType.unwrapPrimitiveLikeDeep with
+    let private readInt32Out
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (ptr : ManagedPointerSource)
+        : int32
+        =
+        match
+            IlMachineState.readManagedByref baseClassTypes state ptr
+            |> CliType.unwrapPrimitiveLikeDeep
+        with
         | CliType.Numeric (CliNumericType.Int32 value) -> value
         | other -> failwith $"expected Int32 out value, got %O{other}"
 
@@ -459,10 +467,10 @@ public class TypesWithMembers
                 ]
                 state
 
-        let length = readInt32Out state lengthOut
+        let length = readInt32Out fixture.BaseClassTypes state lengthOut
 
         let tokens, storage =
-            match IlMachineState.readManagedByref state longResult with
+            match IlMachineState.readManagedByref fixture.BaseClassTypes state longResult with
             | CliType.ObjectRef (Some arrayAddr) ->
                 let tokens =
                     [ 0 .. int length - 1 ]
@@ -507,7 +515,7 @@ public class TypesWithMembers
                 state
 
         let returnValue, state = IlMachineState.popEvalStack (ThreadId 0) state
-        returnValue, readInt32Out state attributesOut, state
+        returnValue, readInt32Out fixture.BaseClassTypes state attributesOut, state
 
     let private allocateConstArrayOut
         (fixture : MetadataImportFixture)
@@ -528,7 +536,7 @@ public class TypesWithMembers
         (ptr : ManagedPointerSource)
         : int32 * byte array
         =
-        let cli = IlMachineState.readManagedByref state ptr
+        let cli = IlMachineState.readManagedByref fixture.BaseClassTypes state ptr
 
         let valueType =
             match cli with
@@ -602,7 +610,7 @@ public class TypesWithMembers
                 state
 
         let returnValue, state = IlMachineState.popEvalStack (ThreadId 0) state
-        let ctorToken = readInt32Out state ctorOut
+        let ctorToken = readInt32Out fixture.BaseClassTypes state ctorOut
         let constArray = readConstArrayOut fixture state signatureOut
         returnValue, ctorToken, constArray, state
 
@@ -748,7 +756,7 @@ public class TypesWithMembers
                 state
 
         let returnValue, state = IlMachineState.popEvalStack (ThreadId 0) state
-        returnValue, readInt32Out state parentOut, state
+        returnValue, readInt32Out fixture.BaseClassTypes state parentOut, state
 
     let private methodDefToken (handle : MethodDefinitionHandle) : int32 =
         let handle : EntityHandle = MethodDefinitionHandle.op_Implicit handle

--- a/WoofWare.PawPrint/BinaryArithmetic.fs
+++ b/WoofWare.PawPrint/BinaryArithmetic.fs
@@ -49,10 +49,15 @@ module private ArithmeticTarget =
                 ArithmeticTarget.ByteViewTarget (root, List.rev revRest, ty, 0)
             | [] -> failwith $"refusing to do pointer arithmetic on a bare stack slot address: {ptr}"
 
-    let getFieldContainerValue (state : IlMachineState) (container : FieldContainer) : CliType =
+    let getFieldContainerValue
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (container : FieldContainer)
+        : CliType
+        =
         match container with
         | FieldContainer.HeapObject addr -> CliType.ValueType (ManagedHeap.get addr state.ManagedHeap).Contents
-        | FieldContainer.ByrefContainer ptr -> IlMachineState.readManagedByref state ptr
+        | FieldContainer.ByrefContainer ptr -> IlMachineState.readManagedByref baseClassTypes state ptr
 
 type IArithmeticOperation =
     abstract Int32Int32 : int32 -> int32 -> int32
@@ -201,7 +206,7 @@ module ArithmeticOperation =
                 v
             |> Choice1Of2
         | ArithmeticTarget.FieldTarget (container, field) ->
-            let obj = ArithmeticTarget.getFieldContainerValue state container
+            let obj = ArithmeticTarget.getFieldContainerValue baseClassTypes state container
 
             let offset, _ = CliType.getFieldLayoutById field obj
             let offset = checkedAddInt32 "field byte offset" offset v
@@ -458,8 +463,8 @@ module ArithmeticOperation =
                             failwith
                                 $"refusing to subtract pointers to fields of different containers: %O{container1} vs %O{container2}"
 
-                        let obj1 = ArithmeticTarget.getFieldContainerValue state container1
-                        let obj2 = ArithmeticTarget.getFieldContainerValue state container2
+                        let obj1 = ArithmeticTarget.getFieldContainerValue baseClassTypes state container1
+                        let obj2 = ArithmeticTarget.getFieldContainerValue baseClassTypes state container2
 
                         let offset1, _ = CliType.getFieldLayoutById field1 obj1
                         let offset2, _ = CliType.getFieldLayoutById field2 obj2

--- a/WoofWare.PawPrint/ExternImplementations/System.Threading.Monitor.fs
+++ b/WoofWare.PawPrint/ExternImplementations/System.Threading.Monitor.fs
@@ -22,11 +22,16 @@ module System_Threading_Monitor =
     /// Monitor.Enter_Slowpath, which calls back into the QCall path. PawPrint runs each
     /// thread to completion between scheduler points, so a "Locked by another thread"
     /// SyncBlock represents real contention with no way to make progress in a fast path.
-    let TryEnter_FastPath (currentThread : ThreadId) (state : IlMachineState) : ExecutionResult =
+    let TryEnter_FastPath
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (currentThread : ThreadId)
+        (state : IlMachineState)
+        : ExecutionResult
+        =
         let lockObj, state = popOneObject currentThread 0 state
 
         let acquired, state =
-            match IlMachineState.evalStackValueToObjectRef state lockObj with
+            match IlMachineState.evalStackValueToObjectRef baseClassTypes state lockObj with
             | None -> failwith "TODO: Monitor.TryEnter_FastPath should throw ArgumentNullException for null obj"
             | Some addr ->
                 match IlMachineState.getSyncBlock addr state with
@@ -53,7 +58,12 @@ module System_Threading_Monitor =
     /// Caller treats the result as: 0 (Contention) → return false; 1 (Entered) → return true;
     /// 2 (UseSlowPath) → call Monitor.TryEnter_Slowpath. We never need the slowpath because
     /// PawPrint can answer Free / SelfHeld / OtherHeld directly from the SyncBlock.
-    let TryEnter_FastPath_WithTimeout (currentThread : ThreadId) (state : IlMachineState) : ExecutionResult =
+    let TryEnter_FastPath_WithTimeout
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (currentThread : ThreadId)
+        (state : IlMachineState)
+        : ExecutionResult
+        =
         let lockObj, state = popOneObject currentThread 0 state
         let timeoutVal, state = popInt32 currentThread 1 state
 
@@ -63,7 +73,7 @@ module System_Threading_Monitor =
             | other -> failwith $"Monitor.TryEnter_FastPath_WithTimeout: expected int32 timeout, got %O{other}"
 
         let result, state =
-            match IlMachineState.evalStackValueToObjectRef state lockObj with
+            match IlMachineState.evalStackValueToObjectRef baseClassTypes state lockObj with
             | None ->
                 failwith "TODO: Monitor.TryEnter_FastPath_WithTimeout should throw ArgumentNullException for null obj"
             | Some addr ->
@@ -98,11 +108,16 @@ module System_Threading_Monitor =
 
     /// .NET 10 InternalCall: Monitor.IsEnteredNative(obj) -> bool.
     /// Returns true if the SyncBlock for `obj` is held by the current thread.
-    let IsEnteredNative (currentThread : ThreadId) (state : IlMachineState) : ExecutionResult =
+    let IsEnteredNative
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (currentThread : ThreadId)
+        (state : IlMachineState)
+        : ExecutionResult
+        =
         let lockObj, state = popOneObject currentThread 0 state
 
         let result =
-            match IlMachineState.evalStackValueToObjectRef state lockObj with
+            match IlMachineState.evalStackValueToObjectRef baseClassTypes state lockObj with
             | None -> failwith "TODO: Monitor.IsEnteredNative should throw ArgumentNullException for null obj"
             | Some addr ->
                 match IlMachineState.getSyncBlock addr state with
@@ -119,11 +134,16 @@ module System_Threading_Monitor =
     /// any non-zero value (Signal/Yield/Contention/Error) routes the IL through Exit_Slowpath.
     /// PawPrint can decrement the SyncBlock directly, so we always return None on success and
     /// fail loud if the unlock would have surfaced as Error in the real runtime.
-    let Exit_FastPath (currentThread : ThreadId) (state : IlMachineState) : ExecutionResult =
+    let Exit_FastPath
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (currentThread : ThreadId)
+        (state : IlMachineState)
+        : ExecutionResult
+        =
         let lockObj, state = popOneObject currentThread 0 state
 
         let state =
-            match IlMachineState.evalStackValueToObjectRef state lockObj with
+            match IlMachineState.evalStackValueToObjectRef baseClassTypes state lockObj with
             | None -> failwith "TODO: Monitor.Exit_FastPath should throw ArgumentNullException for null obj"
             | Some addr ->
                 match IlMachineState.getSyncBlock addr state with

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -757,7 +757,22 @@ module IlMachineManagedByref =
             match List.rev projs with
             | ByrefProjection.ByteOffset _ :: ByrefProjection.ReinterpretAs ty :: _
             | ByrefProjection.ReinterpretAs ty :: _ ->
-                let targetTemplate = zeroForConcreteType baseClassTypes state ty
+                // Flatten primitive-like single-field wrappers (IntPtr, UIntPtr,
+                // RuntimeTypeHandle, ...) before driving the byte-view read.
+                // Stored cells use the bare primitive shape (e.g. localloc'd
+                // `Span<IntPtr>` cells written by `Stind_I` are bare
+                // `Numeric (NativeInt ...)`), so the `tryReadCell` fast path in
+                // `readLocalMemoryBytesAs` needs the same shape on the template
+                // to preserve tagged provenance like `TypeHandlePtr` /
+                // `FieldHandlePtr`. Without the unwrap the read falls through
+                // to `LocalMemoryPool.readBytes`, which cannot serialise tagged
+                // sources and so rejects the otherwise-valid read used by the
+                // `RuntimeTypeHandle.Instantiate` / `ModuleHandle.ResolveType`
+                // QCalls. Non-primitive-like wrappers (structs proper) are
+                // unaffected: `unwrapPrimitiveLikeDeep` is a no-op there.
+                let targetTemplate =
+                    zeroForConcreteType baseClassTypes state ty |> CliType.unwrapPrimitiveLikeDeep
+
                 readManagedByrefBytesAs state src targetTemplate
             | ByrefProjection.ByteOffset n :: _ ->
                 failwith

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -104,37 +104,6 @@ module IlMachineManagedByref =
         | CliByteAddressability.Rejected _ -> ValueNone
         | CliByteAddressability.ByteAddressable -> ValueSome (CliType.ToBytes value)
 
-    /// Zero `CliType` template for the trailing `ReinterpretAs` of a byte-view byref
-    /// that the read/write dispatchers use to drive `readManagedByrefBytesAs`. Covers
-    /// the corelib primitives plus `System.Object`, which is the shape produced by
-    /// `Unsafe.As<byte, object>` and the only reference-type reinterpret reachable
-    /// without further metadata. Returning `ValueNone` falls through to the explicit
-    /// failure path in the caller.
-    let private zeroForReinterpretTemplate (ty : ConcreteType<ConcreteTypeHandle>) : CliType voption =
-        if ty.Namespace <> "System" || not ty.Generics.IsEmpty then
-            ValueNone
-        else
-            match ty.Name with
-            | "Boolean" -> ValueSome (CliType.Bool 0uy)
-            | "SByte" -> ValueSome (CliType.Numeric (CliNumericType.Int8 0y))
-            | "Byte" -> ValueSome (CliType.Numeric (CliNumericType.UInt8 0uy))
-            | "Int16" -> ValueSome (CliType.Numeric (CliNumericType.Int16 0s))
-            | "UInt16" -> ValueSome (CliType.Numeric (CliNumericType.UInt16 0us))
-            | "Char" -> ValueSome (CliType.Char (0uy, 0uy))
-            | "Int32"
-            | "UInt32" ->
-                // ECMA III.1.1.1 has no separate unsigned 32-bit stack type;
-                // PawPrint stores UInt32-shaped values in the same CliType as Int32.
-                ValueSome (CliType.Numeric (CliNumericType.Int32 0))
-            | "Int64"
-            | "UInt64" -> ValueSome (CliType.Numeric (CliNumericType.Int64 (Int64Source.Verbatim 0L)))
-            | "IntPtr"
-            | "UIntPtr" -> ValueSome (CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim 0L)))
-            | "Single" -> ValueSome (CliType.Numeric (CliNumericType.Float32 0.0f))
-            | "Double" -> ValueSome (CliType.Numeric (CliNumericType.Float64 0.0))
-            | "Object" -> ValueSome (CliType.ObjectRef None)
-            | _ -> ValueNone
-
     let setStatic
         (ty : ConcreteTypeHandle)
         (field : ComparableFieldDefinitionHandle)
@@ -761,23 +730,6 @@ module IlMachineManagedByref =
                 byteAddressableCellBytesAt $"plain byref %O{src}" 0 targetSize raw
                 |> CliType.ofBytesLike targetTemplate
 
-    let readManagedByref (state : IlMachineState) (src : ManagedPointerSource) : CliType =
-        match src with
-        | ManagedPointerSource.Null -> failwith "TODO: throw NullReferenceException"
-        | ManagedPointerSource.Byref (root, projs) ->
-            match List.rev projs with
-            | ByrefProjection.ByteOffset _ :: ByrefProjection.ReinterpretAs ty :: _
-            | ByrefProjection.ReinterpretAs ty :: _ ->
-                match zeroForReinterpretTemplate ty with
-                | ValueSome targetTemplate -> readManagedByrefBytesAs state src targetTemplate
-                | ValueNone ->
-                    failwith
-                        $"TODO: read through `ReinterpretAs` as non-primitive type %s{ty.Namespace}.%s{ty.Name}; struct/object byte views are not modelled"
-            | ByrefProjection.ByteOffset n :: _ ->
-                failwith
-                    $"ByteOffset %d{n} without a preceding ReinterpretAs in projection chain: %O{src} (this is an interpreter bug)"
-            | _ -> readProjectedValue (readRootValue state root) projs
-
     let private zeroForConcreteType
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (state : IlMachineState)
@@ -792,6 +744,25 @@ module IlMachineManagedByref =
 
         CliType.zeroOf state.ConcreteTypes state._LoadedAssemblies baseClassTypes handle
         |> fst
+
+    let readManagedByref
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (src : ManagedPointerSource)
+        : CliType
+        =
+        match src with
+        | ManagedPointerSource.Null -> failwith "TODO: throw NullReferenceException"
+        | ManagedPointerSource.Byref (root, projs) ->
+            match List.rev projs with
+            | ByrefProjection.ByteOffset _ :: ByrefProjection.ReinterpretAs ty :: _
+            | ByrefProjection.ReinterpretAs ty :: _ ->
+                let targetTemplate = zeroForConcreteType baseClassTypes state ty
+                readManagedByrefBytesAs state src targetTemplate
+            | ByrefProjection.ByteOffset n :: _ ->
+                failwith
+                    $"ByteOffset %d{n} without a preceding ReinterpretAs in projection chain: %O{src} (this is an interpreter bug)"
+            | _ -> readProjectedValue (readRootValue state root) projs
 
     /// Outcome of classifying the projection
     /// `[..., ReinterpretAs reinterpretTy, Field field]` over storage of some
@@ -1539,7 +1510,8 @@ module IlMachineManagedByref =
                     $"TODO: primitive indirect store of %O{newValue} through byte-view byref %O{src} cannot preserve %s{reason}"
             | ValueNone ->
                 let existing =
-                    knownExisting |> Option.defaultWith (fun () -> readManagedByref state src)
+                    knownExisting
+                    |> Option.defaultWith (fun () -> readManagedByref baseClassTypes state src)
 
                 let existingSize = CliType.sizeOf existing
                 let newSize = CliType.sizeOf newValue
@@ -1617,7 +1589,7 @@ module IlMachineManagedByref =
                     // Even a byte-renderable payload may need a typed store
                     // when the destination cell carries non-byte-renderable
                     // numeric provenance.
-                    let existing = readManagedByref state src
+                    let existing = readManagedByref baseClassTypes state src
 
                     match byteAddressabilityRejection existing with
                     | Some rejection when isNumericProvenanceRejection rejection ->

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -201,12 +201,17 @@ module IlMachineRuntimeMetadata =
 
         result, state
 
-    let evalStackValueToObjectRef (state : IlMachineState) (value : EvalStackValue) : ManagedHeapAddress option =
+    let evalStackValueToObjectRef
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (value : EvalStackValue)
+        : ManagedHeapAddress option
+        =
         match value with
         | EvalStackValue.NullObjectRef -> None
         | EvalStackValue.ObjectRef addr -> Some addr
         | EvalStackValue.ManagedPointer src ->
-            match IlMachineManagedByref.readManagedByref state src with
+            match IlMachineManagedByref.readManagedByref baseClassTypes state src with
             | CliType.ObjectRef addr -> addr
             | other -> failwith $"expected object reference, got {other}"
         | other -> failwith $"expected object reference, got {other}"

--- a/WoofWare.PawPrint/IntrinsicHelpers.fs
+++ b/WoofWare.PawPrint/IntrinsicHelpers.fs
@@ -155,6 +155,7 @@ module internal IntrinsicHelpers =
         |> fun (state, _, result) -> state, result
 
     let popRuntimeTypeHandle
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (currentThread : ThreadId)
         (state : IlMachineState)
         : RuntimeTypeHandleTarget * IlMachineState
@@ -164,8 +165,11 @@ module internal IntrinsicHelpers =
         let this =
             match this with
             | EvalStackValue.ObjectRef ptr ->
-                IlMachineState.readManagedByref state (ManagedPointerSource.Byref (ByrefRoot.HeapValue ptr, []))
-            | EvalStackValue.ManagedPointer ptr -> IlMachineState.readManagedByref state ptr
+                IlMachineState.readManagedByref
+                    baseClassTypes
+                    state
+                    (ManagedPointerSource.Byref (ByrefRoot.HeapValue ptr, []))
+            | EvalStackValue.ManagedPointer ptr -> IlMachineState.readManagedByref baseClassTypes state ptr
             | EvalStackValue.NullObjectRef -> failwith "TODO: Type intrinsic receiver was null; throw NRE"
             | EvalStackValue.Float _
             | EvalStackValue.Int32 _
@@ -571,6 +575,7 @@ module internal IntrinsicHelpers =
             failwith $"%s{operation}: %s{ex.Message}"
 
     let readSpanHelpersSequenceEqualByte
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (operation : string)
         (state : IlMachineState)
         (src : ManagedPointerSource)
@@ -593,14 +598,14 @@ module internal IntrinsicHelpers =
                 | ByrefRoot.StringCharAt _, [] -> readPrimitiveByteView ()
                 | _ ->
                     let basePtr = ManagedPointerSource.Byref (byteViewRoot, prefixProjs)
-                    let value = IlMachineState.readManagedByref state basePtr
+                    let value = IlMachineState.readManagedByref baseClassTypes state basePtr
 
                     match value with
                     | CliType.ValueType _ -> byteAtOffset operation src byteOffset value
                     | _ -> readPrimitiveByteView ()
             | ValueNone ->
                 let value =
-                    IlMachineState.readManagedByref state (ManagedPointerSource.Byref (root, projs))
+                    IlMachineState.readManagedByref baseClassTypes state (ManagedPointerSource.Byref (root, projs))
 
                 byteAtOffset operation src 0 value
 
@@ -666,7 +671,8 @@ module internal IntrinsicHelpers =
                         ManagedPointerByteView.addByteOffset baseClassTypes state byteType i rightPtr
 
                     equal <-
-                        readSpanHelpersSequenceEqualByte operation state left = readSpanHelpersSequenceEqualByte
+                        readSpanHelpersSequenceEqualByte baseClassTypes operation state left = readSpanHelpersSequenceEqualByte
+                            baseClassTypes
                             operation
                             state
                             right
@@ -788,7 +794,7 @@ module internal IntrinsicHelpers =
         let declaringTypeHandle = intrinsicDeclaringTypeHandle state methodToCall
 
         let span =
-            match IlMachineState.readManagedByref state thisPtr with
+            match IlMachineState.readManagedByref baseClassTypes state thisPtr with
             | CliType.ValueType vt when vt.Declared = declaringTypeHandle -> vt
             | CliType.ValueType vt ->
                 failwith
@@ -870,10 +876,16 @@ module internal IntrinsicHelpers =
             && isCorelibConcreteType state "System" "Char" ty.Generics.[0]
         | None -> false
 
-    let spanReceiverValue (operation : string) (state : IlMachineState) (receiver : EvalStackValue) : CliValueType =
+    let spanReceiverValue
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (operation : string)
+        (state : IlMachineState)
+        (receiver : EvalStackValue)
+        : CliValueType
+        =
         match receiver with
         | EvalStackValue.ManagedPointer src ->
-            match IlMachineState.readManagedByref state src with
+            match IlMachineState.readManagedByref baseClassTypes state src with
             | CliType.ValueType vt -> vt
             | other -> failwith $"%s{operation}: receiver byref read produced non-value-type %O{other}"
         | EvalStackValue.UserDefinedValueType vt -> vt
@@ -944,7 +956,7 @@ module internal IntrinsicHelpers =
 
                 let value =
                     match ptr with
-                    | EvalStackValue.ManagedPointer src -> IlMachineState.readManagedByref state src
+                    | EvalStackValue.ManagedPointer src -> IlMachineState.readManagedByref baseClassTypes state src
                     | other -> failwith $"%s{operation}: element pointer was not a managed pointer: %O{other}"
 
                 charOfCliType operation value :: chars, state
@@ -969,7 +981,7 @@ module internal IntrinsicHelpers =
         let operation = $"{methodToCall.DeclaringType.Name}.ToString"
         let elementType = methodToCall.DeclaringType.Generics |> Seq.exactlyOne
         let receiver, state = IlMachineState.popEvalStack currentThread state
-        let span = spanReceiverValue operation state receiver
+        let span = spanReceiverValue baseClassTypes operation state receiver
         let reference, length = spanReferenceAndLength operation state span
 
         if length < 0 then
@@ -992,7 +1004,7 @@ module internal IntrinsicHelpers =
 
                     let value =
                         match ptr with
-                        | EvalStackValue.ManagedPointer src -> IlMachineState.readManagedByref state src
+                        | EvalStackValue.ManagedPointer src -> IlMachineState.readManagedByref baseClassTypes state src
                         | other -> failwith $"%s{operation}: element pointer was not a managed pointer: %O{other}"
 
                     charOfCliType operation value :: chars, state
@@ -1040,8 +1052,8 @@ module internal IntrinsicHelpers =
         let left, state = IlMachineState.popEvalStack currentThread state
 
         let comparisonType = int32OfEvalStackValue operation comparisonType
-        let left = spanReceiverValue operation state left
-        let right = spanReceiverValue operation state right
+        let left = spanReceiverValue baseClassTypes operation state left
+        let right = spanReceiverValue baseClassTypes operation state right
         let left, state = readCharSpanContents baseClassTypes operation state left
         let right, state = readCharSpanContents baseClassTypes operation state right
 

--- a/WoofWare.PawPrint/IntrinsicHelpers.fsi
+++ b/WoofWare.PawPrint/IntrinsicHelpers.fsi
@@ -19,7 +19,10 @@ module internal IntrinsicHelpers =
     /// Pop a `System.Type`/`System.RuntimeType` receiver from the guest evaluation stack and
     /// recover the runtime type-handle target it represents.
     val popRuntimeTypeHandle :
-        currentThread : ThreadId -> state : IlMachineState -> RuntimeTypeHandleTarget * IlMachineState
+        baseClassTypes : BaseClassTypes<DumpedAssembly> ->
+        currentThread : ThreadId ->
+        state : IlMachineState ->
+            RuntimeTypeHandleTarget * IlMachineState
 
     /// Add an element-count offset to a managed byref, preserving PawPrint's byte-view and
     /// reinterpretation invariants for arrays, strings, local memory, and existing byref views.

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -147,7 +147,7 @@ module Intrinsics =
                 | EvalStackValue.NullObjectRef ->
                     failwith "TODO: Object.GetType receiver was null; throw NullReferenceException"
                 | EvalStackValue.ManagedPointer ptr ->
-                    match IlMachineState.readManagedByref state ptr with
+                    match IlMachineState.readManagedByref baseClassTypes state ptr with
                     | CliType.ObjectRef (Some addr) -> ManagedHeap.getObjectConcreteType addr state.ManagedHeap, state
                     | CliType.ObjectRef None ->
                         failwith "TODO: Object.GetType receiver was null; throw NullReferenceException"
@@ -269,7 +269,7 @@ module Intrinsics =
             | [], MethodReturnType.Returns (ConcreteBool state.ConcreteTypes) -> ()
             | _ -> failwith "bad signature Type.get_IsValueType"
 
-            let target, state = popRuntimeTypeHandle currentThread state
+            let target, state = popRuntimeTypeHandle baseClassTypes currentThread state
 
             let isValueType =
                 match target with
@@ -353,7 +353,7 @@ module Intrinsics =
             | [], MethodReturnType.Returns (ConcreteBool state.ConcreteTypes) -> ()
             | _ -> failwith "bad signature Type.get_IsEnum"
 
-            let target, state = popRuntimeTypeHandle currentThread state
+            let target, state = popRuntimeTypeHandle baseClassTypes currentThread state
 
             let isEnum, state =
                 match target with
@@ -426,7 +426,7 @@ module Intrinsics =
             | [], MethodReturnType.Returns (ConcreteBool state.ConcreteTypes) -> ()
             | _ -> failwith "bad signature Type.get_IsGenericType"
 
-            let target, state = popRuntimeTypeHandle currentThread state
+            let target, state = popRuntimeTypeHandle baseClassTypes currentThread state
 
             let isGenericType =
                 match target with
@@ -574,7 +574,7 @@ module Intrinsics =
                     |> Option.defaultWith (fun () -> failwith $"%s{operation}: expected int32 value, got %O{valueArg}")
 
                 let byrefSrc = popManagedByrefArgument operation byrefArg
-                let currentValue = IlMachineState.readManagedByref state byrefSrc
+                let currentValue = IlMachineState.readManagedByref baseClassTypes state byrefSrc
 
                 let current =
                     match EvalStackValue.ofCliType currentValue with
@@ -610,7 +610,7 @@ module Intrinsics =
                     |> Option.defaultWith (fun () -> failwith $"%s{operation}: expected int64 value, got %O{valueArg}")
 
                 let byrefSrc = popManagedByrefArgument operation byrefArg
-                let currentValue = IlMachineState.readManagedByref state byrefSrc
+                let currentValue = IlMachineState.readManagedByref baseClassTypes state byrefSrc
 
                 let current =
                     match EvalStackValue.ofCliType currentValue with
@@ -669,7 +669,7 @@ module Intrinsics =
                 let byrefArg, state = IlMachineState.popEvalStack currentThread state
 
                 let byrefSrc = popManagedByrefArgument operation byrefArg
-                let currentValue = IlMachineState.readManagedByref state byrefSrc
+                let currentValue = IlMachineState.readManagedByref baseClassTypes state byrefSrc
                 let currentEval = EvalStackValue.ofCliType currentValue
                 let valueCli = EvalStackValue.toCliTypeCoerced currentValue value
                 let comparandCli = EvalStackValue.toCliTypeCoerced currentValue comparand
@@ -721,7 +721,7 @@ module Intrinsics =
                 let comparandSrc = toNativeIntSource comparand
                 let valueSrc = toNativeIntSource value
 
-                let currentValue = IlMachineState.readManagedByref state byrefSrc
+                let currentValue = IlMachineState.readManagedByref baseClassTypes state byrefSrc
 
                 // `ref IntPtr` / `ref UIntPtr` derefs to a wrapper struct. Route the read/write through
                 // the eval-stack flatten/rewrap boundary: `ofCliType` peels the primitive-like
@@ -781,7 +781,7 @@ module Intrinsics =
 
                 let byrefSrc = popManagedByrefArgument "Interlocked.CompareExchange<T>" byrefArg
 
-                let currentValue = IlMachineState.readManagedByref state byrefSrc
+                let currentValue = IlMachineState.readManagedByref baseClassTypes state byrefSrc
 
                 let objectTarget (argName : string) (value : CliType) : ManagedHeapAddress option =
                     match value with
@@ -824,7 +824,7 @@ module Intrinsics =
                 let byrefArg, state = IlMachineState.popEvalStack currentThread state
 
                 let byrefSrc = popManagedByrefArgument operation byrefArg
-                let currentValue = IlMachineState.readManagedByref state byrefSrc
+                let currentValue = IlMachineState.readManagedByref baseClassTypes state byrefSrc
                 let valueCli = EvalStackValue.toCliTypeCoerced currentValue value
 
                 // The intrinsic bypasses normal method-frame construction, so coerce the
@@ -867,7 +867,7 @@ module Intrinsics =
 
                 let valueSrc = toNativeIntSource value
 
-                let currentValue = IlMachineState.readManagedByref state byrefSrc
+                let currentValue = IlMachineState.readManagedByref baseClassTypes state byrefSrc
 
                 // `ref IntPtr` / `ref UIntPtr` derefs to a wrapper struct. Route the read/write through
                 // the eval-stack flatten/rewrap boundary: `ofCliType` peels the primitive-like
@@ -913,7 +913,7 @@ module Intrinsics =
 
                 let byrefSrc = popManagedByrefArgument "Interlocked.Exchange<T>" byrefArg
 
-                let currentValue = IlMachineState.readManagedByref state byrefSrc
+                let currentValue = IlMachineState.readManagedByref baseClassTypes state byrefSrc
 
                 let valueCli = EvalStackValue.toCliTypeCoerced currentValue value
 
@@ -1960,7 +1960,7 @@ module Intrinsics =
             let span : CliValueType =
                 match receiver with
                 | EvalStackValue.ManagedPointer src ->
-                    match IlMachineState.readManagedByref state src with
+                    match IlMachineState.readManagedByref baseClassTypes state src with
                     | CliType.ValueType vt -> vt
                     | other ->
                         failwith $"%s{spanTypeName}.get_Item receiver byref read produced non-value-type %O{other}"
@@ -2022,7 +2022,7 @@ module Intrinsics =
             let span : CliValueType =
                 match receiver with
                 | EvalStackValue.ManagedPointer src ->
-                    match IlMachineState.readManagedByref state src with
+                    match IlMachineState.readManagedByref baseClassTypes state src with
                     | CliType.ValueType vt -> vt
                     | other -> failwith $"Span`1.Clear receiver byref read produced non-value-type %O{other}"
                 | EvalStackValue.UserDefinedValueType vt -> vt

--- a/WoofWare.PawPrint/Native/NativeArray.fs
+++ b/WoofWare.PawPrint/Native/NativeArray.fs
@@ -8,6 +8,7 @@ module NativeArray =
         | other -> failwith $"%s{operation}: expected %s{argName} as Int32, got %O{other}"
 
     let private readInt32Pointer
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (operation : string)
         (state : IlMachineState)
         (argName : string)
@@ -16,7 +17,9 @@ module NativeArray =
         =
         match ptr with
         | ManagedPointerSource.Null -> failwith $"%s{operation}: expected non-null %s{argName} pointer"
-        | ManagedPointerSource.Byref _ -> IlMachineState.readManagedByref state ptr |> int32OfCliType operation argName
+        | ManagedPointerSource.Byref _ ->
+            IlMachineState.readManagedByref baseClassTypes state ptr
+            |> int32OfCliType operation argName
 
     let private arrayTypeForCreateInstance
         (operation : string)
@@ -105,7 +108,8 @@ module NativeArray =
             let retArray =
                 NativeCall.objectHandleOnStackTarget operation state "retArray" instruction.Arguments.[5]
 
-            let arrayLength = readInt32Pointer operation state "lengths[0]" lengths
+            let arrayLength =
+                readInt32Pointer ctx.BaseClassTypes operation state "lengths[0]" lengths
 
             if arrayLength < 0 then
                 failwith "TODO: Array.CreateInstance with negative length should throw ArgumentOutOfRangeException"
@@ -113,7 +117,8 @@ module NativeArray =
             match lowerBounds with
             | ManagedPointerSource.Null -> ()
             | ManagedPointerSource.Byref _ ->
-                let lowerBound = readInt32Pointer operation state "lowerBounds[0]" lowerBounds
+                let lowerBound =
+                    readInt32Pointer ctx.BaseClassTypes operation state "lowerBounds[0]" lowerBounds
 
                 if lowerBound <> 0 then
                     failwith

--- a/WoofWare.PawPrint/Native/NativeMonitor.fs
+++ b/WoofWare.PawPrint/Native/NativeMonitor.fs
@@ -32,7 +32,8 @@ module NativeMonitor =
           "TryEnter_FastPath",
           [ ConcretePrimitive state.ConcreteTypes PrimitiveType.Object ],
           MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Boolean) ->
-            System_Threading_Monitor.TryEnter_FastPath ctx.Thread state |> Some
+            System_Threading_Monitor.TryEnter_FastPath ctx.BaseClassTypes ctx.Thread state
+            |> Some
         | "System.Private.CoreLib",
           "System.Threading",
           "Monitor",
@@ -40,19 +41,22 @@ module NativeMonitor =
           [ ConcretePrimitive state.ConcreteTypes PrimitiveType.Object
             ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32 ],
           MethodReturnType.Returns (MonitorNestedEnum state.ConcreteTypes "EnterHelperResult") ->
-            System_Threading_Monitor.TryEnter_FastPath_WithTimeout ctx.Thread state |> Some
+            System_Threading_Monitor.TryEnter_FastPath_WithTimeout ctx.BaseClassTypes ctx.Thread state
+            |> Some
         | "System.Private.CoreLib",
           "System.Threading",
           "Monitor",
           "Exit_FastPath",
           [ ConcretePrimitive state.ConcreteTypes PrimitiveType.Object ],
           MethodReturnType.Returns (MonitorNestedEnum state.ConcreteTypes "LeaveHelperAction") ->
-            System_Threading_Monitor.Exit_FastPath ctx.Thread state |> Some
+            System_Threading_Monitor.Exit_FastPath ctx.BaseClassTypes ctx.Thread state
+            |> Some
         | "System.Private.CoreLib",
           "System.Threading",
           "Monitor",
           "IsEnteredNative",
           [ ConcretePrimitive state.ConcreteTypes PrimitiveType.Object ],
           MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Boolean) ->
-            System_Threading_Monitor.IsEnteredNative ctx.Thread state |> Some
+            System_Threading_Monitor.IsEnteredNative ctx.BaseClassTypes ctx.Thread state
+            |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeRuntimeType.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeType.fs
@@ -1144,6 +1144,7 @@ module NativeRuntimeType =
     /// closed `ConcreteTypeHandle` it points to. Open generic type-parameter
     /// references aren't yet representable here and fail loudly.
     let private readTypeHandleInstantiationElement
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (operation : string)
         (state : IlMachineState)
         (buffer : ManagedPointerSource)
@@ -1152,7 +1153,10 @@ module NativeRuntimeType =
         =
         let ptr = nativeIntElementPointer operation buffer index
 
-        match IlMachineState.readManagedByref state ptr |> CliType.unwrapPrimitiveLikeDeep with
+        match
+            IlMachineState.readManagedByref baseClassTypes state ptr
+            |> CliType.unwrapPrimitiveLikeDeep
+        with
         | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed handle))) ->
             handle
         | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity))) ->
@@ -1891,7 +1895,7 @@ module NativeRuntimeType =
             let genericArguments =
                 [
                     for index in 0 .. genericArgumentCount - 1 ->
-                        readTypeHandleInstantiationElement operation state instantiationPointer index
+                        readTypeHandleInstantiationElement ctx.BaseClassTypes operation state instantiationPointer index
                 ]
 
             // Stage B2: validate the special-constraint flags
@@ -2343,7 +2347,7 @@ module NativeRuntimeType =
                 let genericArguments =
                     [
                         for index in 0 .. cInstArray - 1 ->
-                            readTypeHandleInstantiationElement operation state pInstArray index
+                            readTypeHandleInstantiationElement ctx.BaseClassTypes operation state pInstArray index
                     ]
 
                 let instantiatedHandle, state =
@@ -2682,7 +2686,7 @@ module NativeRuntimeType =
                 ImmutableArray.CreateRange (
                     seq {
                         for index in 0 .. typeInstCount - 1 ->
-                            readTypeHandleInstantiationElement operation state typeInstArgsPtr index
+                            readTypeHandleInstantiationElement ctx.BaseClassTypes operation state typeInstArgsPtr index
                     }
                 )
 
@@ -2690,7 +2694,12 @@ module NativeRuntimeType =
                 ImmutableArray.CreateRange (
                     seq {
                         for index in 0 .. methodInstCount - 1 ->
-                            readTypeHandleInstantiationElement operation state methodInstArgsPtr index
+                            readTypeHandleInstantiationElement
+                                ctx.BaseClassTypes
+                                operation
+                                state
+                                methodInstArgsPtr
+                                index
                     }
                 )
 
@@ -3834,7 +3843,8 @@ module NativeRuntimeType =
             let methodPtr =
                 NativeCall.managedPointerOfPointerArgument operation "method" instruction.Arguments.[0]
 
-            let currentValue = IlMachineState.readManagedByref state methodPtr
+            let currentValue =
+                IlMachineState.readManagedByref ctx.BaseClassTypes state methodPtr
 
             // RuntimeMethodHandleInternal wraps a single IntPtr-shaped m_handle. The byref came
             // from a managed local of struct type, so primitive-like rewrapping during the

--- a/WoofWare.PawPrint/Native/NativeSignature.fs
+++ b/WoofWare.PawPrint/Native/NativeSignature.fs
@@ -187,7 +187,8 @@ module NativeSignature =
             // ObjectHandleOnStack carries a managed byref to a slot that holds an object
             // reference; use the object-aware reader rather than the byte-view variant
             // (which rejects object references as not byte-addressable).
-            let signatureValue = IlMachineState.readManagedByref state signaturePtr
+            let signatureValue =
+                IlMachineState.readManagedByref ctx.BaseClassTypes state signaturePtr
 
             let signatureAddr =
                 match signatureValue with

--- a/WoofWare.PawPrint/Native/NativeThreading.fs
+++ b/WoofWare.PawPrint/Native/NativeThreading.fs
@@ -189,7 +189,7 @@ module NativeThreading =
             let threadPtr =
                 NativeCall.objectHandleOnStackTarget operation state "thread" instruction.Arguments.[0]
 
-            let threadValue = IlMachineState.readManagedByref state threadPtr
+            let threadValue = IlMachineState.readManagedByref ctx.BaseClassTypes state threadPtr
 
             let threadAddr =
                 match threadValue with
@@ -226,7 +226,7 @@ module NativeThreading =
             let threadPtr =
                 NativeCall.objectHandleOnStackTarget operation state "thread" instruction.Arguments.[0]
 
-            let threadValue = IlMachineState.readManagedByref state threadPtr
+            let threadValue = IlMachineState.readManagedByref ctx.BaseClassTypes state threadPtr
 
             let threadAddr =
                 match threadValue with

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -354,7 +354,7 @@ module NullaryIlOp =
             match popped with
             | EvalStackValue.ManagedPointer src when isLocalMemoryPointer src || isTrailingByteViewPointer src ->
                 IlMachineState.readManagedByrefBytesAs state src targetCliType
-            | EvalStackValue.ManagedPointer src -> IlMachineState.readManagedByref state src
+            | EvalStackValue.ManagedPointer src -> IlMachineState.readManagedByref corelib state src
             | EvalStackValue.NativeInt (NativeIntSource.ManagedPointer src) ->
                 IlMachineState.readManagedByrefBytesAs state src targetCliType
             | EvalStackValue.NativeInt nativeIntSource ->
@@ -1687,7 +1687,7 @@ module NullaryIlOp =
 
             let referenced =
                 match addr with
-                | EvalStackValue.ManagedPointer src -> IlMachineState.readManagedByref state src
+                | EvalStackValue.ManagedPointer src -> IlMachineState.readManagedByref corelib state src
                 | EvalStackValue.NativeInt (NativeIntSource.GcHandlePtr handle) ->
                     GcHandleRegistry.target handle state.GcHandles |> CliType.ObjectRef
                 | EvalStackValue.NullObjectRef -> failwith "unreachable: NullObjectRef handled above"

--- a/WoofWare.PawPrint/UnaryMetadataArrayOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataArrayOps.fs
@@ -106,7 +106,7 @@ module internal UnaryMetadataArrayOps =
             | _ -> failwith $"TODO: {index}"
 
         let arrAddr =
-            match IlMachineState.evalStackValueToObjectRef state arr with
+            match IlMachineState.evalStackValueToObjectRef baseClassTypes state arr with
             | Some addr -> addr
             | None -> failwith "TODO: throw NRE"
 
@@ -216,7 +216,7 @@ module internal UnaryMetadataArrayOps =
         let arr, state = IlMachineState.popEvalStack thread state
 
         let arr =
-            match IlMachineState.evalStackValueToObjectRef state arr with
+            match IlMachineState.evalStackValueToObjectRef baseClassTypes state arr with
             | Some addr -> addr
             | None -> failwith "expected heap allocation for array, got null"
 
@@ -280,7 +280,7 @@ module internal UnaryMetadataArrayOps =
         let arr, state = IlMachineState.popEvalStack thread state
 
         let arr =
-            match IlMachineState.evalStackValueToObjectRef state arr with
+            match IlMachineState.evalStackValueToObjectRef baseClassTypes state arr with
             | Some addr -> addr
             | None -> failwith "expected heap allocation for array, got null"
 

--- a/WoofWare.PawPrint/UnaryMetadataCallOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataCallOps.fs
@@ -432,7 +432,7 @@ module internal UnaryMetadataCallOps =
 
                 match ptr with
                 | EvalStackValue.ManagedPointer src ->
-                    let deref = IlMachineState.readManagedByref state src
+                    let deref = IlMachineState.readManagedByref baseClassTypes state src
                     IlMachineState.pushToEvalStack deref thread state
                 | other ->
                     failwith $"constrained.callvirt: expected ManagedPointer receiver on the eval stack, got %O{other}"
@@ -507,7 +507,7 @@ module internal UnaryMetadataCallOps =
                                 failwith
                                     $"constrained.callvirt (box case): expected ManagedPointer receiver on the eval stack, got %O{other}"
 
-                        let derefCli = IlMachineState.readManagedByref state src
+                        let derefCli = IlMachineState.readManagedByref baseClassTypes state src
                         let derefEval = EvalStackValue.ofCliType derefCli
 
                         // Share the Box opcode's construction strategy: reuse an existing

--- a/WoofWare.PawPrint/UnaryMetadataMemoryOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataMemoryOps.fs
@@ -152,7 +152,7 @@ module internal UnaryMetadataMemoryOps =
             | EvalStackValue.NullObjectRef -> failwith "TODO: throw NullReferenceException"
             | EvalStackValue.ObjectRef _ ->
                 failwith "Ldobj on an object reference is invalid; expected a managed pointer"
-            | EvalStackValue.ManagedPointer ptr -> IlMachineState.readManagedByref state ptr
+            | EvalStackValue.ManagedPointer ptr -> IlMachineState.readManagedByref baseClassTypes state ptr
             | EvalStackValue.Float _
             | EvalStackValue.Int64 _
             | EvalStackValue.Int32 _ -> failwith "refusing to interpret constant as address"

--- a/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
@@ -589,7 +589,7 @@ module internal UnaryMetadataObjectOps =
                 let concreteType = ManagedHeap.getObjectConcreteType addr state.ManagedHeap
                 isinstCheck state concreteType actualObj
             | EvalStackValue.ManagedPointer src ->
-                match IlMachineState.readManagedByref state src with
+                match IlMachineState.readManagedByref baseClassTypes state src with
                 | CliType.ObjectRef None -> state, EvalStackValue.NullObjectRef
                 | CliType.ObjectRef (Some addr) ->
                     let concreteType = ManagedHeap.getObjectConcreteType addr state.ManagedHeap


### PR DESCRIPTION
## Summary

- Drop the hand-rolled `zeroForReinterpretTemplate` primitive-name table inside `readManagedByref`. The classifier now asks the type registry (via `zeroForConcreteType` → `CliType.zeroOf`) for the byte-view template, so the reinterpret path is no longer gated on a hardcoded list of `System` primitives. Honest classifier, no special-casing — every concrete type that has a registered zero participates.
- Cascade `BaseClassTypes<DumpedAssembly>` into `readManagedByref` and the helpers that fan out from it (`popRuntimeTypeHandle`, `evalStackValueToObjectRef`, `readInt32Pointer`, `readTypeHandleInstantiationElement`, the Monitor fast-paths, …). Internal callers already had the bundle in scope (`baseClassTypes` / `ctx.BaseClassTypes` / `corelib`), so this is purely plumbing.
- Unwrap primitive-like single-field wrappers before driving the byte-view read. Stored cells (`stackalloc IntPtr[N]` written by `Stind_I`, etc.) carry the bare primitive shape with tagged `NativeIntSource` provenance; the fast-path shape comparison in `readLocalMemoryBytesAs` needs the same shape to return the typed cell. Without the unwrap, the `RuntimeTypeHandle.Instantiate` / `ModuleHandle.ResolveType` QCalls fell through to the byte path and rejected tagged sources. A focused regression test exercises this exact shape (`Span<IntPtr>`-style `ReinterpretAs IntPtr` over a local-memory `TypeHandlePtr` cell) and fails without the unwrap.

## Test plan

- [x] `nix develop -c dotnet build` (full solution)
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --no-build` — 686/686 pass
- [x] New regression test `readManagedByref through ReinterpretAs IntPtr preserves tagged native-int provenance` (verified to fail before the unwrap fix, pass after)
- [x] `codex review --base main` — no issues flagged on the final state

🤖 Generated with [Claude Code](https://claude.com/claude-code)