### PR TITLE
Flatten primitive-like wrappers in haveSameCliShape

### DIFF
--- a/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
+++ b/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
@@ -2620,6 +2620,82 @@ public unsafe struct PointerWrapper
         | other -> failwith $"expected FourBytes-shaped result from byte-walk path; got %O{other}"
 
     [<Test>]
+    let ``writeManagedByrefBytesOrTypedCell refuses to install wrapped IntPtr over bare tagged-NativeInt heap field``
+        ()
+        : unit
+        =
+        // Pins the strict (`sameCliConstructor`) shape predicate used by
+        // `tryWriteHeapValueFieldPrecise`. A widened `haveSameCliShape` here
+        // would let `WithFieldSetById` silently install a wrapped-IntPtr
+        // `newValue` into a heap field whose stored shape is bare
+        // `Numeric (NativeInt ...)`, corrupting the field's CLI shape (and,
+        // in the tagged-source case, losing provenance to boot).
+        //
+        // The corruption scenario is the natural composition of two
+        // already-supported flows: an earlier `Stind_I` deposits a
+        // non-byte-addressable `NativeIntSource` (e.g. `FieldHandlePtr` from
+        // `RuntimeFieldHandle.Value`) into a boxed `IntPtr`'s `_value`
+        // slot through a `HeapObjectField` byref, and a later
+        // `Unsafe.WriteUnaligned<IntPtr>` arrives over the box's `HeapValue`
+        // byref carrying a wrapped-IntPtr `newValue` produced by
+        // `cliTypeZeroOfHandle` + `toCliTypeCoerced`. With the strict
+        // comparator the field-precise fast path declines on shape mismatch
+        // and we fall through to byte scatter, which refuses the
+        // non-byte-addressable target loudly. With the widened comparator
+        // we would silently overwrite both the shape and the tag.
+        let _, loggerFactory = LoggerFactory.makeTest ()
+
+        let state, _ =
+            stateWithSingleInstruction loggerFactory (IlOp.Nullary NullaryIlOp.Nop)
+
+        let boxedAddr, state = allocateBoxedIntPtr 0L state
+        let fieldId = intPtrValueFieldId ()
+        let taggedSource = NativeIntSource.FieldHandlePtr 0xBEEFL
+
+        let fieldPtr =
+            ManagedPointerSource.Byref (ByrefRoot.HeapObjectField (boxedAddr, fieldId), [])
+
+        let state =
+            IlMachineState.writeManagedByref state fieldPtr (CliType.Numeric (CliNumericType.NativeInt taggedSource))
+
+        // The boxed IntPtr's `_value` field really is bare NativeInt with
+        // the tagged source — this is the precondition for the shape-
+        // corruption regression. If a future refactor canonicalises the
+        // field shape to wrapped form on install, this assertion will fail
+        // before the regression check itself, surfacing the unrelated
+        // representation drift rather than papering over it.
+        ManagedHeap.get boxedAddr state.ManagedHeap
+        |> _.Contents
+        |> CliValueType.DereferenceFieldById fieldId
+        |> shouldEqual (CliType.Numeric (CliNumericType.NativeInt taggedSource))
+
+        // The wrapped-IntPtr template `Unsafe.WriteUnaligned<IntPtr>`
+        // produces via `cliTypeZeroOfHandle` + `EvalStackValue.toCliTypeCoerced`.
+        let wrappedIntPtrNewValue, state =
+            IlMachineState.cliTypeZeroOfHandle state bct (handleFor bct.IntPtr)
+
+        match wrappedIntPtrNewValue with
+        | CliType.ValueType vt when vt.PrimitiveLikeKind.IsSome -> ()
+        | other -> failwith $"expected cliTypeZeroOfHandle for IntPtr to return a primitive-like wrapper; got %O{other}"
+
+        let heapPtr = ManagedPointerSource.Byref (ByrefRoot.HeapValue boxedAddr, [])
+
+        Assert.Throws<System.Exception> (fun () ->
+            IlMachineState.writeManagedByrefBytesOrTypedCell state heapPtr wrappedIntPtrNewValue
+            |> ignore
+        )
+        |> ignore
+
+        // The field cell is genuinely unchanged: same constructor (bare
+        // NativeInt, not wrapped ValueType) and same tagged source. A
+        // regression to the widened comparator would have installed the
+        // wrapped value instead.
+        ManagedHeap.get boxedAddr state.ManagedHeap
+        |> _.Contents
+        |> CliValueType.DereferenceFieldById fieldId
+        |> shouldEqual (CliType.Numeric (CliNumericType.NativeInt taggedSource))
+
+    [<Test>]
     let ``Stind_I8 preserves tagged int64 provenance for exact-width typed destinations`` () : unit =
         let observedSources = HashSet<Int64Source> ()
         let observedDestinations = HashSet<TaggedInt64Destination> ()

--- a/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
+++ b/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
@@ -2522,6 +2522,104 @@ public unsafe struct PointerWrapper
         |> shouldEqual taggedHandle
 
     [<Test>]
+    let ``readManagedByrefBytesAs with wrapped IntPtr template preserves tagged NativeIntSource`` () : unit =
+        // Regression for `Unsafe.ReadUnaligned<IntPtr>` (Intrinsics.fs) and any
+        // other byte-view caller whose `tZero` template comes from
+        // `cliTypeZeroOfHandle` for a primitive-like wrapper. The template is
+        // the wrapped value-type form of IntPtr; the byte-view read must still
+        // recognise that a stored bare `Numeric (NativeInt ...)` cell — written
+        // by e.g. `Stind_I` from another path — is byte-equivalent to the
+        // requested template, so the fast path returns the cell as-is with its
+        // tagged `NativeIntSource` provenance intact. Without the `haveSameCliShape`
+        // widening, the read falls through to `LocalMemoryPool.readBytes`,
+        // which cannot serialise tagged sources and rejects the otherwise-valid
+        // read.
+        let _, loggerFactory = LoggerFactory.makeTest ()
+
+        let state, thread =
+            stateWithSingleInstruction loggerFactory (IlOp.Nullary NullaryIlOp.Nop)
+
+        let bareLocallocPtr, state =
+            IlMachineState.allocateLocalMemory thread LocalMemoryInitialization.ZeroInitialized 8 state
+
+        let taggedHandle =
+            CliType.Numeric (
+                CliNumericType.NativeInt (
+                    NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed (handleFor bct.Int32))
+                )
+            )
+
+        let state = IlMachineState.writeManagedByref state bareLocallocPtr taggedHandle
+
+        let wrappedIntPtrTemplate, state =
+            IlMachineState.cliTypeZeroOfHandle state bct (handleFor bct.IntPtr)
+
+        // Sanity-check the template is the wrapped form (the regression
+        // assumes that `cliTypeZeroOfHandle` returns a primitive-like wrapper
+        // for `IntPtr`; if that ever changes, this regression must be revisited
+        // because the exposure shape will be different).
+        match wrappedIntPtrTemplate with
+        | CliType.ValueType vt when vt.PrimitiveLikeKind.IsSome -> ()
+        | other -> failwith $"expected cliTypeZeroOfHandle for IntPtr to return a primitive-like wrapper; got %O{other}"
+
+        IlMachineState.readManagedByrefBytesAs state bareLocallocPtr wrappedIntPtrTemplate
+        |> CliType.unwrapPrimitiveLikeDeep
+        |> shouldEqual taggedHandle
+
+    [<Test>]
+    let ``readManagedByrefBytesAs takes byte-walk path for non-primitive-like struct template over bare primitive cell``
+        ()
+        : unit
+        =
+        // Pins the half of `haveSameCliShape` that *doesn't* widen: non-primitive-like
+        // value-type templates (e.g. multi-field structs) must not fast-path against
+        // bare-primitive cells of the same size, because the resulting CLI shape would
+        // be silently misinterpreted. The byte-walk fallback is correct here: it reads
+        // the four bytes of the Int32 cell and reconstructs a `FourBytes` value with
+        // the bytes populated as fields. If the comparator widened too far (e.g. a
+        // future change collapsing `ValueType` shape comparison to size-equality),
+        // this test would fail because the fast path would return the bare Int32 cell
+        // verbatim.
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        let types = reinterpretWriteTypes loggerFactory
+
+        let state, thread =
+            stateWithSingleInstructionFromState loggerFactory (IlOp.Nullary NullaryIlOp.Nop) types.State
+
+        let ptr, state =
+            IlMachineState.allocateLocalMemory thread LocalMemoryInitialization.ZeroInitialized 4 state
+
+        let bareInt32Cell = CliType.Numeric (CliNumericType.Int32 0x04030201)
+        let state = IlMachineState.writeManagedByref state ptr bareInt32Cell
+
+        let fourBytesHandle =
+            AllConcreteTypes.findExistingNonGenericConcreteType state.ConcreteTypes types.FourBytesConcrete.Identity
+            |> Option.defaultWith (fun () -> failwith "FourBytes handle missing")
+
+        let fourBytesTemplate, state =
+            IlMachineState.cliTypeZeroOfHandle state bct fourBytesHandle
+
+        // Sanity-check the template is non-primitive-like.
+        match fourBytesTemplate with
+        | CliType.ValueType vt when vt.PrimitiveLikeKind.IsNone -> ()
+        | other -> failwith $"expected FourBytes to be a non-primitive-like value type; got %O{other}"
+
+        let result = IlMachineState.readManagedByrefBytesAs state ptr fourBytesTemplate
+
+        match result with
+        | CliType.ValueType vt ->
+            vt.PrimitiveLikeKind |> shouldEqual None
+
+            let readField (fieldIndex : int) : byte =
+                match CliValueType.DereferenceFieldById types.FourBytesFields.[fieldIndex] vt with
+                | CliType.Numeric (CliNumericType.UInt8 b) -> b
+                | other -> failwith $"FourBytes::B%d{fieldIndex} was not UInt8: %O{other}"
+
+            [| readField 0 ; readField 1 ; readField 2 ; readField 3 |]
+            |> shouldEqual (System.BitConverter.GetBytes 0x04030201)
+        | other -> failwith $"expected FourBytes-shaped result from byte-walk path; got %O{other}"
+
+    [<Test>]
     let ``Stind_I8 preserves tagged int64 provenance for exact-width typed destinations`` () : unit =
         let observedSources = HashSet<Int64Source> ()
         let observedDestinations = HashSet<TaggedInt64Destination> ()

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -102,13 +102,19 @@ module IlMachineManagedByref =
     /// contents share byte representation and `EvalStackValue.ofCliType`
     /// flattening behaviour.
     ///
-    /// **Asymmetric output shape.** Because this predicate is permissive about
-    /// wrapper depth, sites that `match` on it and return the stored cell
-    /// (`readLocalMemoryBytesAs`, `tryReadHeapValueFieldPrecise`) emit values
-    /// whose CLI shape may not match the requested template — fast-path
-    /// returns reflect the *storage* shape, while the byte-walk fallback
-    /// returns the *template* shape. Callers reconcile this with
-    /// `unwrapPrimitiveLikeDeep` or `EvalStackValue.ofCliType`.
+    /// **Asymmetric output shape, gated by byte-addressability.** Because
+    /// this predicate is permissive about wrapper depth, the sites that
+    /// `match` on it and would otherwise return the stored cell
+    /// (`readLocalMemoryBytesAs`, `tryReadHeapValueFieldPrecise`) further
+    /// gate the fast-path return on `CliType.ByteAddressability`: only
+    /// non-byte-addressable cells (tagged `NativeIntSource`, object refs,
+    /// runtime pointers) skip the byte-walk and propagate storage shape,
+    /// since those carry provenance the byte path cannot reconstruct.
+    /// Byte-addressable cells fall through to the byte-walk so the result
+    /// has the *template*'s exact CLI shape. Callers that pass a wrapped
+    /// template against a non-byte-addressable storage cell still see the
+    /// storage shape and must reconcile via `unwrapPrimitiveLikeDeep` or
+    /// `EvalStackValue.ofCliType`.
     ///
     /// **Do NOT use on the write side.** Installing a wrapper-vs-bare-shape
     /// `newValue` into a heap field whose recorded `Contents` has a different
@@ -274,19 +280,20 @@ module IlMachineManagedByref =
                             | ValueNone -> false
 
                     let preservesExistingShape =
-                        // The widened comparator treats a wrapper-vs-bare
-                        // `existing`/`updated` pair as same-shape, so a
-                        // byte-identical store of a wrapped primitive over a
-                        // bare-primitive cell (or vice versa) is treated as a
-                        // no-op rather than installed — keeping whichever
-                        // shape was already there preserves any tagged
-                        // `NativeIntSource` provenance the cell may carry.
-                        // The comparator is deliberately conservative for
-                        // unrelated structs, so byte-identical writes between
-                        // two non-primitive-like value types of the same size
-                        // still restamp (install through the else branch
-                        // below) rather than shortcut here.
-                        existingSize <> updatedSize || haveSameCliShape existing updated
+                        // Strict constructor check (no primitive-like
+                        // unwrap): a typed store whose `updated` shape
+                        // differs from the cell's `existing` shape, even by
+                        // only a wrapper layer, must restamp the cell rather
+                        // than short-circuit. Otherwise a `stind.i` writing
+                        // bare `NativeInt` followed by a byte-identical
+                        // `stobj IntPtr` would leave the cell bare, and the
+                        // next read through the wrapped template would
+                        // observe a shape it can't service. The strict
+                        // comparator also rejects unrelated structs of the
+                        // same size, so byte-identical writes between two
+                        // non-primitive-like value types of the same size
+                        // still restamp through the else branch below.
+                        existingSize <> updatedSize || sameCliConstructor existing updated
 
                     if isNoop && preservesExistingShape then
                         state
@@ -684,27 +691,46 @@ module IlMachineManagedByref =
         // gate matters because, e.g., an `Int32` cell and a `Float32` template
         // have the same size but distinct meanings — falling through here
         // forces a proper bit-reinterpret via the byte path.
-        match LocalMemoryPool.tryReadCell block byteOffset pool with
-        | Some cell when CliType.sizeOf cell = targetSize && haveSameCliShape cell targetTemplate -> cell
-        | _ ->
+        //
+        // The byte-addressability gate (symmetric with
+        // `tryReadHeapValueFieldPrecise`) is what justifies the widened
+        // `haveSameCliShape` here: when the stored cell is byte-addressable
+        // we still defer to the byte-walk, which reconstructs the value in
+        // the *template*'s exact CLI shape via `CliType.ofBytesLike`. So
+        // callers reading with a bare `UInt8` template against a byte-sized
+        // wrapped cell (or vice versa) get the requested shape back, while
+        // non-byte-addressable storage (tagged `NativeIntSource` etc.) keeps
+        // its storage shape so provenance survives.
+        let fastPath =
+            match LocalMemoryPool.tryReadCell block byteOffset pool with
+            | Some cell when CliType.sizeOf cell = targetSize && haveSameCliShape cell targetTemplate ->
+                match CliType.ByteAddressability cell with
+                | CliByteAddressability.Rejected _ -> Some cell
+                | CliByteAddressability.ByteAddressable -> None
+            | _ -> None
+
+        match fastPath with
+        | Some cell -> cell
+        | None ->
 
         let buf = LocalMemoryPool.readBytes block byteOffset targetSize pool
         CliType.ofBytesLike targetTemplate buf
 
     /// Read the byte range at `src` and rebuild a value of CLI shape compatible
     /// with `targetTemplate`. **Output shape is path-dependent for primitive-
-    /// like wrapper templates.** When a typed storage cell starts at the byref
-    /// and `haveSameCliShape` accepts it, the cell is returned as-is — so a
-    /// wrapped `IntPtr` template against a bare `Numeric (NativeInt ...)` cell
-    /// returns the bare cell with its tagged `NativeIntSource` provenance
-    /// intact (the byte-walk fallback in `LocalMemoryPool.readBytes` cannot
-    /// serialise tagged sources, so this fast path is load-bearing). When the
-    /// fast path is missed (no typed cell at the offset, or `Bytes`-overlay
-    /// storage), the byte-walk produces a value with the *template*'s exact
-    /// CLI shape. Callers must therefore not rely on the returned shape
-    /// matching the template exactly; downstream consumers typically reconcile
-    /// via `EvalStackValue.ofCliType` (which flattens primitive-like wrappers)
-    /// or an explicit `CliType.unwrapPrimitiveLikeDeep`.
+    /// like wrapper templates against non-byte-addressable storage.** When a
+    /// typed storage cell starts at the byref, `haveSameCliShape` accepts it,
+    /// and the cell is non-byte-addressable, the cell is returned as-is — so
+    /// a wrapped `IntPtr` template against a bare tagged `Numeric (NativeInt
+    /// FieldHandlePtr ...)` cell returns the bare cell with its provenance
+    /// intact (the byte-walk fallback cannot serialise tagged sources, so
+    /// this fast path is load-bearing). When the cell is byte-addressable,
+    /// the fast path defers to the byte-walk, which produces a value with
+    /// the *template*'s exact CLI shape. Callers reading with a primitive
+    /// template that may land on tagged-pointer storage must reconcile the
+    /// returned shape via `EvalStackValue.ofCliType` (which flattens
+    /// primitive-like wrappers) or an explicit
+    /// `CliType.unwrapPrimitiveLikeDeep`.
     let readManagedByrefBytesAs
         (state : IlMachineState)
         (src : ManagedPointerSource)

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -63,14 +63,28 @@ module IlMachineManagedByref =
 
             equal
 
-    /// True iff the two values have the same primitive shape (same top-level
-    /// `CliType` constructor, and for `Numeric` the same `CliNumericType`
-    /// constructor). Returning a cell as-is when the requested template has a
-    /// different shape would silently produce, for example, an `Int32` value
-    /// where the caller asked for a `Float32` (their bit patterns differ in
-    /// meaning even when the size matches), so the typed-cell fast paths gate
-    /// on shape equality before short-circuiting the byte-walk reconstruction.
+    /// True iff the two values have the same primitive shape for typed-cell
+    /// fast-path purposes (same top-level `CliType` constructor, and for
+    /// `Numeric` the same `CliNumericType` constructor). Returning a cell as-is
+    /// when the requested template has a different shape would silently
+    /// produce, for example, an `Int32` value where the caller asked for a
+    /// `Float32` (their bit patterns differ in meaning even when the size
+    /// matches), so the typed-cell fast paths gate on shape equality before
+    /// short-circuiting the byte-walk reconstruction.
+    ///
+    /// Primitive-like single-field wrappers (`IntPtr`, `RuntimeTypeHandle`,
+    /// `EnumLike`, ...) are flattened to their stored primitive before
+    /// comparison. The wrapper and its bare-primitive contents share both byte
+    /// representation and `EvalStackValue.ofCliType` flattening behaviour, so
+    /// treating them as the same shape is what lets a wrapped template recover
+    /// a bare cell (and vice versa) without losing tagged `NativeIntSource`
+    /// provenance via the byte-walk fallback. Non-primitive-like value types
+    /// remain deliberately distinct: two unrelated structs of the same size are
+    /// not interchangeable.
     let private haveSameCliShape (a : CliType) (b : CliType) : bool =
+        let a = CliType.unwrapPrimitiveLikeDeep a
+        let b = CliType.unwrapPrimitiveLikeDeep b
+
         match a, b with
         | CliType.Bool _, CliType.Bool _
         | CliType.Char _, CliType.Char _
@@ -90,9 +104,10 @@ module IlMachineManagedByref =
             | CliNumericType.Float64 _, CliNumericType.Float64 _ -> true
             | _ -> false
         | CliType.ValueType _, CliType.ValueType _ ->
-            // Two value-type cells with the same size could still be wholly
-            // unrelated structures; force the byte-walk path to reconstruct
-            // through the requested template rather than aliasing them.
+            // Both sides are non-primitive-like value types (otherwise the
+            // unwrap above would have peeled them away). Two structs with the
+            // same size could still be wholly unrelated, so force the byte-walk
+            // path to reconstruct through the requested template.
             false
         | _ -> false
 
@@ -246,9 +261,11 @@ module IlMachineManagedByref =
                             | ValueNone -> false
 
                     let preservesExistingShape =
-                        // `haveSameCliShape` is deliberately conservative for
-                        // value types, so byte-identical value-type writes
-                        // restamp rather than shortcut through this branch.
+                        // `haveSameCliShape` flattens primitive-like wrappers
+                        // and remains deliberately conservative for arbitrary
+                        // structs, so byte-identical writes between two unrelated
+                        // non-primitive-like value types restamp rather than
+                        // shortcut through this branch.
                         existingSize <> updatedSize || haveSameCliShape existing updated
 
                     if isNoop && preservesExistingShape then
@@ -757,22 +774,7 @@ module IlMachineManagedByref =
             match List.rev projs with
             | ByrefProjection.ByteOffset _ :: ByrefProjection.ReinterpretAs ty :: _
             | ByrefProjection.ReinterpretAs ty :: _ ->
-                // Flatten primitive-like single-field wrappers (IntPtr, UIntPtr,
-                // RuntimeTypeHandle, ...) before driving the byte-view read.
-                // Stored cells use the bare primitive shape (e.g. localloc'd
-                // `Span<IntPtr>` cells written by `Stind_I` are bare
-                // `Numeric (NativeInt ...)`), so the `tryReadCell` fast path in
-                // `readLocalMemoryBytesAs` needs the same shape on the template
-                // to preserve tagged provenance like `TypeHandlePtr` /
-                // `FieldHandlePtr`. Without the unwrap the read falls through
-                // to `LocalMemoryPool.readBytes`, which cannot serialise tagged
-                // sources and so rejects the otherwise-valid read used by the
-                // `RuntimeTypeHandle.Instantiate` / `ModuleHandle.ResolveType`
-                // QCalls. Non-primitive-like wrappers (structs proper) are
-                // unaffected: `unwrapPrimitiveLikeDeep` is a no-op there.
-                let targetTemplate =
-                    zeroForConcreteType baseClassTypes state ty |> CliType.unwrapPrimitiveLikeDeep
-
+                let targetTemplate = zeroForConcreteType baseClassTypes state ty
                 readManagedByrefBytesAs state src targetTemplate
             | ByrefProjection.ByteOffset n :: _ ->
                 failwith

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -63,28 +63,15 @@ module IlMachineManagedByref =
 
             equal
 
-    /// True iff the two values have the same primitive shape for typed-cell
-    /// fast-path purposes (same top-level `CliType` constructor, and for
-    /// `Numeric` the same `CliNumericType` constructor). Returning a cell as-is
-    /// when the requested template has a different shape would silently
-    /// produce, for example, an `Int32` value where the caller asked for a
-    /// `Float32` (their bit patterns differ in meaning even when the size
-    /// matches), so the typed-cell fast paths gate on shape equality before
-    /// short-circuiting the byte-walk reconstruction.
-    ///
-    /// Primitive-like single-field wrappers (`IntPtr`, `RuntimeTypeHandle`,
-    /// `EnumLike`, ...) are flattened to their stored primitive before
-    /// comparison. The wrapper and its bare-primitive contents share both byte
-    /// representation and `EvalStackValue.ofCliType` flattening behaviour, so
-    /// treating them as the same shape is what lets a wrapped template recover
-    /// a bare cell (and vice versa) without losing tagged `NativeIntSource`
-    /// provenance via the byte-walk fallback. Non-primitive-like value types
-    /// remain deliberately distinct: two unrelated structs of the same size are
-    /// not interchangeable.
-    let private haveSameCliShape (a : CliType) (b : CliType) : bool =
-        let a = CliType.unwrapPrimitiveLikeDeep a
-        let b = CliType.unwrapPrimitiveLikeDeep b
-
+    /// Constructor-level shape comparison: true iff `a` and `b` share the same
+    /// top-level `CliType` constructor (and, for `Numeric`, the same
+    /// `CliNumericType` constructor). Used as the shared primitive by both the
+    /// strict and the widened comparators below; not called directly by the
+    /// fast-path sites. Two value-type cells of the same size could still be
+    /// wholly unrelated structures, so this returns `false` for the
+    /// `ValueType, ValueType` pair and lets the byte-walk path reconstruct
+    /// through the requested template.
+    let private sameCliConstructor (a : CliType) (b : CliType) : bool =
         match a, b with
         | CliType.Bool _, CliType.Bool _
         | CliType.Char _, CliType.Char _
@@ -103,13 +90,39 @@ module IlMachineManagedByref =
             | CliNumericType.Float32 _, CliNumericType.Float32 _
             | CliNumericType.Float64 _, CliNumericType.Float64 _ -> true
             | _ -> false
-        | CliType.ValueType _, CliType.ValueType _ ->
-            // Both sides are non-primitive-like value types (otherwise the
-            // unwrap above would have peeled them away). Two structs with the
-            // same size could still be wholly unrelated, so force the byte-walk
-            // path to reconstruct through the requested template.
-            false
+        | CliType.ValueType _, CliType.ValueType _ -> false
         | _ -> false
+
+    /// True iff the two values have the same primitive shape *after* peeling
+    /// primitive-like single-field wrappers (`IntPtr`, `RuntimeTypeHandle`,
+    /// `EnumLike`, ...) from both sides. This is the *read-side* fast-path
+    /// comparator: it lets a wrapped template recover a stored bare cell (and
+    /// vice versa) without losing tagged `NativeIntSource` provenance through
+    /// the byte-walk fallback, since the wrapper and its bare-primitive
+    /// contents share byte representation and `EvalStackValue.ofCliType`
+    /// flattening behaviour.
+    ///
+    /// **Asymmetric output shape.** Because this predicate is permissive about
+    /// wrapper depth, sites that `match` on it and return the stored cell
+    /// (`readLocalMemoryBytesAs`, `tryReadHeapValueFieldPrecise`) emit values
+    /// whose CLI shape may not match the requested template — fast-path
+    /// returns reflect the *storage* shape, while the byte-walk fallback
+    /// returns the *template* shape. Callers reconcile this with
+    /// `unwrapPrimitiveLikeDeep` or `EvalStackValue.ofCliType`.
+    ///
+    /// **Do NOT use on the write side.** Installing a wrapper-vs-bare-shape
+    /// `newValue` into a heap field whose recorded `Contents` has a different
+    /// shape would overwrite the field's CLI shape via `WithFieldSetById`,
+    /// silently coercing e.g. a boxed-IntPtr `_value` field from bare
+    /// `NativeInt` to wrapped `IntPtr`. Write-side sites use
+    /// `sameCliConstructor` (strict, no unwrap) so a shape mismatch falls
+    /// through to byte-scatter; in the case where byte-scatter can't service
+    /// the write (non-byte-addressable storage), the failure is loud rather
+    /// than a silent corruption of the field's CLI shape.
+    let private haveSameCliShape (a : CliType) (b : CliType) : bool =
+        let a = CliType.unwrapPrimitiveLikeDeep a
+        let b = CliType.unwrapPrimitiveLikeDeep b
+        sameCliConstructor a b
 
     /// Byte image of a CLI value for noop-detection purposes. If a value is
     /// classified as byte-addressable, `CliType.ToBytes` must be able to render
@@ -261,11 +274,18 @@ module IlMachineManagedByref =
                             | ValueNone -> false
 
                     let preservesExistingShape =
-                        // `haveSameCliShape` flattens primitive-like wrappers
-                        // and remains deliberately conservative for arbitrary
-                        // structs, so byte-identical writes between two unrelated
-                        // non-primitive-like value types restamp rather than
-                        // shortcut through this branch.
+                        // The widened comparator treats a wrapper-vs-bare
+                        // `existing`/`updated` pair as same-shape, so a
+                        // byte-identical store of a wrapped primitive over a
+                        // bare-primitive cell (or vice versa) is treated as a
+                        // no-op rather than installed — keeping whichever
+                        // shape was already there preserves any tagged
+                        // `NativeIntSource` provenance the cell may carry.
+                        // The comparator is deliberately conservative for
+                        // unrelated structs, so byte-identical writes between
+                        // two non-primitive-like value types of the same size
+                        // still restamp (install through the else branch
+                        // below) rather than shortcut here.
                         existingSize <> updatedSize || haveSameCliShape existing updated
 
                     if isNoop && preservesExistingShape then
@@ -671,6 +691,20 @@ module IlMachineManagedByref =
         let buf = LocalMemoryPool.readBytes block byteOffset targetSize pool
         CliType.ofBytesLike targetTemplate buf
 
+    /// Read the byte range at `src` and rebuild a value of CLI shape compatible
+    /// with `targetTemplate`. **Output shape is path-dependent for primitive-
+    /// like wrapper templates.** When a typed storage cell starts at the byref
+    /// and `haveSameCliShape` accepts it, the cell is returned as-is — so a
+    /// wrapped `IntPtr` template against a bare `Numeric (NativeInt ...)` cell
+    /// returns the bare cell with its tagged `NativeIntSource` provenance
+    /// intact (the byte-walk fallback in `LocalMemoryPool.readBytes` cannot
+    /// serialise tagged sources, so this fast path is load-bearing). When the
+    /// fast path is missed (no typed cell at the offset, or `Bytes`-overlay
+    /// storage), the byte-walk produces a value with the *template*'s exact
+    /// CLI shape. Callers must therefore not rely on the returned shape
+    /// matching the template exactly; downstream consumers typically reconcile
+    /// via `EvalStackValue.ofCliType` (which flattens primitive-like wrappers)
+    /// or an explicit `CliType.unwrapPrimitiveLikeDeep`.
     let readManagedByrefBytesAs
         (state : IlMachineState)
         (src : ManagedPointerSource)
@@ -1103,11 +1137,18 @@ module IlMachineManagedByref =
     /// non-byte-addressable (object-reference or runtime-pointer), update it directly via
     /// `WithFieldSetById` and return the new state. Returns `None` when no such field
     /// exists, so the caller falls through to byte scatter (which itself rejects when
-    /// the heap object's storage isn't byte-addressable). Symmetric to
-    /// `tryReadHeapValueFieldPrecise`; the same non-byte-addressable gate keeps
-    /// byte-addressable primitive writes on the byte-scatter path so explicit-layout
-    /// overlap semantics (resolved by `WithBytesAtIfChanged` and `EditedAtTime`) are
-    /// preserved.
+    /// the heap object's storage isn't byte-addressable). Symmetric in *shape* to
+    /// `tryReadHeapValueFieldPrecise`, but deliberately stricter on the shape predicate:
+    /// the comparator here is `sameCliConstructor` (no primitive-like unwrap), so a
+    /// wrapper-vs-bare `newValue` mismatch does *not* fire the install. Widening to
+    /// `haveSameCliShape` here would let `WithFieldSetById` overwrite the field's CLI
+    /// shape — e.g. coercing a boxed `IntPtr._value` from bare `NativeInt` to wrapped
+    /// `IntPtr` when an `Unsafe.WriteUnaligned<IntPtr>` arrives — which is a silent
+    /// corruption of the heap object's structural shape, not the recoverable read-side
+    /// asymmetry that `haveSameCliShape` is designed for. The non-byte-addressable gate
+    /// keeps byte-addressable primitive writes on the byte-scatter path so explicit-
+    /// layout overlap semantics (resolved by `WithBytesAtIfChanged` and `EditedAtTime`)
+    /// are preserved.
     let private tryWriteHeapValueFieldPrecise
         (state : IlMachineState)
         (addr : ManagedHeapAddress)
@@ -1120,7 +1161,7 @@ module IlMachineManagedByref =
 
         let candidates =
             CliValueType.TryFieldsAt byteOffset obj.Contents
-            |> List.filter (fun f -> f.Size = destSize && haveSameCliShape f.Contents newValue)
+            |> List.filter (fun f -> f.Size = destSize && sameCliConstructor f.Contents newValue)
 
         match candidates with
         | [ f ] ->


### PR DESCRIPTION
## Summary

Centralise the bare-primitive vs primitive-like-wrapper shape equivalence inside the typed-cell fast-path comparator `haveSameCliShape`, replacing the per-callsite `unwrapPrimitiveLikeDeep` decoration that PR #497 added to `readManagedByref`. The wrapper and its stored primitive share both byte representation and `EvalStackValue.ofCliType` flattening behaviour, so treating them as the same shape is the truthful answer to the question the comparator is asked.

The same regression pattern was reachable through a second site: `Unsafe.ReadUnaligned<T>` in `Intrinsics.fs:1208/1229` builds `tZero` via `cliTypeZeroOfHandle`, which returns a wrapped IntPtr for `T = IntPtr`. Without the comparator widening, a stored bare `Numeric (NativeInt ...)` cell (e.g. tagged `NativeIntSource.TypeHandlePtr` written by `Stind_I` elsewhere) would fail to fast-path on the read and fall through to `LocalMemoryPool.readBytes`, which cannot serialise tagged sources. The new comparator covers this site without any further code change in `Intrinsics.fs`.

Non-primitive-like value types still return false: two unrelated multi-field structs of the same size are not interchangeable, so the byte-walk fallback continues to handle them.

## Test plan

- [x] `nix develop -c dotnet test` — 689/689 pass.
- [x] New `readManagedByrefBytesAs with wrapped IntPtr template preserves tagged NativeIntSource` test pins the Intrinsics exposure independently of the byref-reinterpret path.
- [x] New `readManagedByrefBytesAs takes byte-walk path for non-primitive-like struct template over bare primitive cell` test pins the safety boundary: arbitrary structs of equal size still take the byte-walk path.
- [x] Existing `readManagedByref through ReinterpretAs IntPtr preserves tagged native-int provenance` regression test from #497 continues to pass without its caller-side `unwrapPrimitiveLikeDeep` (it still has the post-call unwrap on the assertion side, which is now a no-op but harmless).

Codex review against `main` was attempted but blocked by a usage-limit cap; it can be re-run once the limit resets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)