### PR TITLE
Promote MarshalSizeOfDateTime out of unimplemented

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -18,7 +18,6 @@ module TestPureCases =
     let unimplemented =
         [
             "AdvancedStructLayout.cs" // blocked after fixed-buffer pointer arithmetic by MarshalNative_SizeOfHelper for ByValTStr string marshalling
-            "MarshalSizeOfDateTime.cs" // a `System.DateTime` field inside a sequential struct trips the marshal walk's AutoLayout rejection (DateTime metadata is LayoutKind.Auto), but CoreCLR's `MarshalInfo` special-cases it as `MARSHAL_TYPE_DATE` (8 bytes). Needs DateTime recognised as a host-known primitive-like wrapper before the walk recurses into it.
             "LdtokenField.cs" // past InternalCall System.Buffer::BulkMoveWithWriteBarrierInternal; now blocked during reflection-cache update because Buffer's byte-wise copy refuses to byte-view object-reference array cells (`validateByteAddressableCell` rejects ObjectRef storage)
             "RuntimeFieldHandleGetUtf8Name.cs" // exercises RuntimeFieldHandle::GetUtf8NameInternal, RuntimeTypeHandle::GetInterfaces, and Volatile.Write of object refs successfully; now blocked at the next step in the reflection-cache copy by `validateByteAddressableCell` refusing to byte-view object-reference cells inside Buffer::BulkMoveWithWriteBarrierInternal
             "RuntimeTypeGetInterfacesInherited.cs" // exercises the QCall's inherited-base + transitive-interface walk; now blocked during the reflection-cache update by `validateByteAddressableCell` refusing to byte-view object-reference cells inside Buffer::BulkMoveWithWriteBarrierInternal


### PR DESCRIPTION
## Summary
- The DateTime/AutoLayout blocker described in the `unimplemented` comment was resolved by the marshalling work that landed in #478, #480, #484, and #499 (primitive-like wrapper flattening + FieldMarshalDescriptor plumbing).
- The entry was simply stale; the test passes as a standard pure case once removed.

## Test plan
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --filter "Name~MarshalSizeOfDateTime"` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)