### PR TITLE
Add SerString decoder for CustomAttrib blobs

### DIFF
--- a/WoofWare.PawPrint.Domain/CustomAttribute.fs
+++ b/WoofWare.PawPrint.Domain/CustomAttribute.fs
@@ -57,3 +57,76 @@ module CustomAttribute =
             Constructor = ctor
             Value = value
         }
+
+    /// <summary>
+    /// Decode the leading <c>SerString</c> from a <c>CustomAttrib</c> blob
+    /// (ECMA-335 II.23.3). The blob must start with the two-byte prolog
+    /// <c>0x0001</c> followed by a <c>SerString</c> as the first fixed argument.
+    /// </summary>
+    /// <returns>
+    /// <c>Ok None</c> if the leading <c>SerString</c> is the null sentinel
+    /// (<c>0xFF</c>); <c>Ok (Some s)</c> for an empty or non-empty UTF-8 string;
+    /// <c>Error msg</c> if the blob is malformed for this purpose.
+    /// </returns>
+    /// <remarks>
+    /// Trailing bytes (subsequent fixed args, the <c>NumNamed</c> count, and any
+    /// named args) are ignored. Mirrors CoreCLR's
+    /// <c>CustomAttributeParser::GetString</c> in <c>caparser.h</c>.
+    /// </remarks>
+    let tryReadLeadingSerString (blob : ImmutableArray<byte>) : Result<string option, string> =
+        let len = blob.Length
+
+        if len < 2 then
+            Error "CustomAttrib blob is shorter than the 2-byte prolog"
+        else
+            let prolog = uint16 blob.[0] ||| (uint16 blob.[1] <<< 8)
+
+            if prolog <> 0x0001us then
+                Error (sprintf "CustomAttrib blob has unexpected prolog 0x%04X (expected 0x0001)" prolog)
+            elif len = 2 then
+                Error "CustomAttrib blob ends after the prolog; expected a SerString"
+            else
+                let first = blob.[2]
+
+                if first = 0xFFuy then
+                    Ok None
+                else
+                    // PackedLen per ECMA-335 II.23.2.
+                    let lengthResult : Result<int * int, string> =
+                        if first &&& 0x80uy = 0uy then
+                            Ok (int first, 3)
+                        elif first &&& 0xC0uy = 0x80uy then
+                            if len < 4 then
+                                Error "CustomAttrib blob: truncated 2-byte PackedLen"
+                            else
+                                let length = ((int first &&& 0x3F) <<< 8) ||| int blob.[3]
+                                Ok (length, 4)
+                        elif first &&& 0xE0uy = 0xC0uy then
+                            if len < 6 then
+                                Error "CustomAttrib blob: truncated 4-byte PackedLen"
+                            else
+                                let length =
+                                    ((int first &&& 0x1F) <<< 24)
+                                    ||| (int blob.[3] <<< 16)
+                                    ||| (int blob.[4] <<< 8)
+                                    ||| int blob.[5]
+
+                                Ok (length, 6)
+                        else
+                            Error (sprintf "CustomAttrib blob: invalid PackedLen leading byte 0x%02X" first)
+
+                    match lengthResult with
+                    | Error e -> Error e
+                    | Ok (length, bodyStart) ->
+                        if bodyStart + length > len then
+                            Error (
+                                sprintf
+                                    "CustomAttrib blob: SerString body truncated (declared %d bytes, %d available)"
+                                    length
+                                    (len - bodyStart)
+                            )
+                        else
+                            let bytes = Array.zeroCreate<byte> length
+                            blob.CopyTo (bodyStart, bytes, 0, length)
+                            let s = System.Text.Encoding.UTF8.GetString bytes
+                            Ok (Some s)

--- a/WoofWare.PawPrint.Test/TestCustomAttributeBlob.fs
+++ b/WoofWare.PawPrint.Test/TestCustomAttributeBlob.fs
@@ -1,0 +1,159 @@
+namespace WoofWare.PawPrint.Test
+
+open System.Collections.Immutable
+open System.Text
+open FsCheck
+open FsCheck.FSharp
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestCustomAttributeBlob =
+
+    /// Encode a PackedLen per ECMA-335 II.23.2.
+    let private encodePackedLen (length : int) : byte array =
+        if length < 0 then
+            failwithf "negative length %d" length
+        elif length < 0x80 then
+            [| byte length |]
+        elif length < 0x4000 then
+            let hi = (length >>> 8) ||| 0x80
+            let lo = length &&& 0xFF
+            [| byte hi ; byte lo |]
+        elif length < 0x20000000 then
+            let b0 = ((length >>> 24) &&& 0x1F) ||| 0xC0
+            let b1 = (length >>> 16) &&& 0xFF
+            let b2 = (length >>> 8) &&& 0xFF
+            let b3 = length &&& 0xFF
+            [| byte b0 ; byte b1 ; byte b2 ; byte b3 |]
+        else
+            failwithf "length %d exceeds PackedLen maximum" length
+
+    /// Build a CustomAttrib blob carrying a single SerString fixed arg.
+    /// If `s` is None, encodes the null sentinel.
+    let private buildBlob (s : string option) : ImmutableArray<byte> =
+        let prolog = [| 0x01uy ; 0x00uy |] // little-endian 0x0001
+
+        let serString =
+            match s with
+            | None -> [| 0xFFuy |]
+            | Some str ->
+                let utf8 = Encoding.UTF8.GetBytes (str : string)
+                Array.append (encodePackedLen utf8.Length) utf8
+
+        Array.append prolog serString |> ImmutableArray.Create<byte>
+
+    [<Test>]
+    let ``decodes empty string`` () : unit =
+        CustomAttribute.tryReadLeadingSerString (buildBlob (Some ""))
+        |> shouldEqual (Ok (Some ""))
+
+    [<Test>]
+    let ``decodes short ASCII string`` () : unit =
+        CustomAttribute.tryReadLeadingSerString (buildBlob (Some "Hello"))
+        |> shouldEqual (Ok (Some "Hello"))
+
+    [<Test>]
+    let ``decodes null sentinel`` () : unit =
+        CustomAttribute.tryReadLeadingSerString (buildBlob None)
+        |> shouldEqual (Ok None)
+
+    [<Test>]
+    let ``decodes two-byte packed length`` () : unit =
+        let s = String.replicate 200 "a"
+
+        CustomAttribute.tryReadLeadingSerString (buildBlob (Some s))
+        |> shouldEqual (Ok (Some s))
+
+    [<Test>]
+    let ``decodes four-byte packed length`` () : unit =
+        let s = String.replicate 0x4000 "z"
+
+        CustomAttribute.tryReadLeadingSerString (buildBlob (Some s))
+        |> shouldEqual (Ok (Some s))
+
+    [<Test>]
+    let ``decodes multibyte UTF-8`` () : unit =
+        let s = "é中\U0001F600" // é + 中 + emoji
+
+        CustomAttribute.tryReadLeadingSerString (buildBlob (Some s))
+        |> shouldEqual (Ok (Some s))
+
+    [<Test>]
+    let ``rejects wrong prolog`` () : unit =
+        let blob = ImmutableArray.Create<byte> ([| 0x02uy ; 0x00uy ; 0x00uy |])
+
+        match CustomAttribute.tryReadLeadingSerString blob with
+        | Error msg -> msg |> shouldContainText "prolog"
+        | Ok r -> failwithf "expected Error, got Ok %A" r
+
+    [<Test>]
+    let ``rejects blob shorter than prolog`` () : unit =
+        let blob = ImmutableArray.Create<byte> ([| 0x01uy |])
+
+        match CustomAttribute.tryReadLeadingSerString blob with
+        | Error _ -> ()
+        | Ok r -> failwithf "expected Error, got Ok %A" r
+
+    [<Test>]
+    let ``rejects empty blob`` () : unit =
+        match CustomAttribute.tryReadLeadingSerString ImmutableArray.Empty with
+        | Error _ -> ()
+        | Ok r -> failwithf "expected Error, got Ok %A" r
+
+    [<Test>]
+    let ``rejects truncated string body`` () : unit =
+        // Prolog + claims-length-5 + only 2 body bytes
+        let blob =
+            ImmutableArray.Create<byte> ([| 0x01uy ; 0x00uy ; 0x05uy ; byte 'a' ; byte 'b' |])
+
+        match CustomAttribute.tryReadLeadingSerString blob with
+        | Error msg -> msg |> shouldContainText "truncated"
+        | Ok r -> failwithf "expected Error, got Ok %A" r
+
+    [<Test>]
+    let ``rejects truncated two-byte length`` () : unit =
+        // Prolog + first byte of a 2-byte packed length, no second byte
+        let blob = ImmutableArray.Create<byte> ([| 0x01uy ; 0x00uy ; 0x80uy |])
+
+        match CustomAttribute.tryReadLeadingSerString blob with
+        | Error _ -> ()
+        | Ok r -> failwithf "expected Error, got Ok %A" r
+
+    [<Test>]
+    let ``rejects truncated four-byte length`` () : unit =
+        // Prolog + first byte (0xC0) of a 4-byte packed length, no remaining bytes
+        let blob = ImmutableArray.Create<byte> ([| 0x01uy ; 0x00uy ; 0xC0uy |])
+
+        match CustomAttribute.tryReadLeadingSerString blob with
+        | Error _ -> ()
+        | Ok r -> failwithf "expected Error, got Ok %A" r
+
+    [<Test>]
+    let ``ignores trailing bytes after SerString`` () : unit =
+        // Real IVT blob has NumNamed (2 bytes) + named args after the SerString.
+        // We only need the leading string; tail must be ignored.
+        let prolog = [| 0x01uy ; 0x00uy |]
+        let body = Encoding.UTF8.GetBytes "ok"
+        let serString = Array.append (encodePackedLen body.Length) body
+        let trailing = [| 0x00uy ; 0x00uy ; 0xAAuy ; 0xBBuy |]
+
+        let blob =
+            Array.concat [ prolog ; serString ; trailing ] |> ImmutableArray.Create<byte>
+
+        CustomAttribute.tryReadLeadingSerString blob |> shouldEqual (Ok (Some "ok"))
+
+    let private propertyConfig : Config = Config.QuickThrowOnFailure.WithMaxTest 200
+
+    [<Test>]
+    let ``round-trips arbitrary unicode strings`` () : unit =
+        let property (NonNull (s : string)) : bool =
+            let blob = buildBlob (Some s)
+
+            match CustomAttribute.tryReadLeadingSerString blob with
+            | Ok (Some out) -> out = s
+            | _ -> false
+
+        Check.One (propertyConfig, property)

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -11,6 +11,7 @@
     <Compile Include="Assembly.fs" />
     <Compile Include="Roslyn.fs" />
     <Compile Include="TestAssemblyReadCache.fs" />
+    <Compile Include="TestCustomAttributeBlob.fs" />
     <Compile Include="RealRuntime.fs" />
     <Compile Include="TestHarness.fs"/>
     <Compile Include="CrossAssemblyHarness.fs" />


### PR DESCRIPTION
## Summary
- Add `CustomAttribute.tryReadLeadingSerString` in `WoofWare.PawPrint.Domain`: decodes the leading SerString fixed argument of an ECMA-335 II.23.3 CustomAttrib blob (the common shape for attributes like `InternalsVisibleTo` and `IgnoresAccessChecksTo`).
- Mirrors CoreCLR's `CustomAttributeParser::GetString` (`caparser.h`) + `CPackedLen::SafeGetLength` (`stgpooli.cpp`): handles the 0xFF null sentinel and all three PackedLen forms (1/2/4 byte), with truncation checks on every step.
- Trailing bytes after the SerString (named-arg section, additional fixed args) are ignored.
- 13 example tests + a 200-iteration FsCheck round-trip property; all pass. Full suite (777 tests) still passes.

This is slice 1 of the `RuntimeMethodHandle::IsCAVisibleFromDecoratedType` work. A later slice will scan `DumpedAssembly.Attributes` for IVT / IgnoresAccessChecksTo records and decode the assembly-name argument with this helper.

## Test plan
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --filter "FullyQualifiedName~TestCustomAttributeBlob"` (14/14 pass)
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` (777/777 pass)
- [x] `nix develop -c dotnet fantomas .`
- [x] `codex review --base main` — no actionable findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)