### PR TITLE
Lazily intern System.String::Empty on first ldsfld/ldsflda

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -20,8 +20,7 @@ module TestPureCases =
             "AdvancedStructLayout.cs" // blocked after fixed-buffer pointer arithmetic by MarshalNative_SizeOfHelper for ByValTStr string marshalling
             "LdtokenField.cs" // past Volatile.Write of an object reference; now blocked by unimplemented InternalCall System.Buffer::BulkMoveWithWriteBarrierInternal during reflection-cache update
             "RuntimeFieldHandleGetUtf8Name.cs" // exercises RuntimeFieldHandle::GetUtf8NameInternal, RuntimeTypeHandle::GetInterfaces, and Volatile.Write of object refs successfully; now blocked at the next step by unimplemented InternalCall System.Buffer::BulkMoveWithWriteBarrierInternal
-            "RuntimeTypeGetInterfacesEmpty.cs" // past RuntimeTypeHandle::GetInterfaces QCall; now blocked by unimplemented QCall Environment_FailFast (same as ArraySortHelperDefaultInt.cs)
-            "RuntimeTypeGetInterfacesInherited.cs" // exercises the QCall's inherited-base + transitive-interface walk; same Environment_FailFast blocker as RuntimeTypeGetInterfacesEmpty.cs
+            "RuntimeTypeGetInterfacesInherited.cs" // exercises the QCall's inherited-base + transitive-interface walk; now blocked by unimplemented InternalCall System.Buffer::BulkMoveWithWriteBarrierInternal during reflection-cache update
             "GenericEdgeCases.cs" // blocked after BitOperations.Log2 by unimplemented JIT intrinsic System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned (reached via int.ToString -> Number.UInt32ToDecStr)
             "CrossAssemblyTypes.cs" // past MethodTable::ParentMethodTable projection; now blocked by unimplemented QCall EventPipeInternal_CreateProvider during static init of System.Diagnostics.Tracing.EventPipeInternal
             "InterfaceDispatch.cs" // past MetadataImport::GetCustomAttributeProps; now blocked by unimplemented InternalCall MetadataImport::GetParentToken

--- a/WoofWare.PawPrint.Test/sourcesPure/StringEmpty.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/StringEmpty.cs
@@ -1,0 +1,14 @@
+namespace StringEmpty
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            string e = string.Empty;
+            if (e is null) return 1;
+            if (e.Length != 0) return 2;
+            if (!ReferenceEquals(e, "")) return 3;
+            return 0;
+        }
+    }
+}

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -523,6 +523,26 @@ module IlMachineRuntimeMetadata =
 
         addr, state
 
+    /// Return the address of the canonical empty managed string, allocating it lazily
+    /// on first request. This is the single shared instance that backs both `ldstr ""`
+    /// and `ldsfld System.String::Empty`, satisfying the CLR's invariant that
+    /// `ReferenceEquals(string.Empty, "")` holds.
+    let internCanonicalEmptyString
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        : ManagedHeapAddress * IlMachineState
+        =
+        match state.InternedStrings.TryGetValue "" with
+        | true, addr -> addr, state
+        | false, _ ->
+            let addr, state = allocateManagedString loggerFactory baseClassTypes "" state
+
+            addr,
+            { state with
+                InternedStrings = state.InternedStrings.Add ("", addr)
+            }
+
     let private concreteTypeFullName (state : IlMachineState) (ty : ConcreteType<ConcreteTypeHandle>) : string =
         match state.LoadedAssembly ty.Assembly with
         | Some assy -> Assembly.fullName assy ty.Identity

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -167,6 +167,8 @@ module IlMachineState =
 
     let allocateManagedString = IlMachineRuntimeMetadata.allocateManagedString
 
+    let internCanonicalEmptyString = IlMachineRuntimeMetadata.internCanonicalEmptyString
+
     let setExceptionStackTraceString =
         IlMachineRuntimeMetadata.setExceptionStackTraceString
 

--- a/WoofWare.PawPrint/UnaryMetadataFieldOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataFieldOps.fs
@@ -7,6 +7,25 @@ open Microsoft.Extensions.Logging
 
 [<RequireQualifiedAccess>]
 module internal UnaryMetadataFieldOps =
+    /// `System.String::Empty` is `[Intrinsic]` in the BCL: the source declares it as
+    /// `static readonly string Empty;` with no initialiser, and the CLR's execution engine
+    /// populates it during startup rather than via a class constructor. Because PawPrint has
+    /// no equivalent EE startup hook, the field reads as uninitialised when guest code touches
+    /// it, and `cliTypeZeroOf` of a string yields a null object reference. Returning null here
+    /// triggers downstream NREs deep in the BCL (e.g. `MemberInfoCache.Populate` calling
+    /// `GetListByName` on a null cache key), which then trip SR's resource-lookup recursion
+    /// guard and `FailFast` the whole process. Detect the field at `ldsfld`/`ldsflda` time
+    /// and lazily intern the canonical empty managed string so that
+    /// `ReferenceEquals(string.Empty, "")` holds, matching CLR semantics.
+    let private isSystemStringEmptyField
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (field : FieldInfo<'typeGeneric, 'fieldGeneric>)
+        : bool
+        =
+        field.Name = "Empty"
+        && field.DeclaringType.Generics.IsEmpty
+        && field.DeclaringType.Identity = baseClassTypes.String.Identity
+
     let executeStfld (ctx : UnaryMetadataIlOpContext) (state : IlMachineState) : IlMachineState * WhatWeDid =
         let loggerFactory = ctx.LoggerFactory
         let baseClassTypes = ctx.BaseClassTypes
@@ -474,6 +493,18 @@ module internal UnaryMetadataFieldOps =
             match
                 IlMachineState.getStatic declaringTypeHandle (ComparableFieldDefinitionHandle.Make field.Handle) state
             with
+            | None when isSystemStringEmptyField baseClassTypes field ->
+                let addr, state =
+                    IlMachineState.internCanonicalEmptyString loggerFactory baseClassTypes state
+
+                let newVal = CliType.ObjectRef (Some addr)
+
+                newVal,
+                IlMachineState.setStatic
+                    declaringTypeHandle
+                    (ComparableFieldDefinitionHandle.Make field.Handle)
+                    newVal
+                    state
             | None ->
                 let state, newVal, concreteTypeHandle =
                     IlMachineState.cliTypeZeroOf
@@ -558,6 +589,12 @@ module internal UnaryMetadataFieldOps =
             let state =
                 match IlMachineState.getStatic declaringTypeHandle fieldHandle state with
                 | Some _ -> state
+                | None when isSystemStringEmptyField baseClassTypes field ->
+                    // See `isSystemStringEmptyField` for why this is special-cased.
+                    let addr, state =
+                        IlMachineState.internCanonicalEmptyString loggerFactory baseClassTypes state
+
+                    IlMachineState.setStatic declaringTypeHandle fieldHandle (CliType.ObjectRef (Some addr)) state
                 | None ->
                     // Field is not yet initialised
                     let state, zero, _concreteTypeHandle =


### PR DESCRIPTION
## Summary
- `System.String::Empty` is declared `[Intrinsic]` in the BCL with no initialiser; the real CLR's execution engine populates it during startup rather than via a cctor. PawPrint had no equivalent hook, so guest reads fell through to `cliTypeZeroOf` and got a null object reference, which then triggered downstream NREs deep in the BCL (e.g. `MemberInfoCache.Populate` calling `GetListByName` on a null cache key) and tripped SR's resource-lookup recursion guard into `FailFast` — masking the real root cause behind a generic FailFast.
- `executeLdsfld` / `executeLdsflda` now detect the field and lazily intern the canonical empty managed string via a new `IlMachineRuntimeMetadata.internCanonicalEmptyString` helper, so `ReferenceEquals(string.Empty, "")` holds, matching CLR semantics.
- `RuntimeTypeGetInterfacesEmpty.cs` is now unblocked end-to-end and moves out of the `unimplemented` set. `RuntimeTypeGetInterfacesInherited.cs` advances past the FailFast and now stops at a downstream `System.Buffer::BulkMoveWithWriteBarrierInternal` InternalCall; its comment is updated to reflect the new blocker.

## Test plan
- [x] New `StringEmpty.cs` pure test covers non-null, length-0, and reference-equality contracts.
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 686/686 pass.
- [x] `RuntimeTypeGetInterfacesEmpty.cs` runs as a Standard test and passes.
- [x] `codex review --base main` reported no actionable correctness issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)