### PR TITLE
Introduce Int64Source.OpaqueHashBits for pointer-bit mixing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,17 @@ nix develop -c dotnet run --project WoofWare.PawPrint.App/WoofWare.PawPrint.App.
   * For example, preserve the distinction between identity and view/projection. Prefer making walks total rather than adding projection helpers. If a traversal over runtime types fails at a structural/synthetic handle, teach the traversal how to step through the appropriate relationship; do not coerce the handle into a different identity just to reuse metadata code.
 * If callers use a classifier, guard, predicate, or DU case to justify a later operation, keep that classifier's contract truthful and load-bearing. Fixes should ensure the classifier/representation is reliable for its callers.
 
+When you find yourself making an architectural decision, please come up with at least two genuinely different options and choose explicitly between them.
+"Genuinely different" means structurally different approaches, not adjacent variants of the same idea.
+Consider not just correctness on the immediate use case but also blast radius if the choice turns out wrong, reversibility, and how much information each option preserves for downstream consumers.
+
+For non-trivial choices, write the option set down (in a plan doc or in chat) and confirm with the user before touching code.
+If you are unsure, stop and ask rather than guess.
+
+Example: bit-twiddling on provenance-tracked pointers in unsafe C# is a recurring instance of this kind of decision.
+Options range from synthesising a bit pattern eagerly (smallest implementation cost, largest loss of information), to maintaining an AST of the transformations performed on a logical set of bits (largest cost, most information preserved), to a middle ground that waits until the last moment before materialising bits.
+The right call depends on what downstream code does with the result.
+
 ### Development Workflow
 
 Use the `/implement-il-instruction` skill when adding support for a new IL opcode.

--- a/WoofWare.PawPrint.Test/TestBinaryArithmetic.fs
+++ b/WoofWare.PawPrint.Test/TestBinaryArithmetic.fs
@@ -45,7 +45,7 @@ module TestBinaryArithmetic =
         (val2 : EvalStackValue)
         : EvalStackValue
         =
-        BinaryArithmetic.execute baseClassTypes op state val1 val2
+        BinaryArithmetic.execute baseClassTypes op state val1 val2 |> fst
 
     let private concreteTypeFor
         (typeInfo : TypeInfo<GenericParamFromMetadata, TypeDefn>)

--- a/WoofWare.PawPrint.Test/TestEvalStack.fs
+++ b/WoofWare.PawPrint.Test/TestEvalStack.fs
@@ -1,5 +1,6 @@
 namespace WoofWare.PawPrint.Test
 
+open FsUnitTyped
 open NUnit.Framework
 open WoofWare.PawPrint
 
@@ -195,6 +196,34 @@ module TestEvalStack =
 
         if EvalStackValueComparisons.ceq byrefMethodTable byrefRuntimeTypeHandle then
             failwith "Expected TypeDesc Byref handles to remain distinct from MethodTablePtr"
+
+    [<Test>]
+    let ``ceq of WidenedNativeInt vs OpaqueHashBits fails loudly rather than returning silently wrong`` () : unit =
+        // Under the counter-based pointer-hash scheme, an identity bit op such as `x ^ 0UL`
+        // materialises the WidenedNativeInt's bits into OpaqueHashBits. A subsequent
+        // `x == y` would then ask: do `WidenedNativeInt x`'s materialised bits equal `b`?
+        // Answering that requires the PointerHashCounters map which ceq does not currently
+        // thread; the silent-false answer that prior versions returned is wrong under
+        // identity ops, so this case fails loudly until ceq is taught to look it up.
+        let widened =
+            EvalStackValue.Int64 (
+                Int64Source.WidenedNativeInt (NativeIntSource.MethodTablePtr (ConcreteTypeHandle.Concrete 42), true)
+            )
+
+        let hashBits = EvalStackValue.Int64 (Int64Source.OpaqueHashBits 4L)
+
+        let ex =
+            Assert.Throws<System.Exception> (fun () -> EvalStackValueComparisons.ceq widened hashBits |> ignore)
+
+        ex.Message |> shouldContainText "WidenedNativeInt"
+        ex.Message |> shouldContainText "OpaqueHashBits"
+        ex.Message |> shouldContainText "PointerHashCounters"
+
+        // And symmetrically the other direction.
+        let exSym =
+            Assert.Throws<System.Exception> (fun () -> EvalStackValueComparisons.ceq hashBits widened |> ignore)
+
+        exSym.Message |> shouldContainText "PointerHashCounters"
 
     [<Test>]
     let ``ceq compares managed pointers with native-int pointer forms`` () : unit =

--- a/WoofWare.PawPrint.Test/TestEvalStack.fs
+++ b/WoofWare.PawPrint.Test/TestEvalStack.fs
@@ -226,6 +226,28 @@ module TestEvalStack =
         exSym.Message |> shouldContainText "PointerHashCounters"
 
     [<Test>]
+    let ``ceq of SyntheticCrossArrayOffset vs OpaqueHashBits returns false (cross-shape)`` () : unit =
+        // SyntheticCrossArrayOffset is a delta between two distinct byte-storage roots;
+        // OpaqueHashBits is synthesised pointer hash bits. The two shapes are not
+        // comparable as numeric values — there is no bit pattern at which they could
+        // sensibly be considered equal — so ceq returns false rather than failing.
+        let offset =
+            SyntheticCrossArrayOffset.make
+                (ByteStorageIdentity.Array (ManagedHeapAddress 1))
+                0L
+                (ByteStorageIdentity.Array (ManagedHeapAddress 2))
+                0L
+
+        let offsetEsv = EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset offset)
+        let hashBits = EvalStackValue.Int64 (Int64Source.OpaqueHashBits 12L)
+
+        if EvalStackValueComparisons.ceq offsetEsv hashBits then
+            failwith "Expected ceq(SyntheticCrossArrayOffset, OpaqueHashBits) to be false"
+
+        if EvalStackValueComparisons.ceq hashBits offsetEsv then
+            failwith "Expected ceq(OpaqueHashBits, SyntheticCrossArrayOffset) to be false (symmetric)"
+
+    [<Test>]
     let ``ceq compares managed pointers with native-int pointer forms`` () : unit =
         let ptr =
             ManagedPointerSource.Byref (ByrefRoot.HeapValue (ManagedHeapAddress 707), [])

--- a/WoofWare.PawPrint.Test/TestNativeIntSource.fs
+++ b/WoofWare.PawPrint.Test/TestNativeIntSource.fs
@@ -223,8 +223,8 @@ module TestNativeIntSource =
     [<Test>]
     let ``Int64Source.negate on a cross-storage offset returns the negated synthetic`` () : unit =
         let property (s : SyntheticCrossArrayOffset) : unit =
-            match Int64Source.negate (Int64Source.SyntheticCrossArrayOffset s) with
-            | Some (Int64Source.SyntheticCrossArrayOffset negated) ->
+            match Int64Source.negate "test" (Int64Source.SyntheticCrossArrayOffset s) PointerHashCounters.empty with
+            | Some (Int64Source.SyntheticCrossArrayOffset negated, _) ->
                 negated |> shouldEqual (SyntheticCrossArrayOffset.negate s)
             | other -> failwith $"expected negate to return Some (synthetic), got %O{other}"
 
@@ -235,12 +235,12 @@ module TestNativeIntSource =
         let property (s : SyntheticCrossArrayOffset) : unit =
             let original = Int64Source.SyntheticCrossArrayOffset s
 
-            match Int64Source.negate original with
+            match Int64Source.negate "test" original PointerHashCounters.empty with
             | None -> failwith "negate of synthetic returned None"
-            | Some onceNegated ->
-                match Int64Source.negate onceNegated with
+            | Some (onceNegated, counters) ->
+                match Int64Source.negate "test" onceNegated counters with
                 | None -> failwith "double-negate of synthetic returned None"
-                | Some twiceNegated -> twiceNegated |> shouldEqual original
+                | Some (twiceNegated, _) -> twiceNegated |> shouldEqual original
 
         Check.One (propertyConfig, Prop.forAll (Arb.fromGen genSyntheticCrossArrayOffset) property)
 

--- a/WoofWare.PawPrint.Test/TestPointerHashSynthesis.fs
+++ b/WoofWare.PawPrint.Test/TestPointerHashSynthesis.fs
@@ -1,0 +1,388 @@
+namespace WoofWare.PawPrint.Test
+
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+/// Tests pinning the counter-based pointer-hash synthesis contract. These
+/// assertions are what makes the synthesised bits a faithful guest-observable
+/// surrogate for real pointer bits: same key → same bits; distinct keys → distinct
+/// bits; MethodTablePtr/TypeHandlePtr alias for Concrete/OneDimArrayZero/Array
+/// shapes collapses to identical bits; the low-bit shape contract is upheld.
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestPointerHashSynthesis =
+
+    let private materialise (src : NativeIntSource) (counters : PointerHashCounters) : int64 * PointerHashCounters =
+        PointerHashSynthesis.materialiseHashBits "test" src counters
+
+    [<Test>]
+    let ``same source materialised twice returns same bits and bumps counter only once`` () : unit =
+        let src = NativeIntSource.MethodTablePtr (ConcreteTypeHandle.Concrete 42)
+
+        let bits1, counters1 = materialise src PointerHashCounters.empty
+        counters1.NextCounter |> shouldEqual 1UL
+        counters1.Assigned.Count |> shouldEqual 1
+
+        let bits2, counters2 = materialise src counters1
+        bits2 |> shouldEqual bits1
+        counters2.NextCounter |> shouldEqual 1UL
+        counters2.Assigned |> shouldEqual counters1.Assigned
+
+    [<Test>]
+    let ``distinct sources get distinct bits`` () : unit =
+        let a = NativeIntSource.MethodTablePtr (ConcreteTypeHandle.Concrete 1)
+        let b = NativeIntSource.MethodTablePtr (ConcreteTypeHandle.Concrete 2)
+
+        let bitsA, counters = materialise a PointerHashCounters.empty
+        let bitsB, counters = materialise b counters
+
+        bitsA |> shouldNotEqual bitsB
+        counters.NextCounter |> shouldEqual 2UL
+        counters.Assigned.Count |> shouldEqual 2
+
+    [<Test>]
+    let ``order-stable assignment - same sequence on two fresh fixtures produces same bits`` () : unit =
+        let sources : NativeIntSource list =
+            [
+                NativeIntSource.MethodTablePtr (ConcreteTypeHandle.Concrete 7)
+                NativeIntSource.MethodTablePtr (ConcreteTypeHandle.Concrete 8)
+                NativeIntSource.TypeHandlePtr (
+                    RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Pointer (ConcreteTypeHandle.Concrete 9))
+                )
+                NativeIntSource.MethodHandlePtr 100L
+                NativeIntSource.FieldHandlePtr 200L
+            ]
+
+        let materialiseAll (counters : PointerHashCounters) =
+            ((counters, []), sources)
+            ||> List.fold (fun (counters, bitsSoFar) src ->
+                let bits, counters = materialise src counters
+                counters, bits :: bitsSoFar
+            )
+            |> snd
+            |> List.rev
+
+        let bitsRunA = materialiseAll PointerHashCounters.empty
+        let bitsRunB = materialiseAll PointerHashCounters.empty
+        bitsRunA |> shouldEqual bitsRunB
+
+    [<Test>]
+    let ``registration order assigns counters in order; first-registered gets smaller bits`` () : unit =
+        let a = NativeIntSource.MethodTablePtr (ConcreteTypeHandle.Concrete 11)
+        let b = NativeIntSource.MethodTablePtr (ConcreteTypeHandle.Concrete 12)
+
+        // First registration in any sequence gets counter 0 → bits = ((0+1) <<< 2) | 0 = 4.
+        let bitsAAlone, _ = materialise a PointerHashCounters.empty
+        let bitsBAlone, _ = materialise b PointerHashCounters.empty
+        bitsAAlone |> shouldEqual 4L
+        bitsBAlone |> shouldEqual 4L
+
+        // Register a then b: a gets counter 0, b gets counter 1.
+        let bitsA_AB, ab = materialise a PointerHashCounters.empty
+        let bitsB_AB, _ = materialise b ab
+        bitsA_AB |> shouldEqual 4L
+        bitsB_AB |> shouldEqual 8L
+
+        // Register b then a: b gets counter 0, a gets counter 1. The bits depend only on
+        // registration order, not on the source identity — that is the load-bearing
+        // determinism contract.
+        let bitsB_BA, ba = materialise b PointerHashCounters.empty
+        let bitsA_BA, _ = materialise a ba
+        bitsB_BA |> shouldEqual 4L
+        bitsA_BA |> shouldEqual 8L
+
+        // Same-counters → same bits regardless of which source occupies it.
+        bitsA_AB |> shouldEqual bitsB_BA
+        bitsB_AB |> shouldEqual bitsA_BA
+
+    [<Test>]
+    let ``MethodTablePtr and TypeHandlePtr(Closed _) alias for Concrete shape`` () : unit =
+        let handle = ConcreteTypeHandle.Concrete 99
+        let mtSrc = NativeIntSource.MethodTablePtr handle
+        let thSrc = NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed handle)
+
+        let bitsMt, counters = materialise mtSrc PointerHashCounters.empty
+        let bitsTh, counters = materialise thSrc counters
+
+        bitsMt |> shouldEqual bitsTh
+        // The two encodings share a canonical key, so the second materialisation
+        // must reuse the first counter — no new assignment.
+        counters.NextCounter |> shouldEqual 1UL
+        counters.Assigned.Count |> shouldEqual 1
+
+    [<Test>]
+    let ``MethodTablePtr and TypeHandlePtr(Closed _) alias for OneDimArrayZero shape`` () : unit =
+        let handle = ConcreteTypeHandle.OneDimArrayZero (ConcreteTypeHandle.Concrete 5)
+
+        let bitsMt, counters =
+            materialise (NativeIntSource.MethodTablePtr handle) PointerHashCounters.empty
+
+        let bitsTh, counters =
+            materialise (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed handle)) counters
+
+        bitsMt |> shouldEqual bitsTh
+        counters.NextCounter |> shouldEqual 1UL
+
+    [<Test>]
+    let ``MethodTablePtr and TypeHandlePtr(Closed _) alias for Array shape`` () : unit =
+        let handle = ConcreteTypeHandle.Array (ConcreteTypeHandle.Concrete 3, 2)
+
+        let bitsMt, counters =
+            materialise (NativeIntSource.MethodTablePtr handle) PointerHashCounters.empty
+
+        let bitsTh, counters =
+            materialise (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed handle)) counters
+
+        bitsMt |> shouldEqual bitsTh
+        counters.NextCounter |> shouldEqual 1UL
+
+    [<Test>]
+    let ``TypeHandlePtr(Closed Pointer _) does NOT alias to MethodTablePtr - distinct canonical keys`` () : unit =
+        // Pointer-shaped TypeHandles are TypeDesc-shaped in CoreCLR; they live in a
+        // different memory region from MethodTables, so the two encodings must NOT collapse.
+        let element = ConcreteTypeHandle.Concrete 13
+        let pointerHandle = ConcreteTypeHandle.Pointer element
+
+        let bitsMt, counters =
+            materialise (NativeIntSource.MethodTablePtr element) PointerHashCounters.empty
+
+        let bitsTh, counters =
+            materialise (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed pointerHandle)) counters
+
+        bitsMt |> shouldNotEqual bitsTh
+        counters.NextCounter |> shouldEqual 2UL
+
+    [<Test>]
+    let ``low bits are clear for MethodTablePtr`` () : unit =
+        let bits, _ =
+            materialise (NativeIntSource.MethodTablePtr (ConcreteTypeHandle.Concrete 7)) PointerHashCounters.empty
+
+        bits &&& 3L |> shouldEqual 0L
+
+    [<Test>]
+    let ``low bits are clear for MethodTablePtr of OneDimArrayZero`` () : unit =
+        let handle = ConcreteTypeHandle.OneDimArrayZero (ConcreteTypeHandle.Concrete 7)
+
+        let bits, _ =
+            materialise (NativeIntSource.MethodTablePtr handle) PointerHashCounters.empty
+
+        bits &&& 3L |> shouldEqual 0L
+
+    [<Test>]
+    let ``bit 1 is set for TypeHandlePtr of Pointer-shaped (TypeDesc)`` () : unit =
+        let handle = ConcreteTypeHandle.Pointer (ConcreteTypeHandle.Concrete 7)
+
+        let bits, _ =
+            materialise
+                (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed handle))
+                PointerHashCounters.empty
+
+        bits &&& 2L |> shouldEqual 2L
+
+    [<Test>]
+    let ``bit 1 is set for TypeHandlePtr of Byref-shaped (TypeDesc)`` () : unit =
+        let handle = ConcreteTypeHandle.Byref (ConcreteTypeHandle.Concrete 7)
+
+        let bits, _ =
+            materialise
+                (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed handle))
+                PointerHashCounters.empty
+
+        bits &&& 2L |> shouldEqual 2L
+
+    [<Test>]
+    let ``low bits are clear for MethodHandlePtr`` () : unit =
+        let bits, _ =
+            materialise (NativeIntSource.MethodHandlePtr 0xCAFEL) PointerHashCounters.empty
+
+        bits &&& 3L |> shouldEqual 0L
+
+    [<Test>]
+    let ``low bits are clear for FieldHandlePtr`` () : unit =
+        let bits, _ =
+            materialise (NativeIntSource.FieldHandlePtr 0xBEEFL) PointerHashCounters.empty
+
+        bits &&& 3L |> shouldEqual 0L
+
+    [<Test>]
+    let ``low bits are clear for GcHandlePtr`` () : unit =
+        let bits, _ =
+            materialise (NativeIntSource.GcHandlePtr (GcHandleAddress.GcHandleAddress 17)) PointerHashCounters.empty
+
+        bits &&& 3L |> shouldEqual 0L
+
+    [<Test>]
+    let ``low bits are clear for AssemblyHandle / ModuleHandle / MetadataImportHandle`` () : unit =
+        let assyBits, counters =
+            materialise (NativeIntSource.AssemblyHandle "Foo") PointerHashCounters.empty
+
+        let modBits, counters = materialise (NativeIntSource.ModuleHandle "Bar") counters
+        let midBits, _ = materialise (NativeIntSource.MetadataImportHandle "Baz") counters
+
+        assyBits &&& 3L |> shouldEqual 0L
+        modBits &&& 3L |> shouldEqual 0L
+        midBits &&& 3L |> shouldEqual 0L
+
+    [<Test>]
+    let ``Verbatim is returned unchanged and does not touch counters`` () : unit =
+        let bits, counters =
+            materialise (NativeIntSource.Verbatim 12345L) PointerHashCounters.empty
+
+        bits |> shouldEqual 12345L
+        counters |> shouldEqual PointerHashCounters.empty
+
+    [<Test>]
+    let ``Verbatim works for negative values without sign mangling`` () : unit =
+        let bits, counters =
+            materialise (NativeIntSource.Verbatim -7L) PointerHashCounters.empty
+
+        bits |> shouldEqual -7L
+        counters |> shouldEqual PointerHashCounters.empty
+
+    [<Test>]
+    let ``null managed pointer is materialised to 0L and does not touch counters`` () : unit =
+        let bits, counters =
+            materialise (NativeIntSource.ManagedPointer ManagedPointerSource.Null) PointerHashCounters.empty
+
+        bits |> shouldEqual 0L
+        counters |> shouldEqual PointerHashCounters.empty
+
+    [<Test>]
+    let ``non-null managed pointer is refused with reason embedded in message`` () : unit =
+        let src =
+            NativeIntSource.ManagedPointer (
+                ManagedPointerSource.Byref (ByrefRoot.HeapValue (ManagedHeapAddress.ManagedHeapAddress 21), [])
+            )
+
+        let ex =
+            Assert.Throws<System.Exception> (fun () ->
+                PointerHashSynthesis.materialiseHashBits "my-call-site" src PointerHashCounters.empty
+                |> ignore
+            )
+
+        ex.Message |> shouldContainText "my-call-site"
+        ex.Message |> shouldContainText "managed pointer"
+
+    [<Test>]
+    let ``SyntheticCrossArrayOffset is refused with reason embedded in message`` () : unit =
+        let offset =
+            SyntheticCrossArrayOffset.make
+                (ByteStorageIdentity.Array (ManagedHeapAddress.ManagedHeapAddress 1))
+                0L
+                (ByteStorageIdentity.Array (ManagedHeapAddress.ManagedHeapAddress 2))
+                0L
+
+        let src = NativeIntSource.SyntheticCrossArrayOffset offset
+
+        let ex =
+            Assert.Throws<System.Exception> (fun () ->
+                PointerHashSynthesis.materialiseHashBits "cross-array-callsite" src PointerHashCounters.empty
+                |> ignore
+            )
+
+        ex.Message |> shouldContainText "cross-array-callsite"
+        ex.Message |> shouldContainText "cross-array offset"
+
+    [<Test>]
+    let ``no collisions across 100 distinct canonical keys of varying shape`` () : unit =
+        // Drawn from a mix of shapes so we cover the major canonical-key arms:
+        // MethodTable, TypeHandle (TypeDesc-shaped), MethodTableAuxiliaryData,
+        // MethodHandle, FieldHandle, GcHandle, EventPipeProvider, EventPipeEvent,
+        // AssemblyHandle, ModuleHandle, MetadataImportHandle.
+        let sources : NativeIntSource list =
+            [
+                for i in 0..9 -> NativeIntSource.MethodTablePtr (ConcreteTypeHandle.Concrete i)
+                for i in 0..9 ->
+                    NativeIntSource.MethodTablePtr (ConcreteTypeHandle.OneDimArrayZero (ConcreteTypeHandle.Concrete i))
+                for i in 0..9 ->
+                    NativeIntSource.TypeHandlePtr (
+                        RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Pointer (ConcreteTypeHandle.Concrete i))
+                    )
+                for i in 0..9 ->
+                    NativeIntSource.TypeHandlePtr (
+                        RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Byref (ConcreteTypeHandle.Concrete i))
+                    )
+                for i in 0..9 ->
+                    NativeIntSource.MethodTableAuxiliaryDataPtr (
+                        RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete i)
+                    )
+                for i in 0..9 -> NativeIntSource.MethodHandlePtr (int64 i)
+                for i in 0..9 -> NativeIntSource.FieldHandlePtr (int64 i)
+                for i in 0..9 -> NativeIntSource.GcHandlePtr (GcHandleAddress.GcHandleAddress i)
+                for i in 0..9 -> NativeIntSource.EventPipeProviderPtr (int64 i)
+                for i in 0..9 -> NativeIntSource.EventPipeEventPtr (int64 i)
+            ]
+
+        sources.Length |> shouldEqual 100
+
+        let _, allBits =
+            ((PointerHashCounters.empty, []), sources)
+            ||> List.fold (fun (counters, acc) src ->
+                let bits, counters = materialise src counters
+                counters, bits :: acc
+            )
+
+        let distinct = allBits |> List.distinct
+
+        if distinct.Length <> allBits.Length then
+            let collisionCount = allBits.Length - distinct.Length
+
+            failwith
+                $"counter-based synthesis produced %d{collisionCount} colliding bit pattern(s) across %d{allBits.Length} distinct canonical keys"
+
+    [<Test>]
+    let ``aliased encodings materialised separately do not double-bump the counter`` () : unit =
+        let handle = ConcreteTypeHandle.Concrete 50
+        let mt = NativeIntSource.MethodTablePtr handle
+        let th = NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed handle)
+
+        // Register the alias under one encoding, then via the other; total assigned should remain 1.
+        let _, counters = materialise mt PointerHashCounters.empty
+        let _, counters = materialise th counters
+        let _, counters = materialise mt counters
+        let _, counters = materialise th counters
+
+        counters.NextCounter |> shouldEqual 1UL
+        counters.Assigned.Count |> shouldEqual 1
+
+    [<Test>]
+    let ``MethodTableAuxiliaryDataPtr is canonicalised distinctly from MethodTablePtr`` () : unit =
+        let handle = ConcreteTypeHandle.Concrete 77
+        let mt = NativeIntSource.MethodTablePtr handle
+
+        let aux =
+            NativeIntSource.MethodTableAuxiliaryDataPtr (RuntimeTypeHandleTarget.Closed handle)
+
+        let bitsMt, counters = materialise mt PointerHashCounters.empty
+        let bitsAux, counters = materialise aux counters
+
+        bitsMt |> shouldNotEqual bitsAux
+        counters.NextCounter |> shouldEqual 2UL
+
+    [<Test>]
+    let ``EventPipeProviderPtr and EventPipeEventPtr with the same id are distinct canonical keys`` () : unit =
+        let bitsProv, counters =
+            materialise (NativeIntSource.EventPipeProviderPtr 5L) PointerHashCounters.empty
+
+        let bitsEvt, counters = materialise (NativeIntSource.EventPipeEventPtr 5L) counters
+
+        bitsProv |> shouldNotEqual bitsEvt
+        counters.NextCounter |> shouldEqual 2UL
+
+    [<Test>]
+    let ``AssemblyHandle ModuleHandle MetadataImportHandle with same name are distinct canonical keys`` () : unit =
+        let name = "X"
+
+        let bitsAssy, counters =
+            materialise (NativeIntSource.AssemblyHandle name) PointerHashCounters.empty
+
+        let bitsMod, counters = materialise (NativeIntSource.ModuleHandle name) counters
+
+        let bitsMid, counters =
+            materialise (NativeIntSource.MetadataImportHandle name) counters
+
+        bitsAssy |> shouldNotEqual bitsMod
+        bitsAssy |> shouldNotEqual bitsMid
+        bitsMod |> shouldNotEqual bitsMid
+        counters.NextCounter |> shouldEqual 3UL

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -24,7 +24,7 @@ module TestPureCases =
             "RuntimeTypeGetInterfacesInherited.cs" // exercises the QCall's inherited-base + transitive-interface walk; now blocked during the reflection-cache update by `validateByteAddressableCell` refusing to byte-view object-reference cells inside Buffer::BulkMoveWithWriteBarrierInternal
             "CrossAssemblyTypes.cs" // past MethodTable::ParentMethodTable projection; now blocked by unimplemented QCall EventPipeInternal_CreateProvider during static init of System.Diagnostics.Tracing.EventPipeInternal
             "InterfaceDispatch.cs" // past MetadataImport::GetCustomAttributeProps; now blocked by unimplemented InternalCall MetadataImport::GetParentToken
-            "NullDereferenceTest.cs" // past CastHelpers.s_table lazy-init, RawData::Data array projection, and Unsafe.AddByteOffset intrinsic; now blocked by `shl` on a widened native int (bit-twiddling on pointer bits) inside CastCache.TableData
+            "NullDereferenceTest.cs" // past Int64 OpaqueHashBits bit-mixing on widened nuint (RotateLeft inlining); now blocked because the BCL's `BitOperations.RotateLeft(nuint, int)` narrows the ulong result back to nuint via `conv.u`, and Conv_U from Int64.OpaqueHashBits refuses to forge pointer provenance. Needs a parallel `NativeIntSource.OpaqueHashBits` round-trip.
             "CastClassInvalid.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
             "CastclassFailures.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource
             "ComplexTryCatch.cs" // blocked after Unsafe.IsNullRef by unimplemented QCall!AssemblyNative_GetResource

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -21,6 +21,7 @@
     <Compile Include="TestTypeIdentityProperties.fs" />
     <Compile Include="TestEvalStack.fs" />
     <Compile Include="TestNativeIntSource.fs" />
+    <Compile Include="TestPointerHashSynthesis.fs" />
     <Compile Include="TestCliTypeBytes.fs" />
     <Compile Include="TestManagedHeap.fs" />
     <Compile Include="TestBinaryArithmetic.fs" />

--- a/WoofWare.PawPrint.Test/sourcesPure/Int64HashBitMix.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/Int64HashBitMix.cs
@@ -1,0 +1,25 @@
+using System;
+
+class Program
+{
+    // Exercises the Int64 `OpaqueHashBits` pipeline: widen a pointer-shaped
+    // nuint to ulong via `conv.u8`, bit-mix via shl/shr.un/and/or/xor, then
+    // extract the low 32 bits via `conv.i4`. This stays entirely in the int64
+    // domain — it does not narrow back to nuint mid-stream — so it should
+    // succeed with the OpaqueHashBits machinery alone, without requiring a
+    // parallel `NativeIntSource.OpaqueHashBits` variant.
+    static int Main(string[] args)
+    {
+        IntPtr h = typeof(int).TypeHandle.Value;
+        ulong widened = (ulong)h;
+        ulong mixed = ((widened << 16) ^ (widened >> 13)) | 0x1234UL;
+        mixed &= 0xFFFFUL;
+        int bucket = (int)mixed;
+        if (bucket < 0 || bucket > 0xFFFF)
+        {
+            return 1;
+        }
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/Int64HashMulFirst.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/Int64HashMulFirst.cs
@@ -1,0 +1,26 @@
+using System;
+
+class Program
+{
+    // Exercises the Int64 `OpaqueHashBits` pipeline when arithmetic — not a
+    // bit-mixing shift/xor/and — is the first op applied to a widened native
+    // int. This is the shape used by CastCache.KeyToBucket's multiply-by-
+    // golden-ratio step: `hash * 11400714819323198485ul` arrives at the
+    // dispatcher as `WidenedNativeInt × Verbatim`, not `OpaqueHashBits ×
+    // Verbatim`, so it must materialise the pointer bits in
+    // `BinaryArithmetic` rather than relying on the bit-mixing helpers.
+    static int Main(string[] args)
+    {
+        IntPtr h = typeof(int).TypeHandle.Value;
+        ulong widened = (ulong)h;
+        ulong mixed = widened * 11400714819323198485UL;
+        mixed &= 0xFFFFUL;
+        int bucket = (int)mixed;
+        if (bucket < 0 || bucket > 0xFFFF)
+        {
+            return 1;
+        }
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/BinaryArithmetic.fs
+++ b/WoofWare.PawPrint/BinaryArithmetic.fs
@@ -763,6 +763,45 @@ module BinaryArithmetic =
 
             op.Int32ManagedPtr baseClassTypes state val1 val2
             |> widenedManagedPtrChoiceAsInt64 signed
+        // Arithmetic on a widened non-managed-pointer source materialises the
+        // synthesised hash bits up-front, so a pointer-hash expression starting
+        // with arithmetic (e.g. `(ulong)handle * C` for the CastCache golden-
+        // ratio mix) doesn't fall through to "invalid operation". The
+        // ManagedPointer arms above match first, so `src` here is always one
+        // of the non-managed pointer shapes that `materialiseHashBits`
+        // accepts (TypeHandlePtr, MethodTablePtr, function/method/field
+        // handles, etc.). Result is tagged OpaqueHashBits so it can't
+        // round-trip back to a pointer via `conv.u` / `conv.i`.
+        | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)), EvalStackValue.Int64 (Int64Source.Verbatim val2) ->
+            let val1 = Int64Source.materialiseHashBits src
+            op.Int64Int64 val1 val2 |> Int64Source.OpaqueHashBits |> EvalStackValue.Int64
+        | EvalStackValue.Int64 (Int64Source.Verbatim val1), EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
+            let val2 = Int64Source.materialiseHashBits src
+            op.Int64Int64 val1 val2 |> Int64Source.OpaqueHashBits |> EvalStackValue.Int64
+        | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)),
+          EvalStackValue.Int64 (Int64Source.OpaqueHashBits val2) ->
+            let val1 = Int64Source.materialiseHashBits src
+            op.Int64Int64 val1 val2 |> Int64Source.OpaqueHashBits |> EvalStackValue.Int64
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits val1),
+          EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
+            let val2 = Int64Source.materialiseHashBits src
+            op.Int64Int64 val1 val2 |> Int64Source.OpaqueHashBits |> EvalStackValue.Int64
+        | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src1, _)),
+          EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src2, _)) ->
+            // Mixing managed-pointer arithmetic with non-pointer hash bits in
+            // the same op is unsupported — pointer × pointer arithmetic on
+            // bare nativeints is itself rare, and falls through to the
+            // existing "invalid operation" failwith if either side is a
+            // managed pointer.
+            match src1, src2 with
+            | NativeIntSource.ManagedPointer _, _
+            | _, NativeIntSource.ManagedPointer _ ->
+                failwith
+                    $"TODO: BinaryArithmetic %s{op.Name} on (WidenedNativeInt %O{src1}) and (WidenedNativeInt %O{src2}): one side is a managed pointer, the other isn't"
+            | _ ->
+                let val1 = Int64Source.materialiseHashBits src1
+                let val2 = Int64Source.materialiseHashBits src2
+                op.Int64Int64 val1 val2 |> Int64Source.OpaqueHashBits |> EvalStackValue.Int64
         | EvalStackValue.NativeInt (NativeIntSource.ManagedPointer val1), EvalStackValue.Int32 val2 ->
             op.ManagedPtrInt32 baseClassTypes state val1 val2 |> managedPtrChoiceAsNativeInt
         | EvalStackValue.NativeInt val1, EvalStackValue.Int32 val2 ->

--- a/WoofWare.PawPrint/BinaryArithmetic.fs
+++ b/WoofWare.PawPrint/BinaryArithmetic.fs
@@ -658,13 +658,19 @@ module ArithmeticOperation =
 
 [<RequireQualifiedAccess>]
 module BinaryArithmetic =
+    /// Apply a binary arithmetic operation. Returns the result together with
+    /// the (possibly updated) machine state — the WidenedNativeInt arms that
+    /// materialise synthesised pointer-hash bits register new
+    /// `PointerHashCounters` entries on `state`; every other arm returns
+    /// `state` unchanged. Callers MUST use the returned state, not the input
+    /// state, when pushing the result.
     let execute
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (op : IArithmeticOperation)
         (state : IlMachineState)
         (val1 : EvalStackValue)
         (val2 : EvalStackValue)
-        : EvalStackValue
+        : EvalStackValue * IlMachineState
         =
         let managedPtrManagedPtr (ptr1 : ManagedPointerSource) (ptr2 : ManagedPointerSource) : EvalStackValue =
             match op.ManagedPtrManagedPtr baseClassTypes state ptr1 ptr2 with
@@ -714,11 +720,19 @@ module BinaryArithmetic =
                 EvalStackValue.Int64 (Int64Source.widenedNativeInt (NativeIntSource.ManagedPointer ptr) signed)
             | Choice2Of2 i -> EvalStackValue.Int64 (Int64Source.Verbatim (int64<int32> i))
 
+        let materialise (src : NativeIntSource) (counters : PointerHashCounters) : int64 * PointerHashCounters =
+            PointerHashSynthesis.materialiseHashBits $"BinaryArithmetic.%s{op.Name}" src counters
+
+        let withState (esv : EvalStackValue) : EvalStackValue * IlMachineState = esv, state
+
         // see table at https://learn.microsoft.com/en-us/dotnet/api/system.reflection.emit.opcodes.add?view=net-9.0
         match val1, val2 with
-        | EvalStackValue.Int32 val1, EvalStackValue.Int32 val2 -> op.Int32Int32 val1 val2 |> EvalStackValue.Int32
+        | EvalStackValue.Int32 val1, EvalStackValue.Int32 val2 ->
+            op.Int32Int32 val1 val2 |> EvalStackValue.Int32 |> withState
         | EvalStackValue.Int32 val1, EvalStackValue.NativeInt (NativeIntSource.ManagedPointer val2) ->
-            op.Int32ManagedPtr baseClassTypes state val1 val2 |> managedPtrChoiceAsNativeInt
+            op.Int32ManagedPtr baseClassTypes state val1 val2
+            |> managedPtrChoiceAsNativeInt
+            |> withState
         | EvalStackValue.Int32 val1, EvalStackValue.NativeInt val2 ->
             let val2 =
                 match val2 with
@@ -729,40 +743,59 @@ module BinaryArithmetic =
             |> int64<nativeint>
             |> NativeIntSource.Verbatim
             |> EvalStackValue.NativeInt
+            |> withState
         | EvalStackValue.Int32 val1, EvalStackValue.ManagedPointer val2 ->
             match op.Int32ManagedPtr baseClassTypes state val1 val2 with
-            | Choice1Of2 v -> EvalStackValue.ManagedPointer v
-            | Choice2Of2 i -> EvalStackValue.Int32 i
-        | EvalStackValue.Int32 val1, EvalStackValue.ObjectRef val2 -> failwith "" |> EvalStackValue.ObjectRef
+            | Choice1Of2 v -> EvalStackValue.ManagedPointer v |> withState
+            | Choice2Of2 i -> EvalStackValue.Int32 i |> withState
+        | EvalStackValue.Int32 val1, EvalStackValue.ObjectRef val2 ->
+            failwith "" |> EvalStackValue.ObjectRef |> withState
         | EvalStackValue.Int32 _, EvalStackValue.NullObjectRef -> failwith ""
         | EvalStackValue.Int64 (Int64Source.Verbatim val1), EvalStackValue.Int64 (Int64Source.Verbatim val2) ->
-            op.Int64Int64 val1 val2 |> Int64Source.Verbatim |> EvalStackValue.Int64
+            op.Int64Int64 val1 val2
+            |> Int64Source.Verbatim
+            |> EvalStackValue.Int64
+            |> withState
         // Arithmetic on synthesised pointer-hash bits stays in the hash domain:
         // the bits are not a real numeric quantity, but the bit-mixing pipeline
         // (e.g. `hash * 11400714819323198485ul` in CastCache.KeyToBucket) needs
         // arithmetic ops to combine them. Keep the OpaqueHashBits tag so the
         // result can't round-trip back to a pointer via `conv.u`/`conv.i`.
         | EvalStackValue.Int64 (Int64Source.OpaqueHashBits val1), EvalStackValue.Int64 (Int64Source.OpaqueHashBits val2) ->
-            op.Int64Int64 val1 val2 |> Int64Source.OpaqueHashBits |> EvalStackValue.Int64
+            op.Int64Int64 val1 val2
+            |> Int64Source.OpaqueHashBits
+            |> EvalStackValue.Int64
+            |> withState
         | EvalStackValue.Int64 (Int64Source.OpaqueHashBits val1), EvalStackValue.Int64 (Int64Source.Verbatim val2) ->
-            op.Int64Int64 val1 val2 |> Int64Source.OpaqueHashBits |> EvalStackValue.Int64
+            op.Int64Int64 val1 val2
+            |> Int64Source.OpaqueHashBits
+            |> EvalStackValue.Int64
+            |> withState
         | EvalStackValue.Int64 (Int64Source.Verbatim val1), EvalStackValue.Int64 (Int64Source.OpaqueHashBits val2) ->
-            op.Int64Int64 val1 val2 |> Int64Source.OpaqueHashBits |> EvalStackValue.Int64
+            op.Int64Int64 val1 val2
+            |> Int64Source.OpaqueHashBits
+            |> EvalStackValue.Int64
+            |> withState
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset val1),
           EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset val2) ->
-            op.CrossArrayOffsets val1 val2 |> Int64Source.Verbatim |> EvalStackValue.Int64
+            op.CrossArrayOffsets val1 val2
+            |> Int64Source.Verbatim
+            |> EvalStackValue.Int64
+            |> withState
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (NativeIntSource.ManagedPointer val1, signed)),
           EvalStackValue.Int64 (Int64Source.Verbatim val2) ->
             let val2 = widenedInt64OffsetForPointerArithmetic val2
 
             op.ManagedPtrInt32 baseClassTypes state val1 val2
             |> widenedManagedPtrChoiceAsInt64 signed
+            |> withState
         | EvalStackValue.Int64 (Int64Source.Verbatim val1),
           EvalStackValue.Int64 (Int64Source.WidenedNativeInt (NativeIntSource.ManagedPointer val2, signed)) ->
             let val1 = widenedInt64OffsetForPointerArithmetic val1
 
             op.Int32ManagedPtr baseClassTypes state val1 val2
             |> widenedManagedPtrChoiceAsInt64 signed
+            |> withState
         // Arithmetic on a widened non-managed-pointer source materialises the
         // synthesised hash bits up-front, so a pointer-hash expression starting
         // with arithmetic (e.g. `(ulong)handle * C` for the CastCache golden-
@@ -773,19 +806,43 @@ module BinaryArithmetic =
         // handles, etc.). Result is tagged OpaqueHashBits so it can't
         // round-trip back to a pointer via `conv.u` / `conv.i`.
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)), EvalStackValue.Int64 (Int64Source.Verbatim val2) ->
-            let val1 = Int64Source.materialiseHashBits src
-            op.Int64Int64 val1 val2 |> Int64Source.OpaqueHashBits |> EvalStackValue.Int64
+            let val1, counters = materialise src state.PointerHashCounters
+
+            let state =
+                { state with
+                    PointerHashCounters = counters
+                }
+
+            op.Int64Int64 val1 val2 |> Int64Source.OpaqueHashBits |> EvalStackValue.Int64, state
         | EvalStackValue.Int64 (Int64Source.Verbatim val1), EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
-            let val2 = Int64Source.materialiseHashBits src
-            op.Int64Int64 val1 val2 |> Int64Source.OpaqueHashBits |> EvalStackValue.Int64
+            let val2, counters = materialise src state.PointerHashCounters
+
+            let state =
+                { state with
+                    PointerHashCounters = counters
+                }
+
+            op.Int64Int64 val1 val2 |> Int64Source.OpaqueHashBits |> EvalStackValue.Int64, state
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)),
           EvalStackValue.Int64 (Int64Source.OpaqueHashBits val2) ->
-            let val1 = Int64Source.materialiseHashBits src
-            op.Int64Int64 val1 val2 |> Int64Source.OpaqueHashBits |> EvalStackValue.Int64
+            let val1, counters = materialise src state.PointerHashCounters
+
+            let state =
+                { state with
+                    PointerHashCounters = counters
+                }
+
+            op.Int64Int64 val1 val2 |> Int64Source.OpaqueHashBits |> EvalStackValue.Int64, state
         | EvalStackValue.Int64 (Int64Source.OpaqueHashBits val1),
           EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
-            let val2 = Int64Source.materialiseHashBits src
-            op.Int64Int64 val1 val2 |> Int64Source.OpaqueHashBits |> EvalStackValue.Int64
+            let val2, counters = materialise src state.PointerHashCounters
+
+            let state =
+                { state with
+                    PointerHashCounters = counters
+                }
+
+            op.Int64Int64 val1 val2 |> Int64Source.OpaqueHashBits |> EvalStackValue.Int64, state
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src1, _)),
           EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src2, _)) ->
             // Mixing managed-pointer arithmetic with non-pointer hash bits in
@@ -799,11 +856,19 @@ module BinaryArithmetic =
                 failwith
                     $"TODO: BinaryArithmetic %s{op.Name} on (WidenedNativeInt %O{src1}) and (WidenedNativeInt %O{src2}): one side is a managed pointer, the other isn't"
             | _ ->
-                let val1 = Int64Source.materialiseHashBits src1
-                let val2 = Int64Source.materialiseHashBits src2
-                op.Int64Int64 val1 val2 |> Int64Source.OpaqueHashBits |> EvalStackValue.Int64
+                let val1, counters = materialise src1 state.PointerHashCounters
+                let val2, counters = materialise src2 counters
+
+                let state =
+                    { state with
+                        PointerHashCounters = counters
+                    }
+
+                op.Int64Int64 val1 val2 |> Int64Source.OpaqueHashBits |> EvalStackValue.Int64, state
         | EvalStackValue.NativeInt (NativeIntSource.ManagedPointer val1), EvalStackValue.Int32 val2 ->
-            op.ManagedPtrInt32 baseClassTypes state val1 val2 |> managedPtrChoiceAsNativeInt
+            op.ManagedPtrInt32 baseClassTypes state val1 val2
+            |> managedPtrChoiceAsNativeInt
+            |> withState
         | EvalStackValue.NativeInt val1, EvalStackValue.Int32 val2 ->
             let val1 =
                 match val1 with
@@ -814,16 +879,24 @@ module BinaryArithmetic =
             |> int64<nativeint>
             |> NativeIntSource.Verbatim
             |> EvalStackValue.NativeInt
+            |> withState
         | EvalStackValue.NativeInt (NativeIntSource.ManagedPointer val1),
           EvalStackValue.NativeInt (NativeIntSource.ManagedPointer val2) ->
             op.ManagedPtrManagedPtr baseClassTypes state val1 val2
             |> managedPtrManagedPtrAsNativeInt
+            |> withState
         | EvalStackValue.NativeInt (NativeIntSource.ManagedPointer val1), EvalStackValue.NativeInt val2 ->
             let val2 = nativeIntOffsetForPointerArithmetic val2
-            op.ManagedPtrInt32 baseClassTypes state val1 val2 |> managedPtrChoiceAsNativeInt
+
+            op.ManagedPtrInt32 baseClassTypes state val1 val2
+            |> managedPtrChoiceAsNativeInt
+            |> withState
         | EvalStackValue.NativeInt val1, EvalStackValue.NativeInt (NativeIntSource.ManagedPointer val2) ->
             let val1 = nativeIntOffsetForPointerArithmetic val1
-            op.Int32ManagedPtr baseClassTypes state val1 val2 |> managedPtrChoiceAsNativeInt
+
+            op.Int32ManagedPtr baseClassTypes state val1 val2
+            |> managedPtrChoiceAsNativeInt
+            |> withState
         | EvalStackValue.NativeInt val1, EvalStackValue.NativeInt val2 ->
             match val1, val2 with
             | NativeIntSource.SyntheticCrossArrayOffset val1, NativeIntSource.SyntheticCrossArrayOffset val2 ->
@@ -831,6 +904,7 @@ module BinaryArithmetic =
                 op.CrossArrayOffsets val1 val2
                 |> NativeIntSource.Verbatim
                 |> EvalStackValue.NativeInt
+                |> withState
             | NativeIntSource.Verbatim val1, NativeIntSource.Verbatim val2 ->
                 let val1 = nativeint<int64> val1
                 let val2 = nativeint<int64> val2
@@ -839,37 +913,50 @@ module BinaryArithmetic =
                 |> int64<nativeint>
                 |> NativeIntSource.Verbatim
                 |> EvalStackValue.NativeInt
+                |> withState
             | val1, val2 -> failwith $"refusing to operate %s{op.Name} on non-verbatim native ints %O{val1}, %O{val2}"
 
         | EvalStackValue.NativeInt (NativeIntSource.ManagedPointer val1), EvalStackValue.ManagedPointer val2 ->
             op.ManagedPtrManagedPtr baseClassTypes state val1 val2
             |> managedPtrManagedPtrAsNativeInt
+            |> withState
         | EvalStackValue.NativeInt val1, EvalStackValue.ManagedPointer val2 ->
             let val1 = nativeIntOffsetForPointerArithmetic val1
 
             match op.Int32ManagedPtr baseClassTypes state val1 val2 with
-            | Choice1Of2 v -> EvalStackValue.ManagedPointer v
-            | Choice2Of2 i -> EvalStackValue.NativeInt (NativeIntSource.Verbatim (int64<int32> i))
-        | EvalStackValue.NativeInt val1, EvalStackValue.ObjectRef val2 -> failwith "" |> EvalStackValue.ObjectRef
+            | Choice1Of2 v -> EvalStackValue.ManagedPointer v |> withState
+            | Choice2Of2 i ->
+                EvalStackValue.NativeInt (NativeIntSource.Verbatim (int64<int32> i))
+                |> withState
+        | EvalStackValue.NativeInt val1, EvalStackValue.ObjectRef val2 ->
+            failwith "" |> EvalStackValue.ObjectRef |> withState
         | EvalStackValue.NativeInt _, EvalStackValue.NullObjectRef -> failwith ""
-        | EvalStackValue.Float val1, EvalStackValue.Float val2 -> op.FloatFloat val1 val2 |> EvalStackValue.Float
+        | EvalStackValue.Float val1, EvalStackValue.Float val2 ->
+            op.FloatFloat val1 val2 |> EvalStackValue.Float |> withState
         | EvalStackValue.ManagedPointer val1, EvalStackValue.NativeInt (NativeIntSource.ManagedPointer val2) ->
             match op.ManagedPtrManagedPtr baseClassTypes state val1 val2 with
-            | Choice1Of2 result -> EvalStackValue.ManagedPointer result
-            | Choice2Of2 result -> EvalStackValue.NativeInt result
+            | Choice1Of2 result -> EvalStackValue.ManagedPointer result |> withState
+            | Choice2Of2 result -> EvalStackValue.NativeInt result |> withState
         | EvalStackValue.ManagedPointer val1, EvalStackValue.NativeInt val2 ->
             let val2 = nativeIntOffsetForPointerArithmetic val2
 
             match op.ManagedPtrInt32 baseClassTypes state val1 val2 with
-            | Choice1Of2 result -> EvalStackValue.ManagedPointer result
-            | Choice2Of2 result -> EvalStackValue.NativeInt (NativeIntSource.Verbatim (int64<int32> result))
-        | EvalStackValue.ObjectRef val1, EvalStackValue.NativeInt val2 -> failwith "" |> EvalStackValue.ObjectRef
+            | Choice1Of2 result -> EvalStackValue.ManagedPointer result |> withState
+            | Choice2Of2 result ->
+                EvalStackValue.NativeInt (NativeIntSource.Verbatim (int64<int32> result))
+                |> withState
+        | EvalStackValue.ObjectRef val1, EvalStackValue.NativeInt val2 ->
+            failwith "" |> EvalStackValue.ObjectRef |> withState
         | EvalStackValue.NullObjectRef, EvalStackValue.NativeInt _ -> failwith ""
         | EvalStackValue.ManagedPointer val1, EvalStackValue.Int32 val2 ->
             match op.ManagedPtrInt32 baseClassTypes state val1 val2 with
-            | Choice1Of2 result -> EvalStackValue.ManagedPointer result
-            | Choice2Of2 result -> EvalStackValue.NativeInt (NativeIntSource.Verbatim (int64<int32> result))
-        | EvalStackValue.ObjectRef val1, EvalStackValue.Int32 val2 -> failwith "" |> EvalStackValue.ObjectRef
+            | Choice1Of2 result -> EvalStackValue.ManagedPointer result |> withState
+            | Choice2Of2 result ->
+                EvalStackValue.NativeInt (NativeIntSource.Verbatim (int64<int32> result))
+                |> withState
+        | EvalStackValue.ObjectRef val1, EvalStackValue.Int32 val2 ->
+            failwith "" |> EvalStackValue.ObjectRef |> withState
         | EvalStackValue.NullObjectRef, EvalStackValue.Int32 _ -> failwith ""
-        | EvalStackValue.ManagedPointer val1, EvalStackValue.ManagedPointer val2 -> managedPtrManagedPtr val1 val2
+        | EvalStackValue.ManagedPointer val1, EvalStackValue.ManagedPointer val2 ->
+            managedPtrManagedPtr val1 val2 |> withState
         | val1, val2 -> failwith $"invalid %s{op.Name} operation: {val1} and {val2}"

--- a/WoofWare.PawPrint/BinaryArithmetic.fs
+++ b/WoofWare.PawPrint/BinaryArithmetic.fs
@@ -737,6 +737,17 @@ module BinaryArithmetic =
         | EvalStackValue.Int32 _, EvalStackValue.NullObjectRef -> failwith ""
         | EvalStackValue.Int64 (Int64Source.Verbatim val1), EvalStackValue.Int64 (Int64Source.Verbatim val2) ->
             op.Int64Int64 val1 val2 |> Int64Source.Verbatim |> EvalStackValue.Int64
+        // Arithmetic on synthesised pointer-hash bits stays in the hash domain:
+        // the bits are not a real numeric quantity, but the bit-mixing pipeline
+        // (e.g. `hash * 11400714819323198485ul` in CastCache.KeyToBucket) needs
+        // arithmetic ops to combine them. Keep the OpaqueHashBits tag so the
+        // result can't round-trip back to a pointer via `conv.u`/`conv.i`.
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits val1), EvalStackValue.Int64 (Int64Source.OpaqueHashBits val2) ->
+            op.Int64Int64 val1 val2 |> Int64Source.OpaqueHashBits |> EvalStackValue.Int64
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits val1), EvalStackValue.Int64 (Int64Source.Verbatim val2) ->
+            op.Int64Int64 val1 val2 |> Int64Source.OpaqueHashBits |> EvalStackValue.Int64
+        | EvalStackValue.Int64 (Int64Source.Verbatim val1), EvalStackValue.Int64 (Int64Source.OpaqueHashBits val2) ->
+            op.Int64Int64 val1 val2 |> Int64Source.OpaqueHashBits |> EvalStackValue.Int64
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset val1),
           EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset val2) ->
             op.CrossArrayOffsets val1 val2 |> Int64Source.Verbatim |> EvalStackValue.Int64

--- a/WoofWare.PawPrint/CliNumericType.fs
+++ b/WoofWare.PawPrint/CliNumericType.fs
@@ -56,122 +56,6 @@ type Int64Source =
 [<RequireQualifiedAccess>]
 module Int64Source =
 
-    /// Low-bit contract for pointer-shaped handles. Mirrors
-    /// `NullaryIlOp.typeHandleLowAddressBits`, kept in sync so that
-    /// `materialiseHashBits` honours the same alignment / tagging convention
-    /// when synthesising bits for hashing. Centralising this would require
-    /// promoting types — for now the contract is small enough to duplicate.
-    let private typeHandleLowAddressBitsForHash (target : RuntimeTypeHandleTarget) : int64 =
-        match target with
-        | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ -> 0L
-        | RuntimeTypeHandleTarget.GenericParameter _
-        | RuntimeTypeHandleTarget.MethodGenericParameter _ -> 2L
-        | RuntimeTypeHandleTarget.Closed typeHandle ->
-            match typeHandle with
-            | ConcreteTypeHandle.Byref _
-            | ConcreteTypeHandle.Pointer _
-            | ConcreteTypeHandle.FunctionPointer _ -> 2L
-            | ConcreteTypeHandle.Concrete _
-            | ConcreteTypeHandle.OneDimArrayZero _
-            | ConcreteTypeHandle.Array _ -> 0L
-
-    /// Canonical string for hashing a `NativeIntSource`. The point of going
-    /// through a string is determinism (see `fnv1aHash` below); the point of
-    /// canonicalisation is alias preservation. CoreCLR exposes a
-    /// `MethodTable*` and the `TypeHandle` for the same Concrete/Array type
-    /// as the same address, and the existing `NativeInt` `ceq` arms in
-    /// `EvalStackValueComparisons` treat the two encodings as aliases for
-    /// Concrete/OneDimArrayZero/Array shapes. The hash-bit pipeline must
-    /// agree: `MethodTablePtr h` and `TypeHandlePtr (Closed h)` for those
-    /// concrete shapes must produce identical `OpaqueHashBits`, or guest
-    /// code that widens and bit-mixes the two aliases will see fake
-    /// inequality / different hash buckets for the same pointer. For
-    /// TypeDesc-shaped handles (Byref / Pointer / FunctionPointer) and for
-    /// non-Closed targets, the canonical form is just `ToString` — those
-    /// encodings are not aliases of any `MethodTablePtr`.
-    let private canonicalHashKey (src : NativeIntSource) : string =
-        match src with
-        | NativeIntSource.MethodTablePtr h -> $"<MethodTable %O{h}>"
-        | NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed h) ->
-            match h with
-            | ConcreteTypeHandle.Concrete _
-            | ConcreteTypeHandle.OneDimArrayZero _
-            | ConcreteTypeHandle.Array _ -> $"<MethodTable %O{h}>"
-            | ConcreteTypeHandle.Byref _
-            | ConcreteTypeHandle.Pointer _
-            | ConcreteTypeHandle.FunctionPointer _ -> src.ToString ()
-        | _ -> src.ToString ()
-
-    /// Deterministic FNV-1a hash on the canonical hash key.
-    /// `NativeIntSource.GetHashCode` uses `System.HashCode.Combine`, which
-    /// folds in a per-process randomised seed and therefore yields different
-    /// hash codes across PawPrint invocations. The interpreter's
-    /// determinism guarantee (deterministic replay, fuzzing over thread
-    /// schedules) requires that any guest-observable hash bits be derived
-    /// from process-stable identifiers instead. `canonicalHashKey` projects
-    /// each `NativeIntSource` into a string that is (a) stable within a
-    /// process and (b) identical for aliasing encodings of the same
-    /// underlying pointer, so FNV-1a of that string is a stable surrogate
-    /// suitable for the guest's bit-mixing pipeline.
-    let private fnv1aHash (src : NativeIntSource) : int64 =
-        let mutable hash = 0xCBF29CE484222325UL
-        let s = canonicalHashKey src
-
-        for c in s do
-            hash <- hash ^^^ uint64 c
-            hash <- Operators.(*) hash 0x100000001B3UL
-
-        Operators.int64 hash
-
-    /// Synthesise a deterministic 64-bit pattern from a pointer-shaped
-    /// `NativeIntSource`. Used only when a bit-mixing operation fires on a
-    /// `WidenedNativeInt`; the resulting bits get tagged as
-    /// `Int64Source.OpaqueHashBits` so subsequent ops compute on the bits
-    /// directly and the value cannot be round-tripped back to a real
-    /// pointer.
-    ///
-    /// Determinism: derives bits via `fnv1aHash`, which folds the source's
-    /// `canonicalHashKey` (stable within a process — see above). The upper
-    /// 16 bits aren't cleared so `RotateLeft(_, 32)` produces a
-    /// non-degenerate hash mix.
-    ///
-    /// Low-bit contract: matches `typeHandleLowAddressBitsForHash` so the
-    /// synthesised bits agree with the existing `and`-mask path
-    /// (`NullaryIlOp.typeHandleLowAddressBits`).
-    let materialiseHashBits (src : NativeIntSource) : int64 =
-        match src with
-        | NativeIntSource.Verbatim n -> n
-        | NativeIntSource.ManagedPointer ManagedPointerSource.Null -> 0L
-        | NativeIntSource.MethodTablePtr _ -> fnv1aHash src &&& ~~~3L
-        | NativeIntSource.TypeHandlePtr target ->
-            let low = typeHandleLowAddressBitsForHash target
-            (fnv1aHash src &&& ~~~3L) ||| low
-        | NativeIntSource.MethodTableAuxiliaryDataPtr _
-        | NativeIntSource.FunctionPointer _
-        | NativeIntSource.FieldHandlePtr _
-        | NativeIntSource.MethodHandlePtr _
-        | NativeIntSource.GcHandlePtr _
-        | NativeIntSource.EventPipeProviderPtr _
-        | NativeIntSource.EventPipeEventPtr _
-        | NativeIntSource.AssemblyHandle _
-        | NativeIntSource.ModuleHandle _
-        | NativeIntSource.MetadataImportHandle _ -> fnv1aHash src &&& ~~~3L
-        | NativeIntSource.ManagedPointer _ ->
-            // Non-null managed pointers carry real provenance (byref roots,
-            // heap addresses). Hashing them as plain bits would forget the
-            // root identity. Bit ops on a `WidenedNativeInt (ManagedPointer
-            // _, _)` should be routed via BinaryArithmetic (offset arithmetic),
-            // never through this helper.
-            failwith
-                $"materialiseHashBits: refusing to synthesise bits for managed pointer %O{src} (would erase byref provenance)"
-        | NativeIntSource.SyntheticCrossArrayOffset _ ->
-            // Cross-array offsets are explicitly non-numeric; the
-            // `widenedNativeInt` smart constructor normalises these into
-            // `Int64Source.SyntheticCrossArrayOffset`, so a
-            // `WidenedNativeInt (SyntheticCrossArrayOffset _, _)` shouldn't
-            // exist on the eval stack. Fail loudly if one ever does.
-            failwith $"materialiseHashBits: refusing to synthesise bits for synthetic cross-array offset %O{src}"
-
     /// Smart constructor for `Int64Source.WidenedNativeInt`. Normalises the
     /// `Verbatim` and `SyntheticCrossArrayOffset` cases of the underlying
     /// `NativeIntSource` so they round-trip back into the canonical
@@ -191,37 +75,57 @@ module Int64Source =
         | Int64Source.WidenedNativeInt (src, _) -> NativeIntSource.isZero src
         | Int64Source.OpaqueHashBits bits -> bits = 0L
 
-    /// Returns None if the input was Int64.MinValue.
-    let negate (i : Int64Source) : Int64Source option =
+    /// Negate an `Int64Source`. Returns `None` only when the input is the
+    /// genuine `Int64.MinValue` whose negation overflows; for synthesised
+    /// pointer-hash bits the wraparound at `Int64.MinValue` is acceptable
+    /// because the hash domain isn't a genuine signed-int value. Threads
+    /// `PointerHashCounters` because materialising a `WidenedNativeInt`
+    /// may register a new pointer.
+    let negate
+        (reason : string)
+        (i : Int64Source)
+        (counters : PointerHashCounters)
+        : (Int64Source * PointerHashCounters) option
+        =
         match i with
         | Int64Source.Verbatim i ->
             if i = Int64.MinValue then
                 None
             else
-                Int64Source.Verbatim (0L - i) |> Some
+                Some (Int64Source.Verbatim (0L - i), counters)
         | Int64Source.SyntheticCrossArrayOffset i ->
-            SyntheticCrossArrayOffset.negate i
-            |> Int64Source.SyntheticCrossArrayOffset
-            |> Some
+            Some (SyntheticCrossArrayOffset.negate i |> Int64Source.SyntheticCrossArrayOffset, counters)
         | Int64Source.WidenedNativeInt (src, _) ->
-            let bits = materialiseHashBits src
+            let bits, counters = PointerHashSynthesis.materialiseHashBits reason src counters
             // Wraparound at Int64.MinValue is acceptable here: hash bits
             // are an intermediate in the bit-mixing pipeline, not a genuine
             // signed-int value where overflow matters. Use unchecked
             // subtraction explicitly (the file opens `Checked`).
-            Some (Operators.(-) 0L bits |> Int64Source.OpaqueHashBits)
-        | Int64Source.OpaqueHashBits bits -> Some (Operators.(-) 0L bits |> Int64Source.OpaqueHashBits)
+            Some (Operators.(-) 0L bits |> Int64Source.OpaqueHashBits, counters)
+        | Int64Source.OpaqueHashBits bits -> Some (Operators.(-) 0L bits |> Int64Source.OpaqueHashBits, counters)
 
-    let shr (i : Int64Source) (shift : int) : Int64Source =
+    let shr
+        (reason : string)
+        (i : Int64Source)
+        (shift : int)
+        (counters : PointerHashCounters)
+        : Int64Source * PointerHashCounters
+        =
         match i with
-        | Int64Source.Verbatim i -> i >>> shift |> Int64Source.Verbatim
-        | Int64Source.SyntheticCrossArrayOffset _ -> failwith "TODO: SyntheticCrossArrayOffset"
+        | Int64Source.Verbatim i -> i >>> shift |> Int64Source.Verbatim, counters
+        | Int64Source.SyntheticCrossArrayOffset _ -> failwith $"TODO: shr (%s{reason}) on SyntheticCrossArrayOffset"
         | Int64Source.WidenedNativeInt (src, _) ->
-            let bits = materialiseHashBits src
-            bits >>> shift |> Int64Source.OpaqueHashBits
-        | Int64Source.OpaqueHashBits bits -> bits >>> shift |> Int64Source.OpaqueHashBits
+            let bits, counters = PointerHashSynthesis.materialiseHashBits reason src counters
+            bits >>> shift |> Int64Source.OpaqueHashBits, counters
+        | Int64Source.OpaqueHashBits bits -> bits >>> shift |> Int64Source.OpaqueHashBits, counters
 
-    let shrUn (i : Int64Source) (shift : int) : Int64Source =
+    let shrUn
+        (reason : string)
+        (i : Int64Source)
+        (shift : int)
+        (counters : PointerHashCounters)
+        : Int64Source * PointerHashCounters
+        =
         // `open Checked` shadows `uint64` / `int64` with their overflow-checking
         // versions; an unsigned right shift needs the unchecked tag-flip, since a
         // negative int64 has the sign bit set and `Checked.uint64` rejects that.
@@ -229,81 +133,119 @@ module Int64Source =
             Operators.uint64 bits >>> shift |> Operators.int64
 
         match i with
-        | Int64Source.Verbatim i -> unsignedShift i |> Int64Source.Verbatim
-        | Int64Source.SyntheticCrossArrayOffset _ -> failwith "TODO: SyntheticCrossArrayOffset"
+        | Int64Source.Verbatim i -> unsignedShift i |> Int64Source.Verbatim, counters
+        | Int64Source.SyntheticCrossArrayOffset _ -> failwith $"TODO: shrUn (%s{reason}) on SyntheticCrossArrayOffset"
         | Int64Source.WidenedNativeInt (src, _) ->
-            let bits = materialiseHashBits src
-            unsignedShift bits |> Int64Source.OpaqueHashBits
-        | Int64Source.OpaqueHashBits bits -> unsignedShift bits |> Int64Source.OpaqueHashBits
+            let bits, counters = PointerHashSynthesis.materialiseHashBits reason src counters
+            unsignedShift bits |> Int64Source.OpaqueHashBits, counters
+        | Int64Source.OpaqueHashBits bits -> unsignedShift bits |> Int64Source.OpaqueHashBits, counters
 
-    let shl (i : Int64Source) (shift : int) : Int64Source =
+    let shl
+        (reason : string)
+        (i : Int64Source)
+        (shift : int)
+        (counters : PointerHashCounters)
+        : Int64Source * PointerHashCounters
+        =
         match i with
-        | Int64Source.Verbatim i -> i <<< shift |> Int64Source.Verbatim
-        | Int64Source.SyntheticCrossArrayOffset _ -> failwith "TODO: SyntheticCrossArrayOffset"
+        | Int64Source.Verbatim i -> i <<< shift |> Int64Source.Verbatim, counters
+        | Int64Source.SyntheticCrossArrayOffset _ -> failwith $"TODO: shl (%s{reason}) on SyntheticCrossArrayOffset"
         | Int64Source.WidenedNativeInt (src, _) ->
-            let bits = materialiseHashBits src
-            bits <<< shift |> Int64Source.OpaqueHashBits
-        | Int64Source.OpaqueHashBits bits -> bits <<< shift |> Int64Source.OpaqueHashBits
+            let bits, counters = PointerHashSynthesis.materialiseHashBits reason src counters
+            bits <<< shift |> Int64Source.OpaqueHashBits, counters
+        | Int64Source.OpaqueHashBits bits -> bits <<< shift |> Int64Source.OpaqueHashBits, counters
 
-    let bitNot (i : Int64Source) : Int64Source =
+    let bitNot
+        (reason : string)
+        (i : Int64Source)
+        (counters : PointerHashCounters)
+        : Int64Source * PointerHashCounters
+        =
         match i with
-        | Int64Source.Verbatim i -> Int64Source.Verbatim ~~~i
+        | Int64Source.Verbatim i -> Int64Source.Verbatim ~~~i, counters
         | Int64Source.WidenedNativeInt (src, _) ->
-            let bits = materialiseHashBits src
-            ~~~bits |> Int64Source.OpaqueHashBits
-        | Int64Source.OpaqueHashBits bits -> ~~~bits |> Int64Source.OpaqueHashBits
-        | _ -> failwith "TODO: SyntheticCrossArrayOffset"
+            let bits, counters = PointerHashSynthesis.materialiseHashBits reason src counters
+            ~~~bits |> Int64Source.OpaqueHashBits, counters
+        | Int64Source.OpaqueHashBits bits -> ~~~bits |> Int64Source.OpaqueHashBits, counters
+        | Int64Source.SyntheticCrossArrayOffset _ -> failwith $"TODO: bitNot (%s{reason}) on SyntheticCrossArrayOffset"
 
-    let bitAnd (i1 : Int64Source) (i2 : Int64Source) : Int64Source =
+    let bitAnd
+        (reason : string)
+        (i1 : Int64Source)
+        (i2 : Int64Source)
+        (counters : PointerHashCounters)
+        : Int64Source * PointerHashCounters
+        =
         match i1, i2 with
-        | Int64Source.Verbatim i1, Int64Source.Verbatim i2 -> i1 &&& i2 |> Int64Source.Verbatim
+        | Int64Source.Verbatim a, Int64Source.Verbatim b -> a &&& b |> Int64Source.Verbatim, counters
         | Int64Source.WidenedNativeInt (src1, _), Int64Source.WidenedNativeInt (src2, _) ->
-            (materialiseHashBits src1) &&& (materialiseHashBits src2)
-            |> Int64Source.OpaqueHashBits
+            let a, counters = PointerHashSynthesis.materialiseHashBits reason src1 counters
+            let b, counters = PointerHashSynthesis.materialiseHashBits reason src2 counters
+            a &&& b |> Int64Source.OpaqueHashBits, counters
         | Int64Source.WidenedNativeInt (src, _), Int64Source.Verbatim b
         | Int64Source.Verbatim b, Int64Source.WidenedNativeInt (src, _) ->
-            (materialiseHashBits src) &&& b |> Int64Source.OpaqueHashBits
-        | Int64Source.OpaqueHashBits a, Int64Source.OpaqueHashBits b -> a &&& b |> Int64Source.OpaqueHashBits
+            let a, counters = PointerHashSynthesis.materialiseHashBits reason src counters
+            a &&& b |> Int64Source.OpaqueHashBits, counters
+        | Int64Source.OpaqueHashBits a, Int64Source.OpaqueHashBits b -> a &&& b |> Int64Source.OpaqueHashBits, counters
         | Int64Source.OpaqueHashBits a, Int64Source.Verbatim b
-        | Int64Source.Verbatim b, Int64Source.OpaqueHashBits a -> a &&& b |> Int64Source.OpaqueHashBits
+        | Int64Source.Verbatim b, Int64Source.OpaqueHashBits a -> a &&& b |> Int64Source.OpaqueHashBits, counters
         | Int64Source.OpaqueHashBits a, Int64Source.WidenedNativeInt (src, _)
         | Int64Source.WidenedNativeInt (src, _), Int64Source.OpaqueHashBits a ->
-            a &&& materialiseHashBits src |> Int64Source.OpaqueHashBits
-        | _, _ -> failwith "TODO: SyntheticCrossArrayOffset"
+            let b, counters = PointerHashSynthesis.materialiseHashBits reason src counters
+            a &&& b |> Int64Source.OpaqueHashBits, counters
+        | _, _ -> failwith $"TODO: bitAnd (%s{reason}) on SyntheticCrossArrayOffset"
 
-    let bitOr (i1 : Int64Source) (i2 : Int64Source) : Int64Source =
+    let bitOr
+        (reason : string)
+        (i1 : Int64Source)
+        (i2 : Int64Source)
+        (counters : PointerHashCounters)
+        : Int64Source * PointerHashCounters
+        =
         match i1, i2 with
-        | Int64Source.Verbatim i1, Int64Source.Verbatim i2 -> i1 ||| i2 |> Int64Source.Verbatim
+        | Int64Source.Verbatim a, Int64Source.Verbatim b -> a ||| b |> Int64Source.Verbatim, counters
         | Int64Source.WidenedNativeInt (src1, _), Int64Source.WidenedNativeInt (src2, _) ->
-            (materialiseHashBits src1) ||| (materialiseHashBits src2)
-            |> Int64Source.OpaqueHashBits
+            let a, counters = PointerHashSynthesis.materialiseHashBits reason src1 counters
+            let b, counters = PointerHashSynthesis.materialiseHashBits reason src2 counters
+            a ||| b |> Int64Source.OpaqueHashBits, counters
         | Int64Source.WidenedNativeInt (src, _), Int64Source.Verbatim b
         | Int64Source.Verbatim b, Int64Source.WidenedNativeInt (src, _) ->
-            (materialiseHashBits src) ||| b |> Int64Source.OpaqueHashBits
-        | Int64Source.OpaqueHashBits a, Int64Source.OpaqueHashBits b -> a ||| b |> Int64Source.OpaqueHashBits
+            let a, counters = PointerHashSynthesis.materialiseHashBits reason src counters
+            a ||| b |> Int64Source.OpaqueHashBits, counters
+        | Int64Source.OpaqueHashBits a, Int64Source.OpaqueHashBits b -> a ||| b |> Int64Source.OpaqueHashBits, counters
         | Int64Source.OpaqueHashBits a, Int64Source.Verbatim b
-        | Int64Source.Verbatim b, Int64Source.OpaqueHashBits a -> a ||| b |> Int64Source.OpaqueHashBits
+        | Int64Source.Verbatim b, Int64Source.OpaqueHashBits a -> a ||| b |> Int64Source.OpaqueHashBits, counters
         | Int64Source.OpaqueHashBits a, Int64Source.WidenedNativeInt (src, _)
         | Int64Source.WidenedNativeInt (src, _), Int64Source.OpaqueHashBits a ->
-            a ||| materialiseHashBits src |> Int64Source.OpaqueHashBits
-        | _, _ -> failwith "TODO: SyntheticCrossArrayOffset"
+            let b, counters = PointerHashSynthesis.materialiseHashBits reason src counters
+            a ||| b |> Int64Source.OpaqueHashBits, counters
+        | _, _ -> failwith $"TODO: bitOr (%s{reason}) on SyntheticCrossArrayOffset"
 
-    let bitXor (i1 : Int64Source) (i2 : Int64Source) : Int64Source =
+    let bitXor
+        (reason : string)
+        (i1 : Int64Source)
+        (i2 : Int64Source)
+        (counters : PointerHashCounters)
+        : Int64Source * PointerHashCounters
+        =
         match i1, i2 with
-        | Int64Source.Verbatim i1, Int64Source.Verbatim i2 -> i1 ^^^ i2 |> Int64Source.Verbatim
+        | Int64Source.Verbatim a, Int64Source.Verbatim b -> a ^^^ b |> Int64Source.Verbatim, counters
         | Int64Source.WidenedNativeInt (src1, _), Int64Source.WidenedNativeInt (src2, _) ->
-            (materialiseHashBits src1) ^^^ (materialiseHashBits src2)
-            |> Int64Source.OpaqueHashBits
+            let a, counters = PointerHashSynthesis.materialiseHashBits reason src1 counters
+            let b, counters = PointerHashSynthesis.materialiseHashBits reason src2 counters
+            a ^^^ b |> Int64Source.OpaqueHashBits, counters
         | Int64Source.WidenedNativeInt (src, _), Int64Source.Verbatim b
         | Int64Source.Verbatim b, Int64Source.WidenedNativeInt (src, _) ->
-            (materialiseHashBits src) ^^^ b |> Int64Source.OpaqueHashBits
-        | Int64Source.OpaqueHashBits a, Int64Source.OpaqueHashBits b -> a ^^^ b |> Int64Source.OpaqueHashBits
+            let a, counters = PointerHashSynthesis.materialiseHashBits reason src counters
+            a ^^^ b |> Int64Source.OpaqueHashBits, counters
+        | Int64Source.OpaqueHashBits a, Int64Source.OpaqueHashBits b -> a ^^^ b |> Int64Source.OpaqueHashBits, counters
         | Int64Source.OpaqueHashBits a, Int64Source.Verbatim b
-        | Int64Source.Verbatim b, Int64Source.OpaqueHashBits a -> a ^^^ b |> Int64Source.OpaqueHashBits
+        | Int64Source.Verbatim b, Int64Source.OpaqueHashBits a -> a ^^^ b |> Int64Source.OpaqueHashBits, counters
         | Int64Source.OpaqueHashBits a, Int64Source.WidenedNativeInt (src, _)
         | Int64Source.WidenedNativeInt (src, _), Int64Source.OpaqueHashBits a ->
-            a ^^^ materialiseHashBits src |> Int64Source.OpaqueHashBits
-        | _, _ -> failwith "TODO: SyntheticCrossArrayOffset"
+            let b, counters = PointerHashSynthesis.materialiseHashBits reason src counters
+            a ^^^ b |> Int64Source.OpaqueHashBits, counters
+        | _, _ -> failwith $"TODO: bitXor (%s{reason}) on SyntheticCrossArrayOffset"
 
     /// Returns None if we can't decide whether this number is nonnegative.
     let isNonnegative (i : Int64Source) : bool option =

--- a/WoofWare.PawPrint/CliNumericType.fs
+++ b/WoofWare.PawPrint/CliNumericType.fs
@@ -75,21 +75,47 @@ module Int64Source =
             | ConcreteTypeHandle.OneDimArrayZero _
             | ConcreteTypeHandle.Array _ -> 0L
 
-    /// Deterministic FNV-1a hash on the `ToString` projection of a source.
+    /// Canonical string for hashing a `NativeIntSource`. The point of going
+    /// through a string is determinism (see `fnv1aHash` below); the point of
+    /// canonicalisation is alias preservation. CoreCLR exposes a
+    /// `MethodTable*` and the `TypeHandle` for the same Concrete/Array type
+    /// as the same address, and the existing `NativeInt` `ceq` arms in
+    /// `EvalStackValueComparisons` treat the two encodings as aliases for
+    /// Concrete/OneDimArrayZero/Array shapes. The hash-bit pipeline must
+    /// agree: `MethodTablePtr h` and `TypeHandlePtr (Closed h)` for those
+    /// concrete shapes must produce identical `OpaqueHashBits`, or guest
+    /// code that widens and bit-mixes the two aliases will see fake
+    /// inequality / different hash buckets for the same pointer. For
+    /// TypeDesc-shaped handles (Byref / Pointer / FunctionPointer) and for
+    /// non-Closed targets, the canonical form is just `ToString` — those
+    /// encodings are not aliases of any `MethodTablePtr`.
+    let private canonicalHashKey (src : NativeIntSource) : string =
+        match src with
+        | NativeIntSource.MethodTablePtr h -> $"<MethodTable %O{h}>"
+        | NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed h) ->
+            match h with
+            | ConcreteTypeHandle.Concrete _
+            | ConcreteTypeHandle.OneDimArrayZero _
+            | ConcreteTypeHandle.Array _ -> $"<MethodTable %O{h}>"
+            | ConcreteTypeHandle.Byref _
+            | ConcreteTypeHandle.Pointer _
+            | ConcreteTypeHandle.FunctionPointer _ -> src.ToString ()
+        | _ -> src.ToString ()
+
+    /// Deterministic FNV-1a hash on the canonical hash key.
     /// `NativeIntSource.GetHashCode` uses `System.HashCode.Combine`, which
     /// folds in a per-process randomised seed and therefore yields different
     /// hash codes across PawPrint invocations. The interpreter's
     /// determinism guarantee (deterministic replay, fuzzing over thread
     /// schedules) requires that any guest-observable hash bits be derived
-    /// from process-stable identifiers instead. Each `NativeIntSource`
-    /// variant's `ToString` is structural in identifiers that are stable
-    /// within a process (e.g., `ConcreteTypeHandle.Concrete` carries an int
-    /// assigned in registration order), so FNV-1a of that string is a
-    /// stable surrogate that we can publish to the guest's bit-mixing
-    /// pipeline.
+    /// from process-stable identifiers instead. `canonicalHashKey` projects
+    /// each `NativeIntSource` into a string that is (a) stable within a
+    /// process and (b) identical for aliasing encodings of the same
+    /// underlying pointer, so FNV-1a of that string is a stable surrogate
+    /// suitable for the guest's bit-mixing pipeline.
     let private fnv1aHash (src : NativeIntSource) : int64 =
         let mutable hash = 0xCBF29CE484222325UL
-        let s = src.ToString ()
+        let s = canonicalHashKey src
 
         for c in s do
             hash <- hash ^^^ uint64 c
@@ -105,14 +131,14 @@ module Int64Source =
     /// pointer.
     ///
     /// Determinism: derives bits via `fnv1aHash`, which folds the source's
-    /// `ToString` projection (stable within a process — see above). The
-    /// upper 16 bits aren't cleared so `RotateLeft(_, 32)` produces a
+    /// `canonicalHashKey` (stable within a process — see above). The upper
+    /// 16 bits aren't cleared so `RotateLeft(_, 32)` produces a
     /// non-degenerate hash mix.
     ///
     /// Low-bit contract: matches `typeHandleLowAddressBitsForHash` so the
     /// synthesised bits agree with the existing `and`-mask path
     /// (`NullaryIlOp.typeHandleLowAddressBits`).
-    let private materialiseHashBits (src : NativeIntSource) : int64 =
+    let materialiseHashBits (src : NativeIntSource) : int64 =
         match src with
         | NativeIntSource.Verbatim n -> n
         | NativeIntSource.ManagedPointer ManagedPointerSource.Null -> 0L

--- a/WoofWare.PawPrint/CliNumericType.fs
+++ b/WoofWare.PawPrint/CliNumericType.fs
@@ -24,6 +24,23 @@ type Int64Source =
     /// pattern matches that assume `Verbatim` / `SyntheticCrossArrayOffset`
     /// cover all "purely numeric" int64 values.
     | WidenedNativeInt of source : NativeIntSource * signed : bool
+    /// Deterministic synthesised bits produced when a bit-mixing operation
+    /// (`shl` / `shr` / `shrUn` / `bitAnd` / `bitOr` / `bitXor` / `bitNot` /
+    /// `negate` / `add`) fires on a `WidenedNativeInt` whose underlying source is a pointer
+    /// shape (`MethodTablePtr`, `TypeHandlePtr`, etc.). The hash bits derive
+    /// from the source's identity (see `materialiseHashBits`) and respect
+    /// the low-bit contract used elsewhere in the interpreter
+    /// (MethodTable* → low 2 bits clear; TypeDesc-shaped → low 2 bits set
+    /// to `0b10`). Once a value has this tag, further bit ops compute on
+    /// the bits directly and the result keeps the same tag.
+    ///
+    /// The tag's load-bearing job: an `OpaqueHashBits` value MUST NOT be
+    /// converted back to a `NativeInt` (via `conv.u` / `conv.i`); doing so
+    /// would let a synthesised non-pointer be used as a real pointer and
+    /// silently dereferenced. `conv.i4` is allowed — that path is how the
+    /// cast-cache hash becomes an array index. See
+    /// `docs/plans/2026-05-13-castcache-synthetic-hash-bits.md`.
+    | OpaqueHashBits of int64
 
     override this.ToString () =
         match this with
@@ -32,9 +49,85 @@ type Int64Source =
         | Int64Source.WidenedNativeInt (src, signed) ->
             let conv = if signed then "conv.i8" else "conv.u8"
             $"<%s{conv} %O{src}>"
+        | Int64Source.OpaqueHashBits bits -> $"<opaque hash bits 0x%x{bits}>"
 
 [<RequireQualifiedAccess>]
 module Int64Source =
+
+    /// Low-bit contract for pointer-shaped handles. Mirrors
+    /// `NullaryIlOp.typeHandleLowAddressBits`, kept in sync so that
+    /// `materialiseHashBits` honours the same alignment / tagging convention
+    /// when synthesising bits for hashing. Centralising this would require
+    /// promoting types — for now the contract is small enough to duplicate.
+    let private typeHandleLowAddressBitsForHash (target : RuntimeTypeHandleTarget) : int64 =
+        match target with
+        | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ -> 0L
+        | RuntimeTypeHandleTarget.GenericParameter _
+        | RuntimeTypeHandleTarget.MethodGenericParameter _ -> 2L
+        | RuntimeTypeHandleTarget.Closed typeHandle ->
+            match typeHandle with
+            | ConcreteTypeHandle.Byref _
+            | ConcreteTypeHandle.Pointer _
+            | ConcreteTypeHandle.FunctionPointer _ -> 2L
+            | ConcreteTypeHandle.Concrete _
+            | ConcreteTypeHandle.OneDimArrayZero _
+            | ConcreteTypeHandle.Array _ -> 0L
+
+    /// Synthesise a deterministic 64-bit pattern from a pointer-shaped
+    /// `NativeIntSource`. Used only when a bit-mixing operation fires on a
+    /// `WidenedNativeInt`; the resulting bits get tagged as
+    /// `Int64Source.OpaqueHashBits` so subsequent ops compute on the bits
+    /// directly and the value cannot be round-tripped back to a real
+    /// pointer.
+    ///
+    /// Determinism: derives bits from `GetHashCode` on the structural DU
+    /// payload. PawPrint identity types use structural hashing, so two
+    /// processes loading the same assemblies produce identical hash bits
+    /// for the same `MethodTablePtr`/`TypeHandlePtr`. The cast-cache
+    /// hashing only needs determinism *within* a process anyway.
+    ///
+    /// Low-bit contract: matches `typeHandleLowAddressBitsForHash` so the
+    /// synthesised bits agree with the existing `and`-mask path. The
+    /// upper bits are shifted to ensure `RotateLeft(_, 32)` produces a
+    /// non-degenerate hash mix.
+    let private materialiseHashBits (src : NativeIntSource) : int64 =
+        match src with
+        | NativeIntSource.Verbatim n -> n
+        | NativeIntSource.ManagedPointer ManagedPointerSource.Null -> 0L
+        | NativeIntSource.MethodTablePtr _ ->
+            let h = int64 (hash src) <<< 16
+            h &&& ~~~3L
+        | NativeIntSource.TypeHandlePtr target ->
+            let low = typeHandleLowAddressBitsForHash target
+            let h = int64 (hash src) <<< 16
+            (h &&& ~~~3L) ||| low
+        | NativeIntSource.MethodTableAuxiliaryDataPtr _
+        | NativeIntSource.FunctionPointer _
+        | NativeIntSource.FieldHandlePtr _
+        | NativeIntSource.MethodHandlePtr _
+        | NativeIntSource.GcHandlePtr _
+        | NativeIntSource.EventPipeProviderPtr _
+        | NativeIntSource.EventPipeEventPtr _
+        | NativeIntSource.AssemblyHandle _
+        | NativeIntSource.ModuleHandle _
+        | NativeIntSource.MetadataImportHandle _ ->
+            let h = int64 (hash src) <<< 16
+            h &&& ~~~3L
+        | NativeIntSource.ManagedPointer _ ->
+            // Non-null managed pointers carry real provenance (byref roots,
+            // heap addresses). Hashing them as plain bits would forget the
+            // root identity. Bit ops on a `WidenedNativeInt (ManagedPointer
+            // _, _)` should be routed via BinaryArithmetic (offset arithmetic),
+            // never through this helper.
+            failwith
+                $"materialiseHashBits: refusing to synthesise bits for managed pointer %O{src} (would erase byref provenance)"
+        | NativeIntSource.SyntheticCrossArrayOffset _ ->
+            // Cross-array offsets are explicitly non-numeric; the
+            // `widenedNativeInt` smart constructor normalises these into
+            // `Int64Source.SyntheticCrossArrayOffset`, so a
+            // `WidenedNativeInt (SyntheticCrossArrayOffset _, _)` shouldn't
+            // exist on the eval stack. Fail loudly if one ever does.
+            failwith $"materialiseHashBits: refusing to synthesise bits for synthetic cross-array offset %O{src}"
 
     /// Smart constructor for `Int64Source.WidenedNativeInt`. Normalises the
     /// `Verbatim` and `SyntheticCrossArrayOffset` cases of the underlying
@@ -53,6 +146,7 @@ module Int64Source =
         | Int64Source.Verbatim i -> i = 0L
         | Int64Source.SyntheticCrossArrayOffset _ -> failwith "TODO: is SyntheticCrossArrayOffset zero?"
         | Int64Source.WidenedNativeInt (src, _) -> NativeIntSource.isZero src
+        | Int64Source.OpaqueHashBits bits -> bits = 0L
 
     /// Returns None if the input was Int64.MinValue.
     let negate (i : Int64Source) : Int64Source option =
@@ -67,21 +161,46 @@ module Int64Source =
             |> Int64Source.SyntheticCrossArrayOffset
             |> Some
         | Int64Source.WidenedNativeInt (src, _) ->
-            failwith $"TODO: refusing to negate widened native int %O{src} (would lose provenance)"
+            let bits = materialiseHashBits src
+            // Wraparound at Int64.MinValue is acceptable here: hash bits
+            // are an intermediate in the bit-mixing pipeline, not a genuine
+            // signed-int value where overflow matters. Use unchecked
+            // subtraction explicitly (the file opens `Checked`).
+            Some (Operators.(-) 0L bits |> Int64Source.OpaqueHashBits)
+        | Int64Source.OpaqueHashBits bits -> Some (Operators.(-) 0L bits |> Int64Source.OpaqueHashBits)
 
     let shr (i : Int64Source) (shift : int) : Int64Source =
         match i with
         | Int64Source.Verbatim i -> i >>> shift |> Int64Source.Verbatim
         | Int64Source.SyntheticCrossArrayOffset _ -> failwith "TODO: SyntheticCrossArrayOffset"
         | Int64Source.WidenedNativeInt (src, _) ->
-            failwith $"TODO: refusing to shr widened native int %O{src} (bit-twiddling on pointer bits)"
+            let bits = materialiseHashBits src
+            bits >>> shift |> Int64Source.OpaqueHashBits
+        | Int64Source.OpaqueHashBits bits -> bits >>> shift |> Int64Source.OpaqueHashBits
+
+    let shrUn (i : Int64Source) (shift : int) : Int64Source =
+        // `open Checked` shadows `uint64` / `int64` with their overflow-checking
+        // versions; an unsigned right shift needs the unchecked tag-flip, since a
+        // negative int64 has the sign bit set and `Checked.uint64` rejects that.
+        let unsignedShift (bits : int64) : int64 =
+            Operators.uint64 bits >>> shift |> Operators.int64
+
+        match i with
+        | Int64Source.Verbatim i -> unsignedShift i |> Int64Source.Verbatim
+        | Int64Source.SyntheticCrossArrayOffset _ -> failwith "TODO: SyntheticCrossArrayOffset"
+        | Int64Source.WidenedNativeInt (src, _) ->
+            let bits = materialiseHashBits src
+            unsignedShift bits |> Int64Source.OpaqueHashBits
+        | Int64Source.OpaqueHashBits bits -> unsignedShift bits |> Int64Source.OpaqueHashBits
 
     let shl (i : Int64Source) (shift : int) : Int64Source =
         match i with
         | Int64Source.Verbatim i -> i <<< shift |> Int64Source.Verbatim
         | Int64Source.SyntheticCrossArrayOffset _ -> failwith "TODO: SyntheticCrossArrayOffset"
         | Int64Source.WidenedNativeInt (src, _) ->
-            failwith $"TODO: refusing to shl widened native int %O{src} (bit-twiddling on pointer bits)"
+            let bits = materialiseHashBits src
+            bits <<< shift |> Int64Source.OpaqueHashBits
+        | Int64Source.OpaqueHashBits bits -> bits <<< shift |> Int64Source.OpaqueHashBits
 
     let add (i1 : Int64Source) (i2 : Int64Source) : Int64Source =
         match i1, i2 with
@@ -91,37 +210,72 @@ module Int64Source =
             // Pointer-shaped int64 arithmetic is handled by BinaryArithmetic.execute
             // (which dispatches on EvalStackValue pairs), not via this generic helper.
             failwith $"TODO: Int64Source.add on widened native int %O{src} should be routed through BinaryArithmetic"
+        | Int64Source.OpaqueHashBits a, Int64Source.OpaqueHashBits b ->
+            // Adding two synthesised hash values is a bit-mixing operation,
+            // not pointer arithmetic — keep the tag and wrap on overflow.
+            (Operators.(+) a b) |> Int64Source.OpaqueHashBits
+        | Int64Source.OpaqueHashBits a, Int64Source.Verbatim b
+        | Int64Source.Verbatim b, Int64Source.OpaqueHashBits a -> (Operators.(+) a b) |> Int64Source.OpaqueHashBits
         | _, _ -> failwith "TODO: SyntheticCrossArrayOffset"
 
     let bitNot (i : Int64Source) : Int64Source =
         match i with
         | Int64Source.Verbatim i -> Int64Source.Verbatim ~~~i
         | Int64Source.WidenedNativeInt (src, _) ->
-            failwith $"TODO: refusing to bitNot widened native int %O{src} (bit-twiddling on pointer bits)"
+            let bits = materialiseHashBits src
+            ~~~bits |> Int64Source.OpaqueHashBits
+        | Int64Source.OpaqueHashBits bits -> ~~~bits |> Int64Source.OpaqueHashBits
         | _ -> failwith "TODO: SyntheticCrossArrayOffset"
 
     let bitAnd (i1 : Int64Source) (i2 : Int64Source) : Int64Source =
         match i1, i2 with
         | Int64Source.Verbatim i1, Int64Source.Verbatim i2 -> i1 &&& i2 |> Int64Source.Verbatim
-        | Int64Source.WidenedNativeInt (src, _), _
-        | _, Int64Source.WidenedNativeInt (src, _) ->
-            failwith $"TODO: refusing to bitAnd widened native int %O{src} (bit-twiddling on pointer bits)"
+        | Int64Source.WidenedNativeInt (src1, _), Int64Source.WidenedNativeInt (src2, _) ->
+            (materialiseHashBits src1) &&& (materialiseHashBits src2)
+            |> Int64Source.OpaqueHashBits
+        | Int64Source.WidenedNativeInt (src, _), Int64Source.Verbatim b
+        | Int64Source.Verbatim b, Int64Source.WidenedNativeInt (src, _) ->
+            (materialiseHashBits src) &&& b |> Int64Source.OpaqueHashBits
+        | Int64Source.OpaqueHashBits a, Int64Source.OpaqueHashBits b -> a &&& b |> Int64Source.OpaqueHashBits
+        | Int64Source.OpaqueHashBits a, Int64Source.Verbatim b
+        | Int64Source.Verbatim b, Int64Source.OpaqueHashBits a -> a &&& b |> Int64Source.OpaqueHashBits
+        | Int64Source.OpaqueHashBits a, Int64Source.WidenedNativeInt (src, _)
+        | Int64Source.WidenedNativeInt (src, _), Int64Source.OpaqueHashBits a ->
+            a &&& materialiseHashBits src |> Int64Source.OpaqueHashBits
         | _, _ -> failwith "TODO: SyntheticCrossArrayOffset"
 
     let bitOr (i1 : Int64Source) (i2 : Int64Source) : Int64Source =
         match i1, i2 with
         | Int64Source.Verbatim i1, Int64Source.Verbatim i2 -> i1 ||| i2 |> Int64Source.Verbatim
-        | Int64Source.WidenedNativeInt (src, _), _
-        | _, Int64Source.WidenedNativeInt (src, _) ->
-            failwith $"TODO: refusing to bitOr widened native int %O{src} (bit-twiddling on pointer bits)"
+        | Int64Source.WidenedNativeInt (src1, _), Int64Source.WidenedNativeInt (src2, _) ->
+            (materialiseHashBits src1) ||| (materialiseHashBits src2)
+            |> Int64Source.OpaqueHashBits
+        | Int64Source.WidenedNativeInt (src, _), Int64Source.Verbatim b
+        | Int64Source.Verbatim b, Int64Source.WidenedNativeInt (src, _) ->
+            (materialiseHashBits src) ||| b |> Int64Source.OpaqueHashBits
+        | Int64Source.OpaqueHashBits a, Int64Source.OpaqueHashBits b -> a ||| b |> Int64Source.OpaqueHashBits
+        | Int64Source.OpaqueHashBits a, Int64Source.Verbatim b
+        | Int64Source.Verbatim b, Int64Source.OpaqueHashBits a -> a ||| b |> Int64Source.OpaqueHashBits
+        | Int64Source.OpaqueHashBits a, Int64Source.WidenedNativeInt (src, _)
+        | Int64Source.WidenedNativeInt (src, _), Int64Source.OpaqueHashBits a ->
+            a ||| materialiseHashBits src |> Int64Source.OpaqueHashBits
         | _, _ -> failwith "TODO: SyntheticCrossArrayOffset"
 
     let bitXor (i1 : Int64Source) (i2 : Int64Source) : Int64Source =
         match i1, i2 with
         | Int64Source.Verbatim i1, Int64Source.Verbatim i2 -> i1 ^^^ i2 |> Int64Source.Verbatim
-        | Int64Source.WidenedNativeInt (src, _), _
-        | _, Int64Source.WidenedNativeInt (src, _) ->
-            failwith $"TODO: refusing to bitXor widened native int %O{src} (bit-twiddling on pointer bits)"
+        | Int64Source.WidenedNativeInt (src1, _), Int64Source.WidenedNativeInt (src2, _) ->
+            (materialiseHashBits src1) ^^^ (materialiseHashBits src2)
+            |> Int64Source.OpaqueHashBits
+        | Int64Source.WidenedNativeInt (src, _), Int64Source.Verbatim b
+        | Int64Source.Verbatim b, Int64Source.WidenedNativeInt (src, _) ->
+            (materialiseHashBits src) ^^^ b |> Int64Source.OpaqueHashBits
+        | Int64Source.OpaqueHashBits a, Int64Source.OpaqueHashBits b -> a ^^^ b |> Int64Source.OpaqueHashBits
+        | Int64Source.OpaqueHashBits a, Int64Source.Verbatim b
+        | Int64Source.Verbatim b, Int64Source.OpaqueHashBits a -> a ^^^ b |> Int64Source.OpaqueHashBits
+        | Int64Source.OpaqueHashBits a, Int64Source.WidenedNativeInt (src, _)
+        | Int64Source.WidenedNativeInt (src, _), Int64Source.OpaqueHashBits a ->
+            a ^^^ materialiseHashBits src |> Int64Source.OpaqueHashBits
         | _, _ -> failwith "TODO: SyntheticCrossArrayOffset"
 
     /// Returns None if we can't decide whether this number is nonnegative.
@@ -129,6 +283,7 @@ module Int64Source =
         match i with
         | Int64Source.Verbatim i -> Some (i >= 0L)
         | Int64Source.WidenedNativeInt (src, _) -> Some (NativeIntSource.isNonnegative src)
+        | Int64Source.OpaqueHashBits bits -> Some (bits >= 0L)
         | _ -> failwith "TODO: SyntheticCrossArrayOffset"
 
     /// Signed comparison of two `Int64Source` values, treating each as the
@@ -136,13 +291,18 @@ module Int64Source =
     /// `compare` convention. `Int64Source` no longer supports structural
     /// comparison (it now contains a `NativeIntSource`, which is
     /// `[<NoComparison>]`), so callers must funnel through this helper.
-    /// Non-`Verbatim` variants don't have a meaningful numeric ordering and
-    /// fail loudly — provenance-tracked offsets and widened pointer bits
-    /// shouldn't be compared as plain integers. For unsigned comparison see
-    /// the `cgt.un` / `clt.un` paths in `EvalStackValueComparisons`.
+    /// Non-`Verbatim` numeric variants (`OpaqueHashBits`) compare on their
+    /// synthesised bits; `WidenedNativeInt` and `SyntheticCrossArrayOffset`
+    /// don't have a meaningful numeric ordering and fail loudly — pointer
+    /// provenance and cross-storage offsets shouldn't be compared as plain
+    /// integers. For unsigned comparison see the `cgt.un` / `clt.un` paths
+    /// in `EvalStackValueComparisons`.
     let compareSigned (i1 : Int64Source) (i2 : Int64Source) : int =
         match i1, i2 with
         | Int64Source.Verbatim a, Int64Source.Verbatim b -> compare a b
+        | Int64Source.OpaqueHashBits a, Int64Source.OpaqueHashBits b -> compare a b
+        | Int64Source.OpaqueHashBits a, Int64Source.Verbatim b
+        | Int64Source.Verbatim b, Int64Source.OpaqueHashBits a -> compare a b
         | _, _ -> failwith $"TODO: refusing to compare Int64Source values numerically: %O{i1} vs %O{i2}"
 
 /// Defined in III.1.1.1
@@ -180,6 +340,8 @@ type CliNumericType =
             failwith "refusing to convert cross-array offset to bytes"
         | CliNumericType.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
             failwith $"refusing to convert widened native int %O{src} to bytes"
+        | CliNumericType.Int64 (Int64Source.OpaqueHashBits bits) ->
+            failwith $"refusing to convert synthesised pointer-hash bits 0x%x{bits} to bytes"
         | CliNumericType.NativeInt src ->
             match src with
             | NativeIntSource.Verbatim i -> BitConverter.GetBytes i

--- a/WoofWare.PawPrint/CliNumericType.fs
+++ b/WoofWare.PawPrint/CliNumericType.fs
@@ -26,13 +26,15 @@ type Int64Source =
     | WidenedNativeInt of source : NativeIntSource * signed : bool
     /// Deterministic synthesised bits produced when a bit-mixing operation
     /// (`shl` / `shr` / `shrUn` / `bitAnd` / `bitOr` / `bitXor` / `bitNot` /
-    /// `negate` / `add`) fires on a `WidenedNativeInt` whose underlying source is a pointer
-    /// shape (`MethodTablePtr`, `TypeHandlePtr`, etc.). The hash bits derive
-    /// from the source's identity (see `materialiseHashBits`) and respect
-    /// the low-bit contract used elsewhere in the interpreter
-    /// (MethodTable* → low 2 bits clear; TypeDesc-shaped → low 2 bits set
-    /// to `0b10`). Once a value has this tag, further bit ops compute on
-    /// the bits directly and the result keeps the same tag.
+    /// `negate`) fires on a `WidenedNativeInt` whose underlying source is a
+    /// pointer shape (`MethodTablePtr`, `TypeHandlePtr`, etc.), or when an
+    /// arithmetic opcode (`Add`, `Mul`, …) runs through `BinaryArithmetic`
+    /// with at least one OpaqueHashBits operand. The hash bits derive from
+    /// the source's identity (see `materialiseHashBits`) and respect the
+    /// low-bit contract used elsewhere in the interpreter (MethodTable* →
+    /// low 2 bits clear; TypeDesc-shaped → low 2 bits set to `0b10`). Once
+    /// a value has this tag, further bit ops compute on the bits directly
+    /// and the result keeps the same tag.
     ///
     /// The tag's load-bearing job: an `OpaqueHashBits` value MUST NOT be
     /// converted back to a `NativeInt` (via `conv.u` / `conv.i`); doing so
@@ -73,6 +75,28 @@ module Int64Source =
             | ConcreteTypeHandle.OneDimArrayZero _
             | ConcreteTypeHandle.Array _ -> 0L
 
+    /// Deterministic FNV-1a hash on the `ToString` projection of a source.
+    /// `NativeIntSource.GetHashCode` uses `System.HashCode.Combine`, which
+    /// folds in a per-process randomised seed and therefore yields different
+    /// hash codes across PawPrint invocations. The interpreter's
+    /// determinism guarantee (deterministic replay, fuzzing over thread
+    /// schedules) requires that any guest-observable hash bits be derived
+    /// from process-stable identifiers instead. Each `NativeIntSource`
+    /// variant's `ToString` is structural in identifiers that are stable
+    /// within a process (e.g., `ConcreteTypeHandle.Concrete` carries an int
+    /// assigned in registration order), so FNV-1a of that string is a
+    /// stable surrogate that we can publish to the guest's bit-mixing
+    /// pipeline.
+    let private fnv1aHash (src : NativeIntSource) : int64 =
+        let mutable hash = 0xCBF29CE484222325UL
+        let s = src.ToString ()
+
+        for c in s do
+            hash <- hash ^^^ uint64 c
+            hash <- Operators.(*) hash 0x100000001B3UL
+
+        Operators.int64 hash
+
     /// Synthesise a deterministic 64-bit pattern from a pointer-shaped
     /// `NativeIntSource`. Used only when a bit-mixing operation fires on a
     /// `WidenedNativeInt`; the resulting bits get tagged as
@@ -80,27 +104,22 @@ module Int64Source =
     /// directly and the value cannot be round-tripped back to a real
     /// pointer.
     ///
-    /// Determinism: derives bits from `GetHashCode` on the structural DU
-    /// payload. PawPrint identity types use structural hashing, so two
-    /// processes loading the same assemblies produce identical hash bits
-    /// for the same `MethodTablePtr`/`TypeHandlePtr`. The cast-cache
-    /// hashing only needs determinism *within* a process anyway.
+    /// Determinism: derives bits via `fnv1aHash`, which folds the source's
+    /// `ToString` projection (stable within a process — see above). The
+    /// upper 16 bits aren't cleared so `RotateLeft(_, 32)` produces a
+    /// non-degenerate hash mix.
     ///
     /// Low-bit contract: matches `typeHandleLowAddressBitsForHash` so the
-    /// synthesised bits agree with the existing `and`-mask path. The
-    /// upper bits are shifted to ensure `RotateLeft(_, 32)` produces a
-    /// non-degenerate hash mix.
+    /// synthesised bits agree with the existing `and`-mask path
+    /// (`NullaryIlOp.typeHandleLowAddressBits`).
     let private materialiseHashBits (src : NativeIntSource) : int64 =
         match src with
         | NativeIntSource.Verbatim n -> n
         | NativeIntSource.ManagedPointer ManagedPointerSource.Null -> 0L
-        | NativeIntSource.MethodTablePtr _ ->
-            let h = int64 (hash src) <<< 16
-            h &&& ~~~3L
+        | NativeIntSource.MethodTablePtr _ -> fnv1aHash src &&& ~~~3L
         | NativeIntSource.TypeHandlePtr target ->
             let low = typeHandleLowAddressBitsForHash target
-            let h = int64 (hash src) <<< 16
-            (h &&& ~~~3L) ||| low
+            (fnv1aHash src &&& ~~~3L) ||| low
         | NativeIntSource.MethodTableAuxiliaryDataPtr _
         | NativeIntSource.FunctionPointer _
         | NativeIntSource.FieldHandlePtr _
@@ -110,9 +129,7 @@ module Int64Source =
         | NativeIntSource.EventPipeEventPtr _
         | NativeIntSource.AssemblyHandle _
         | NativeIntSource.ModuleHandle _
-        | NativeIntSource.MetadataImportHandle _ ->
-            let h = int64 (hash src) <<< 16
-            h &&& ~~~3L
+        | NativeIntSource.MetadataImportHandle _ -> fnv1aHash src &&& ~~~3L
         | NativeIntSource.ManagedPointer _ ->
             // Non-null managed pointers carry real provenance (byref roots,
             // heap addresses). Hashing them as plain bits would forget the
@@ -202,22 +219,6 @@ module Int64Source =
             bits <<< shift |> Int64Source.OpaqueHashBits
         | Int64Source.OpaqueHashBits bits -> bits <<< shift |> Int64Source.OpaqueHashBits
 
-    let add (i1 : Int64Source) (i2 : Int64Source) : Int64Source =
-        match i1, i2 with
-        | Int64Source.Verbatim i1, Int64Source.Verbatim i2 -> i1 + i2 |> Int64Source.Verbatim
-        | Int64Source.WidenedNativeInt (src, _), _
-        | _, Int64Source.WidenedNativeInt (src, _) ->
-            // Pointer-shaped int64 arithmetic is handled by BinaryArithmetic.execute
-            // (which dispatches on EvalStackValue pairs), not via this generic helper.
-            failwith $"TODO: Int64Source.add on widened native int %O{src} should be routed through BinaryArithmetic"
-        | Int64Source.OpaqueHashBits a, Int64Source.OpaqueHashBits b ->
-            // Adding two synthesised hash values is a bit-mixing operation,
-            // not pointer arithmetic — keep the tag and wrap on overflow.
-            (Operators.(+) a b) |> Int64Source.OpaqueHashBits
-        | Int64Source.OpaqueHashBits a, Int64Source.Verbatim b
-        | Int64Source.Verbatim b, Int64Source.OpaqueHashBits a -> (Operators.(+) a b) |> Int64Source.OpaqueHashBits
-        | _, _ -> failwith "TODO: SyntheticCrossArrayOffset"
-
     let bitNot (i : Int64Source) : Int64Source =
         match i with
         | Int64Source.Verbatim i -> Int64Source.Verbatim ~~~i
@@ -301,8 +302,8 @@ module Int64Source =
         match i1, i2 with
         | Int64Source.Verbatim a, Int64Source.Verbatim b -> compare a b
         | Int64Source.OpaqueHashBits a, Int64Source.OpaqueHashBits b -> compare a b
-        | Int64Source.OpaqueHashBits a, Int64Source.Verbatim b
-        | Int64Source.Verbatim b, Int64Source.OpaqueHashBits a -> compare a b
+        | Int64Source.OpaqueHashBits a, Int64Source.Verbatim b -> compare a b
+        | Int64Source.Verbatim a, Int64Source.OpaqueHashBits b -> compare a b
         | _, _ -> failwith $"TODO: refusing to compare Int64Source values numerically: %O{i1} vs %O{i2}"
 
 /// Defined in III.1.1.1

--- a/WoofWare.PawPrint/CliType.fs
+++ b/WoofWare.PawPrint/CliType.fs
@@ -75,9 +75,12 @@ module private ByteAddressabilityClassifier =
         | Int64Source.Verbatim _ -> CliByteAddressability.ByteAddressable
         // `WidenedNativeInt` is itself provenance: `CliNumericType.ToBytes`
         // refuses every widened value, even non-canonical wrappers around a
-        // byte-renderable native-int source.
+        // byte-renderable native-int source. `OpaqueHashBits` is a synthesised
+        // hash with no meaningful byte interpretation — spilling it to memory
+        // would imply it's a real numeric value, which it isn't.
         | Int64Source.SyntheticCrossArrayOffset _
-        | Int64Source.WidenedNativeInt _ ->
+        | Int64Source.WidenedNativeInt _
+        | Int64Source.OpaqueHashBits _ ->
             CliByteAddressability.Rejected (CliByteAddressabilityRejection.Int64SourceNotByteAddressable source)
 
     let numeric (numeric : CliNumericType) : CliByteAddressability =

--- a/WoofWare.PawPrint/EvalStack.fs
+++ b/WoofWare.PawPrint/EvalStack.fs
@@ -201,6 +201,9 @@ module EvalStackValue =
                 Some (UnsignedNativeIntSource.FromSyntheticCrossArrayStorage s)
             | NativeIntSource.Verbatim n -> Some (UnsignedNativeIntSource.Verbatim (uint64 n))
             | _ -> failwith $"TODO: Conv_U from widened native int with non-pointer source %O{src}"
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits bits) ->
+            failwith
+                $"Conv_U from synthesised pointer-hash bits 0x%x{bits}: refusing to materialise a real native int from hashed pointer provenance"
         | EvalStackValue.NativeInt i ->
             match i with
             | NativeIntSource.Verbatim i -> uint64 i |> UnsignedNativeIntSource.Verbatim |> Some
@@ -251,6 +254,9 @@ module EvalStackValue =
             // the matching arm in `toUnsignedNativeInt` for the architecture
             // assumption.
             Some src
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits bits) ->
+            failwith
+                $"Conv_I from synthesised pointer-hash bits 0x%x{bits}: refusing to materialise a real native int from hashed pointer provenance"
         | EvalStackValue.Int32 i -> i |> convIFromInt32 |> NativeIntSource.Verbatim |> Some
         | EvalStackValue.NativeInt src -> Some src
         | EvalStackValue.Float f -> f |> convIFromFloat |> NativeIntSource.Verbatim |> Some
@@ -266,6 +272,7 @@ module EvalStackValue =
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _) -> failwith "TODO: SyntheticCrossArrayOffset"
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
             failwith $"TODO: Conv_I1 from widened native int %O{src} (truncating pointer-shaped int64 to int8)"
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits bits) -> convI1FromInt64 bits |> Some
         | EvalStackValue.NativeInt src -> nativeIntBitsForIntegerConversion "Conv_I1" src |> convI1FromInt64 |> Some
         | EvalStackValue.Float f -> convI1FromFloat f |> Some
         | EvalStackValue.ManagedPointer _
@@ -280,6 +287,7 @@ module EvalStackValue =
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _) -> failwith "TODO: SyntheticCrossArrayOffset"
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
             failwith $"TODO: Conv_I2 from widened native int %O{src} (truncating pointer-shaped int64 to int16)"
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits bits) -> convI2FromInt64 bits |> Some
         | EvalStackValue.NativeInt src -> nativeIntBitsForIntegerConversion "Conv_I2" src |> convI2FromInt64 |> Some
         | EvalStackValue.Float f -> convI2FromFloat f |> Some
         | EvalStackValue.ManagedPointer _
@@ -294,6 +302,12 @@ module EvalStackValue =
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _) -> failwith "TODO: SyntheticCrossArrayOffset"
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
             failwith $"TODO: Conv_I4 from widened native int %O{src} (truncating pointer-shaped int64 to int32)"
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits bits) ->
+            // Truncating synthesised hash bits to int32 is the load-bearing
+            // path: `CastCache.KeyToBucket` ends in `(int)((hash * c) >> shift)`
+            // to produce an array index. The result has no provenance, but
+            // an array index doesn't need one.
+            convI4FromInt64 bits |> Some
         | EvalStackValue.NativeInt src -> nativeIntBitsForIntegerConversion "Conv_I4" src |> convI4FromInt64 |> Some
         | EvalStackValue.Float f -> convI4FromFloat f |> Some
         | EvalStackValue.ManagedPointer _
@@ -345,6 +359,7 @@ module EvalStackValue =
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _) -> failwith "TODO: SyntheticCrossArrayOffset"
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
             failwith $"TODO: Conv_U1 from widened native int %O{src} (truncating pointer-shaped int64 to uint8)"
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits bits) -> convU1FromInt64 bits |> Some
         | EvalStackValue.NativeInt src -> nativeIntBitsForIntegerConversion "Conv_U1" src |> convU1FromInt64 |> Some
         | EvalStackValue.Float f -> convU1FromFloat f |> Some
         | EvalStackValue.ManagedPointer _
@@ -360,6 +375,7 @@ module EvalStackValue =
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _) -> failwith "TODO: SyntheticCrossArrayOffset"
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
             failwith $"TODO: Conv_U2 from widened native int %O{src} (truncating pointer-shaped int64 to uint16)"
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits bits) -> convU2FromInt64 bits |> Some
         | EvalStackValue.NativeInt src -> nativeIntBitsForIntegerConversion "Conv_U2" src |> convU2FromInt64 |> Some
         | EvalStackValue.Float f -> convU2FromFloat f |> Some
         | EvalStackValue.ManagedPointer _
@@ -375,6 +391,7 @@ module EvalStackValue =
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _) -> failwith "TODO: SyntheticCrossArrayOffset"
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
             failwith $"TODO: Conv_U4 from widened native int %O{src} (truncating pointer-shaped int64 to uint32)"
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits bits) -> convU4FromInt64 bits |> Some
         | EvalStackValue.NativeInt src -> nativeIntBitsForIntegerConversion "Conv_U4" src |> convU4FromInt64 |> Some
         | EvalStackValue.Float f -> convU4FromFloat f |> Some
         | EvalStackValue.ManagedPointer _
@@ -390,6 +407,8 @@ module EvalStackValue =
             failwith "Refusing to convert byte offset to float"
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
             failwith $"Refusing to convert widened native int %O{src} to float"
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits bits) ->
+            failwith $"Refusing to convert synthesised pointer-hash bits 0x%x{bits} to float"
         | EvalStackValue.NativeInt src -> nativeIntBitsForIntegerConversion "Conv_R4" src |> convR4FromInt64 |> Some
         | EvalStackValue.Float f -> convR4FromFloat f |> Some
         | EvalStackValue.ManagedPointer _
@@ -405,6 +424,8 @@ module EvalStackValue =
             failwith "Refusing to convert byte offset to float"
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
             failwith $"Refusing to convert widened native int %O{src} to float"
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits bits) ->
+            failwith $"Refusing to convert synthesised pointer-hash bits 0x%x{bits} to float"
         | EvalStackValue.NativeInt src -> nativeIntBitsForIntegerConversion "Conv_R8" src |> convR8FromInt64 |> Some
         | EvalStackValue.Float f -> convR8FromFloat f |> Some
         | EvalStackValue.ManagedPointer _
@@ -420,6 +441,8 @@ module EvalStackValue =
             failwith "Refusing to convert byte offset to float"
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
             failwith $"Refusing to convert widened native int %O{src} to float"
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits bits) ->
+            failwith $"Refusing to convert synthesised pointer-hash bits 0x%x{bits} to float"
         | EvalStackValue.NativeInt src -> nativeIntBitsForIntegerConversion "Conv_R_Un" src |> convRUnFromInt64 |> Some
         | EvalStackValue.Float _ -> failwith "Conv_R_Un: refusing to convert an existing float as unsigned integer"
         | EvalStackValue.ManagedPointer _
@@ -539,6 +562,9 @@ module EvalStackValue =
                             // back to native int recovers the original source on
                             // 64-bit (the widening is bit-preserving).
                             CliType.Numeric (CliNumericType.NativeInt src)
+                        | Int64Source.OpaqueHashBits bits ->
+                            failwith
+                                $"refusing to coerce synthesised pointer-hash bits 0x%x{bits} into a native int (would forge pointer provenance)"
                     | CliType.RuntimePointer ptr ->
                         match ptr with
                         | CliRuntimePointer.Verbatim i ->

--- a/WoofWare.PawPrint/EvalStackValueComparisons.fs
+++ b/WoofWare.PawPrint/EvalStackValueComparisons.fs
@@ -315,15 +315,28 @@ module EvalStackValueComparisons =
         // need to compare against a known pointer value arises.
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt _), EvalStackValue.Int64 (Int64Source.Verbatim _)
         | EvalStackValue.Int64 (Int64Source.Verbatim _), EvalStackValue.Int64 (Int64Source.WidenedNativeInt _) -> false
-        // WidenedNativeInt × OpaqueHashBits / SyntheticCrossArrayOffset: a
-        // real pointer can't equal synthesised hash bits or a cross-storage
-        // delta; matches prior structural-DU semantics.
-        | EvalStackValue.Int64 (Int64Source.WidenedNativeInt _), EvalStackValue.Int64 (Int64Source.OpaqueHashBits _)
-        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits _), EvalStackValue.Int64 (Int64Source.WidenedNativeInt _)
+        // WidenedNativeInt × SyntheticCrossArrayOffset: a real pointer can't
+        // equal a cross-storage delta; cross-array offsets are synthetic
+        // markers for unrepresentable address deltas, not pointer values.
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt _),
           EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _)
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _),
           EvalStackValue.Int64 (Int64Source.WidenedNativeInt _) -> false
+        // WidenedNativeInt × OpaqueHashBits is genuinely ambiguous: under the
+        // counter-based synthesis scheme an identity bit op such as `x ^ 0UL`
+        // or `x & ulong.MaxValue` materialises the WidenedNativeInt's bits
+        // into an OpaqueHashBits carrier whose bit pattern is *exactly* what
+        // the WidenedNativeInt would synthesise to — so the answer here is
+        // "equal iff WidenedNativeInt's materialised bits equal the
+        // OpaqueHashBits value". Producing the right answer requires reading
+        // the `PointerHashCounters` map, which `ceq` does not thread today.
+        // Fail loudly rather than silently returning false (which would have
+        // been wrong under identity ops) or true (which would be wrong when
+        // bits genuinely differ).
+        | EvalStackValue.Int64 (Int64Source.WidenedNativeInt _), EvalStackValue.Int64 (Int64Source.OpaqueHashBits _)
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits _), EvalStackValue.Int64 (Int64Source.WidenedNativeInt _) ->
+            failwith
+                $"TODO: ceq of WidenedNativeInt vs OpaqueHashBits requires looking up the pointer's materialised hash bits via PointerHashCounters; thread state through ceq to resolve. Got %O{var1} vs %O{var2}"
         // Verbatim and OpaqueHashBits both carry unambiguous int64 bit patterns,
         // so equality is bit-pattern equality regardless of how the bits were
         // produced. Structural DU equality would incorrectly treat

--- a/WoofWare.PawPrint/EvalStackValueComparisons.fs
+++ b/WoofWare.PawPrint/EvalStackValueComparisons.fs
@@ -300,11 +300,30 @@ module EvalStackValueComparisons =
         | EvalStackValue.Int32 var1, EvalStackValue.Int32 var2 -> var1 = var2
         | EvalStackValue.Int32 var1, EvalStackValue.NativeInt var2 -> failwith "TODO: int32 CEQ nativeint"
         | EvalStackValue.Int32 _, _ -> failwith $"bad ceq: Int32 vs {var2}"
-        // WidenedNativeInt is the int64 bit-pattern of a NativeInt: route the
-        // comparison through the NativeInt arms so byref / function-pointer /
-        // type-handle identity comparisons land in the right place.
-        | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)), _ -> ceq (EvalStackValue.NativeInt src) var2
-        | _, EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) -> ceq var1 (EvalStackValue.NativeInt src)
+        // WidenedNativeInt × WidenedNativeInt: route both sides through the
+        // NativeInt arms so pointer-identity (TypeHandlePtr, MethodTablePtr,
+        // function-pointer, …) is decided structurally.
+        | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src1, _)),
+          EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src2, _)) ->
+            ceq (EvalStackValue.NativeInt src1) (EvalStackValue.NativeInt src2)
+        // WidenedNativeInt × Verbatim n: the underlying source is a non-null
+        // pointer shape (Null is normalised to `Verbatim 0L` by the
+        // `widenedNativeInt` smart constructor), so it can't equal 0. For
+        // non-zero `n` we don't know the pointer's actual numeric address —
+        // the safe and previously-structurally-correct answer is still
+        // `false`, but we keep that arm explicit so we can revisit if a real
+        // need to compare against a known pointer value arises.
+        | EvalStackValue.Int64 (Int64Source.WidenedNativeInt _), EvalStackValue.Int64 (Int64Source.Verbatim _)
+        | EvalStackValue.Int64 (Int64Source.Verbatim _), EvalStackValue.Int64 (Int64Source.WidenedNativeInt _) -> false
+        // WidenedNativeInt × OpaqueHashBits / SyntheticCrossArrayOffset: a
+        // real pointer can't equal synthesised hash bits or a cross-storage
+        // delta; matches prior structural-DU semantics.
+        | EvalStackValue.Int64 (Int64Source.WidenedNativeInt _), EvalStackValue.Int64 (Int64Source.OpaqueHashBits _)
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits _), EvalStackValue.Int64 (Int64Source.WidenedNativeInt _)
+        | EvalStackValue.Int64 (Int64Source.WidenedNativeInt _),
+          EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _)
+        | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _),
+          EvalStackValue.Int64 (Int64Source.WidenedNativeInt _) -> false
         // Verbatim and OpaqueHashBits both carry unambiguous int64 bit patterns,
         // so equality is bit-pattern equality regardless of how the bits were
         // produced. Structural DU equality would incorrectly treat

--- a/WoofWare.PawPrint/EvalStackValueComparisons.fs
+++ b/WoofWare.PawPrint/EvalStackValueComparisons.fs
@@ -356,10 +356,11 @@ module EvalStackValueComparisons =
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset s1),
           EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset s2) -> s1 = s2
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _), EvalStackValue.Int64 (Int64Source.Verbatim _)
-        | EvalStackValue.Int64 (Int64Source.Verbatim _), EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _) ->
-            false
-        | EvalStackValue.Int64 var1, EvalStackValue.Int64 var2 ->
-            failwith $"TODO: ceq on non-numeric Int64 sources: %O{var1} vs %O{var2}"
+        | EvalStackValue.Int64 (Int64Source.Verbatim _), EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _)
+        | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _),
+          EvalStackValue.Int64 (Int64Source.OpaqueHashBits _)
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits _),
+          EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _) -> false
         | EvalStackValue.Int64 _, _ -> failwith $"bad ceq: Int64 vs {var2}"
         | EvalStackValue.Float var1, EvalStackValue.Float var2 -> var1 = var2
         | EvalStackValue.Float _, _ -> failwith $"bad ceq: Float vs {var2}"

--- a/WoofWare.PawPrint/EvalStackValueComparisons.fs
+++ b/WoofWare.PawPrint/EvalStackValueComparisons.fs
@@ -92,6 +92,15 @@ module EvalStackValueComparisons =
         | EvalStackValue.Int32 _, _ -> failwith $"Cgt.un invalid for comparing %O{var1} with %O{var2}"
         | EvalStackValue.Int64 (Int64Source.Verbatim var1), EvalStackValue.Int64 (Int64Source.Verbatim var2) ->
             uint64 var1 > uint64 var2
+        // OpaqueHashBits carries an unambiguous int64 bit pattern, so unsigned
+        // comparison is well-defined against any other unambiguous bit-pattern
+        // source. The cast-cache bucket selection compares hashes/bucket indices
+        // exactly this way.
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits var1), EvalStackValue.Int64 (Int64Source.OpaqueHashBits var2) ->
+            uint64 var1 > uint64 var2
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits var1), EvalStackValue.Int64 (Int64Source.Verbatim var2)
+        | EvalStackValue.Int64 (Int64Source.Verbatim var1), EvalStackValue.Int64 (Int64Source.OpaqueHashBits var2) ->
+            uint64 var1 > uint64 var2
         | EvalStackValue.Int64 _, _ -> failwith $"Cgt.un invalid for comparing %O{var1} with %O{var2}"
         | EvalStackValue.NativeInt var1, EvalStackValue.NativeInt var2 ->
             match var1, var2 with
@@ -179,6 +188,13 @@ module EvalStackValueComparisons =
             failwith "TODO: comparison of unsigned int32 with nativeint"
         | EvalStackValue.Int32 _, _ -> failwith $"Cgt.un invalid for comparing %O{var1} with %O{var2}"
         | EvalStackValue.Int64 (Int64Source.Verbatim var1), EvalStackValue.Int64 (Int64Source.Verbatim var2) ->
+            uint64 var1 < uint64 var2
+        // See cgtUn: OpaqueHashBits is bit-pattern unambiguous and can be
+        // compared unsigned against any other unambiguous Int64 source.
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits var1), EvalStackValue.Int64 (Int64Source.OpaqueHashBits var2) ->
+            uint64 var1 < uint64 var2
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits var1), EvalStackValue.Int64 (Int64Source.Verbatim var2)
+        | EvalStackValue.Int64 (Int64Source.Verbatim var1), EvalStackValue.Int64 (Int64Source.OpaqueHashBits var2) ->
             uint64 var1 < uint64 var2
         | EvalStackValue.Int64 _, _ -> failwith $"Cgt.un invalid for comparing %O{var1} with %O{var2}"
         | EvalStackValue.NativeInt var1, EvalStackValue.NativeInt var2 ->
@@ -284,7 +300,34 @@ module EvalStackValueComparisons =
         | EvalStackValue.Int32 var1, EvalStackValue.Int32 var2 -> var1 = var2
         | EvalStackValue.Int32 var1, EvalStackValue.NativeInt var2 -> failwith "TODO: int32 CEQ nativeint"
         | EvalStackValue.Int32 _, _ -> failwith $"bad ceq: Int32 vs {var2}"
-        | EvalStackValue.Int64 var1, EvalStackValue.Int64 var2 -> var1 = var2
+        // WidenedNativeInt is the int64 bit-pattern of a NativeInt: route the
+        // comparison through the NativeInt arms so byref / function-pointer /
+        // type-handle identity comparisons land in the right place.
+        | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)), _ -> ceq (EvalStackValue.NativeInt src) var2
+        | _, EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) -> ceq var1 (EvalStackValue.NativeInt src)
+        // Verbatim and OpaqueHashBits both carry unambiguous int64 bit patterns,
+        // so equality is bit-pattern equality regardless of how the bits were
+        // produced. Structural DU equality would incorrectly treat
+        // `Verbatim 0xABCD` and `OpaqueHashBits 0xABCD` as unequal.
+        | EvalStackValue.Int64 (Int64Source.Verbatim var1), EvalStackValue.Int64 (Int64Source.Verbatim var2) ->
+            var1 = var2
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits var1), EvalStackValue.Int64 (Int64Source.OpaqueHashBits var2) ->
+            var1 = var2
+        | EvalStackValue.Int64 (Int64Source.Verbatim var1), EvalStackValue.Int64 (Int64Source.OpaqueHashBits var2)
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits var1), EvalStackValue.Int64 (Int64Source.Verbatim var2) ->
+            var1 = var2
+        // SyntheticCrossArrayOffset values are equal iff they reference the
+        // same source/target roots at the same offsets — that's structural
+        // equality on the record. Cross-shape (offset vs verbatim/hash bits)
+        // can't sensibly equal: the offset is a marker for an unrepresentable
+        // address delta, not a number we can pin to a verbatim bit pattern.
+        | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset s1),
+          EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset s2) -> s1 = s2
+        | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _), EvalStackValue.Int64 (Int64Source.Verbatim _)
+        | EvalStackValue.Int64 (Int64Source.Verbatim _), EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _) ->
+            false
+        | EvalStackValue.Int64 var1, EvalStackValue.Int64 var2 ->
+            failwith $"TODO: ceq on non-numeric Int64 sources: %O{var1} vs %O{var2}"
         | EvalStackValue.Int64 _, _ -> failwith $"bad ceq: Int64 vs {var2}"
         | EvalStackValue.Float var1, EvalStackValue.Float var2 -> var1 = var2
         | EvalStackValue.Float _, _ -> failwith $"bad ceq: Float vs {var2}"

--- a/WoofWare.PawPrint/IlMachineStateModel.fs
+++ b/WoofWare.PawPrint/IlMachineStateModel.fs
@@ -67,6 +67,11 @@ type IlMachineState =
         /// only need to be unique and non-zero (the BCL treats handle 0 as
         /// "create failed" and throws OOM).
         NextEventPipeId : int64
+        /// Deterministic counter-assignment state for synthesised pointer
+        /// hash bits. Each canonical pointer key gets a stable bit pattern
+        /// derived from its registration order; distinct keys produce
+        /// distinct bits with no collisions. See `PointerHashSynthesis`.
+        PointerHashCounters : PointerHashCounters
     }
 
     member this.WithTypeBeginInit (thread : ThreadId) (ty : ConcreteTypeHandle) =

--- a/WoofWare.PawPrint/IlMachineThreadState.fs
+++ b/WoofWare.PawPrint/IlMachineThreadState.fs
@@ -308,6 +308,7 @@ module IlMachineThreadState =
                 LastPInvokeError = 0
                 LastSystemError = 0
                 NextEventPipeId = 1L
+                PointerHashCounters = PointerHashCounters.empty
             }
 
         state.WithLoadedAssembly assyName entryAssembly

--- a/WoofWare.PawPrint/IntrinsicHelpers.fs
+++ b/WoofWare.PawPrint/IntrinsicHelpers.fs
@@ -542,6 +542,9 @@ module internal IntrinsicHelpers =
                 | Int64Source.WidenedNativeInt (src, _) ->
                     failwith
                         $"%s{operation}: byte count came from a widened native int %O{src}; refusing to interpret pointer-shaped int64 as byte count"
+                | Int64Source.OpaqueHashBits bits ->
+                    failwith
+                        $"%s{operation}: byte count came from synthesised pointer-hash bits 0x%x{bits}; refusing to interpret hashed pointer provenance as byte count"
                 | Int64Source.Verbatim count -> checkedByteCount operation count
             | _ -> failwith "unexpectedly got negative byte count"
         | EvalStackValue.Int32 count -> checkedByteCount operation (int64 count)

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -228,23 +228,28 @@ module NullaryIlOp =
     let private negInt64Unchecked (value : int64) : int64 =
         0UL - uint64<int64> value |> int64<uint64>
 
-    let private negValue (value : EvalStackValue) : EvalStackValue =
+    let private negValue
+        (value : EvalStackValue)
+        (counters : PointerHashCounters)
+        : EvalStackValue * PointerHashCounters
+        =
         match value with
-        | EvalStackValue.Int32 value -> negInt32Unchecked value |> EvalStackValue.Int32
+        | EvalStackValue.Int32 value -> negInt32Unchecked value |> EvalStackValue.Int32, counters
         | EvalStackValue.Int64 value ->
-            match Int64Source.negate value with
-            | Some v -> EvalStackValue.Int64 v
-            | None -> EvalStackValue.Int64 (Int64Source.Verbatim Int64.MinValue)
+            match Int64Source.negate "Neg" value counters with
+            | Some (v, counters) -> EvalStackValue.Int64 v, counters
+            | None -> EvalStackValue.Int64 (Int64Source.Verbatim Int64.MinValue), counters
         | EvalStackValue.NativeInt source ->
             match source with
             | NativeIntSource.Verbatim value ->
-                negInt64Unchecked value |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt
+                negInt64Unchecked value |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt, counters
             | NativeIntSource.SyntheticCrossArrayOffset value ->
                 SyntheticCrossArrayOffset.negate value
                 |> NativeIntSource.SyntheticCrossArrayOffset
-                |> EvalStackValue.NativeInt
+                |> EvalStackValue.NativeInt,
+                counters
             | NativeIntSource.ManagedPointer ManagedPointerSource.Null ->
-                NativeIntSource.Verbatim 0L |> EvalStackValue.NativeInt
+                NativeIntSource.Verbatim 0L |> EvalStackValue.NativeInt, counters
             | NativeIntSource.ManagedPointer ptr -> failwith $"Neg: refusing to negate managed pointer %O{ptr}"
             | NativeIntSource.FunctionPointer methodInfo ->
                 failwith $"Neg: refusing to negate function pointer %O{methodInfo}"
@@ -268,7 +273,7 @@ module NullaryIlOp =
             | NativeIntSource.EventPipeProviderPtr id ->
                 failwith $"Neg: refusing to negate EventPipe provider handle %d{id}"
             | NativeIntSource.EventPipeEventPtr id -> failwith $"Neg: refusing to negate EventPipe event handle %d{id}"
-        | EvalStackValue.Float value -> -value |> EvalStackValue.Float
+        | EvalStackValue.Float value -> -value |> EvalStackValue.Float, counters
         | EvalStackValue.ManagedPointer ptr -> failwith $"Neg: refusing to negate managed pointer %O{ptr}"
         | EvalStackValue.NullObjectRef -> failwith "Neg: refusing to negate null object reference"
         | EvalStackValue.ObjectRef addr -> failwith $"Neg: refusing to negate object reference %O{addr}"
@@ -784,7 +789,7 @@ module NullaryIlOp =
             let val2, state = IlMachineState.popEvalStack currentThread state
             let val1, state = IlMachineState.popEvalStack currentThread state
 
-            let result =
+            let result, state =
                 BinaryArithmetic.execute corelib ArithmeticOperation.sub state val1 val2
 
             state
@@ -798,7 +803,7 @@ module NullaryIlOp =
             let val2, state = IlMachineState.popEvalStack currentThread state
             let val1, state = IlMachineState.popEvalStack currentThread state
 
-            let result =
+            let result, state =
                 BinaryArithmetic.execute corelib ArithmeticOperation.add state val1 val2
 
             state
@@ -819,7 +824,7 @@ module NullaryIlOp =
 
             let state =
                 match result with
-                | Ok result -> state |> IlMachineState.pushToEvalStack' result currentThread
+                | Ok (result, state) -> state |> IlMachineState.pushToEvalStack' result currentThread
                 | Error excToThrow -> failwith "TODO: throw OverflowException"
 
             state
@@ -831,7 +836,7 @@ module NullaryIlOp =
             let val2, state = IlMachineState.popEvalStack currentThread state
             let val1, state = IlMachineState.popEvalStack currentThread state
 
-            let result =
+            let result, state =
                 BinaryArithmetic.execute corelib ArithmeticOperation.mul state val1 val2
 
             state
@@ -852,7 +857,7 @@ module NullaryIlOp =
 
             let state =
                 match result with
-                | Ok result -> state |> IlMachineState.pushToEvalStack' result currentThread
+                | Ok (result, state) -> state |> IlMachineState.pushToEvalStack' result currentThread
                 | Error excToThrow -> failwith "TODO: throw OverflowException"
 
             state
@@ -870,7 +875,7 @@ module NullaryIlOp =
                 with :? OverflowException as e ->
                     Error e
             with
-            | Ok result ->
+            | Ok (result, state) ->
                 state
                 |> IlMachineState.pushToEvalStack' result currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
@@ -896,7 +901,7 @@ module NullaryIlOp =
 
             let state =
                 match result with
-                | Ok result -> state |> IlMachineState.pushToEvalStack' result currentThread
+                | Ok (result, state) -> state |> IlMachineState.pushToEvalStack' result currentThread
                 | Error excToThrow -> failwith "TODO: throw OverflowException"
 
             state
@@ -924,13 +929,19 @@ module NullaryIlOp =
                 | EvalStackValue.NativeInt (NativeIntSource.Verbatim i) -> int<int64> i
                 | _ -> failwith $"Not allowed shift of {shift}"
 
-            let result =
+            let result, state =
                 // See table III.6
                 match number with
-                | EvalStackValue.Int32 i -> i >>> shift |> EvalStackValue.Int32
-                | EvalStackValue.Int64 i -> Int64Source.shr i shift |> EvalStackValue.Int64
+                | EvalStackValue.Int32 i -> i >>> shift |> EvalStackValue.Int32, state
+                | EvalStackValue.Int64 i ->
+                    let r, counters = Int64Source.shr "Shr" i shift state.PointerHashCounters
+
+                    EvalStackValue.Int64 r,
+                    { state with
+                        PointerHashCounters = counters
+                    }
                 | EvalStackValue.NativeInt (NativeIntSource.Verbatim i) ->
-                    (i >>> shift) |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt
+                    (i >>> shift) |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt, state
                 | _ -> failwith $"Not allowed to shift {number}"
 
             let state =
@@ -949,15 +960,22 @@ module NullaryIlOp =
                 | EvalStackValue.NativeInt (NativeIntSource.Verbatim i) -> int<int64> i
                 | _ -> failwith $"Not allowed shift of {shift}"
 
-            let result =
+            let result, state =
                 // See table III.6
                 match number with
-                | EvalStackValue.Int32 i -> uint32<int> i >>> shift |> int32<uint32> |> EvalStackValue.Int32
-                | EvalStackValue.Int64 i -> Int64Source.shrUn i shift |> EvalStackValue.Int64
+                | EvalStackValue.Int32 i -> uint32<int> i >>> shift |> int32<uint32> |> EvalStackValue.Int32, state
+                | EvalStackValue.Int64 i ->
+                    let r, counters = Int64Source.shrUn "Shr_un" i shift state.PointerHashCounters
+
+                    EvalStackValue.Int64 r,
+                    { state with
+                        PointerHashCounters = counters
+                    }
                 | EvalStackValue.NativeInt (NativeIntSource.Verbatim i) ->
                     (uint64<int64> i >>> shift |> int64<uint64>)
                     |> NativeIntSource.Verbatim
-                    |> EvalStackValue.NativeInt
+                    |> EvalStackValue.NativeInt,
+                    state
                 | _ -> failwith $"Not allowed to shift {number}"
 
             let state =
@@ -976,13 +994,19 @@ module NullaryIlOp =
                 | EvalStackValue.NativeInt (NativeIntSource.Verbatim i) -> int<int64> i
                 | _ -> failwith $"Not allowed shift of {shift}"
 
-            let result =
+            let result, state =
                 // See table III.6
                 match number with
-                | EvalStackValue.Int32 i -> i <<< shift |> EvalStackValue.Int32
-                | EvalStackValue.Int64 i -> Int64Source.shl i shift |> EvalStackValue.Int64
+                | EvalStackValue.Int32 i -> i <<< shift |> EvalStackValue.Int32, state
+                | EvalStackValue.Int64 i ->
+                    let r, counters = Int64Source.shl "Shl" i shift state.PointerHashCounters
+
+                    EvalStackValue.Int64 r,
+                    { state with
+                        PointerHashCounters = counters
+                    }
                 | EvalStackValue.NativeInt (NativeIntSource.Verbatim i) ->
-                    (i <<< shift) |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt
+                    (i <<< shift) |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt, state
                 | _ -> failwith $"Not allowed to shift {number}"
 
             let state =
@@ -995,33 +1019,39 @@ module NullaryIlOp =
             let v2, state = IlMachineState.popEvalStack currentThread state
             let v1, state = IlMachineState.popEvalStack currentThread state
 
-            let result =
+            let result, state =
                 match v1, v2 with
-                | EvalStackValue.Int32 v1, EvalStackValue.Int32 v2 -> v1 &&& v2 |> EvalStackValue.Int32
+                | EvalStackValue.Int32 v1, EvalStackValue.Int32 v2 -> v1 &&& v2 |> EvalStackValue.Int32, state
                 | EvalStackValue.Int32 mask, EvalStackValue.NativeInt (NativeIntSource.ManagedPointer ptr) ->
-                    int64<int32> mask |> andManagedPointerAddressBits state ptr
+                    int64<int32> mask |> andManagedPointerAddressBits state ptr, state
                 | EvalStackValue.Int32 v1, EvalStackValue.NativeInt (NativeIntSource.Verbatim v2) ->
-                    int64<int32> v1 &&& v2 |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt
+                    int64<int32> v1 &&& v2 |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt, state
                 | EvalStackValue.Int32 mask, EvalStackValue.NativeInt src ->
-                    andNativeIntAddressBits state src (int64<int32> mask)
+                    andNativeIntAddressBits state src (int64<int32> mask), state
                 | EvalStackValue.Int32 mask, EvalStackValue.ManagedPointer ptr ->
-                    int64<int32> mask |> andManagedPointerAddressBits state ptr
-                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.bitAnd v1 v2 |> EvalStackValue.Int64
+                    int64<int32> mask |> andManagedPointerAddressBits state ptr, state
+                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 ->
+                    let r, counters = Int64Source.bitAnd "And" v1 v2 state.PointerHashCounters
+
+                    EvalStackValue.Int64 r,
+                    { state with
+                        PointerHashCounters = counters
+                    }
                 | EvalStackValue.Int64 mask, EvalStackValue.ManagedPointer ptr -> failwith "TODO"
                 // andManagedPointerAddressBits state ptr mask
                 | EvalStackValue.Int64 mask, EvalStackValue.NativeInt (NativeIntSource.ManagedPointer ptr) ->
                     // andManagedPointerAddressBits state ptr mask
                     failwith "TODO"
                 | EvalStackValue.ManagedPointer ptr, EvalStackValue.Int32 mask ->
-                    int64<int32> mask |> andManagedPointerAddressBits state ptr
+                    int64<int32> mask |> andManagedPointerAddressBits state ptr, state
                 | EvalStackValue.ManagedPointer ptr, EvalStackValue.Int64 mask ->
                     // andManagedPointerAddressBits state ptr mask
                     failwith "TODO"
                 | EvalStackValue.ManagedPointer ptr, EvalStackValue.NativeInt (NativeIntSource.Verbatim mask)
                 | EvalStackValue.NativeInt (NativeIntSource.Verbatim mask), EvalStackValue.ManagedPointer ptr ->
-                    andManagedPointerAddressBits state ptr mask
+                    andManagedPointerAddressBits state ptr mask, state
                 | EvalStackValue.NativeInt (NativeIntSource.ManagedPointer ptr), EvalStackValue.Int32 mask ->
-                    int64<int32> mask |> andManagedPointerAddressBits state ptr
+                    int64<int32> mask |> andManagedPointerAddressBits state ptr, state
                 | EvalStackValue.NativeInt (NativeIntSource.ManagedPointer ptr), EvalStackValue.Int64 mask ->
                     // andManagedPointerAddressBits state ptr mask
                     failwith "TODO"
@@ -1029,18 +1059,18 @@ module NullaryIlOp =
                   EvalStackValue.NativeInt (NativeIntSource.Verbatim mask)
                 | EvalStackValue.NativeInt (NativeIntSource.Verbatim mask),
                   EvalStackValue.NativeInt (NativeIntSource.ManagedPointer ptr) ->
-                    andManagedPointerAddressBits state ptr mask
+                    andManagedPointerAddressBits state ptr mask, state
                 | EvalStackValue.NativeInt (NativeIntSource.Verbatim v1), EvalStackValue.Int32 v2 ->
-                    v1 &&& int64<int32> v2 |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt
+                    v1 &&& int64<int32> v2 |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt, state
                 | EvalStackValue.NativeInt src, EvalStackValue.Int32 mask ->
-                    andNativeIntAddressBits state src (int64<int32> mask)
+                    andNativeIntAddressBits state src (int64<int32> mask), state
                 | EvalStackValue.NativeInt (NativeIntSource.Verbatim v1),
                   EvalStackValue.NativeInt (NativeIntSource.Verbatim v2) ->
-                    v1 &&& v2 |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt
+                    v1 &&& v2 |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt, state
                 | EvalStackValue.NativeInt (NativeIntSource.Verbatim mask), EvalStackValue.NativeInt src ->
-                    andNativeIntAddressBits state src mask
+                    andNativeIntAddressBits state src mask, state
                 | EvalStackValue.NativeInt src, EvalStackValue.NativeInt (NativeIntSource.Verbatim mask) ->
-                    andNativeIntAddressBits state src mask
+                    andNativeIntAddressBits state src mask, state
                 | _, _ -> failwith $"refusing to do binary operation on {v1} and {v2}"
 
             let state =
@@ -1053,21 +1083,27 @@ module NullaryIlOp =
             let v2, state = IlMachineState.popEvalStack currentThread state
             let v1, state = IlMachineState.popEvalStack currentThread state
 
-            let result =
+            let result, state =
                 match v1, v2 with
-                | EvalStackValue.Int32 v1, EvalStackValue.Int32 v2 -> v1 ||| v2 |> EvalStackValue.Int32
+                | EvalStackValue.Int32 v1, EvalStackValue.Int32 v2 -> v1 ||| v2 |> EvalStackValue.Int32, state
                 | EvalStackValue.Int32 v1, EvalStackValue.NativeInt (NativeIntSource.Verbatim v2) ->
-                    int64<int32> v1 ||| v2 |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt
+                    int64<int32> v1 ||| v2 |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt, state
                 | EvalStackValue.Int32 _, EvalStackValue.NativeInt _ ->
                     failwith $"can't do binary operation on non-verbatim native int {v2}"
-                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.bitOr v1 v2 |> EvalStackValue.Int64
+                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 ->
+                    let r, counters = Int64Source.bitOr "Or" v1 v2 state.PointerHashCounters
+
+                    EvalStackValue.Int64 r,
+                    { state with
+                        PointerHashCounters = counters
+                    }
                 | EvalStackValue.NativeInt (NativeIntSource.Verbatim v1), EvalStackValue.Int32 v2 ->
-                    v1 ||| int64<int32> v2 |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt
+                    v1 ||| int64<int32> v2 |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt, state
                 | EvalStackValue.NativeInt _, EvalStackValue.Int32 _ ->
                     failwith $"can't do binary operation on non-verbatim native int {v1}"
                 | EvalStackValue.NativeInt (NativeIntSource.Verbatim v1),
                   EvalStackValue.NativeInt (NativeIntSource.Verbatim v2) ->
-                    v1 ||| v2 |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt
+                    v1 ||| v2 |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt, state
                 | EvalStackValue.NativeInt (NativeIntSource.Verbatim _), EvalStackValue.NativeInt _ ->
                     failwith $"can't do binary operation on non-verbatim native int {v2}"
                 | EvalStackValue.NativeInt _, EvalStackValue.NativeInt (NativeIntSource.Verbatim _) ->
@@ -1084,21 +1120,27 @@ module NullaryIlOp =
             let v2, state = IlMachineState.popEvalStack currentThread state
             let v1, state = IlMachineState.popEvalStack currentThread state
 
-            let result =
+            let result, state =
                 match v1, v2 with
-                | EvalStackValue.Int32 v1, EvalStackValue.Int32 v2 -> v1 ^^^ v2 |> EvalStackValue.Int32
+                | EvalStackValue.Int32 v1, EvalStackValue.Int32 v2 -> v1 ^^^ v2 |> EvalStackValue.Int32, state
                 | EvalStackValue.Int32 v1, EvalStackValue.NativeInt (NativeIntSource.Verbatim v2) ->
-                    int64<int32> v1 ^^^ v2 |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt
+                    int64<int32> v1 ^^^ v2 |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt, state
                 | EvalStackValue.Int32 _, EvalStackValue.NativeInt _ ->
                     failwith $"can't do binary operation on non-verbatim native int {v2}"
-                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.bitXor v1 v2 |> EvalStackValue.Int64
+                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 ->
+                    let r, counters = Int64Source.bitXor "Xor" v1 v2 state.PointerHashCounters
+
+                    EvalStackValue.Int64 r,
+                    { state with
+                        PointerHashCounters = counters
+                    }
                 | EvalStackValue.NativeInt (NativeIntSource.Verbatim v1), EvalStackValue.Int32 v2 ->
-                    v1 ^^^ int64<int32> v2 |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt
+                    v1 ^^^ int64<int32> v2 |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt, state
                 | EvalStackValue.NativeInt _, EvalStackValue.Int32 _ ->
                     failwith $"can't do binary operation on non-verbatim native int {v1}"
                 | EvalStackValue.NativeInt (NativeIntSource.Verbatim v1),
                   EvalStackValue.NativeInt (NativeIntSource.Verbatim v2) ->
-                    v1 ^^^ v2 |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt
+                    v1 ^^^ v2 |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt, state
                 | EvalStackValue.NativeInt (NativeIntSource.Verbatim _), EvalStackValue.NativeInt _ ->
                     failwith $"can't do binary operation on non-verbatim native int {v2}"
                 | EvalStackValue.NativeInt _, EvalStackValue.NativeInt (NativeIntSource.Verbatim _) ->
@@ -1599,7 +1641,7 @@ module NullaryIlOp =
             let val2, state = IlMachineState.popEvalStack currentThread state
             let val1, state = IlMachineState.popEvalStack currentThread state
 
-            let result =
+            let result, state =
                 BinaryArithmetic.execute corelib ArithmeticOperation.rem state val1 val2
 
             state
@@ -1611,7 +1653,7 @@ module NullaryIlOp =
             let val2, state = IlMachineState.popEvalStack currentThread state
             let val1, state = IlMachineState.popEvalStack currentThread state
 
-            let result =
+            let result, state =
                 BinaryArithmetic.execute corelib ArithmeticOperation.remUn state val1 val2
 
             state
@@ -1650,7 +1692,12 @@ module NullaryIlOp =
         | Conv_ovf_u -> failwith "TODO: Conv_ovf_u unimplemented"
         | Neg ->
             let val1, state = IlMachineState.popEvalStack currentThread state
-            let result = negValue val1
+            let result, counters = negValue val1 state.PointerHashCounters
+
+            let state =
+                { state with
+                    PointerHashCounters = counters
+                }
 
             state
             |> IlMachineState.pushToEvalStack' result currentThread
@@ -1660,10 +1707,16 @@ module NullaryIlOp =
         | Not ->
             let val1, state = IlMachineState.popEvalStack currentThread state
 
-            let result =
+            let result, state =
                 match val1 with
-                | EvalStackValue.Int32 i -> ~~~i |> EvalStackValue.Int32
-                | EvalStackValue.Int64 i -> Int64Source.bitNot i |> EvalStackValue.Int64
+                | EvalStackValue.Int32 i -> ~~~i |> EvalStackValue.Int32, state
+                | EvalStackValue.Int64 i ->
+                    let r, counters = Int64Source.bitNot "Not" i state.PointerHashCounters
+
+                    EvalStackValue.Int64 r,
+                    { state with
+                        PointerHashCounters = counters
+                    }
                 | EvalStackValue.ManagedPointer _
                 | EvalStackValue.NullObjectRef
                 | EvalStackValue.ObjectRef _ -> failwith "refusing to negate a pointer"

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -117,6 +117,8 @@ module NullaryIlOp =
                 failwith "Localloc: refusing to use synthetic pointer delta as a byte count"
             | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
                 failwith $"Localloc: refusing to use widened native int %O{src} as a byte count"
+            | EvalStackValue.Int64 (Int64Source.OpaqueHashBits bits) ->
+                failwith $"Localloc: refusing to use synthesised pointer-hash bits 0x%x{bits} as a byte count"
             | EvalStackValue.NativeInt (NativeIntSource.Verbatim i) -> i
             | EvalStackValue.NativeInt (NativeIntSource.SyntheticCrossArrayOffset _) ->
                 failwith "Localloc: refusing to use synthetic pointer delta as a byte count"
@@ -293,6 +295,13 @@ module NullaryIlOp =
             failwith "TODO: synthetic cross-array offset"
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
             failwith $"TODO: Conv_ovf_i4_un from widened native int %O{src}"
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits bits) ->
+            // Synthesised hash bits truncated to int32 is conv.i4, not
+            // conv.ovf.i4.un. If the hash happens to fit in int32 anyway
+            // we could allow it, but the overflow contract on this path
+            // is a real CLR semantic that hash bits don't model; fail
+            // loudly until a call site demonstrates the need.
+            failwith $"TODO: Conv_ovf_i4_un from synthesised pointer-hash bits 0x%x{bits}"
         | EvalStackValue.NativeInt (NativeIntSource.Verbatim i) -> fromUnsignedInt64 "unsigned native int" i
         | EvalStackValue.NativeInt (NativeIntSource.SyntheticCrossArrayOffset i) ->
             failwith "TODO: synthetic cross-array offset"
@@ -944,11 +953,7 @@ module NullaryIlOp =
                 // See table III.6
                 match number with
                 | EvalStackValue.Int32 i -> uint32<int> i >>> shift |> int32<uint32> |> EvalStackValue.Int32
-                | EvalStackValue.Int64 (Int64Source.Verbatim i) ->
-                    uint64<int64> i >>> shift
-                    |> int64<uint64>
-                    |> Int64Source.Verbatim
-                    |> EvalStackValue.Int64
+                | EvalStackValue.Int64 i -> Int64Source.shrUn i shift |> EvalStackValue.Int64
                 | EvalStackValue.NativeInt (NativeIntSource.Verbatim i) ->
                     (uint64<int64> i >>> shift |> int64<uint64>)
                     |> NativeIntSource.Verbatim

--- a/WoofWare.PawPrint/PointerHashSynthesis.fs
+++ b/WoofWare.PawPrint/PointerHashSynthesis.fs
@@ -1,0 +1,184 @@
+namespace WoofWare.PawPrint
+
+/// Canonical identity for a pointer that may need synthesised hash bits.
+/// `NativeIntSource` is projected onto this DU before counter assignment so
+/// that aliasing encodings (`MethodTablePtr h` and the `TypeHandlePtr` form
+/// for the same Concrete/Array shape) collapse to a single key. Verbatim
+/// numeric values and managed pointers never reach this DU — they are
+/// handled directly by `materialiseHashBits`.
+[<RequireQualifiedAccess>]
+type CanonicalPointerKey =
+    /// Concrete / OneDimArrayZero / Array shapes share their MethodTable*
+    /// with their TypeHandle, so both encodings collapse here. CoreCLR
+    /// returns the same address from either path for these shapes; the
+    /// canonical key reflects that aliasing.
+    | MethodTable of ConcreteTypeHandle
+    /// TypeDesc-shaped TypeHandles (Byref / Pointer / FunctionPointer) and
+    /// non-Closed targets (OpenGenericTypeDefinition / GenericParameter /
+    /// MethodGenericParameter) keep distinct keys.
+    | TypeHandle of RuntimeTypeHandleTarget
+    | MethodTableAuxiliaryData of RuntimeTypeHandleTarget
+    | FunctionPointer of
+        declaringTypeIdentity : ResolvedTypeIdentity *
+        declaringTypeGenerics : ConcreteTypeHandle list *
+        methodHandle : ComparableMethodDefinitionHandle *
+        methodGenerics : ConcreteTypeHandle list
+    | MethodHandle of int64
+    | FieldHandle of int64
+    | GcHandle of GcHandleAddress
+    | EventPipeProvider of int64
+    | EventPipeEvent of int64
+    | AssemblyHandle of string
+    | ModuleHandle of string
+    | MetadataImportHandle of string
+
+/// Counter-based assignment of synthesised bits to canonical pointer keys.
+/// The first time a key is materialised, it is assigned counter `n` and
+/// produces bit pattern `((n + 1) <<< 2) ||| lowBitsForKey(key)`. Subsequent
+/// materialisations of the same key return the previously-assigned bits.
+///
+/// Distinct keys get distinct bit patterns by construction (no collisions),
+/// and the assignment order is deterministic given a fixed program and
+/// scheduler. This is the load-bearing property that makes synthesised hash
+/// bits a faithful guest-observable surrogate for real pointer bits in the
+/// CoreCLR cast-cache pipeline.
+type PointerHashCounters =
+    {
+        NextCounter : uint64
+        Assigned : Map<CanonicalPointerKey, uint64>
+    }
+
+[<RequireQualifiedAccess>]
+module PointerHashCounters =
+    let empty : PointerHashCounters =
+        {
+            NextCounter = 0UL
+            Assigned = Map.empty
+        }
+
+[<RequireQualifiedAccess>]
+module PointerHashSynthesis =
+
+    /// Project a `NativeIntSource` into its canonical pointer key. The
+    /// Concrete/OneDimArrayZero/Array alias between `MethodTablePtr` and
+    /// `TypeHandlePtr (Closed _)` collapses here, so the two encodings
+    /// produce identical synthesised bits — that contract is required by
+    /// the `ceq`/`cgtUn`/`cltUn` paths in `EvalStackValueComparisons` and
+    /// by the cast-cache hash pipeline.
+    let private canonicalKey (src : NativeIntSource) : CanonicalPointerKey =
+        match src with
+        | NativeIntSource.MethodTablePtr h -> CanonicalPointerKey.MethodTable h
+        | NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed handle as target) ->
+            match handle with
+            | ConcreteTypeHandle.Concrete _
+            | ConcreteTypeHandle.OneDimArrayZero _
+            | ConcreteTypeHandle.Array _ -> CanonicalPointerKey.MethodTable handle
+            | ConcreteTypeHandle.Byref _
+            | ConcreteTypeHandle.Pointer _
+            | ConcreteTypeHandle.FunctionPointer _ -> CanonicalPointerKey.TypeHandle target
+        | NativeIntSource.TypeHandlePtr target -> CanonicalPointerKey.TypeHandle target
+        | NativeIntSource.MethodTableAuxiliaryDataPtr target -> CanonicalPointerKey.MethodTableAuxiliaryData target
+        | NativeIntSource.FunctionPointer methodInfo ->
+            CanonicalPointerKey.FunctionPointer (
+                methodInfo.DeclaringType.Identity,
+                List.ofSeq methodInfo.DeclaringType.Generics,
+                ComparableMethodDefinitionHandle.Make methodInfo.Handle,
+                List.ofSeq methodInfo.Generics
+            )
+        | NativeIntSource.MethodHandlePtr id -> CanonicalPointerKey.MethodHandle id
+        | NativeIntSource.FieldHandlePtr id -> CanonicalPointerKey.FieldHandle id
+        | NativeIntSource.GcHandlePtr handle -> CanonicalPointerKey.GcHandle handle
+        | NativeIntSource.EventPipeProviderPtr id -> CanonicalPointerKey.EventPipeProvider id
+        | NativeIntSource.EventPipeEventPtr id -> CanonicalPointerKey.EventPipeEvent id
+        | NativeIntSource.AssemblyHandle name -> CanonicalPointerKey.AssemblyHandle name
+        | NativeIntSource.ModuleHandle name -> CanonicalPointerKey.ModuleHandle name
+        | NativeIntSource.MetadataImportHandle name -> CanonicalPointerKey.MetadataImportHandle name
+        | NativeIntSource.Verbatim _
+        | NativeIntSource.ManagedPointer _
+        | NativeIntSource.SyntheticCrossArrayOffset _ ->
+            failwith
+                $"PointerHashSynthesis.canonicalKey: %O{src} is not a canonicalisable pointer shape; verbatim / managed-pointer / cross-array values must be handled before reaching this function"
+
+    /// Low-bit pattern required for a canonical key. Mirrors
+    /// `NullaryIlOp.typeHandleLowAddressBits`: MethodTable* is aligned
+    /// (low 2 bits clear); TypeDesc-shaped handles (Byref / Pointer /
+    /// FunctionPointer / generic parameters) carry bit 1 set as the
+    /// tagged-pointer marker; other handles are conventionally aligned.
+    let private lowBitsForKey (key : CanonicalPointerKey) : uint64 =
+        match key with
+        | CanonicalPointerKey.MethodTable _ -> 0UL
+        | CanonicalPointerKey.TypeHandle target ->
+            match target with
+            | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ -> 0UL
+            | RuntimeTypeHandleTarget.GenericParameter _
+            | RuntimeTypeHandleTarget.MethodGenericParameter _ -> 2UL
+            | RuntimeTypeHandleTarget.Closed handle ->
+                match handle with
+                | ConcreteTypeHandle.Byref _
+                | ConcreteTypeHandle.Pointer _
+                | ConcreteTypeHandle.FunctionPointer _ -> 2UL
+                | ConcreteTypeHandle.Concrete _
+                | ConcreteTypeHandle.OneDimArrayZero _
+                | ConcreteTypeHandle.Array _ ->
+                    failwith
+                        $"PointerHashSynthesis.lowBitsForKey: TypeHandle(Closed(%O{handle})) should have been collapsed to MethodTable by canonicalKey; this is an interpreter bug"
+        | CanonicalPointerKey.MethodTableAuxiliaryData _
+        | CanonicalPointerKey.FunctionPointer _
+        | CanonicalPointerKey.MethodHandle _
+        | CanonicalPointerKey.FieldHandle _
+        | CanonicalPointerKey.GcHandle _
+        | CanonicalPointerKey.EventPipeProvider _
+        | CanonicalPointerKey.EventPipeEvent _
+        | CanonicalPointerKey.AssemblyHandle _
+        | CanonicalPointerKey.ModuleHandle _
+        | CanonicalPointerKey.MetadataImportHandle _ -> 0UL
+
+    /// Synthesise deterministic 64-bit hash bits for a `NativeIntSource`.
+    /// This is the single named site at which synthesised bits come into
+    /// existence; every bit-mixing or arithmetic op that lifts a pointer
+    /// shape into the numeric domain routes through here.
+    ///
+    /// `reason` is woven into the diagnostic if a non-canonicalisable
+    /// source (non-null managed pointer, cross-array offset) reaches this
+    /// helper — those should have been handled by the caller before they
+    /// got here.
+    ///
+    /// Determinism: bits depend only on the canonical key and the order
+    /// in which keys are first registered. The result is stable for a
+    /// given execution trace and reproducible across runs with the same
+    /// scheduler.
+    ///
+    /// Returned as `int64` to match `Int64Source.OpaqueHashBits` storage;
+    /// the conversion from the uint64 bit pattern is an unchecked
+    /// reinterpret (bit-preserving).
+    let materialiseHashBits
+        (reason : string)
+        (src : NativeIntSource)
+        (counters : PointerHashCounters)
+        : int64 * PointerHashCounters
+        =
+        match src with
+        | NativeIntSource.Verbatim n -> n, counters
+        | NativeIntSource.ManagedPointer ManagedPointerSource.Null -> 0L, counters
+        | NativeIntSource.ManagedPointer _ ->
+            failwith
+                $"PointerHashSynthesis.materialiseHashBits (%s{reason}): refusing to synthesise bits for managed pointer %O{src} (would erase byref provenance)"
+        | NativeIntSource.SyntheticCrossArrayOffset _ ->
+            failwith
+                $"PointerHashSynthesis.materialiseHashBits (%s{reason}): refusing to synthesise bits for synthetic cross-array offset %O{src}"
+        | _ ->
+            let key = canonicalKey src
+
+            match Map.tryFind key counters.Assigned with
+            | Some bits -> Operators.int64 bits, counters
+            | None ->
+                let n = counters.NextCounter
+                let bits = ((n + 1UL) <<< 2) ||| lowBitsForKey key
+
+                let counters' =
+                    {
+                        NextCounter = n + 1UL
+                        Assigned = Map.add key bits counters.Assigned
+                    }
+
+                Operators.int64 bits, counters'

--- a/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
+++ b/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
@@ -16,6 +16,7 @@
     <Compile Include="FieldId.fs" />
     <Compile Include="ManagedPointerSource.fs" />
     <Compile Include="NativeIntSource.fs" />
+    <Compile Include="PointerHashSynthesis.fs" />
     <Compile Include="CliNumericType.fs" />
     <Compile Include="CliType.fs" />
     <Compile Include="FieldIdentity.fs" />

--- a/docs/plans/2026-05-13-castcache-synthetic-hash-bits.md
+++ b/docs/plans/2026-05-13-castcache-synthetic-hash-bits.md
@@ -1,0 +1,442 @@
+# Plan: synthesise hash bits from pointer-shaped widened int64s
+
+Date: 2026-05-13
+Author: Claude
+Status: Proposed
+Branch: `castcache-bit-twiddling-blocker`
+
+## Context
+
+`NullDereferenceTest.cs` enters
+`System.Runtime.CompilerServices.CastCache.TryGet(int[], nuint, nuint)`
+and trips on the first bit-twiddling step in `KeyToBucket`:
+
+```
+System.Exception : TODO: refusing to shl widened native int <type ID 184>
+                   (bit-twiddling on pointer bits)
+   at WoofWare.PawPrint.Int64SourceModule.shl (CliNumericType.fs:84)
+   from NullaryIlOp.fs:978 (Shl)
+```
+
+The reaching IL is `KeyToBucket`
+(`dotnet-runtime/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastCache.cs:87-101`):
+
+```csharp
+nuint hash = BitOperations.RotateLeft(source, (nuint.Size * 8) / 2) ^ target;
+return (int)((hash * 11400714819323198485ul) >> hashShift);
+```
+
+`source` and `target` originate at `CastHelpers.cs:70,216,243,265,475,507`
+as `(nuint)methodTablePtr`. In PawPrint these are
+`NativeIntSource.MethodTablePtr (ConcreteTypeHandle)` — opaque
+provenance-tracked handles, not bit patterns. After `conv.u8`
+they live on the eval stack as
+`Int64Source.WidenedNativeInt (MethodTablePtr _, signed)`.
+
+`Int64Source.shl/shr/bitAnd/bitOr/bitXor/bitNot/negate` (CliNumericType.fs
+lines 58-125) deliberately refuse to bit-twiddle `WidenedNativeInt`:
+fabricating bits would either silently lose provenance or break the
+"conv.i8 then conv.u" round-trip invariant that lets us deref a pointer
+that has been widened to int64 and back.
+
+An earlier draft (now removed) proposed treating `CastCache.TryGet`
+as if it were a runtime intrinsic and short-circuiting it to
+`MaybeCast`. That framing was misleading — `TryGet` carries no
+`[Intrinsic]` attribute, it has a real managed body, and substituting
+it at the call boundary tells a user-visible lie about which managed
+code we executed. The user chose this plan instead, which faithfully
+executes the cache's hashing while preserving the provenance discipline.
+
+## Design
+
+### The fundamental observation
+
+`KeyToBucket`'s output flows to exactly one consumer: `Element(tableData, index)`,
+where `index` is `(int)((hash * c) >> shift)` — a 32-bit array index.
+The hash never round-trips back to a pointer; it is destroyed by
+`conv.i4` and consumed as an integer index. The downstream entry
+comparison `entrySource == source` does *not* compare hash bits: it
+compares the *stored* entry (an nuint read out of the array) against
+the live `source` argument, both as pointer-shaped values. The
+provenance discipline only matters along the path that constructs
+the hash.
+
+So the design only needs to:
+
+1. Let `conv.i8`/`conv.u8` of a pointer-shaped NativeInt continue to
+   produce a `WidenedNativeInt` (unchanged — pointer round-trip stays
+   honest).
+2. When a bit-mixing operation (shl/shr/bitXor/bitAnd/bitOr/bitNot/mul)
+   fires on a `WidenedNativeInt`, transition the value to a new tagged
+   variant carrying deterministic synthesised bits. Further bit ops on
+   the tagged value compute on those bits directly.
+3. Allow `conv.i4` (and only `conv.i4`) to extract the low 32 bits of
+   the tagged variant as a plain `Int32`. The result is a deterministic
+   index with no provenance — which is fine: array indices don't need
+   provenance.
+4. **Reject** conversion of the tagged variant back into a `NativeInt`
+   (e.g. via `conv.u`/`conv.i`), or any use as a managed pointer. The
+   tag's job is to make "this came from a pointer hash, not a pointer"
+   visible at runtime.
+
+### New variant
+
+```fsharp
+// In Int64Source:
+| OpaqueHashBits of bits : int64
+```
+
+`OpaqueHashBits 0xDEADBEEF` carries deterministic bits with no
+provenance. Construction happens only via the materialisation pathway
+from `WidenedNativeInt` (see below), or transitively from another
+`OpaqueHashBits` via further bit ops.
+
+### Materialisation: `WidenedNativeInt` → `OpaqueHashBits`
+
+A new private helper in `Int64Source`:
+
+```fsharp
+let private materialiseHashBits (src : NativeIntSource) : int64 =
+    // Synthesise a deterministic 64-bit pattern from the source's
+    // identity. Must respect `typeHandleLowAddressBits`' contract:
+    //   - MethodTable*       → low 2 bits clear (alignment)
+    //   - TypeDesc-shaped    → low 2 bits = 0b10 (tag)
+    // Anything that would otherwise be a plain pointer (ManagedPointer,
+    // FunctionPointer, MethodTableAuxiliaryDataPtr, etc.) keeps low bits
+    // clear since CoreCLR aligns those too. The upper bits are derived
+    // from the source's hash to produce per-identity distinctness.
+    match src with
+    | NativeIntSource.Verbatim n -> n
+    | NativeIntSource.ManagedPointer ManagedPointerSource.Null -> 0L
+    | NativeIntSource.MethodTablePtr handle ->
+        // Hash the handle id; clear low 2 bits to honour alignment.
+        let h = int64 (hash handle) <<< 16
+        h &&& ~~~3L
+    | NativeIntSource.TypeHandlePtr target ->
+        let low = NullaryIlOp.typeHandleLowAddressBits target
+        let h = int64 (hash target) <<< 16
+        (h &&& ~~~3L) ||| low
+    | NativeIntSource.MethodTableAuxiliaryDataPtr _
+    | NativeIntSource.FunctionPointer _
+    | NativeIntSource.FieldHandlePtr _
+    | NativeIntSource.MethodHandlePtr _
+    | NativeIntSource.GcHandlePtr _
+    | NativeIntSource.EventPipeProviderPtr _
+    | NativeIntSource.EventPipeEventPtr _
+    | NativeIntSource.AssemblyHandle _
+    | NativeIntSource.ModuleHandle _
+    | NativeIntSource.MetadataImportHandle _ ->
+        let h = int64 (hash src) <<< 16
+        h &&& ~~~3L
+    | NativeIntSource.ManagedPointer _
+    | NativeIntSource.SyntheticCrossArrayOffset _ ->
+        failwith $"materialiseHashBits: provenance-preserving source %O{src} cannot be hashed"
+```
+
+Notes:
+- `typeHandleLowAddressBits` currently lives `private` in `NullaryIlOp`.
+  Promote it to a module-level helper (or duplicate the small DU match
+  here) so `CliNumericType` can call it without a layering inversion.
+  CliNumericType already references `NativeIntSource`, which is below
+  it in compilation order; the only constraint is that
+  `RuntimeTypeHandleTarget` is visible there. (Verify; if it isn't,
+  inline the few-line match here.)
+- The `<<< 16` shift is arbitrary: it ensures the synthesised bits
+  exercise both halves of the int64 so `RotateLeft` produces a
+  non-degenerate hash. Any deterministic non-trivial shape works.
+- `ManagedPointer` (non-null) and `SyntheticCrossArrayOffset` are the
+  cases where materialisation would actively destroy useful
+  provenance — those should never reach `materialiseHashBits` because
+  bit ops on `WidenedNativeInt (ManagedPointer _)` are handled by
+  `BinaryArithmetic.execute` (offset arithmetic). If one ever does
+  reach this helper, failing loudly is the right outcome.
+
+### Operation semantics
+
+Each bit op in `CliNumericType.fs` (`shl`, `shr`, `bitAnd`, `bitOr`,
+`bitXor`, `bitNot`) gains:
+
+```fsharp
+| Int64Source.WidenedNativeInt (src, _) ->
+    let bits = materialiseHashBits src
+    op bits shift |> Int64Source.OpaqueHashBits
+| Int64Source.OpaqueHashBits bits ->
+    op bits shift |> Int64Source.OpaqueHashBits
+```
+
+Mixed `WidenedNativeInt × Verbatim` (e.g. `bitXor`) materialises the
+widened side and computes against the verbatim bits — the result is
+`OpaqueHashBits`. Mixed `OpaqueHashBits × Verbatim` likewise.
+
+Multiplication of a widened value by a constant is *not* presently
+handled by `Int64Source` (it goes through `BinaryArithmetic.execute`'s
+`Int64 × Int64` path, which only handles `Verbatim × Verbatim`). Add
+a new arm in `BinaryArithmetic.execute` (around lines 738-754) that
+materialises a `WidenedNativeInt` or `OpaqueHashBits` operand into
+its bits, runs `op.Int64Int64`, and returns `OpaqueHashBits`. The
+existing `WidenedNativeInt(ManagedPointer _) × Verbatim` arm
+(line 743) stays as is — that's managed-pointer offset arithmetic
+and must not flip to OpaqueHashBits.
+
+`negate` (line 58): never fires on hash bits in `KeyToBucket`, but for
+completeness it should produce `OpaqueHashBits` for both
+`WidenedNativeInt` and `OpaqueHashBits` inputs.
+
+`add` (line 86): the existing `failwith` route for `WidenedNativeInt`
+documents that pointer arithmetic must go through `BinaryArithmetic`,
+not `Int64Source.add`. That stays. For `OpaqueHashBits + Verbatim`
+and `OpaqueHashBits + OpaqueHashBits`, add arms returning
+`OpaqueHashBits` (since these are computing on already-synthesised
+bits, not real pointer arithmetic). Note `add` here uses `Checked`
+arithmetic — switch to unchecked for the hash arms (matches what the
+real `nuint *` would do on wraparound).
+
+### Conversions
+
+In `EvalStack.fs`:
+- `convToInt8/16/32/64/UInt8/16/32` of `OpaqueHashBits`: produce the
+  appropriate narrow `Some i`. For `convToInt32` specifically, return
+  the low 32 bits as `Int32` — this is the path `KeyToBucket`'s
+  `(int)` cast follows.
+- `convToInt64`/`convToUInt64`: `OpaqueHashBits` round-trips as itself
+  (already int64).
+- `convToNativeInt` (line 244-249): **must fail** for `OpaqueHashBits`.
+  The tag says "this came from a pointer hash" — converting back to a
+  NativeInt would erase that lie. Match arm:
+  ```fsharp
+  | EvalStackValue.Int64 (Int64Source.OpaqueHashBits bits) ->
+      failwith
+        $"conv.i / conv.u of OpaqueHashBits %d{bits}: refusing to \
+          synthesise a pointer from hashed pointer bits"
+  ```
+- `convToFloat`/`convR4`/`convR8`: also fail — hashes have no
+  meaningful float interpretation. (None of CastCache exercises these,
+  so failing loudly is safest.)
+
+### Equality and ordering
+
+`EvalStackValueComparisons.fs`:
+- `cltSigned`/`cgtSigned` (lines 8, 45): `Int64Source.compareSigned`
+  already governs these. `compareSigned` should treat `OpaqueHashBits`
+  numerically (the bits are deterministic integers), so add an arm
+  `Int64Source.OpaqueHashBits a, Int64Source.OpaqueHashBits b -> compare a b`
+  and the mixed `OpaqueHashBits × Verbatim` arms. Likewise for
+  `OpaqueHashBits × WidenedNativeInt` (materialise the widened side
+  to compare).
+- `cltUn`/`cgtUn` (lines 87-88, 159-160): the current code unwraps
+  `WidenedNativeInt` and re-dispatches via `EvalStackValue.NativeInt`.
+  For `OpaqueHashBits` we can compare as plain unsigned int64, so:
+  ```fsharp
+  | EvalStackValue.Int64 (Int64Source.OpaqueHashBits a),
+    EvalStackValue.Int64 (Int64Source.OpaqueHashBits b) ->
+      uint64 a < uint64 b
+  | EvalStackValue.Int64 (Int64Source.OpaqueHashBits a),
+    EvalStackValue.Int64 (Int64Source.Verbatim b) ->
+      uint64 a < uint64 b
+  ```
+  (etc. with the Verbatim-left case).
+
+`ceq` (somewhere else; need to grep — likely `EvalStackValue.equal` or
+similar): same shape. Equal-by-bits for `OpaqueHashBits × OpaqueHashBits`
+and `OpaqueHashBits × Verbatim`.
+
+### Predicates
+
+`Int64Source.isZero`: `OpaqueHashBits bits -> bits = 0L`.
+`Int64Source.isNonnegative`: `OpaqueHashBits bits -> Some (bits >= 0L)`.
+
+### Byte-addressability (CliType.fs)
+
+`Int64Source.OpaqueHashBits` should be `Rejected` like `WidenedNativeInt`
+and `SyntheticCrossArrayOffset` — these bits are a fiction, not a real
+byte pattern. Add the arm to `int64Source` (line 73-81).
+
+### `ToBytes`
+
+`OpaqueHashBits` should fail to convert to bytes (mirroring
+`SyntheticCrossArrayOffset`'s refusal at CliNumericType.fs:179). The
+hash is computed for an in-register comparison; spilling it to memory
+makes no sense and indicates a misuse.
+
+### `ToString`
+
+`Int64Source.OpaqueHashBits bits -> $"<opaque hash bits 0x%x{bits}>"`.
+
+## Touch-point inventory
+
+Files with `Int64Source` match arms that need a new `OpaqueHashBits`
+case. Count is approximate (some matches are constructor-only):
+
+| File | Approx. match arms |
+| --- | --- |
+| `WoofWare.PawPrint/CliNumericType.fs` | ~20 (definition + every helper) |
+| `WoofWare.PawPrint/EvalStack.fs` | ~14 (all the `convTo*` helpers + `Choice2Of2`/`Choice1Of2` extractors at line 533) |
+| `WoofWare.PawPrint/EvalStackValueComparisons.fs` | ~6 (cltSigned, cgtSigned, cltUn, cgtUn, possibly ceq) |
+| `WoofWare.PawPrint/CliType.fs` | ~4 (byte-addressability + boxing/unboxing arms) |
+| `WoofWare.PawPrint/NullaryIlOp.fs` | ~6 (locallocSizeBytes, divUnValues, fromUnsignedInt64, etc.) |
+| `WoofWare.PawPrint/UnaryConstIlOp.fs` | (compareSigned + isZero only — handled centrally, likely zero additional arms) |
+| `WoofWare.PawPrint/IntrinsicHelpers.fs` | 1 (line 540-545: checked-byte-count) |
+| `WoofWare.PawPrint/BinaryArithmetic.fs` | 1 new arm + 1 expanded arm (`Int64 × Int64` multiplication) |
+| `WoofWare.PawPrint/Intrinsics.fs` | 0–2 (only if any of the existing intrinsics destructure Int64Source directly) |
+| `WoofWare.PawPrint/Native/*` | 0–4 — most natives use `Int64Source.Verbatim` constructors only, no matches |
+
+Total: ~55–60 mechanical arms across ~7 core files. The vast majority
+mirror the existing `Verbatim` arm (for ops that are numerically
+well-defined on bits) or the existing `WidenedNativeInt` arm (for ops
+that must reject — e.g. `ToBytes`, `convToNativeInt`).
+
+The compiler will catch missed arms (warnings-as-errors with
+incomplete pattern matches), so the inventory will be ground-truthed
+during implementation.
+
+## Test plan
+
+### Unit-level (focused C# in `sourcesPure/`)
+
+Add `WoofWare.PawPrint.Test/sourcesPure/CastCacheBucketing.cs` — small
+C# exercising the bit-twiddling chain end-to-end through `isinst` and
+`castclass` calls, without depending on NRE plumbing:
+
+```csharp
+interface IFoo { }
+class Foo : IFoo { }
+
+public static int Test1()
+{
+    // isinst — hits IsInstanceOfAny → CastCache.TryGet → KeyToBucket
+    object o = new Foo();
+    if (o is IFoo) return 0;
+    return 1;
+}
+
+public static int Test2()
+{
+    // castclass — hits ChkCastAny → CastCache.TryGet → KeyToBucket
+    object o = new Foo();
+    IFoo f = (IFoo)o;
+    return f is null ? 1 : 0;
+}
+
+public static int Test3()
+{
+    // isinst, negative branch
+    object o = "hello";
+    return (o is int[]) ? 1 : 0;
+}
+```
+
+This is auto-discovered. If any variant trips a downstream blocker
+in the cast slow paths, document it in `unimplemented` and trim the
+variant. Keep the test focused on what *this* PR fixes.
+
+### `NullDereferenceTest.cs`
+
+The motivating test. After this PR, expected outcomes:
+- Best case: it passes — promote out of `unimplemented`.
+- Likely case: it trips the next blocker (entry comparison, exception
+  unwinding, or somewhere in the cast slow paths). Document the new
+  blocker in the `unimplemented` comment.
+
+### Determinism check
+
+Add (or extend) a property-style test asserting that hashing the same
+`MethodTablePtr` twice produces the same `OpaqueHashBits`. This is the
+core determinism contract — the cast cache lookup must be reproducible
+across runs.
+
+The simplest expression: two consecutive `isinst` operations on the
+same `(o, T)` pair should reach `Element` with the same index. We can
+verify this indirectly by checking that the test passes deterministically
+under the existing harness (which already exercises trace-replay).
+
+### Unit-level (F# unit tests)
+
+Optional: a small NUnit test in `WoofWare.PawPrint.Test` that drives
+`Int64Source.shl/shr/bitXor` directly on a `WidenedNativeInt(MethodTablePtr h, _)`
+and asserts the resulting `OpaqueHashBits` is deterministic and is
+rejected by `convToNativeInt`. This pins the contract in code rather
+than relying on the C# integration tests to exercise every arm.
+
+## Validation
+
+1. `nix develop -c dotnet build` — clean.
+2. `nix develop -c dotnet fantomas .` — formatted.
+3. `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --filter "Name~CastCacheBucketing"` — passes.
+4. `nix develop -c dotnet test ... --filter "Name~NullDereferenceTest"` — pass or new-blocker.
+5. Full suite: `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --verbosity normal` — no regressions in the 689+ tests.
+6. Commit on branch `castcache-bit-twiddling-blocker`. Push.
+7. `codex review --base main`. Address findings.
+
+## Risks
+
+- **Touch-point miss.** The compiler catches missed match arms, so the
+  risk is bounded to "build fails" rather than "wrong behaviour at
+  runtime". Low.
+- **`materialiseHashBits` determinism.** Uses `hash` (i.e.
+  `Object.GetHashCode`) on the inner identity. `ConcreteTypeHandle` and
+  the various handle DUs are structural records with structural hash;
+  this is deterministic per-process. Across processes it would still
+  be deterministic given identical assembly loads — which is precisely
+  what PawPrint's determinism contract gives us. If we ever introduce
+  identity types with reference-equality hashes, materialisation would
+  silently differ between runs; flag this in the helper's doc comment.
+- **`typeHandleLowAddressBits` cross-module access.** It's currently
+  `private` in `NullaryIlOp`. Promoting it to a module-level helper
+  (or inlining the few-line match into `materialiseHashBits`) is a
+  small cleanup; no architectural risk.
+- **Downstream blocker resurfaces.** After hashing works, the next
+  step in `TryGet` is reading `pEntry._source` from the sentinel int[]
+  and comparing it (as nuint) against the live pointer-shaped input.
+  PawPrint may not currently support reading an nuint out of an int[]
+  reinterpreted as `CastCacheEntry`. If so, that's the next plan, and
+  it's exactly the kind of incremental progress AGENTS.md prescribes.
+- **Performance.** `materialiseHashBits` runs once per cast (when the
+  cache misses, which is every cast in PawPrint since we never write
+  back). The hash is `O(handle structure)`; on a single-threaded
+  interpreter this is invisible.
+
+## Non-goals
+
+- **Modelling cast-cache writes.** PawPrint runs no native JIT
+  helpers, so the cache is intrinsically empty. Adding host-side
+  memoisation would speed up casts but is orthogonal to correctness
+  and adds hidden state that's tricky to reason about under
+  deterministic replay.
+- **General-purpose pointer-bit arithmetic outside CastCache.** This
+  PR's design is targeted: bit ops on pointer-shaped widened ints
+  produce hash bits, not real pointer bits. Code paths that *do* need
+  real pointer-bit arithmetic (low-bit tagging schemes, alignment
+  checks) should continue to use the existing `andManagedPointerAddressBits`
+  / `typeHandleLowAddressBits` machinery in `NullaryIlOp`, which
+  preserves provenance. If a future code path mixes "tag check" and
+  "general hash", revisit then.
+- **Removing `internCastCacheSentinelTable`.** The sentinel is kept
+  so any caller that does `ldsfld CastHelpers::s_table` observes a
+  non-null array. Removing it is a follow-up cleanup PR.
+- **Round-tripping `OpaqueHashBits` back to a pointer.** Explicitly
+  refused. The tag's load-bearing job is to reject this.
+
+## Why this design over the alternatives
+
+- **vs. call-boundary substitution of `TryGet` → `MaybeCast`:** the
+  previous draft would have skipped `KeyToBucket` entirely. That's
+  correct in the contract sense — `MaybeCast` means "consult the slow
+  path" and managed code never writes to the cache — but it misleads
+  about what code ran. A guest crash in a frame above `TryGet` would
+  show a stack trace that elides the cache-lookup hop. Faithfully
+  executing the bit-twiddling preserves the trace and validates more
+  of the managed BCL under interpretation. The user chose this design
+  on those grounds.
+- **vs. materialising into `Verbatim` directly:** plain `Verbatim`
+  bits could be converted back to a `NativeInt` (via `conv.u`) and
+  then potentially dereferenced through `executeLdind` if a future
+  code path tried. The tag explicitly closes that leak. The cost is
+  ~60 mechanical match arms; the benefit is that "this int came from
+  hashing a pointer" is a runtime-checked claim instead of an
+  unenforced convention.
+- **vs. promoting the cast helpers to intrinsics:** broader than
+  necessary. The cast slow paths (`*_NoCacheLookup`) contain real
+  cast-decision logic — variance, interface dispatch, type-equivalence
+  fallbacks — that we want to run faithfully through the interpreter.
+  The cache is the only artificial bit underneath them; this PR
+  targets exactly the cache.

--- a/docs/plans/2026-05-14-pointer-hash-counter-strategy.md
+++ b/docs/plans/2026-05-14-pointer-hash-counter-strategy.md
@@ -1,0 +1,448 @@
+# Plan: counter-based pointer-bit synthesis (supersedes FNV-1a-of-ToString)
+
+Date: 2026-05-14
+Status: Proposed
+Branch: `castcache-synthetic-hash-bits` (extends current branch in place)
+Supersedes the synthesis strategy in `docs/plans/2026-05-13-castcache-synthetic-hash-bits.md`.
+
+## Context
+
+The current branch (commits `b241a5e` … `d02dbe6`) introduces
+`Int64Source.OpaqueHashBits` — a tagged variant carrying synthesised
+bits derived from a pointer's identity, produced whenever a bit-mixing
+or arithmetic operation fires on a `WidenedNativeInt`. The tag's
+load-bearing job is to refuse round-trip back to a pointer, so a
+synthesised hash cannot be reinterpreted as managed-pointer provenance.
+
+The synthesis itself, as currently implemented, is FNV-1a over a
+canonical string projection of the source (`canonicalHashKey` →
+`fnv1aHash` in `CliNumericType.fs`). This has three issues that surfaced
+during review:
+
+1. **Determinism by detour.** `NativeIntSource.GetHashCode` goes through
+   `System.HashCode.Combine`, which folds in a per-process randomised
+   seed. The current branch routes around this by hashing
+   `ToString`'d output instead. The determinism contract therefore
+   depends on `ToString` being structurally stable for every member of
+   every handle DU forever, with no compiler-enforced guarantee.
+
+2. **Hash-function accretion.** Commit `d02dbe6` teaches
+   `canonicalHashKey` that `MethodTablePtr h` and
+   `TypeHandlePtr (Closed h)` for Concrete/OneDimArrayZero/Array shapes
+   are aliases for the same CoreCLR `MethodTable*`. This is correct
+   behaviour, but it lives inside the hashing function as a string-key
+   special case. The next aliasing rule we discover will land there
+   too, gradually rebuilding a partial type-identity system inside a
+   hash function.
+
+3. **Collisions are possible in principle.** FNV-1a is a 64-bit hash;
+   the birthday bound is ~2^32 distinct pointers before a collision is
+   likely. PawPrint will not approach this in practice, but a collision
+   between two distinct pointers would silently make them compare equal
+   under `ceq` against their bit pattern — an undetectable correctness
+   bug for as long as it lasted.
+
+The cast-cache motivating use case (`KeyToBucket` in
+`CastCache.cs`) requires synthesis only at one demand site: the
+`int32` array index that consumes the hash. Everything before that
+demand site is decidable algebraically (shape low-bit checks,
+identity equality of pointers, alignment masks) provided the
+synthesis honours its low-bit contract and assigns distinct bits to
+distinct pointers.
+
+An AST-based alternative was explored in a now-deleted spike. The
+conclusion was that the AST's only unique contribution over a
+suitable eager scheme is a forcing function for *undecidable*
+comparisons (e.g. sorting pointers by value), and no known code path
+in PawPrint asks such questions. The bookkeeping cost of the AST
+exceeded its practical benefit.
+
+## Design
+
+### Counter-based synthesis
+
+Replace FNV-1a with a counter-assignment scheme. The interpreter
+maintains a map from canonical pointer keys to assigned bit patterns.
+The first time a pointer of canonical key `k` is presented for
+materialisation, it is assigned the next counter value, shifted left
+by 2 and OR'd with the shape's required low-bit pattern (so
+alignment / TypeDesc-tag checks continue to work). Subsequent
+materialisations of the same `k` return the previously-assigned bits.
+
+```fsharp
+type PointerHashCounters =
+    {
+        NextCounter : uint64
+        Assigned : Map<CanonicalPointerKey, uint64>
+    }
+```
+
+Properties:
+
+- **No collisions.** Distinct keys get distinct bits by construction.
+- **Determinism is structural.** Counter assignments depend only on
+  the order in which the interpreter first materialises each canonical
+  key. Given a fixed program and a fixed scheduler, that order is
+  deterministic.
+- **Canonicalisation moves to where it belongs.** `CanonicalPointerKey`
+  is a structured DU whose equality is F#'s structural equality. The
+  `MethodTablePtr` / `TypeHandlePtr` alias is a constructor choice in
+  the canonical-key projection, not a string-transform special case.
+  Adding future aliases means adding new arms to the projection — a
+  single function, type-checked.
+
+### Canonical pointer key
+
+```fsharp
+[<RequireQualifiedAccess>]
+type CanonicalPointerKey =
+    /// Concrete / OneDimArrayZero / Array shapes share their MethodTable*
+    /// with their TypeHandle, so both encodings collapse here.
+    | MethodTable of ConcreteTypeHandle
+    /// TypeDesc-shaped (Byref / Pointer / FunctionPointer) and
+    /// open-generic / generic-parameter targets keep distinct keys.
+    | TypeHandle of RuntimeTypeHandleTarget
+    | FunctionPointer of /* whatever NativeIntSource.FunctionPointer carries */
+    | FieldHandle of /* ... */
+    | MethodHandle of /* ... */
+    | MethodTableAuxiliaryData of /* ... */
+    | GcHandle of /* ... */
+    | EventPipeProvider of /* ... */
+    | EventPipeEvent of /* ... */
+    | AssemblyHandle of /* ... */
+    | ModuleHandle of /* ... */
+    | MetadataImportHandle of /* ... */
+    /// Verbatim values don't reach the canonicalisation path
+    /// (`materialiseHashBits` returns the numeric value directly).
+    /// Null managed pointer becomes Verbatim 0L before this point.
+
+let canonicalKey (src : NativeIntSource) : CanonicalPointerKey = ...
+```
+
+The projection lifts each `NativeIntSource` constructor to its
+canonical key. The Concrete/Array `MethodTablePtr` ↔ `TypeHandlePtr`
+alias collapses at construction. Other shapes pass through
+identity-preserving.
+
+### Low-bit contract
+
+The existing `typeHandleLowAddressBitsForHash` stays, repurposed
+slightly:
+
+```fsharp
+let private lowBitsForKey (key : CanonicalPointerKey) : uint64 =
+    match key with
+    | CanonicalPointerKey.MethodTable _ -> 0UL                // MethodTable aligned
+    | CanonicalPointerKey.TypeHandle (RuntimeTypeHandleTarget.OpenGenericTypeDefinition _)
+    | CanonicalPointerKey.TypeHandle (RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete _))
+    | CanonicalPointerKey.TypeHandle (RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.OneDimArrayZero _))
+    | CanonicalPointerKey.TypeHandle (RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Array _)) -> 0UL
+    | CanonicalPointerKey.TypeHandle _ -> 2UL                 // TypeDesc-shaped
+    | _ -> 0UL                                                // other handles aligned by convention
+```
+
+Counter bits occupy bits 2..63; shape bits occupy bits 0..1.
+
+### Materialisation helper
+
+```fsharp
+/// The single named site at which synthesised bits come into existence.
+/// Every bit op that lifts a `WidenedNativeInt` calls this with a `reason`
+/// string identifying the demand site; the reason flows into any
+/// diagnostic emitted from here.
+let materialiseHashBits
+    (reason : string)
+    (src : NativeIntSource)
+    (counters : PointerHashCounters)
+    : uint64 * PointerHashCounters
+    =
+    match src with
+    | NativeIntSource.Verbatim n -> uint64 n, counters
+    | NativeIntSource.ManagedPointer ManagedPointerSource.Null -> 0UL, counters
+    | NativeIntSource.ManagedPointer _ ->
+        failwith $"materialiseHashBits %s{reason}: refusing to synthesise bits for managed pointer %O{src} (would erase byref provenance)"
+    | NativeIntSource.SyntheticCrossArrayOffset _ ->
+        failwith $"materialiseHashBits %s{reason}: refusing to synthesise bits for cross-array offset %O{src}"
+    | _ ->
+        let key = canonicalKey src
+        match Map.tryFind key counters.Assigned with
+        | Some bits -> bits, counters
+        | None ->
+            let n = counters.NextCounter
+            let bits = ((n + 1UL) <<< 2) ||| lowBitsForKey key
+            let counters' =
+                { NextCounter = n + 1UL ; Assigned = Map.add key bits counters.Assigned }
+            bits, counters'
+```
+
+`reason` is a `string` because the cost of constructing it is small
+relative to the cost of a bit-mixing op, and the diagnostic value when
+something goes wrong is high.
+
+### State threading
+
+`PointerHashCounters` becomes a field of `IlMachineState`. Bit ops in
+`CliNumericType.fs` that previously called `materialiseHashBits`
+synchronously must now thread state. The current branch's
+`Int64Source.bitXor` (etc.) signature changes from pure to
+state-passing:
+
+```fsharp
+// Before:
+val bitXor : Int64Source -> Int64Source -> Int64Source
+
+// After:
+val bitXor
+    : reason : string
+    -> Int64Source
+    -> Int64Source
+    -> PointerHashCounters
+    -> Int64Source * PointerHashCounters
+```
+
+This propagates to callers — primarily `BinaryArithmetic.execute`,
+which already threads `IlMachineState`. The state-threading cost is
+the main implementation tax of this design and is unavoidable: any
+synthesis scheme that gives stable bits per pointer needs *some* state
+(either explicit, as here, or process-global mutable, which we won't
+use because it breaks deterministic replay).
+
+### What stays from the current branch
+
+- `Int64Source.OpaqueHashBits of int64`. The carrier and tag stay.
+- The bit-pattern equality / unsigned-comparison rules in
+  `EvalStackValueComparisons.fs` (`ceq`, `cgtUn`, `cltUn`) stay.
+- The refusals: `conv.u` / `conv.i` / `conv.r4` / `conv.r8` /
+  `ToBytes` / `convToNativeInt` of `OpaqueHashBits` keep failing
+  loudly.
+- The narrow-conversion permissions: `conv.i1` / `conv.i2` / `conv.i4`
+  / `conv.u1` / `conv.u2` / `conv.u4` of `OpaqueHashBits` keep
+  returning a plain integer.
+- The `WidenedNativeInt × Verbatim` and `× OpaqueHashBits` arms in
+  `BinaryArithmetic.execute` stay structurally; they change only to
+  thread the state through the materialiser.
+- The `WidenedNativeInt × WidenedNativeInt` ceq arm in
+  `EvalStackValueComparisons.fs` (route through NativeInt arms for
+  identity-equality of pointers) stays.
+
+### What changes
+
+- Delete `Int64Source.canonicalHashKey` (the string-projection).
+- Delete `Int64Source.fnv1aHash`.
+- Delete `Int64Source.typeHandleLowAddressBitsForHash` if `lowBitsForKey`
+  fully replaces it; otherwise keep with renamed signature.
+- `materialiseHashBits` moves from `Int64Source` module to a small new
+  module (proposed: `PointerHashSynthesis.fs`, placed alongside
+  `CliNumericType.fs`) so it can be called from both `CliNumericType`
+  and `BinaryArithmetic` without circular dependency. The module
+  exports the `CanonicalPointerKey` DU and the `PointerHashCounters`
+  record.
+- `IlMachineState` gains a `PointerHashCounters` field; the
+  constructor initialises it to
+  `{ NextCounter = 0UL ; Assigned = Map.empty }`.
+- Bit-op functions in `CliNumericType.Int64Source` (`shl`, `shr`,
+  `shrUn`, `bitAnd`, `bitOr`, `bitXor`, `bitNot`, `negate`) gain a
+  `reason : string` parameter and return
+  `Int64Source * PointerHashCounters`, threading state.
+- `BinaryArithmetic.execute`'s arms for
+  `WidenedNativeInt × Verbatim`, `WidenedNativeInt × OpaqueHashBits`,
+  `WidenedNativeInt × WidenedNativeInt` switch from inline
+  `Int64Source.materialiseHashBits` calls to the new helper, threading
+  state via the `IlMachineState` it already receives.
+- The `NullDereferenceTest.cs` blocker note is updated: the next
+  blocker is the `conv.u` of an `OpaqueHashBits` value (the
+  `(nuint)RotateLeft((ulong)source, _)` step). Address in a follow-up
+  by adding a parallel `NativeIntSource.SynthesisedBits` variant whose
+  rules mirror `OpaqueHashBits` for round-trip refusal, deref
+  refusal, and indexing permission. Or, decide to intercept
+  `CastCache.TryGet` at the boundary instead; this plan stays
+  agnostic.
+
+## Forward path: synthesis is a strategy
+
+The choice of counter assignment is one valid strategy out of
+several. PawPrint's design direction (per `memory/threading_model.md`)
+already treats nondeterminism as something the user fuzzes over:
+thread schedules vary, and tests are expected to be invariant under
+that variation, with sensitivity discovered by fuzzing. Pointer-bit
+synthesis is the same shape of problem. The real CLR's bit patterns
+depend on OS allocator behaviour, ASLR, and GC compaction history;
+managed code that observes those bits in any way is non-portable by
+construction. The runtime's job is to let users discover such
+sensitivity, not to hide it.
+
+In a future PR, the materialisation helper will gain a strategy
+parameter. The shape we anticipate:
+
+```fsharp
+[<RequireQualifiedAccess>]
+type PointerHashStrategy =
+    /// Deterministic counter assignment in canonical-key registration order.
+    /// The default; recommended for most testing.
+    | Counter
+
+    /// Stateless structural hash. Useful when reproducibility across runs
+    /// without snapshotting counter state is wanted (e.g. comparing two
+    /// runs that legitimately register pointers in different orders).
+    | StatelessHash
+
+    /// Pseudo-random bits seeded from a user-supplied seed. The fuzzing
+    /// mode: rerun the same test with many seeds; results that vary by
+    /// seed depend on pointer magnitudes and are flagged.
+    | Random of seed : uint64
+```
+
+The strategy lives in `IlMachineState` alongside the scheduler
+configuration. This PR does not introduce the strategy DU — only the
+counter scheme — because doing both at once is speculative generality;
+adding the DU is a mechanical change against a single helper boundary
+once a second strategy is actually wanted.
+
+The framing matters for *this* PR because it informs how
+`materialiseHashBits` is shaped: it takes state, returns updated
+state, and is the single audited site at which bits come into
+existence. That seam is what makes adding strategies later cheap.
+
+## Touch-point inventory
+
+| File | Change |
+| --- | --- |
+| New: `WoofWare.PawPrint/PointerHashSynthesis.fs` | `CanonicalPointerKey` DU, `canonicalKey`, `lowBitsForKey`, `PointerHashCounters`, `materialiseHashBits` |
+| `WoofWare.PawPrint/CliNumericType.fs` | Delete `canonicalHashKey`, `fnv1aHash`, inline `materialiseHashBits`; `Int64Source` bit ops thread state and gain `reason` parameter |
+| `WoofWare.PawPrint/BinaryArithmetic.fs` | Existing `WidenedNativeInt × *` arms swap inline materialisation for state-threading calls into the new helper |
+| `WoofWare.PawPrint/IlMachineState.fs` | New `PointerHashCounters` field; initialiser |
+| `WoofWare.PawPrint.fsproj` | Add `PointerHashSynthesis.fs` before `CliNumericType.fs` |
+| `WoofWare.PawPrint.Test/sourcesPure/` | Add a determinism-of-counter test (see below) |
+
+Estimated diff size: smaller than the current branch's, because the
+state-threading mechanically updates ~10 op signatures but most ops
+keep their internal structure.
+
+## Test plan
+
+The existing tests (`Int64HashBitMix.cs`, `Int64HashMulFirst.cs`) keep
+passing; their assertions about behaviour-under-bit-twiddling are
+strategy-agnostic.
+
+New tests:
+
+1. **Counter determinism within a run.** A C# test that bit-twiddles
+   two pointers `A` and `B` and asserts:
+   - `(ulong)A ^ (ulong)A == 0` (same pointer → same bits)
+   - `(ulong)A ^ (ulong)B != 0` (distinct pointers → distinct bits)
+   - `(ulong)A == (ulong)A` (compared as nuint, after a round trip)
+   - `(ulong)A & 3` produces the expected shape low bits
+
+2. **Order-stable counter assignment.** F# unit test in
+   `WoofWare.PawPrint.Test` that constructs two
+   `IlMachineState`-equivalent fixtures, materialises three pointers
+   in the same order, and asserts the assigned bits match. This pins
+   the determinism contract in code without depending on the harness's
+   replay machinery.
+
+3. **Alias unification.** F# unit test that constructs
+   `MethodTablePtr h` and `TypeHandlePtr (Closed (ConcreteTypeHandle.Concrete _))`
+   referring to the same underlying type, materialises both, and
+   asserts the bits are identical. This is the `d02dbe6` contract,
+   relocated.
+
+4. **No collisions across plausible distinct types.** Materialise
+   N pointers (N small, e.g. 100, drawn from
+   `TestPureCases.sourcesPure` types) and assert all assigned bits
+   are distinct. The current FNV-1a scheme could not assert this
+   absolutely; the counter scheme can.
+
+## Validation
+
+1. `nix develop -c dotnet build` — clean.
+2. `nix develop -c dotnet fantomas .` — formatted.
+3. `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --filter "Name~HashBitMix"` — passes.
+4. `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --filter "Name~PointerHashCounter"` — passes.
+5. Full suite: `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --verbosity normal` — no regressions.
+6. Commit as a new commit on `castcache-synthetic-hash-bits` (this
+   branch is still pre-merge to `main`, so we extend it rather than
+   branch off).
+7. `codex review --base main`. Address findings.
+
+## Risks
+
+- **State threading.** `Int64Source` bit ops becoming
+  state-passing is the biggest mechanical change. The compiler
+  catches every miss (type-changed signatures), so the risk is
+  bounded to build failures rather than runtime bugs. Estimated
+  ~12 op signatures change, with maybe ~30 call sites that need
+  threading.
+- **`reason` strings.** Adding a `reason` parameter to every op is
+  forgettable noise that could decay into `""`. Mitigation: enforce
+  by convention initially; if it decays in practice, promote to a
+  typed enum of demand sites.
+- **`canonicalKey` arm coverage.** Adding a new
+  `NativeIntSource` constructor in the future without a matching
+  `canonicalKey` arm would make the match incomplete. Warnings as
+  errors catches this at compile time.
+
+## Non-goals
+
+- **The strategy DU.** Not in this PR (see "Forward path"). The
+  helper's signature stays state-passing so adding strategies later
+  is a mechanical change.
+- **`NativeIntSource.SynthesisedBits`** (the parallel variant the
+  current branch's `unimplemented` note anticipates) — separate
+  follow-up, choice between that and intercepting `CastCache.TryGet`
+  is open.
+- **Removing `internCastCacheSentinelTable`.** As before, follow-up
+  cleanup.
+
+## Why this design over the alternatives
+
+### vs. status quo (FNV-1a-of-ToString)
+
+- Eliminates `ToString` determinism dependency (which is currently
+  unverifiable by the compiler).
+- Eliminates the (small) collision possibility.
+- Moves canonical-key handling from a string-projection inside a
+  hash function to a structured-data function inside the
+  materialiser. Future aliasing rules land in one DU constructor,
+  with compile-time guarantees of coverage.
+- Costs: state threading through ~12 op signatures.
+
+### vs. AST symbolic representation
+
+- The AST's unique contribution over counter+eager is a forcing
+  function for undecidable comparisons (e.g. sorting pointers by
+  value). No known PawPrint code path asks such questions; the
+  forcing function would be dormant.
+- The AST's algebraic simplification (`x ^ x = 0`,
+  `(p & 3) == shape`) is duplicated for free under counter
+  assignment, because counter-assigned bits respect both
+  same-pointer-same-bits and the shape low-bit contract.
+- The AST's inspectability advantage is marginal: an 11-node
+  `Mul(Xor(Or(...)))` tree is not meaningfully more readable than
+  a 64-bit integer plus an `Assigned` map showing which pointer is
+  which counter. The map is the inspectable form.
+- The AST's implementation cost (new module, simplifier,
+  width-threaded carrier across all integer sources) is large for
+  the marginal benefit. Counter assignment costs ~1 small module
+  and the existing state threading.
+
+### vs. intercepting `CastCache.TryGet` higher up
+
+- Intercepting bypasses the bit-twiddling entirely, sidestepping
+  this whole question for the cast cache. Trace fidelity loss
+  is one method boundary.
+- But the bit-twiddling primitives are useful beyond the cast
+  cache (anywhere the BCL does pointer-bit alignment or
+  tagging). Building them on counter synthesis benefits all such
+  paths, including ones we haven't found yet.
+- An interception can still be added on top of this plan if the
+  cast-cache trace fidelity ends up not being worth it. The two
+  are not exclusive.
+
+## Why this PR sequencing
+
+The current branch is pre-merge and the FNV-1a synthesis is the
+substantive concern in review. Replacing the synthesis with counters
+is in-scope as a course correction within the same branch — small
+enough not to warrant a separate branch, large enough that it should
+land as a discrete commit on top of the existing four, with a clear
+message naming the change and the reasoning above.


### PR DESCRIPTION
## Summary

- Adds `Int64Source.OpaqueHashBits`: when a bit-mixing op (`shl` / `shr` / `shrUn` / `bitAnd` / `bitOr` / `bitXor` / `bitNot` / `negate`) or an arithmetic op fires on an `Int64Source.WidenedNativeInt` whose source is a pointer shape (`MethodTablePtr`, `TypeHandlePtr`, …), the interpreter synthesises deterministic hash bits and tags the result. Once tagged, further ops compute on the bits directly and the value can be narrowed via `conv.i4` (the cast-cache array-index path) but cannot round-trip back to a `NativeInt` — that would forge pointer provenance.
- Hash bits derive from FNV-1a over a canonical key, so they are process-stable (no `HashCode.Combine` randomised seed) and alias-preserving: `MethodTablePtr h` and `TypeHandlePtr (Closed h)` for Concrete / OneDimArrayZero / Array shapes produce identical bits, matching the existing `ceq` alias rule.
- Hash bits honour the low-bit contract used elsewhere in the interpreter: MethodTable* → low 2 bits clear; TypeDesc-shaped (Byref / Pointer / FunctionPointer) → low 2 bits `0b10`.
- `BinaryArithmetic.execute` covers the full Int64 arithmetic surface for the new shape: `Verbatim × OpaqueHashBits`, `OpaqueHashBits × Verbatim`, `OpaqueHashBits × OpaqueHashBits`, and arithmetic-first widened-pointer cases (e.g. `(ulong)handle * golden_ratio`) all materialise and tag as `OpaqueHashBits`. Managed-pointer arms still match first, so byref offset arithmetic is unaffected.
- `EvalStackValueComparisons.ceq` / `cgtUn` / `cltUn` compare on the int64 bit pattern when either side is `OpaqueHashBits`. `ceq` also routes `WidenedNativeInt × WidenedNativeInt` through the `NativeInt` arms (so pointer-identity comparisons work) and treats mixed-shape `WidenedNativeInt` vs `Verbatim` / `OpaqueHashBits` / `SyntheticCrossArrayOffset` as `false` (matching prior structural-DU behaviour).
- Plan: `docs/plans/2026-05-13-castcache-synthetic-hash-bits.md`.

## Test plan

- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 702 passing
- [x] `Int64HashBitMix.cs`: end-to-end widened-nuint → shl/shr/xor/or/and → `conv.i4`
- [x] `Int64HashMulFirst.cs`: arithmetic-first widened-pointer mixing (`(ulong)handle * 11400714819323198485UL`)
- [x] `codex review --base main` returns no actionable findings
- [ ] `NullDereferenceTest.cs` remains blocked on a parallel `NativeIntSource.OpaqueHashBits` round-trip (`BitOperations.RotateLeft(nuint, int)` narrows the ulong result back to nuint via `conv.u`) — follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)