### PR TITLE
Pin BCL [Intrinsic] static field set and add sentinel guest tests

### DIFF
--- a/.claude/commands/sync-dotnet-runtime.md
+++ b/.claude/commands/sync-dotnet-runtime.md
@@ -27,6 +27,8 @@ The `../dotnet-runtime` checkout is a clone of `dotnet/runtime`. We use it as a 
 
 4. Verify the source you care about compiles in your head: e.g. for QCall work against RuntimeHandles, glance at `src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs` and `src/coreclr/vm/runtimehandles.cpp` to confirm they look like the .NET 10 shape you expect.
 
+5. Re-audit the JIT's `CORINFO_FIELD_INTRINSIC_*` enum at `src/coreclr/inc/corinfo.h`. As of the audit it has exactly three entries (`ZERO`, `EMPTY_STRING`, `ISLITTLEENDIAN`) and `TestBclIntrinsicStaticFields` in `WoofWare.PawPrint.Test` pins the corresponding BCL field set. If a new entry appears, the JIT is folding `ldsfld` for a slot that PawPrint reads literally: audit the BCL declaration (`grep -nR "\[Intrinsic\]" src/libraries/System.Private.CoreLib/src/`) for any new static field that lacks an initialiser. Don't assume that "the zero-initialised slot is the right value" makes the case safe — `IntPtr::Zero` and `UIntPtr::Zero` look that way but `cliTypeZeroOf` populates them with `NativeIntSource.ManagedPointer Null`, which compares unequal to `Verbatim 0L` in `cgt.un`. Always add a focused guest test (see `IntPtrZero.cs` / `UIntPtrZero.cs` / `BitConverterIsLittleEndian.cs`) before relying on the generic path; lazy population at first `ldsfld`/`ldsflda` (the `System.String::Empty` approach in `UnaryMetadataFieldOps.executeLdsfld`) is the safer default for non-Boolean fields. Then update `expectedIntrinsicStaticFields` in `TestBclIntrinsicStaticFields.fs` to acknowledge the new field.
+
 ## Notes
 
 - The repo's working tree often hosts the user's in-flight PR work; before checking out, confirm `git status` is clean and remember the previous branch (the user can `git switch -` to return).

--- a/WoofWare.PawPrint.Test/TestBclIntrinsicStaticFields.fs
+++ b/WoofWare.PawPrint.Test/TestBclIntrinsicStaticFields.fs
@@ -1,0 +1,126 @@
+namespace WoofWare.PawPrint.Test
+
+open System.IO
+open System.Reflection
+open System.Reflection.Metadata
+open System.Reflection.PortableExecutable
+open FsUnitTyped
+open NUnit.Framework
+
+/// Pin the set of `[Intrinsic]` static fields in `System.Private.CoreLib`. The JIT recognises
+/// each via the closed `CORINFO_FIELD_INTRINSIC_*` enum at `src/coreclr/inc/corinfo.h` and
+/// synthesises the load rather than reading the static slot. An IL interpreter like PawPrint
+/// actually reads the slot, so the value present there has to be correct on its own — either
+/// because a normal `.cctor` writes it, because the zero-initialised slot happens to be the
+/// right value, or because PawPrint has special-cased the field. This test fails whenever a
+/// new entry appears, forcing a deliberate audit.
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestBclIntrinsicStaticFields =
+
+    /// `[Intrinsic]` static fields we have audited:
+    ///
+    /// - `System.String::Empty` — declared without an initialiser. The real CLR's execution
+    ///   engine populates it at startup; PawPrint has no equivalent hook, so the
+    ///   `ldsfld`/`ldsflda` paths in `UnaryMetadataFieldOps` detect this specific field and
+    ///   lazily intern the empty string. See `isSystemStringEmptyField` for the predicate.
+    /// - `System.IntPtr::Zero` and `System.UIntPtr::Zero` — declared without an initialiser.
+    ///   The JIT recognises these via `CORINFO_FIELD_INTRINSIC_ZERO` and synthesises a zero
+    ///   load. PawPrint reads the static slot literally, and `CliType.zeroOfPrimitive`
+    ///   populates the slot with `NativeIntSource.ManagedPointer Null` (an isomorphic but
+    ///   distinct representation of nint zero). `EvalStackValueComparisons.cgtUn` does not
+    ///   relate `ManagedPointer Null` to `Verbatim 0L`, so the simple C# `zero !=
+    ///   default(IntPtr)` fails. The `IntPtrZero.cs` / `UIntPtrZero.cs` pure tests pin this
+    ///   contract; they currently sit in `unimplemented` until the underlying comparison
+    ///   gap is filled.
+    /// - `System.BitConverter::IsLittleEndian` — declared `= true` in the `!BIGENDIAN` build
+    ///   (the only flavour PawPrint executes against). The normal `.cctor` populates it; the
+    ///   `BitConverterIsLittleEndian.cs` pure test passes end-to-end. The `BIGENDIAN` build
+    ///   would have the same shape of problem as `String::Empty`, but the runtime we depend
+    ///   on never ships in that configuration.
+    ///
+    /// If this set changes — a new intrinsic field appears in a future runtime version, or an
+    /// existing declaration changes shape — the JIT's `CORINFO_FIELD_INTRINSIC_*` enum will
+    /// also have grown. Audit each new field, decide how PawPrint should handle it, then
+    /// update this set.
+    let private expectedIntrinsicStaticFields : Set<string> =
+        Set.ofList
+            [
+                "System.BitConverter.IsLittleEndian"
+                "System.IntPtr.Zero"
+                "System.String.Empty"
+                "System.UIntPtr.Zero"
+            ]
+
+    /// Returns true if the custom-attribute constructor lives on
+    /// `System.Runtime.CompilerServices.IntrinsicAttribute`. We resolve the constructor's
+    /// declaring type via either a `MemberReference` (when the attribute is defined in a
+    /// different assembly) or a `MethodDefinition` (when defined in this assembly).
+    let private isIntrinsicAttribute (md : MetadataReader) (attr : CustomAttribute) : bool =
+        let ns, name =
+            match attr.Constructor.Kind with
+            | HandleKind.MemberReference ->
+                let memberRef =
+                    md.GetMemberReference (MemberReferenceHandle.op_Explicit attr.Constructor)
+
+                match memberRef.Parent.Kind with
+                | HandleKind.TypeReference ->
+                    let typeRef = md.GetTypeReference (TypeReferenceHandle.op_Explicit memberRef.Parent)
+
+                    md.GetString typeRef.Namespace, md.GetString typeRef.Name
+                | HandleKind.TypeDefinition ->
+                    let typeDef =
+                        md.GetTypeDefinition (TypeDefinitionHandle.op_Explicit memberRef.Parent)
+
+                    md.GetString typeDef.Namespace, md.GetString typeDef.Name
+                | _ -> "", ""
+            | HandleKind.MethodDefinition ->
+                let methodDef =
+                    md.GetMethodDefinition (MethodDefinitionHandle.op_Explicit attr.Constructor)
+
+                let typeDef = md.GetTypeDefinition (methodDef.GetDeclaringType ())
+                md.GetString typeDef.Namespace, md.GetString typeDef.Name
+            | _ -> "", ""
+
+        ns = "System.Runtime.CompilerServices" && name = "IntrinsicAttribute"
+
+    [<Test>]
+    let ``[Intrinsic] static fields in System.Private.CoreLib match the audited set`` () : unit =
+        let corelibPath = typeof<obj>.Assembly.Location
+
+        use fs = File.OpenRead corelibPath
+        use peReader = new PEReader (fs)
+        let md = peReader.GetMetadataReader ()
+
+        let fields =
+            md.TypeDefinitions
+            |> Seq.collect (fun typeHandle ->
+                let typeDef = md.GetTypeDefinition typeHandle
+
+                typeDef.GetFields ()
+                |> Seq.choose (fun fieldHandle ->
+                    let field = md.GetFieldDefinition fieldHandle
+
+                    if not (field.Attributes.HasFlag FieldAttributes.Static) then
+                        None
+                    else
+                        let isIntrinsic =
+                            field.GetCustomAttributes ()
+                            |> Seq.exists (fun attrHandle ->
+                                isIntrinsicAttribute md (md.GetCustomAttribute attrHandle)
+                            )
+
+                        if isIntrinsic then
+                            let ns = md.GetString typeDef.Namespace
+                            let typeName = md.GetString typeDef.Name
+
+                            let qualifiedType = if ns = "" then typeName else $"%s{ns}.%s{typeName}"
+
+                            Some $"%s{qualifiedType}.%s{md.GetString field.Name}"
+                        else
+                            None
+                )
+            )
+            |> Set.ofSeq
+
+        fields |> shouldEqual expectedIntrinsicStaticFields

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -43,6 +43,8 @@ module TestPureCases =
             "InitializeArrayBoxedFieldHandle.cs" // past String::FastAllocateString(MethodTable*, nint); now blocked by unimplemented MethodTable field projection for ParentMethodTable
             "ArraySortHelperDefaultInt.cs" // past Environment_FailFast QCall (now wired up); now blocked downstream by ResourceManager hitting infinite recursion looking up 'Arg_NullReferenceException' in System.Private.CoreLib, which the BCL escalates to Environment.FailFast
             "GenericEdgeCases.cs" // past Unsafe.CopyBlockUnaligned JIT intrinsic; now blocked downstream by ResourceManager hitting infinite recursion looking up 'Arg_NullReferenceException' in System.Private.CoreLib, which the BCL escalates to Environment.FailFast (same blocker as ArraySortHelperDefaultInt.cs)
+            "IntPtrZero.cs" // `IntPtr.Zero` is `[Intrinsic]` with no IL initialiser; the JIT recognises `CORINFO_FIELD_INTRINSIC_ZERO` but the interpreter reads the static slot, where `cliTypeZeroOf` populates `NativeIntSource.ManagedPointer Null`. The C# inequality `zero != default(IntPtr)` lowers to `cgt.un(zero, (nint)0)`, and `EvalStackValueComparisons.cgtUn` has no case relating `ManagedPointer Null` to `Verbatim 0L` (it only handles ManagedPointer-vs-ManagedPointer)
+            "UIntPtrZero.cs" // same blocker as IntPtrZero.cs: `cliTypeZeroOf` for `UIntPtr` is `NativeIntSource.ManagedPointer Null`, and `cgt.un(ManagedPointer Null, Verbatim 0L)` is unimplemented
         ]
         |> Set.ofList
 

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -56,6 +56,7 @@
     <Compile Include="TestDebuggerState.fs" />
     <Compile Include="TestProgramDebugger.fs" />
     <Compile Include="TestDebuggerServer.fs" />
+    <Compile Include="TestBclIntrinsicStaticFields.fs" />
     <Compile Include="TestPureCases.fs" />
     <Compile Include="TestImpureCases.fs" />
   </ItemGroup>

--- a/WoofWare.PawPrint.Test/sourcesPure/BitConverterIsLittleEndian.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/BitConverterIsLittleEndian.cs
@@ -1,0 +1,11 @@
+namespace BitConverterIsLittleEndian
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            if (!System.BitConverter.IsLittleEndian) return 1;
+            return 0;
+        }
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/IntPtrZero.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/IntPtrZero.cs
@@ -1,0 +1,14 @@
+namespace IntPtrZero
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            System.IntPtr zero = System.IntPtr.Zero;
+            if (zero != default(System.IntPtr)) return 1;
+            if (zero != (System.IntPtr)0) return 2;
+            if (zero.ToInt64() != 0L) return 3;
+            return 0;
+        }
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/UIntPtrZero.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/UIntPtrZero.cs
@@ -1,0 +1,14 @@
+namespace UIntPtrZero
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            System.UIntPtr zero = System.UIntPtr.Zero;
+            if (zero != default(System.UIntPtr)) return 1;
+            if (zero != (System.UIntPtr)0) return 2;
+            if (zero.ToUInt64() != 0UL) return 3;
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
Sweeps System.Private.CoreLib for [Intrinsic] static fields and asserts the audited set matches what PawPrint can handle. A new entry in a future runtime version means the JIT is folding ldsfld for a slot PawPrint reads literally, which needs deliberate handling.

Adds focused guest tests for each currently-audited field so each path is exercised in isolation. BitConverter.IsLittleEndian passes end-to-end; IntPtrZero/UIntPtrZero sit in `unimplemented` because cliTypeZeroOf populates the slot with NativeIntSource.ManagedPointer Null which cgt.un does not relate to Verbatim 0L (a latent bug, separate fix).

Also wires the JIT-enum re-audit into the dotnet-runtime sync command so the check is repeated on each runtime bump.