### PR TITLE
Lazily intern CastHelpers::s_table sentinel cast cache

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,10 @@ If you find you really do need to implement a dependency, please consider whethe
 
 For detailed guidance on type concretization, generic resolution, and common patterns in the emulated CLR type system, see .claude/commands/type-concretization.md .
 
+## Runtime-Initialised Statics
+
+For the catalogue of BCL static fields whose values come from the runtime (JIT or EE) rather than any managed `.cctor` — and the recipe for diagnosing a guest `FailFast` with *"Encountered infinite recursion while looking up resource 'Arg_NullReferenceException'"* — see `docs/runtime-initialised-statics.md`.
+
 ## Instructions for OpenAI Codex agents specifically
 
 When you've completed a change to the point where you think it can be PR'ed, please commit it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,10 +112,6 @@ If you find you really do need to implement a dependency, please consider whethe
 
 For detailed guidance on type concretization, generic resolution, and common patterns in the emulated CLR type system, see .claude/commands/type-concretization.md .
 
-## Runtime-Initialised Statics
-
-For the catalogue of BCL static fields whose values come from the runtime (JIT or EE) rather than any managed `.cctor` — and the recipe for diagnosing a guest `FailFast` with *"Encountered infinite recursion while looking up resource 'Arg_NullReferenceException'"* — see `docs/runtime-initialised-statics.md`.
-
 ## Instructions for OpenAI Codex agents specifically
 
 When you've completed a change to the point where you think it can be PR'ed, please commit it.

--- a/WoofWare.PawPrint.Test/TestHarness.fs
+++ b/WoofWare.PawPrint.Test/TestHarness.fs
@@ -49,6 +49,13 @@ module MockEnv =
                             |> Tuple.withRight WhatWeDid.Executed
                             |> ExecutionResult.Stepped
                     TryGetEnvironmentVariable = tryGetEnvironmentVariable
+                    // Surface FailFast as the abort outcome instead of raising
+                    // NotImplementedException from the generated mock; the test
+                    // harness then reports the guest-supplied diagnostic message,
+                    // which is far more useful than a generic "Unimplemented mock
+                    // function: FailFast" stack trace.
+                    FailFast =
+                        fun thread message _errorSource state -> ExecutionResult.FailFast (state, thread, message)
                 }
         }
 

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -23,7 +23,7 @@ module TestPureCases =
             "RuntimeTypeGetInterfacesInherited.cs" // exercises the QCall's inherited-base + transitive-interface walk; now blocked by unimplemented InternalCall System.Buffer::BulkMoveWithWriteBarrierInternal during reflection-cache update
             "CrossAssemblyTypes.cs" // past MethodTable::ParentMethodTable projection; now blocked by unimplemented QCall EventPipeInternal_CreateProvider during static init of System.Diagnostics.Tracing.EventPipeInternal
             "InterfaceDispatch.cs" // past MetadataImport::GetCustomAttributeProps; now blocked by unimplemented InternalCall MetadataImport::GetParentToken
-            "NullDereferenceTest.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
+            "NullDereferenceTest.cs" // past CastHelpers.s_table lazy-init (no longer FailFasts on Arg_NullReferenceException); now blocked by RuntimeFieldProjection.requireNonArrayHeapObject when CastCache.TableData reads RawData::Data on the s_table int[]
             "CastClassInvalid.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
             "CastclassFailures.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
             "ComplexTryCatch.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -559,9 +559,14 @@ module IlMachineRuntimeMetadata =
     ///
     /// Layout under managed `CastCache.CreateCastCache(2)` on a 64-bit guest:
     /// * `int32[]` length = `(size + 1) * sizeof(CastCacheEntry) / 4` = `3 * 24 / 4` = 18.
-    /// * `TableData(table)` skips `sizeof(nint)` bytes from the array's element storage,
-    ///   so the auxiliary header sits at element indices 2, 3, 4 (`hashShift`, `tableMask`,
-    ///   `victimCounter`). The remaining ints are zero-initialised.
+    /// * `TableData(table)` = `GetRawData(table) + sizeof(nint)`. `GetRawData` on an array
+    ///   starts at the length field (`RawArrayData.Length`), so the `sizeof(nint)` offset
+    ///   skips past `Length` (4 bytes) and the 64-bit padding (4 bytes) and lands at the
+    ///   first element. The auxiliary header therefore sits at element indices 0, 1, 2
+    ///   (`hashShift`, `tableMask`, `victimCounter`). The remaining ints are zero-initialised
+    ///   — in particular indices 3..5 are the unused tail of the aux-slot CastCacheEntry,
+    ///   and indices 6..17 are entries 0 and 1 (zero `_version` triggers the immediate
+    ///   `break` in `TryGet`).
     /// * `hashShift = BitOperations.LeadingZeroCount((nuint)1)` = 63 on 64-bit; PawPrint
     ///   targets 64-bit guests exclusively, so we hard-code 63.
     /// * `tableMask = size - 1 = 1`.
@@ -591,11 +596,15 @@ module IlMachineRuntimeMetadata =
 
         // Auxiliary header: hashShift = 63 (LeadingZeroCount((nuint)1) on 64-bit),
         // tableMask = size - 1 = 1, victimCounter = 0 (already zero, written for clarity).
+        // These live at element indices 0, 1, 2 because `CastCache.TableData` resolves
+        // `GetRawData(table) + sizeof(nint)` to the first int element — `GetRawData` on
+        // arrays returns a pointer at `RawArrayData.Length`, so the 8-byte skip walks past
+        // `Length` + 64-bit padding and lands at element 0.
         let state =
             state
-            |> IlMachineThreadState.setArrayValue addr (CliType.Numeric (CliNumericType.Int32 63)) 2
-            |> IlMachineThreadState.setArrayValue addr (CliType.Numeric (CliNumericType.Int32 1)) 3
-            |> IlMachineThreadState.setArrayValue addr (CliType.Numeric (CliNumericType.Int32 0)) 4
+            |> IlMachineThreadState.setArrayValue addr (CliType.Numeric (CliNumericType.Int32 63)) 0
+            |> IlMachineThreadState.setArrayValue addr (CliType.Numeric (CliNumericType.Int32 1)) 1
+            |> IlMachineThreadState.setArrayValue addr (CliType.Numeric (CliNumericType.Int32 0)) 2
 
         addr, state
 

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -548,6 +548,57 @@ module IlMachineRuntimeMetadata =
                 InternedStrings = state.InternedStrings.Add ("", addr)
             }
 
+    /// Allocate a sentinel 2-entry CastCache backing array shaped to match what the native
+    /// EE's `CastCache::Initialize` writes into `CastHelpers::s_table` at startup. The
+    /// array stays a forever-empty sentinel: managed `CastCache.TryGet` reads `version == 0`
+    /// on every probe and returns `CastResult.MaybeCast`, so callers fall through to the
+    /// slow path that PawPrint's type system already handles. `CastCache.TrySet` would
+    /// take the `TableMask == 1` early-return on the sentinel and never mutate it, but
+    /// in any case PawPrint never invokes the instance `TrySet` (CoreCLR only writes to
+    /// the cache from native code).
+    ///
+    /// Layout under managed `CastCache.CreateCastCache(2)` on a 64-bit guest:
+    /// * `int32[]` length = `(size + 1) * sizeof(CastCacheEntry) / 4` = `3 * 24 / 4` = 18.
+    /// * `TableData(table)` skips `sizeof(nint)` bytes from the array's element storage,
+    ///   so the auxiliary header sits at element indices 2, 3, 4 (`hashShift`, `tableMask`,
+    ///   `victimCounter`). The remaining ints are zero-initialised.
+    /// * `hashShift = BitOperations.LeadingZeroCount((nuint)1)` = 63 on 64-bit; PawPrint
+    ///   targets 64-bit guests exclusively, so we hard-code 63.
+    /// * `tableMask = size - 1 = 1`.
+    let internCastCacheSentinelTable
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        : ManagedHeapAddress * IlMachineState
+        =
+        let state, int32Handle =
+            DumpedAssembly.typeInfoToTypeDefn' baseClassTypes state._LoadedAssemblies baseClassTypes.Int32
+            |> IlMachineTypeResolution.concretizeType
+                loggerFactory
+                baseClassTypes
+                state
+                baseClassTypes.Corelib.Name
+                ImmutableArray.Empty
+                ImmutableArray.Empty
+
+        let arrayTypeHandle = ConcreteTypeHandle.OneDimArrayZero int32Handle
+
+        let zeroInt () : CliType =
+            CliType.Numeric (CliNumericType.Int32 0)
+
+        let addr, state =
+            IlMachineThreadState.allocateArray arrayTypeHandle zeroInt 18 state
+
+        // Auxiliary header: hashShift = 63 (LeadingZeroCount((nuint)1) on 64-bit),
+        // tableMask = size - 1 = 1, victimCounter = 0 (already zero, written for clarity).
+        let state =
+            state
+            |> IlMachineThreadState.setArrayValue addr (CliType.Numeric (CliNumericType.Int32 63)) 2
+            |> IlMachineThreadState.setArrayValue addr (CliType.Numeric (CliNumericType.Int32 1)) 3
+            |> IlMachineThreadState.setArrayValue addr (CliType.Numeric (CliNumericType.Int32 0)) 4
+
+        addr, state
+
     let private concreteTypeFullName (state : IlMachineState) (ty : ConcreteType<ConcreteTypeHandle>) : string =
         match state.LoadedAssembly ty.Assembly with
         | Some assy -> Assembly.fullName assy ty.Identity

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -169,6 +169,9 @@ module IlMachineState =
 
     let internCanonicalEmptyString = IlMachineRuntimeMetadata.internCanonicalEmptyString
 
+    let internCastCacheSentinelTable =
+        IlMachineRuntimeMetadata.internCastCacheSentinelTable
+
     let setExceptionStackTraceString =
         IlMachineRuntimeMetadata.setExceptionStackTraceString
 

--- a/WoofWare.PawPrint/UnaryMetadataFieldOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataFieldOps.fs
@@ -26,6 +26,28 @@ module internal UnaryMetadataFieldOps =
         && field.DeclaringType.Generics.IsEmpty
         && field.DeclaringType.Identity = baseClassTypes.String.Identity
 
+    /// `System.Runtime.CompilerServices.CastHelpers::s_table` is the BCL's managed
+    /// cast-cache backing array. In CoreCLR it is populated at native-EE startup by
+    /// `CastCache::Initialize` (`coreclr/vm/castcache.cpp`), invoked from
+    /// `SystemDomain::LoadBaseSystemClasses`, with a 2-entry sentinel cache. PawPrint
+    /// has no equivalent startup hook, so the field reads as null and the BCL's
+    /// `ldflda RawData::Data` against null inside `CastCache.TableData` throws a
+    /// spurious NRE the first time anything goes through the cache (notably during
+    /// resource-string lookup for the *first* genuine NRE, which then trips SR's
+    /// recursion guard and `FailFast`s). Detect the field at `ldsfld`/`ldsflda` time
+    /// and lazily install the sentinel cache, matching what CoreCLR's EE would have done.
+    /// See `docs/runtime-initialised-statics.md` for the full Category-B catalogue.
+    let private isCastHelpersTableField
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (field : FieldInfo<'typeGeneric, 'fieldGeneric>)
+        : bool
+        =
+        field.Name = "s_table"
+        && field.DeclaringType.Generics.IsEmpty
+        && field.DeclaringType.Namespace = "System.Runtime.CompilerServices"
+        && field.DeclaringType.Name = "CastHelpers"
+        && field.DeclaringType.Assembly.FullName = baseClassTypes.Corelib.Name.FullName
+
     let executeStfld (ctx : UnaryMetadataIlOpContext) (state : IlMachineState) : IlMachineState * WhatWeDid =
         let loggerFactory = ctx.LoggerFactory
         let baseClassTypes = ctx.BaseClassTypes
@@ -505,6 +527,18 @@ module internal UnaryMetadataFieldOps =
                     (ComparableFieldDefinitionHandle.Make field.Handle)
                     newVal
                     state
+            | None when isCastHelpersTableField baseClassTypes field ->
+                let addr, state =
+                    IlMachineState.internCastCacheSentinelTable loggerFactory baseClassTypes state
+
+                let newVal = CliType.ObjectRef (Some addr)
+
+                newVal,
+                IlMachineState.setStatic
+                    declaringTypeHandle
+                    (ComparableFieldDefinitionHandle.Make field.Handle)
+                    newVal
+                    state
             | None ->
                 let state, newVal, concreteTypeHandle =
                     IlMachineState.cliTypeZeroOf
@@ -593,6 +627,15 @@ module internal UnaryMetadataFieldOps =
                     // See `isSystemStringEmptyField` for why this is special-cased.
                     let addr, state =
                         IlMachineState.internCanonicalEmptyString loggerFactory baseClassTypes state
+
+                    IlMachineState.setStatic declaringTypeHandle fieldHandle (CliType.ObjectRef (Some addr)) state
+                | None when isCastHelpersTableField baseClassTypes field ->
+                    // See `isCastHelpersTableField` for why this is special-cased. The BCL
+                    // does not actually take the address of `s_table`, but installing the
+                    // sentinel symmetrically with `ldsfld` keeps the two arms consistent
+                    // and defends against future BCL changes.
+                    let addr, state =
+                        IlMachineState.internCastCacheSentinelTable loggerFactory baseClassTypes state
 
                     IlMachineState.setStatic declaringTypeHandle fieldHandle (CliType.ObjectRef (Some addr)) state
                 | None ->

--- a/docs/plans/2026-05-11-castcache-table-init.md
+++ b/docs/plans/2026-05-11-castcache-table-init.md
@@ -28,13 +28,13 @@ Following managed `CastCache.CreateCastCache(2)` and `TableData` (`CastCache.cs:
 
 - `CastCacheEntry` has sequential layout `{ uint _version; nuint _source; nuint _targetAndResult; }`. On 64-bit, `sizeof(CastCacheEntry) == 24` bytes (uint padded to 8 for the nuint alignment).
 - Array length in `int32` units = `(size + 1) * sizeof(CastCacheEntry) / sizeof(int32)` = `3 * 24 / 4` = **18 ints**.
-- `TableData(table)` skips the first `sizeof(nint)` bytes of `table`'s raw element storage, so on 64-bit the "table data" pointer lands at `&table[2]`.
-  - `table[2]` = `hashShift`
-  - `table[3]` = `tableMask`
-  - `table[4]` = `victimCounter` (treated as `uint`)
-  - `table[5..7]` = the rest of the aux-slot CastCacheEntry, must be zero
-  - `table[8..13]` = entry 0 (zero → `_version == 0`, immediate break in `TryGet`)
-  - `table[14..17]` = entry 1 (zero)
+- `TableData(table) = GetRawData(table) + sizeof(nint)`. `RuntimeHelpers.GetRawData` on an array returns a `ref byte` at the length field (`RawArrayData.Length`), so on 64-bit the 8-byte skip walks past `Length` (4 bytes) and the trailing padding (4 bytes) and the resulting pointer is `&table[0]`.
+  - `table[0]` = `hashShift`
+  - `table[1]` = `tableMask`
+  - `table[2]` = `victimCounter` (treated as `uint`)
+  - `table[3..5]` = the rest of the aux-slot CastCacheEntry, must be zero
+  - `table[6..11]` = entry 0 (zero → `_version == 0`, immediate break in `TryGet`)
+  - `table[12..17]` = entry 1 (zero)
 - `tableMask = size - 1 = 1`.
 - `hashShift = BitOperations.LeadingZeroCount((nuint)1)` — on a 64-bit guest, this is `63`. PawPrint targets 64-bit only, so we hard-code `63` and add a debug assert that `nuint.Size == 8` in the layout helper.
 
@@ -76,7 +76,7 @@ val internCastCacheSentinelTable :
     ManagedHeapAddress * IlMachineState
 ```
 
-Implementation: build a `ConcreteTypeHandle.Array (int32Handle, 1)` via the existing concretisation API, then call `IlMachineState.allocateArray` with `len = 18`, zero-init, and post-allocate-write the three aux ints at positions 2, 3, 4. Use `ManagedHeap.setArrayElement` (or the existing array-mutation seam — see what `Array.Copy` already uses) to set those three entries. Cache the result on `IlMachineState` similarly to `InternedStrings` if/when we need a second caller, but for now a one-shot allocation tied to the field's storage slot is fine.
+Implementation: build a `ConcreteTypeHandle.Array (int32Handle, 1)` via the existing concretisation API, then call `IlMachineState.allocateArray` with `len = 18`, zero-init, and post-allocate-write the three aux ints at positions 0, 1, 2. Use `ManagedHeap.setArrayElement` (or the existing array-mutation seam — see what `Array.Copy` already uses) to set those three entries. Cache the result on `IlMachineState` similarly to `InternedStrings` if/when we need a second caller, but for now a one-shot allocation tied to the field's storage slot is fine.
 
 ### Wiring into `ldsfld` / `ldsflda`
 
@@ -123,10 +123,10 @@ class Program
             return 2;
         }
 
-        // The aux header (tableMask) sits at element 3 and must be size - 1 = 1
+        // The aux header (tableMask) sits at element 1 and must be size - 1 = 1
         // for a 2-element sentinel; if tableMask were 0 or >=2 we'd see different
         // index arithmetic and a TrySet that doesn't take the sentinel early-return.
-        if (arr[3] != 1)
+        if (arr[1] != 1)
         {
             return 3;
         }

--- a/docs/plans/2026-05-11-castcache-table-init.md
+++ b/docs/plans/2026-05-11-castcache-table-init.md
@@ -1,0 +1,178 @@
+# Plan: Initialise `CastHelpers.s_table` so the BCL cast cache no longer NREs
+
+## Context
+
+A cluster of ~17 currently-`unimplemented` tests collapse onto a single blocker: the BCL's `SR.InternalGetResourceString` recursion guard escalates to `Environment.FailFast` with
+
+> Encountered infinite recursion while looking up resource 'Arg_NullReferenceException' in System.Private.CoreLib.
+
+The first NRE is legitimate (e.g. a guest `p._field` on `p = null`, the `NullDereferenceTest.cs` repro). Constructing the message string for that NRE calls `SR.GetResourceString` → `ResourceManager..ctor` → `ManifestBasedResourceGroveler.GetNeutralResourcesLanguage` → custom-attribute filtering → `RuntimeType.IsAssignableFrom` → `RuntimeTypeHandle.CanCastTo` → `TypeHandle.TryCanCastTo` → `CastCache.TryGet` → `CastCache.TableData(table)` → `RuntimeHelpers.GetRawData(table)` → `ldflda RawData::Data` on a null `obj` → second NRE → recursion guard trips.
+
+The null is the static field `System.Runtime.CompilerServices.CastHelpers::s_table` (an `int[]?`). The managed code at `TypeHandle.TryCanCastTo+0x24` is `ldsfld CastHelpers::s_table`; PawPrint reads it as `None`/null because no managed code ever wrote to it.
+
+In CoreCLR, `s_table` is populated by native code at EE startup: `appdomain.cpp:1072 → CastCache::Initialize()` (`castcache.cpp:112-138`) creates a 2-entry sentinel cache via `CreateCastCache(2)` and writes it into the field via `CoreLibBinder::GetField(FIELD__CASTCACHE__TABLE)->GetCurrentStaticAddress(); SetObjectReference(...)`. PawPrint has no equivalent EE startup hook.
+
+This is the same *symptom class* as the recently-fixed `System.String::Empty`, but a different *mechanism*. There are three JIT-intrinsic fields whose `ldsfld` the real JIT replaces with a constant (`String.Empty`, `IntPtr.Zero`/`UIntPtr.Zero`, `BitConverter.IsLittleEndian`; see `getFieldIntrinsic` at `coreclr/vm/jitinterface.cpp:1145-1166`) — and `CastHelpers.s_table` is *not* one of them. It is a regular static slot that the EE writes during `SystemDomain::LoadBaseSystemClasses`. Searching `coreclr/vm` for the same pattern (`SetObjectReference((OBJECTREF*)…)` against a `FieldDesc`'s static address) finds exactly one such field, so this fix is expected to be a one-shot: there is no second native-init static lurking in CoreCLR.
+
+(Notes on the JIT intrinsics: `IntPtr.Zero` / `UIntPtr.Zero` happen to coincide with `cliTypeZeroOf` of `nint`/`nuint` and need no fix; `BitConverter.IsLittleEndian` has a managed initialiser `= true` under `!BIGENDIAN`, so the ordinary `.cctor` does the right thing. `String.Empty` was the genuine omission and is already fixed in HEAD.)
+
+## Approach
+
+Mirror the `System.String::Empty` lazy-init pattern (`6b8bf34`). On `ldsfld`/`ldsflda` of `CastHelpers::s_table` whose backing store is `None`, allocate a managed `int[]` shaped as a 2-entry sentinel cast cache, write the aux header, install it in the static slot, and continue. Subsequent reads see the same array; subsequent BCL `CastCache.TryGet` calls go through the cache, observe `version == 0` on the first probe, return `CastResult.MaybeCast`, and the BCL falls through to the slow path — which on CoreCLR is the same QCall (`RuntimeTypeHandle::CanCastTo`) PawPrint already handles via its existing type-system implementation.
+
+The sentinel never has anything written into it (`CastCache.TrySet` on the sentinel takes the `TableMask == 1` early-return at `CastCache.cs:267-274`), so we don't need to model `TrySet` updates — every cache lookup remains a miss-then-fallthrough. That is the *intended* behaviour of the native sentinel too.
+
+### Sentinel `int[]` shape (size = 2)
+
+Following managed `CastCache.CreateCastCache(2)` and `TableData` (`CastCache.cs:104-130`):
+
+- `CastCacheEntry` has sequential layout `{ uint _version; nuint _source; nuint _targetAndResult; }`. On 64-bit, `sizeof(CastCacheEntry) == 24` bytes (uint padded to 8 for the nuint alignment).
+- Array length in `int32` units = `(size + 1) * sizeof(CastCacheEntry) / sizeof(int32)` = `3 * 24 / 4` = **18 ints**.
+- `TableData(table)` skips the first `sizeof(nint)` bytes of `table`'s raw element storage, so on 64-bit the "table data" pointer lands at `&table[2]`.
+  - `table[2]` = `hashShift`
+  - `table[3]` = `tableMask`
+  - `table[4]` = `victimCounter` (treated as `uint`)
+  - `table[5..7]` = the rest of the aux-slot CastCacheEntry, must be zero
+  - `table[8..13]` = entry 0 (zero → `_version == 0`, immediate break in `TryGet`)
+  - `table[14..17]` = entry 1 (zero)
+- `tableMask = size - 1 = 1`.
+- `hashShift = BitOperations.LeadingZeroCount((nuint)1)` — on a 64-bit guest, this is `63`. PawPrint targets 64-bit only, so we hard-code `63` and add a debug assert that `nuint.Size == 8` in the layout helper.
+
+After installation, `KeyToBucket` shifts the 64-bit hash right by 63 and masks with `1`, returning an index in `{0, 1}`. `Element(ref tableData, 0)` and `Element(ref tableData, 1)` both see zero entries, hit the `version == 0` break, and return `CastResult.MaybeCast`.
+
+### Where to do the detection
+
+The `ldsfld`/`ldsflda` paths in `UnaryMetadataFieldOps.fs` already have a precedent block for `System.String::Empty` (the `None when isSystemStringEmptyField …` arm). Add a sibling arm for `s_table`:
+
+```fsharp
+let private isCastHelpersTableField
+    (field : FieldInfo<'typeGeneric, 'fieldGeneric>)
+    : bool
+    =
+    field.Name = "s_table"
+    && field.DeclaringType.Generics.IsEmpty
+    && field.DeclaringType.Namespace = "System.Runtime.CompilerServices"
+    && field.DeclaringType.Name = "CastHelpers"
+    && field.DeclaringType.Assembly = baseClassTypes.Corelib.Identity  // or whatever the field exposes
+```
+
+`BaseClassTypes` does not carry `CastHelpers` (it's tightly scoped to types the runtime fundamentally needs). Match by namespace/name/assembly directly, the same way other corelib-only detections do — `CastHelpers` is sealed/internal and there is no risk of a guest type colliding under the same FQN.
+
+### The lazy allocator
+
+Add a sibling to `IlMachineRuntimeMetadata.internCanonicalEmptyString`:
+
+```fsharp
+/// Allocate a sentinel 2-entry CastCache backing array shaped to match the
+/// native EE's CastCache::Initialize, and install it in CastHelpers::s_table.
+/// The array is intentionally never updated: TryGet sees zero entries, returns
+/// MaybeCast, and the BCL falls through to the slow path. This satisfies all
+/// managed callers of CastCache.TryGet on this runtime, which has no JIT to
+/// populate the cache for us anyway.
+val internCastCacheSentinelTable :
+    ILoggerFactory ->
+    BaseClassTypes<DumpedAssembly> ->
+    IlMachineState ->
+    ManagedHeapAddress * IlMachineState
+```
+
+Implementation: build a `ConcreteTypeHandle.Array (int32Handle, 1)` via the existing concretisation API, then call `IlMachineState.allocateArray` with `len = 18`, zero-init, and post-allocate-write the three aux ints at positions 2, 3, 4. Use `ManagedHeap.setArrayElement` (or the existing array-mutation seam — see what `Array.Copy` already uses) to set those three entries. Cache the result on `IlMachineState` similarly to `InternedStrings` if/when we need a second caller, but for now a one-shot allocation tied to the field's storage slot is fine.
+
+### Wiring into `ldsfld` / `ldsflda`
+
+In the two `None when …` arms in `UnaryMetadataFieldOps.fs` (existing `executeLdsfld` and `executeLdsflda`), add the `s_table` case alongside `String::Empty`. Both return `CliType.ObjectRef (Some addr)` for the value and update the static via `IlMachineState.setStatic`, identical to the `String::Empty` precedent.
+
+## Files to modify
+
+- `WoofWare.PawPrint/IlMachineRuntimeMetadata.fs` — add `internCastCacheSentinelTable` next to `internCanonicalEmptyString` (~line 535).
+- `WoofWare.PawPrint/IlMachineState.fs` — re-export the new helper (~line 80-95).
+- `WoofWare.PawPrint/UnaryMetadataFieldOps.fs` — add `isCastHelpersTableField` predicate and the `None when isCastHelpersTableField …` arms in `executeLdsfld` and `executeLdsflda`.
+- `WoofWare.PawPrint.Test/sourcesPure/CastHelpersTableInit.cs` — focused test (see below).
+- `WoofWare.PawPrint.Test/TestPureCases.fs` — drop `NullDereferenceTest.cs` (and likely several siblings) from `unimplemented`, refresh comments on any that now hit a different blocker.
+
+## Tests
+
+### Focused new test: `CastHelpersTableInit.cs`
+
+The point is to verify *only* that the cast cache field is non-null and shaped correctly enough to satisfy `CastCache.TryGet` without throwing. End-to-end behaviour (a real NRE catch surviving the resource lookup) is verified by promoting `NullDereferenceTest.cs` out of `unimplemented`.
+
+```csharp
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    static int Main(string[] args)
+    {
+        // Reflectively read CastHelpers.s_table (internal).
+        Type castHelpers = typeof(object).Assembly.GetType("System.Runtime.CompilerServices.CastHelpers", throwOnError: true)!;
+        FieldInfo sTable = castHelpers.GetField("s_table", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        // The first read after the runtime has initialised the field must be non-null
+        // and an int[] (the sentinel cast cache).
+        object? value = sTable.GetValue(null);
+        if (value is not int[] arr)
+        {
+            return 1;
+        }
+
+        // Shape sanity: 18 ints for a size-2 sentinel.
+        if (arr.Length != 18)
+        {
+            return 2;
+        }
+
+        // The aux header (tableMask) sits at element 3 and must be size - 1 = 1
+        // for a 2-element sentinel; if tableMask were 0 or >=2 we'd see different
+        // index arithmetic and a TrySet that doesn't take the sentinel early-return.
+        if (arr[3] != 1)
+        {
+            return 3;
+        }
+
+        return 0;
+    }
+}
+```
+
+Pattern matches existing reflection-driven sanity tests in `sourcesPure/` and is auto-discovered.
+
+### Promote `NullDereferenceTest.cs` out of `unimplemented`
+
+The test asserts the guest exit code matches the real CLR's (0 on success). With `s_table` initialised, the inner NRE during message-string construction stops happening, the legitimate NRE is caught by the guest's `catch (NullReferenceException)`, and the test passes.
+
+If it does *not* pass, expect a *different* blocker further along the resource-lookup chain — most likely an unimplemented QCall surfaced by `ResourceManager.CommonAssemblyInit` once it can get past `IsAssignableFrom`. Keep the test in `unimplemented` and refresh the comment to point at the new blocker, then split that out as a separate plan.
+
+### Sibling tests likely to unblock
+
+The `unimplemented` list currently has 17 entries whose comments end in *"blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource"* or *"blocked downstream by ResourceManager hitting infinite recursion looking up 'Arg_NullReferenceException'"*. Don't preemptively un-mark all of them — change `NullDereferenceTest.cs` only, run the test suite, and *then* sweep the comments based on what actually now passes / what newly-surfaces. The cast-cache fix is one PR; the comment refresh is a follow-up.
+
+## Edge cases & non-issues
+
+- **`ldsflda` of `s_table`.** The BCL never takes the address of `s_table` (it's `int[]?`, a reference, and ECMA semantics for `ldsflda` of a `ref` field would be unusual). Adding the arm symmetrically with `String::Empty` is defensive but should not actually fire — guard with an assertion if convenient, otherwise just install identically.
+- **Multiple writes to `s_table`.** The BCL's `CastCache.TrySet` only writes via the *instance* version, which is never invoked from managed code on CoreCLR (`CastCache.cs:208-209`: "in CoreClr the cache is only updated in the native code"). PawPrint has no native cache-writer, so the sentinel stays a sentinel forever, which is exactly what we want.
+- **`MaybeReplaceCacheWithLarger`.** Only reached through `TrySet`, same gated path. Inert.
+- **Sentinel identity (`s_sentinelTable` in the BCL).** The managed `CastCache` struct has its *own* private `s_sentinelTable` it allocates from within an instance ctor — that's for *instance* CastCaches, not for `CastHelpers.s_table`. We don't need to coordinate.
+- **Endianness.** PawPrint targets 64-bit little-endian guests only; `hashShift = 63` is correct under that constraint. Assert it in the helper.
+- **Type concretisation cost.** `ConcreteTypeHandle.Array (int32Handle, 1)` should already exist in `state.ConcreteTypes` after class init touches `int[]`. If not, concretise it lazily — `allocateArray` requires the handle, but cost is one-shot.
+
+## Verification
+
+1. Build: `nix develop -c dotnet build WoofWare.PawPrint.slnx`.
+2. Format: `nix develop -c dotnet fantomas .`.
+3. Focused new test: `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --no-build --filter "Name~CastHelpersTableInit" --verbosity normal`.
+4. The previously-`unimplemented` repro: `nix develop -c dotnet test … --filter "Name~NullDereferenceTest" …` — expect it to pass under "Standard tests".
+5. Full suite for regressions: `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --verbosity normal`.
+6. Branch + commit, then `codex review --base main` per the project workflow.
+
+## Out of scope (intentional)
+
+- Implementing `CastCache.TrySet` semantics or any cache *update* path. The sentinel is forever-empty by design.
+- Generalising the lazy-init mechanism beyond `String::Empty` and `s_table`. We've now surveyed CoreCLR for native-EE-init managed statics and found these two; adding a generic registry would be speculative until a third one surfaces.
+- Fixing the *other* unimplemented-test blockers (the four native-method blockers — `SystemNative_Malloc`, `SystemNative_LowLevelMonitor_Create`, `BulkMoveWithWriteBarrierInternal`, `GetDeclaringMethodForGenericParameter`). Those are independent.
+- Refreshing comments on the 15 sibling `unimplemented` entries — do that *after* observing what newly passes.
+
+## Documentation update
+
+After landing, update the Category B row for `CastHelpers::s_table` in `docs/runtime-initialised-statics.md` from "Pending" to a pointer at the implementing helper (`IlMachineRuntimeMetadata.internCastCacheSentinelTable` and the `UnaryMetadataFieldOps.isCastHelpersTableField` predicate).

--- a/docs/runtime-initialised-statics.md
+++ b/docs/runtime-initialised-statics.md
@@ -1,0 +1,44 @@
+# Runtime-Initialised Statics
+
+This document catalogues BCL static fields whose values come from the .NET *runtime* (the JIT or the EE) rather than from any managed `.cctor`. PawPrint has neither a JIT nor an EE startup hook, so it must fake these initialisations. If you are reading this because a guest program is failing with
+
+> Encountered infinite recursion while looking up resource 'Arg_NullReferenceException' in System.Private.CoreLib
+
+the most likely cause is a missing entry on this list: a spurious second `NullReferenceException` is being raised because PawPrint read one of these statics as `default(T)` (i.e. `null` for reference types) and the BCL then dereferenced it. Constructing the message for the first NRE re-enters resource lookup, hits `SR.InternalGetResourceString`'s recursion guard, and `FailFast`s.
+
+Debugging recipe: temporarily add a logger to `IlMachineStateExecution.raiseRuntimeException` that walks `ts.ActiveMethodState` along `ReturnState.JumpTo` and emits each frame's `ExecutingMethod`/`IlOpIndex`. The second NRE's stack will name the BCL call site that dereferenced the unfaked static.
+
+## Category A — JIT-intrinsic statics
+
+The CoreCLR JIT replaces `ldsfld` on these three fields with a constant load. Defined exhaustively in `getFieldIntrinsic` at `dotnet-runtime/src/coreclr/vm/jitinterface.cpp` (search for `CORINFO_FIELD_INTRINSIC_EMPTY_STRING`):
+
+| Field | Intrinsic | PawPrint status |
+|---|---|---|
+| `System.String::Empty` | `CORINFO_FIELD_INTRINSIC_EMPTY_STRING` | Faked. `UnaryMetadataFieldOps.isSystemStringEmptyField` + `IlMachineRuntimeMetadata.internCanonicalEmptyString` (commit `6b8bf34`). |
+| `System.IntPtr::Zero` and `System.UIntPtr::Zero` | `CORINFO_FIELD_INTRINSIC_ZERO` | No fix needed. The fields are declared `static readonly nint Zero;` with no initialiser; `cliTypeZeroOf` of `nint`/`nuint` is `0`, which coincides with the intended value. |
+| `System.BitConverter::IsLittleEndian` | `CORINFO_FIELD_INTRINSIC_ISLITTLEENDIAN` | No fix needed on our supported targets. The field has a managed source initialiser `= true` under `!BIGENDIAN` (see `BitConverter.cs`), so the ordinary `.cctor` runs and produces the right value. The intrinsic exists only to fold the `ldsfld` to a constant; correctness does not depend on it. |
+
+## Category B — Native-EE-initialised statics
+
+These are *not* JIT intrinsics. They are regular static slots that the native EE writes during startup via `CoreLibBinder::GetField(...)->GetCurrentStaticAddress()` + `SetObjectReference(...)`. Managed `ldsfld` on them reads whatever the EE installed.
+
+| Field | Initialiser | PawPrint status |
+|---|---|---|
+| `System.Runtime.CompilerServices.CastHelpers::s_table` | `CastCache::Initialize()` in `coreclr/vm/castcache.cpp:112-138`, invoked from `appdomain.cpp:1072` inside `SystemDomain::LoadBaseSystemClasses`. Installs a 2-entry sentinel `int[]` shaped so that `CastCache.TryGet` always returns `MaybeCast` until the native cache writer (only reached from native fast paths) installs a real cache. | Faked. `UnaryMetadataFieldOps.isCastHelpersTableField` + `IlMachineRuntimeMetadata.internCastCacheSentinelTable`. Installs a sentinel `int[18]` on first read of the field, mirroring the `System.String::Empty` lazy-init. |
+
+### Why we believe Category B is complete
+
+Grep across `dotnet-runtime/src/coreclr/vm/` for `SetObjectReference((OBJECTREF *)...)` against a `FieldDesc`'s static address (the marker pattern for native-EE writes to a managed static slot). The only hits are:
+
+- `castcache.cpp:92, 109, 137` — all three are `CastCache::Initialize` / `MaybeReplaceCacheWithLarger` / `FlushCurrentCache` writing to the same `s_table` field.
+- `threadstatics.cpp:483` — writes to a *per-thread* TLS base pointer, not an `ldsfld`-visible managed static.
+
+There are no other instances in CoreCLR. If a future BCL change adds another EE-initialised static, the symptom will again be a spurious NRE during BCL string-construction; the debugging recipe above will identify it, at which point add a row here and another lazy-init arm to `UnaryMetadataFieldOps`.
+
+## Adding a new entry
+
+1. Reproduce the spurious NRE and capture the inner stack with the `raiseRuntimeException` frame-walker.
+2. Identify the `ldsfld`/`ldsflda` site where the unfaked static is read. The IL offset will land at the `Call`/`Ldflda` immediately after the `ldsfld`.
+3. Decide whether `cliTypeZeroOf` already matches the intended value (Category A row 2 and 3) or whether the BCL truly requires a non-default value (everything else).
+4. If a fake is required, add a predicate and a lazy-allocator following the `System.String::Empty` precedent (`UnaryMetadataFieldOps.fs` + `IlMachineRuntimeMetadata.fs`), plus a focused reflection-driven test under `WoofWare.PawPrint.Test/sourcesPure/`.
+5. Update the table here with a one-line summary and a pointer to the implementing helper.


### PR DESCRIPTION
`System.Runtime.CompilerServices.CastHelpers::s_table` is a Category-B runtime-initialised static: CoreCLR's native EE populates it during `SystemDomain::LoadBaseSystemClasses` with a 2-entry sentinel int[], shaped so managed `CastCache.TryGet` always returns `MaybeCast`. PawPrint has no EE startup hook, so the field reads as null. The BCL's `CastCache.TableData` then does `ldflda RawData::Data` against null, which raises a spurious NRE; constructing its resource string re-enters SR's recursion guard and `FailFast`s with the now-familiar "Encountered infinite recursion while looking up resource 'Arg_NullReferenceException'" cascade.

Mirror the `System.String::Empty` precedent (commit 6b8bf34) by detecting the field at ldsfld/ldsflda time and installing an int[18] sentinel populated to match what `CastCache::Initialize` writes: hashShift = 63 (LeadingZeroCount on 64-bit), tableMask = 1, victimCounter = 0.

Bundle the broader docs/runtime-initialised-statics.md catalogue (the recipe for diagnosing further Category-A/B cases) and surface FailFast through the test harness as `ExecutionResult.FailFast` so the message is visible instead of being swallowed by the generic mock.