### PR TITLE
Promote IntPtrZero/UIntPtrZero out of unimplemented

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -44,8 +44,6 @@ module TestPureCases =
             "InitializeArrayBoxedFieldHandle.cs" // past String::FastAllocateString(MethodTable*, nint); now blocked by unimplemented MethodTable field projection for ParentMethodTable
             "ArraySortHelperDefaultInt.cs" // past Environment_FailFast QCall (now wired up); now blocked downstream by ResourceManager hitting infinite recursion looking up 'Arg_NullReferenceException' in System.Private.CoreLib, which the BCL escalates to Environment.FailFast
             "GenericEdgeCases.cs" // past Unsafe.CopyBlockUnaligned JIT intrinsic; now blocked downstream by ResourceManager hitting infinite recursion looking up 'Arg_NullReferenceException' in System.Private.CoreLib, which the BCL escalates to Environment.FailFast (same blocker as ArraySortHelperDefaultInt.cs)
-            "IntPtrZero.cs" // `IntPtr.Zero` is `[Intrinsic]` with no IL initialiser; the JIT recognises `CORINFO_FIELD_INTRINSIC_ZERO` but the interpreter reads the static slot, where `cliTypeZeroOf` populates `NativeIntSource.ManagedPointer Null`. The C# inequality `zero != default(IntPtr)` lowers to `cgt.un(zero, (nint)0)`, and `EvalStackValueComparisons.cgtUn` has no case relating `ManagedPointer Null` to `Verbatim 0L` (it only handles ManagedPointer-vs-ManagedPointer)
-            "UIntPtrZero.cs" // same blocker as IntPtrZero.cs: `cliTypeZeroOf` for `UIntPtr` is `NativeIntSource.ManagedPointer Null`, and `cgt.un(ManagedPointer Null, Verbatim 0L)` is unimplemented
         ]
         |> Set.ofList
 


### PR DESCRIPTION
## Summary
- Both `IntPtrZero.cs` and `UIntPtrZero.cs` were listed as unimplemented because `cgt.un(ManagedPointer Null, Verbatim 0L)` was unsupported.
- That blocker was resolved by #502 (`Relate ManagedPointer Null to Verbatim 0L in cgt.un/clt.un`); the unimplemented entries were stale.
- Removing them moves both tests onto the standard pure-case run.

## Test plan
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --filter "Name~IntPtrZero"` — both `IntPtrZero.cs` and `UIntPtrZero.cs` pass under `Standard tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)