### PR TITLE
Implement Thread.FastPollGC as a host no-op

### DIFF
--- a/WoofWare.PawPrint/IntrinsicMethodKeys.fs
+++ b/WoofWare.PawPrint/IntrinsicMethodKeys.fs
@@ -426,8 +426,6 @@ module IntrinsicMethodKeys =
                 "System.Threading.Volatile"
                 "Write"
                 [ IntrinsicParameterPattern.Byref ; IntrinsicParameterPattern.Any ]
-            pattern "System.Private.CoreLib" "System.Threading.Volatile" "ReadBarrier" []
-            pattern "System.Private.CoreLib" "System.Threading.Volatile" "WriteBarrier" []
         ]
 
     let isSafeIntrinsic (key : IntrinsicMethodKey) : bool =

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -928,6 +928,32 @@ module Intrinsics =
                 // The float/double overloads are not yet intrinsified, matching the
                 // CompareExchange precedent above. Add a dedicated arm when first needed.
                 None
+        | "System.Private.CoreLib", "Thread", "FastPollGC" ->
+            // [Intrinsic] internal static void Thread.FastPollGC() => Thread.FastPollGC();
+            // The managed IL body is an infinite self-recursive call; the JIT replaces
+            // every call site with an inline fast GC poll. PawPrint has no GC, so the
+            // intrinsic is a pure no-op. This cannot live in safeIntrinsics because
+            // executing the IL would loop forever.
+            // https://github.com/dotnet/runtime/blob/HEAD/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs#L389-L392
+            match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
+            | [], MethodReturnType.Void -> ()
+            | _ -> failwith $"Thread.FastPollGC: unexpected signature %A{methodToCall.Signature}"
+
+            state |> IlMachineState.advanceProgramCounter currentThread |> Some
+        | "System.Private.CoreLib", "Volatile", ("ReadBarrier" | "WriteBarrier") ->
+            // [Intrinsic] public static void Volatile.{Read,Write}Barrier() => Volatile.{Read,Write}Barrier();
+            // Same shape as Thread.FastPollGC: the managed body is infinite self-recursion
+            // and the JIT replaces the call with the appropriate processor fence. PawPrint
+            // does not model memory-ordering effects across threads, and even if it did the
+            // single-stepping interpreter has no instruction reordering to fence against,
+            // so the no-op is correct. Cannot live in safeIntrinsics because the IL would
+            // loop forever.
+            // https://github.com/dotnet/runtime/blob/HEAD/src/libraries/System.Private.CoreLib/src/System/Threading/Volatile.cs#L236-L245
+            match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
+            | [], MethodReturnType.Void -> ()
+            | _ -> failwith $"Volatile.%s{methodToCall.Name}: unexpected signature %A{methodToCall.Signature}"
+
+            state |> IlMachineState.advanceProgramCounter currentThread |> Some
         | "System.Private.CoreLib", "BitConverter", "SingleToInt32Bits" ->
             match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
             | [ ConcreteSingle state.ConcreteTypes ], MethodReturnType.Returns (ConcreteInt32 state.ConcreteTypes) -> ()


### PR DESCRIPTION
## Summary

- Add `Thread.FastPollGC` to `Intrinsics.call` as a no-op. It is `[Intrinsic]`-marked and its managed body is `FastPollGC() => FastPollGC();` (infinite self-recursion); the real JIT replaces every call site with an inline fast GC poll. PawPrint has no GC, so the no-op is the correct host-provided semantics.
- Move `Volatile.ReadBarrier` / `Volatile.WriteBarrier` out of `safeIntrinsics` and into the same no-op handler. They have the same self-recursive shape as `FastPollGC`; running their IL would have looped forever. No current test reaches them, so this was a latent bug rather than an observed regression.

`Buffer.BulkMoveWithWriteBarrier` (the path that calls `Thread.FastPollGC`) is the motivating caller — once future work lights up the reference-array bulk-copy path, `FastPollGC` is reached organically.

## Test plan

- [x] `nix develop -c dotnet build WoofWare.PawPrint.slnx` — clean.
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 763/763 pass.
- [x] `nix develop -c dotnet fantomas .` — formatted.
- [x] `codex review --base main` — no actionable issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)