### PR TITLE
Bytewise writes through chained ReinterpretAs managed byrefs

### DIFF
--- a/WoofWare.PawPrint.Test/TestBinaryArithmetic.fs
+++ b/WoofWare.PawPrint.Test/TestBinaryArithmetic.fs
@@ -632,6 +632,7 @@ module TestBinaryArithmetic =
         // Plain typed-cell round-trip at the base offset.
         let state =
             IlMachineState.writeManagedByrefBytesOrTypedCell
+                baseClassTypes
                 state
                 ptr
                 (CliType.Numeric (CliNumericType.Int32 0x11223344))

--- a/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
+++ b/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
@@ -341,6 +341,7 @@ public interface IOpenInterface<T>
         let writeEx =
             Assert.Throws<System.Exception> (fun () ->
                 IlMachineState.writeManagedByrefBytesOrTypedCell
+                    bct
                     state
                     ptr
                     (CliType.Numeric (CliNumericType.UInt8 0xAAuy))
@@ -1375,6 +1376,7 @@ public unsafe struct PointerWrapper
 
         let state =
             IlMachineState.writeManagedByrefBytesOrTypedCell
+                bct
                 state
                 ptrAtOffset
                 (CliType.Numeric (CliNumericType.UInt16 0xBEEFus))
@@ -1417,6 +1419,7 @@ public unsafe struct PointerWrapper
 
             let state =
                 IlMachineState.writeManagedByrefBytesOrTypedCell
+                    bct
                     state
                     ptrAtOffset
                     (CliType.Numeric (CliNumericType.UInt16 sample.Payload))
@@ -1443,6 +1446,7 @@ public unsafe struct PointerWrapper
 
             let state =
                 IlMachineState.writeManagedByrefBytesOrTypedCell
+                    bct
                     state
                     ptr
                     (CliType.Numeric (CliNumericType.UInt16 payload))
@@ -1585,12 +1589,18 @@ public unsafe struct PointerWrapper
                 |> ignore
             )
 
-        ex.Message |> shouldContainText "byte-unaddressable storage (object reference)"
-        ex.Message |> shouldContainText "write through `ReinterpretAs`"
-        ex.Message |> shouldContainText "CLI value byte layout:"
+        // The iterative byte-view peel collapses `[ReinterpretAs FourBytes, Field _]` over an
+        // `object[]` element to a byte write at offset 0 of the element. The array-element byte
+        // writer then refuses the byte view because the element holds an object reference whose
+        // bytes are not part of the model. We still get a clear failure attributing to the storage
+        // shape; the message just no longer attributes through `ReinterpretAs` because the peel
+        // produced a residual offset-only chain, not a residual reinterpret.
+        ex.Message |> shouldContainText "refusing byte view over object reference"
 
         ex.Message
         |> shouldContainText "byte-addressability: rejected: object reference"
+
+        ex.Message |> shouldContainText "Value layout:"
 
     [<Test>]
     let ``Reinterpreted write over runtime-pointer value-type storage reports unsupported storage shape`` () : unit =
@@ -1615,13 +1625,15 @@ public unsafe struct PointerWrapper
                 |> ignore
             )
 
+        // The iterative byte-view peel collapses `[ReinterpretAs FourBytes, Field _]` over an
+        // array element whose declared type is a runtime-pointer-bearing value type to a byte
+        // write at offset 0 of the element. The array-element byte writer refuses because the
+        // element's value type contains runtime pointers whose bytes are not part of the model.
+        // We still get a clear failure attributing to the storage shape.
         ex.Message
-        |> shouldContainText "byte-unaddressable storage (value type containing runtime pointers)"
+        |> shouldContainText "refusing byte view over value type containing runtime pointers"
 
-        ex.Message |> shouldContainText "write through `ReinterpretAs`"
-        ex.Message |> shouldContainText "value type byte layout:"
-        ex.Message |> shouldContainText "declared type:"
-        ex.Message |> shouldContainText "Ptr: range=[0, 8), size=8"
+        ex.Message |> shouldContainText "Value layout:"
 
         ex.Message
         |> shouldContainText "byte-addressability: rejected: value type containing runtime pointers"
@@ -1648,6 +1660,7 @@ public unsafe struct PointerWrapper
 
         let state =
             IlMachineState.writeManagedByrefBytesOrTypedCell
+                bct
                 state
                 ptr
                 (CliType.Numeric (CliNumericType.Int32 replacement))
@@ -1680,6 +1693,7 @@ public unsafe struct PointerWrapper
 
             let state =
                 IlMachineState.writeManagedByrefBytesOrTypedCell
+                    bct
                     state
                     ptr
                     (CliType.Numeric (CliNumericType.UInt16 payload))
@@ -1709,6 +1723,7 @@ public unsafe struct PointerWrapper
 
             let stateAfterPlain =
                 IlMachineState.writeManagedByrefBytesOrTypedCell
+                    bct
                     state
                     plainPtr
                     (CliType.Numeric (CliNumericType.UInt16 plainPayload))
@@ -1727,6 +1742,7 @@ public unsafe struct PointerWrapper
 
             let stateAfterByteView =
                 IlMachineState.writeManagedByrefBytesOrTypedCell
+                    bct
                     state
                     byteViewPtr
                     (CliType.Numeric (CliNumericType.UInt8 initialBytes.[sample.Offset]))
@@ -1747,7 +1763,7 @@ public unsafe struct PointerWrapper
         let arrayBefore = state.ManagedHeap.Arrays.[arrayAddr]
         let ptr = ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arrayAddr, 0), [])
 
-        let state = IlMachineState.writeManagedByrefBytesOrTypedCell state ptr nan
+        let state = IlMachineState.writeManagedByrefBytesOrTypedCell bct state ptr nan
         let arrayAfter = state.ManagedHeap.Arrays.[arrayAddr]
 
         System.Object.ReferenceEquals (arrayAfter, arrayBefore) |> shouldEqual true
@@ -1802,7 +1818,7 @@ public unsafe struct PointerWrapper
             )
 
         let ptr = ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arrayAddr, 0), [])
-        let state = IlMachineState.writeManagedByrefBytesOrTypedCell state ptr written
+        let state = IlMachineState.writeManagedByrefBytesOrTypedCell bct state ptr written
         let arrayAfter = state.ManagedHeap.Arrays.[arrayAddr]
 
         System.Object.ReferenceEquals (arrayAfter, arrayBefore) |> shouldEqual true
@@ -1830,7 +1846,7 @@ public unsafe struct PointerWrapper
                 IlMachineState.allocateArray doubleArrayHandle (fun () -> initial) 1 state
 
             let ptr = ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arrayAddr, 0), [])
-            let state = IlMachineState.writeManagedByrefBytesOrTypedCell state ptr written
+            let state = IlMachineState.writeManagedByrefBytesOrTypedCell bct state ptr written
 
             let actual =
                 IlMachineState.readManagedByrefBytesAs bct state ptr (CliType.Numeric (CliNumericType.Float64 0.0))
@@ -1854,7 +1870,7 @@ public unsafe struct PointerWrapper
         let ptr = ManagedPointerSource.Byref (ByrefRoot.StringCharAt (stringAddr, 0), [])
 
         let stateAfter =
-            IlMachineState.writeManagedByrefBytesOrTypedCell state ptr (CliType.ofChar 'A')
+            IlMachineState.writeManagedByrefBytesOrTypedCell bct state ptr (CliType.ofChar 'A')
 
         System.Object.ReferenceEquals (stateAfter, state) |> shouldEqual true
 
@@ -1876,7 +1892,7 @@ public unsafe struct PointerWrapper
             | other -> failwith $"Expected local-memory root pointer, got %O{other}"
 
         let initial = CliType.Numeric (CliNumericType.Int32 0x11223344)
-        let state = IlMachineState.writeManagedByrefBytesOrTypedCell state ptr initial
+        let state = IlMachineState.writeManagedByrefBytesOrTypedCell bct state ptr initial
 
         let bareBytePtr =
             ManagedPointerSource.Byref (ByrefRoot.StackMemoryByte (thread, frame, block, 0), [])
@@ -1887,7 +1903,7 @@ public unsafe struct PointerWrapper
         System.Object.ReferenceEquals (stateAfterBare, state) |> shouldEqual true
 
         let stateAfterWide =
-            IlMachineState.writeManagedByrefBytesOrTypedCell state ptr initial
+            IlMachineState.writeManagedByrefBytesOrTypedCell bct state ptr initial
 
         System.Object.ReferenceEquals (stateAfterWide, state) |> shouldEqual true
 
@@ -1933,12 +1949,14 @@ public unsafe struct PointerWrapper
 
         let state =
             IlMachineState.writeManagedByrefBytesOrTypedCell
+                bct
                 state
                 (byteViewAt 1)
                 (CliType.Numeric (CliNumericType.UInt8 0xAAuy))
 
         let state =
             IlMachineState.writeManagedByrefBytesOrTypedCell
+                bct
                 state
                 (byteViewAt 2)
                 (CliType.Numeric (CliNumericType.UInt8 0xBBuy))
@@ -1948,7 +1966,7 @@ public unsafe struct PointerWrapper
         Map.count blockBeforeTypedWrite.Bytes |> shouldEqual 2
 
         let updated = CliType.Numeric (CliNumericType.Int32 0x11223344)
-        let state = IlMachineState.writeManagedByrefBytesOrTypedCell state ptr updated
+        let state = IlMachineState.writeManagedByrefBytesOrTypedCell bct state ptr updated
 
         let pool = IlMachineState.getStackMemoryPool thread frame state
         let blockAfterTypedWrite = StackMemoryPool.getBlock block pool
@@ -2121,7 +2139,8 @@ public unsafe struct PointerWrapper
         let handle =
             CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.FieldHandlePtr 9876L))
 
-        let stateAfter = IlMachineState.writeManagedByrefBytesOrTypedCell state ptr handle
+        let stateAfter =
+            IlMachineState.writeManagedByrefBytesOrTypedCell bct state ptr handle
 
         IlMachineState.readManagedByref bct stateAfter ptr |> shouldEqual handle
 
@@ -2147,8 +2166,11 @@ public unsafe struct PointerWrapper
         let secondHandle =
             CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.FieldHandlePtr 2L))
 
-        let state = IlMachineState.writeManagedByrefBytesOrTypedCell state ptr firstHandle
-        let state = IlMachineState.writeManagedByrefBytesOrTypedCell state ptr secondHandle
+        let state =
+            IlMachineState.writeManagedByrefBytesOrTypedCell bct state ptr firstHandle
+
+        let state =
+            IlMachineState.writeManagedByrefBytesOrTypedCell bct state ptr secondHandle
 
         IlMachineState.readManagedByref bct state ptr |> shouldEqual secondHandle
 
@@ -2170,10 +2192,10 @@ public unsafe struct PointerWrapper
         let handle =
             CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.FieldHandlePtr 0xDEADL))
 
-        let state = IlMachineState.writeManagedByrefBytesOrTypedCell state ptr handle
+        let state = IlMachineState.writeManagedByrefBytesOrTypedCell bct state ptr handle
 
         Assert.Throws<System.Exception> (fun () ->
-            IlMachineState.writeManagedByrefBytesOrTypedCell state ptr (CliType.Numeric (CliNumericType.Int32 42))
+            IlMachineState.writeManagedByrefBytesOrTypedCell bct state ptr (CliType.Numeric (CliNumericType.Int32 42))
             |> ignore
         )
         |> ignore
@@ -2255,6 +2277,7 @@ public unsafe struct PointerWrapper
 
         let state =
             IlMachineState.writeManagedByrefBytesOrTypedCell
+                bct
                 state
                 midCellPtr
                 (CliType.Numeric (CliNumericType.UInt8 0xAAuy))
@@ -2285,7 +2308,7 @@ public unsafe struct PointerWrapper
 
         let zero = CliType.Numeric (CliNumericType.Int32 0)
 
-        let stateAfter = IlMachineState.writeManagedByrefBytesOrTypedCell state ptr zero
+        let stateAfter = IlMachineState.writeManagedByrefBytesOrTypedCell bct state ptr zero
 
         IlMachineState.readManagedByref bct stateAfter ptr |> shouldEqual zero
 
@@ -2307,12 +2330,12 @@ public unsafe struct PointerWrapper
         let handle =
             CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.FieldHandlePtr 1234L))
 
-        let state = IlMachineState.writeManagedByrefBytesOrTypedCell state ptr handle
+        let state = IlMachineState.writeManagedByrefBytesOrTypedCell bct state ptr handle
 
         let verbatim =
             CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim 5678L))
 
-        let state = IlMachineState.writeManagedByrefBytesOrTypedCell state ptr verbatim
+        let state = IlMachineState.writeManagedByrefBytesOrTypedCell bct state ptr verbatim
 
         IlMachineState.readManagedByref bct state ptr |> shouldEqual verbatim
 
@@ -2687,7 +2710,7 @@ public unsafe struct PointerWrapper
         let heapPtr = ManagedPointerSource.Byref (ByrefRoot.HeapValue boxedAddr, [])
 
         Assert.Throws<System.Exception> (fun () ->
-            IlMachineState.writeManagedByrefBytesOrTypedCell state heapPtr wrappedIntPtrNewValue
+            IlMachineState.writeManagedByrefBytesOrTypedCell bct state heapPtr wrappedIntPtrNewValue
             |> ignore
         )
         |> ignore
@@ -3197,7 +3220,7 @@ public unsafe struct PointerWrapper
             |> ManagedPointerSource.appendProjection (ByrefProjection.ByteOffset 0)
 
         let state =
-            IlMachineState.writeManagedByrefBytesOrTypedCell state ptr (CliType.ObjectRef (Some replacementAddr))
+            IlMachineState.writeManagedByrefBytesOrTypedCell bct state ptr (CliType.ObjectRef (Some replacementAddr))
 
         IlMachineState.readManagedByrefBytesAs bct state ptr (CliType.ObjectRef None)
         |> shouldEqual (CliType.ObjectRef (Some replacementAddr))
@@ -3219,7 +3242,7 @@ public unsafe struct PointerWrapper
             |> ManagedPointerSource.appendProjection (ByrefProjection.ByteOffset 0)
 
         let state =
-            IlMachineState.writeManagedByrefBytesOrTypedCell state ptr (CliType.ObjectRef None)
+            IlMachineState.writeManagedByrefBytesOrTypedCell bct state ptr (CliType.ObjectRef None)
 
         IlMachineState.readManagedByrefBytesAs bct state ptr (CliType.ObjectRef None)
         |> shouldEqual (CliType.ObjectRef None)
@@ -3345,6 +3368,7 @@ public unsafe struct PointerWrapper
 
         let state =
             IlMachineState.writeManagedByrefBytesOrTypedCell
+                bct
                 state
                 writePtr
                 (CliType.Numeric (CliNumericType.Int16 0xCAFEs))
@@ -3402,6 +3426,7 @@ public unsafe struct PointerWrapper
         let negativeWriteEx =
             Assert.Throws<System.Exception> (fun () ->
                 IlMachineState.writeManagedByrefBytesOrTypedCell
+                    bct
                     state
                     negativePtr
                     (CliType.Numeric (CliNumericType.UInt16 0xBEEFus))
@@ -3413,6 +3438,7 @@ public unsafe struct PointerWrapper
         let writeEx =
             Assert.Throws<System.Exception> (fun () ->
                 IlMachineState.writeManagedByrefBytesOrTypedCell
+                    bct
                     state
                     ptrAtOffset
                     (CliType.Numeric (CliNumericType.UInt16 0xBEEFus))

--- a/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
+++ b/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
@@ -3446,3 +3446,51 @@ public unsafe struct PointerWrapper
             )
 
         writeEx.Message |> shouldContainText "outside 8-byte boxed payload"
+
+    [<Test>]
+    let ``Metadata-light writeManagedByref accepts trailing ReinterpretAs byte view`` () : unit =
+        // Regression: `writeManagedByref` is the BCT-less entry point used by
+        // primitive/external boundaries that do not currently carry type
+        // metadata. Historically it accepted simple trailing byte-view shapes
+        // (`[ReinterpretAs T]` and `[..., ReinterpretAs T; ByteOffset n]`) over
+        // byte-addressable roots, routing through the byte-scatter path of
+        // `writeManagedByrefBytesOrTypedCell`. The forward-walk peel rewrite
+        // initially required BCT, which broke this metadata-light contract;
+        // this test pins the restored behaviour for both the bare reinterpret
+        // shape and the reinterpret-plus-byte-offset shape.
+        let _, loggerFactory = LoggerFactory.makeTest ()
+
+        let state, thread =
+            stateWithSingleInstruction loggerFactory (IlOp.Nullary NullaryIlOp.Nop)
+
+        let ptr, state =
+            IlMachineState.allocateStackMemory thread MemoryBlockInitialization.ZeroInitialized 4 state
+
+        let byteReinterpret = concreteTypeFor bct.Byte
+
+        let bareReinterpretPtr =
+            ptr
+            |> ManagedPointerSource.appendProjection (ByrefProjection.ReinterpretAs byteReinterpret)
+
+        let state =
+            IlMachineState.writeManagedByref state bareReinterpretPtr (CliType.Numeric (CliNumericType.UInt8 0xAAuy))
+
+        IlMachineState.readManagedByrefBytesAs bct state ptr (CliType.Numeric (CliNumericType.UInt8 0uy))
+        |> shouldEqual (CliType.Numeric (CliNumericType.UInt8 0xAAuy))
+
+        let offsetReinterpretPtr =
+            bareReinterpretPtr
+            |> ManagedPointerSource.appendProjection (ByrefProjection.ByteOffset 2)
+
+        let state =
+            IlMachineState.writeManagedByref state offsetReinterpretPtr (CliType.Numeric (CliNumericType.UInt8 0xBBuy))
+
+        let readAt (offset : int) : CliType =
+            let readPtr =
+                bareReinterpretPtr
+                |> ManagedPointerSource.appendProjection (ByrefProjection.ByteOffset offset)
+
+            IlMachineState.readManagedByrefBytesAs bct state readPtr (CliType.Numeric (CliNumericType.UInt8 0uy))
+
+        readAt 0 |> shouldEqual (CliType.Numeric (CliNumericType.UInt8 0xAAuy))
+        readAt 2 |> shouldEqual (CliType.Numeric (CliNumericType.UInt8 0xBBuy))

--- a/WoofWare.PawPrint.Test/sourcesPure/VolatileWriteFieldThroughReinterpret.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/VolatileWriteFieldThroughReinterpret.cs
@@ -1,0 +1,62 @@
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+public class TestVolatileWriteFieldThroughReinterpret
+{
+    // Mirror of VolatileReadFieldThroughReinterpret: a plain sequential struct
+    // of int fields, projected over an `int[]` via `Unsafe.As`.
+    private struct ThreeInts
+    {
+        public int A; // offset 0
+        public int B; // offset 4
+        public int C; // offset 8
+    }
+
+    // Writing a field of an `Unsafe.As`-projected struct view through
+    // `Volatile.Write` produces the byref projection chain
+    //     [ReinterpretAs ThreeInts, Field <name>, ReinterpretAs VolatileInt32]
+    // because the BCL lowers `Volatile.Write(ref int, int)` to
+    //     Unsafe.As<int, VolatileInt32>(ref location).Value = value
+    // The write-side fold has to iteratively peel both trailing byte-view
+    // segments — the bare `ReinterpretAs VolatileInt32` and the
+    // `[ReinterpretAs ThreeInts, Field <name>]` pair — into a byte offset
+    // before dispatching to the array-element byte-view writer. Without the
+    // iterative peel, the residual `[ReinterpretAs ThreeInts, Field <name>]`
+    // is left unhandled and the write fails.
+    public static int Main(string[] argv)
+    {
+        int[] arr = new int[6];
+
+        ref ThreeInts view = ref Unsafe.As<int, ThreeInts>(ref arr[1]);
+
+        Volatile.Write(ref view.A, 200);
+        Volatile.Write(ref view.B, 300);
+        Volatile.Write(ref view.C, 400);
+
+        if (arr[0] != 0) return 1;
+        if (arr[1] != 200) return 2;
+        if (arr[2] != 300) return 3;
+        if (arr[3] != 400) return 4;
+        if (arr[4] != 0) return 5;
+        if (arr[5] != 0) return 6;
+
+        // Same chain shape, but the struct view starts at a different
+        // array index so the per-cell byte offsets differ. The peel must
+        // not bake the array index into the offset — only the in-struct
+        // field offset.
+        ref ThreeInts view2 = ref Unsafe.As<int, ThreeInts>(ref arr[3]);
+
+        Volatile.Write(ref view2.A, 500);
+        Volatile.Write(ref view2.B, 600);
+        Volatile.Write(ref view2.C, 700);
+
+        if (arr[0] != 0) return 7;
+        if (arr[1] != 200) return 8;
+        if (arr[2] != 300) return 9;
+        if (arr[3] != 500) return 10;
+        if (arr[4] != 600) return 11;
+        if (arr[5] != 700) return 12;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/VolatileWriteLocalObject.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/VolatileWriteLocalObject.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+
+class Program
+{
+    static int Main(string[] args)
+    {
+        object value = null;
+        object replacement = new object();
+        Volatile.Write(ref value, replacement);
+
+        if (!object.ReferenceEquals(value, replacement)) return 1;
+
+        Volatile.Write(ref value, null);
+        if (value != null) return 2;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/VolatileWriteNestedFieldNonZeroOffset.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/VolatileWriteNestedFieldNonZeroOffset.cs
@@ -1,0 +1,24 @@
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+public class TestVolatileWriteNestedFieldNonZeroOffset
+{
+    private struct Inner
+    {
+        public int X;
+        public int Y;
+    }
+
+    private struct Outer
+    {
+        public Inner I;
+    }
+
+    public static int Main(string[] argv)
+    {
+        int[] arr = new int[2];
+        ref Outer view = ref Unsafe.As<int, Outer>(ref arr[0]);
+        Volatile.Write(ref view.I.Y, 456);
+        return arr[1] == 456 ? 0 : 1;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/VolatileWriteNestedFieldThroughReinterpret.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/VolatileWriteNestedFieldThroughReinterpret.cs
@@ -1,0 +1,23 @@
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+public class TestVolatileWriteNestedFieldThroughReinterpret
+{
+    private struct Inner
+    {
+        public int X;
+    }
+
+    private struct Outer
+    {
+        public Inner I;
+    }
+
+    public static int Main(string[] argv)
+    {
+        int[] arr = new int[1];
+        ref Outer view = ref Unsafe.As<int, Outer>(ref arr[0]);
+        Volatile.Write(ref view.I.X, 123);
+        return arr[0] == 123 ? 0 : 1;
+    }
+}

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -1894,17 +1894,20 @@ module IlMachineManagedByref =
             // struct view) route to the bytes-or-typed-cell writer. Without
             // BCT, fall back to the trailing-suffix-only classifier.
             //
-            // The bytes-or-typed-cell writer assumes it can target the cell at
-            // an absolute byte offset within the root: it works directly for
-            // chains whose peeled prefix is empty (bare StackMemoryByte /
-            // NativeMemoryByte / HeapValue / HeapObjectField roots). When peel collapses only a
-            // suffix and leaves a structural `Field` prefix, the typed-cell
-            // path can no longer reach the destination cell from the root
-            // alone; the structural projection writer (`writeProjectedValueIfChanged`)
-            // is the right path because it threads the write through
-            // `splitFirstReinterpret` / `writeReinterpretedStorageIfChanged`,
-            // which already handles the same byte-view tail and additionally
-            // walks the structural prefix.
+            // When peel collapses the whole tail (`prefix = []`), the
+            // bytes-or-typed-cell writer can target an absolute byte offset
+            // within the root directly. When peel leaves a residual structural
+            // prefix (e.g. `[Field f]`) and the value being written is not
+            // byte-renderable (object reference, runtime pointer), the
+            // bytes-or-typed-cell writer would attempt a byte scatter that
+            // refuses non-byte-addressable payloads; route those through the
+            // structural projection writer (`writeProjectedValueIfChanged`),
+            // which threads through `writeReinterpretedStorageIfChanged` and
+            // applies the transparent-wrapper fast path for ref↔ref writes.
+            // Byte-renderable writes with a residual prefix stay on the
+            // bytes-or-typed-cell path so the existing `resolveCell` byte
+            // scatter (which lifts back through trailing `Field` projections
+            // for `Unsafe.Add`-style cross-cell writes) keeps working.
             let peeled : (ByrefProjection list * int) voption =
                 match baseClassTypes with
                 | Some bct -> peelTrailingByteView bct state projs
@@ -1912,8 +1915,15 @@ module IlMachineManagedByref =
                     splitTrailingByteView src
                     |> ValueOption.map (fun (_root, prefixProjs, offset) -> prefixProjs, offset)
 
+            let valueIsByteRenderable =
+                match CliType.ByteAddressability newValue with
+                | CliByteAddressability.ByteAddressable -> true
+                | CliByteAddressability.Rejected _ -> false
+
             match peeled, baseClassTypes with
             | ValueSome ([], _), Some bct -> writeManagedByrefBytesOrTypedCell bct state src newValue
+            | ValueSome (_ :: _, _), Some bct when valueIsByteRenderable ->
+                writeManagedByrefBytesOrTypedCell bct state src newValue
             | ValueSome _, None ->
                 // Trailing-suffix-only byte view; legacy callers without BCT
                 // pass through here. Routing without BCT means the bytes path
@@ -1921,7 +1931,7 @@ module IlMachineManagedByref =
                 // splitTrailingByteView contract is preserved.
                 failwith
                     "writeManagedByref: byte-view byref encountered without BaseClassTypes; call writeManagedByrefWithBase instead"
-            | ValueSome (_ :: _, _), _
+            | ValueSome (_ :: _, _), Some _
             | ValueNone, _ ->
                 let rootValue = readRootValue state root
 

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -1934,8 +1934,33 @@ module IlMachineManagedByref =
                 | CliByteAddressability.ByteAddressable -> true
                 | CliByteAddressability.Rejected _ -> false
 
+            // Only fully byte-resolved prefixes (no `ReinterpretAs`) are safe to
+            // route through the bytes writer: `resolveCell` resolves the prefix
+            // via `readProjectedValue`, which does not interpret a residual
+            // `ReinterpretAs` over a non-host-shaped cell. Prefixes containing
+            // `ReinterpretAs` (e.g. `[ReinterpretAs Outer; Field I; Field X]`
+            // produced by `Volatile.Write(ref view.I.X, _)` on
+            // `Unsafe.As<int, Outer>(ref arr[0])`) must fall back to the
+            // structural writer, which handles non-trailing reinterprets via
+            // `splitFirstReinterpret`.
+            let prefixContainsReinterpret (prefixProjs : ByrefProjection list) : bool =
+                prefixProjs
+                |> List.exists (
+                    function
+                    | ByrefProjection.ReinterpretAs _ -> true
+                    | _ -> false
+                )
+
+            let useStructuralWriter () : IlMachineState =
+                let rootValue = readRootValue state root
+
+                match writeProjectedValueIfChanged baseClassTypes state rootValue projs newValue with
+                | None -> state
+                | Some updatedRoot -> writeRootValue state root updatedRoot
+
             match peeled, baseClassTypes, valueIsByteRenderable with
-            | ValueSome _, Some bct, true -> writeManagedByrefBytesOrTypedCell bct state src newValue
+            | ValueSome (prefixProjs, _), Some bct, true when not (prefixContainsReinterpret prefixProjs) ->
+                writeManagedByrefBytesOrTypedCell bct state src newValue
             | ValueSome ([], _), Some bct, false ->
                 // Non-byte-renderable empty-prefix peel: the bytes-or-typed-cell
                 // writer can precise-write for the byte-addressable storage
@@ -1950,12 +1975,7 @@ module IlMachineManagedByref =
                 | ByrefRoot.HeapObjectField _
                 | ByrefRoot.ArrayElement _
                 | ByrefRoot.StringCharAt _ -> writeManagedByrefBytesOrTypedCell bct state src newValue
-                | _ ->
-                    let rootValue = readRootValue state root
-
-                    match writeProjectedValueIfChanged baseClassTypes state rootValue projs newValue with
-                    | None -> state
-                    | Some updatedRoot -> writeRootValue state root updatedRoot
+                | _ -> useStructuralWriter ()
             | ValueSome _, None, _ ->
                 // Trailing-suffix-only byte view; legacy callers without BCT
                 // pass through here. Routing without BCT means the bytes path
@@ -1963,13 +1983,7 @@ module IlMachineManagedByref =
                 // splitTrailingByteView contract is preserved.
                 failwith
                     "writeManagedByref: byte-view byref encountered without BaseClassTypes; call writeManagedByrefWithBase instead"
-            | ValueSome (_ :: _, _), Some _, false
-            | ValueNone, _, _ ->
-                let rootValue = readRootValue state root
-
-                match writeProjectedValueIfChanged baseClassTypes state rootValue projs newValue with
-                | None -> state
-                | Some updatedRoot -> writeRootValue state root updatedRoot
+            | _ -> useStructuralWriter ()
 
     let writeManagedByref (state : IlMachineState) (src : ManagedPointerSource) (newValue : CliType) : IlMachineState =
         // Call sites that can supply BaseClassTypes should use writeManagedByrefWithBase so

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -843,59 +843,79 @@ module IlMachineManagedByref =
         CliType.zeroOf state.ConcreteTypes state._LoadedAssemblies baseClassTypes handle
         |> fst
 
-    /// Collapse any trailing byte-view segment of the projection chain into an
-    /// accumulated byte offset. Once a `ReinterpretAs` appears the underlying
-    /// storage is being treated as raw bytes, so subsequent `ByteOffset`,
-    /// `Field` (resolved against the most recent `ReinterpretAs` target), and
-    /// chained `ReinterpretAs` projections are all bytewise; peeling them
-    /// exposes the residual structural prefix to the existing dispatchers.
-    /// Iterates until a non-byte-view trailing step is reached so chained
-    /// reinterprets like `Volatile.Read(ref entry._version)`
-    /// (`[..., ReinterpretAs CastCacheEntry, Field _version, ReinterpretAs VolatileUInt32]`)
-    /// reduce to the deepest reachable byte offset before
-    /// `readProjectedValue`/`resolveCell` interpret what's left.
+    /// Split a projection chain at the first `ReinterpretAs` and collapse
+    /// everything beyond that point into an accumulated byte offset. Once a
+    /// `ReinterpretAs` appears the underlying storage is being treated as raw
+    /// bytes, so subsequent `Field` (resolved against the most recent
+    /// `ReinterpretAs` target), `ByteOffset`, and chained `ReinterpretAs`
+    /// projections are all bytewise. Walking forward through them accumulates
+    /// the byte offset that the byte-view ultimately addresses, leaving the
+    /// structural prefix (everything before the first `ReinterpretAs`) for
+    /// the dispatcher.
     ///
-    /// Returns `ValueSome (residual, offset)` if any byte-view step was
-    /// peeled, else `ValueNone`. A trailing `ByteOffset n` without a
-    /// preceding `ReinterpretAs` is an interpreter bug and is raised here.
+    /// The forward walk is strictly more general than a right-to-left
+    /// per-pair peel: it handles `[ReinterpretAs Outer; Field I; Field Y]`
+    /// (e.g. `Volatile.Write(ref view.I.Y, _)` on
+    /// `Unsafe.As<int, Outer>(ref arr[0])`), where the second `Field` would
+    /// be unreachable from the right because its layout depends on the type
+    /// chosen by the preceding `Field`.
+    ///
+    /// Returns `ValueSome (structuralPrefix, offset)` when the chain contains
+    /// at least one `ReinterpretAs`, else `ValueNone`. The `structuralPrefix`
+    /// never contains a `ReinterpretAs` by construction. A non-trailing
+    /// `ByteOffset` (which the construction-site canonicaliser never
+    /// produces) is an interpreter bug and is raised here.
     let private peelTrailingByteView
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (state : IlMachineState)
         (projs : ByrefProjection list)
         : (ByrefProjection list * int) voption
         =
-        let rec loop
-            (projs : ByrefProjection list)
-            (offset : int)
-            (peeled : bool)
-            : (ByrefProjection list * int) voption
+        let rec findFirstReinterpret
+            (revPrefix : ByrefProjection list)
+            (remaining : ByrefProjection list)
+            : (ByrefProjection list * ConcreteType<ConcreteTypeHandle> * ByrefProjection list) option
             =
-            let len = List.length projs
+            match remaining with
+            | [] -> None
+            | ByrefProjection.ReinterpretAs reinTy :: rest -> Some (List.rev revPrefix, reinTy, rest)
+            | proj :: rest -> findFirstReinterpret (proj :: revPrefix) rest
 
-            if len = 0 then
-                if peeled then ValueSome ([], offset) else ValueNone
-            else
-                let last = List.item (len - 1) projs
-                let prev = if len >= 2 then Some (List.item (len - 2) projs) else None
+        match findFirstReinterpret [] projs with
+        | None -> ValueNone
+        | Some (structuralPrefix, firstReinTy, afterReinterpret) ->
+            // Walk forward through the byte-view suffix, accumulating byte
+            // offset. `currentTemplate` tracks the CliType of the storage we
+            // are currently navigating through: `Field` projections add the
+            // field's offset within that template; chained `ReinterpretAs`
+            // re-anchors the template to the new type; `ByteOffset` adds raw
+            // bytes and either terminates the walk or re-anchors via the
+            // immediately following `ReinterpretAs`. A `ByteOffset` followed
+            // by a `Field` would require navigating fields on a cursor with
+            // no type anchor and signals an interpreter bug at the
+            // construction site.
+            let rec walk (currentTemplate : CliType) (offset : int) (remaining : ByrefProjection list) : int =
+                match remaining with
+                | [] -> offset
+                | ByrefProjection.Field field :: rest ->
+                    let fieldOffset, _ = CliType.getFieldLayoutById field currentTemplate
+                    let fieldTemplate = CliType.getFieldById field currentTemplate
+                    walk fieldTemplate (offset + fieldOffset) rest
+                | ByrefProjection.ReinterpretAs newReinTy :: rest ->
+                    let newTemplate = zeroForConcreteType baseClassTypes state newReinTy
+                    walk newTemplate offset rest
+                | ByrefProjection.ByteOffset n :: rest ->
+                    match rest with
+                    | [] -> offset + n
+                    | ByrefProjection.ReinterpretAs _ :: _
+                    | ByrefProjection.ByteOffset _ :: _ -> walk currentTemplate (offset + n) rest
+                    | ByrefProjection.Field _ :: _ ->
+                        failwith
+                            $"ByteOffset %d{n} followed by Field navigation without an intervening ReinterpretAs in projection chain: %A{projs} (this is an interpreter bug)"
 
-                match last, prev with
-                | ByrefProjection.Field field, Some (ByrefProjection.ReinterpretAs structType) ->
-                    let template = zeroForConcreteType baseClassTypes state structType
-                    let fieldOffset, _ = CliType.getFieldLayoutById field template
-                    let rest = projs |> List.take (len - 2)
-                    loop rest (offset + fieldOffset) true
-                | ByrefProjection.ByteOffset n, Some (ByrefProjection.ReinterpretAs _) ->
-                    let rest = projs |> List.take (len - 2)
-                    loop rest (offset + n) true
-                | ByrefProjection.ByteOffset n, _ ->
-                    failwith
-                        $"ByteOffset %d{n} without a preceding ReinterpretAs in projection chain: %A{projs} (this is an interpreter bug)"
-                | ByrefProjection.ReinterpretAs _, _ ->
-                    let rest = projs |> List.take (len - 1)
-                    loop rest offset true
-                | _, _ -> if peeled then ValueSome (projs, offset) else ValueNone
-
-        loop projs 0 false
+            let firstReinTemplate = zeroForConcreteType baseClassTypes state firstReinTy
+            let totalOffset = walk firstReinTemplate 0 afterReinterpret
+            ValueSome (structuralPrefix, totalOffset)
 
     let readManagedByrefBytesAs
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
@@ -1934,23 +1954,11 @@ module IlMachineManagedByref =
                 | CliByteAddressability.ByteAddressable -> true
                 | CliByteAddressability.Rejected _ -> false
 
-            // Only fully byte-resolved prefixes (no `ReinterpretAs`) are safe to
-            // route through the bytes writer: `resolveCell` resolves the prefix
-            // via `readProjectedValue`, which does not interpret a residual
-            // `ReinterpretAs` over a non-host-shaped cell. Prefixes containing
-            // `ReinterpretAs` (e.g. `[ReinterpretAs Outer; Field I; Field X]`
-            // produced by `Volatile.Write(ref view.I.X, _)` on
-            // `Unsafe.As<int, Outer>(ref arr[0])`) must fall back to the
-            // structural writer, which handles non-trailing reinterprets via
-            // `splitFirstReinterpret`.
-            let prefixContainsReinterpret (prefixProjs : ByrefProjection list) : bool =
-                prefixProjs
-                |> List.exists (
-                    function
-                    | ByrefProjection.ReinterpretAs _ -> true
-                    | _ -> false
-                )
-
+            // The forward-walk peel guarantees the structural prefix never
+            // contains a `ReinterpretAs`, so the byte-scatter writer's
+            // `resolveCell` (which navigates the prefix via
+            // `readProjectedValue`) can safely take the byte-renderable path
+            // without re-checking the prefix shape.
             let useStructuralWriter () : IlMachineState =
                 let rootValue = readRootValue state root
 
@@ -1959,8 +1967,7 @@ module IlMachineManagedByref =
                 | Some updatedRoot -> writeRootValue state root updatedRoot
 
             match peeled, baseClassTypes, valueIsByteRenderable with
-            | ValueSome (prefixProjs, _), Some bct, true when not (prefixContainsReinterpret prefixProjs) ->
-                writeManagedByrefBytesOrTypedCell bct state src newValue
+            | ValueSome (_, _), Some bct, true -> writeManagedByrefBytesOrTypedCell bct state src newValue
             | ValueSome ([], _), Some bct, false ->
                 // Non-byte-renderable empty-prefix peel: the bytes-or-typed-cell
                 // writer can precise-write for the byte-addressable storage

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -1894,20 +1894,34 @@ module IlMachineManagedByref =
             // struct view) route to the bytes-or-typed-cell writer. Without
             // BCT, fall back to the trailing-suffix-only classifier.
             //
-            // When peel collapses the whole tail (`prefix = []`), the
-            // bytes-or-typed-cell writer can target an absolute byte offset
-            // within the root directly. When peel leaves a residual structural
-            // prefix (e.g. `[Field f]`) and the value being written is not
-            // byte-renderable (object reference, runtime pointer), the
-            // bytes-or-typed-cell writer would attempt a byte scatter that
-            // refuses non-byte-addressable payloads; route those through the
-            // structural projection writer (`writeProjectedValueIfChanged`),
-            // which threads through `writeReinterpretedStorageIfChanged` and
-            // applies the transparent-wrapper fast path for ref↔ref writes.
-            // Byte-renderable writes with a residual prefix stay on the
-            // bytes-or-typed-cell path so the existing `resolveCell` byte
-            // scatter (which lifts back through trailing `Field` projections
-            // for `Unsafe.Add`-style cross-cell writes) keeps working.
+            // Dispatch the byte-view byref through one of two writers:
+            //
+            //  - `writeManagedByrefBytesOrTypedCell` handles byte-scatter writes
+            //    (`stind.i1` updating one byte of a wider cell, partial cell
+            //    writes via `Unsafe.Add`) and a few precise typed-cell fast
+            //    paths for storage that supports byte-level addressability
+            //    (StackMemoryByte, NativeMemoryByte, HeapValue, HeapObjectField,
+            //    ArrayElement, StringCharAt). When it cannot precise-write, it falls back
+            //    through `CliType.ToBytes newValue`, which refuses
+            //    non-byte-renderable values (object references, runtime
+            //    pointers).
+            //  - `writeProjectedValueIfChanged` handles structural writes via
+            //    `writeReinterpretedStorageIfChanged`, including the
+            //    transparent-wrapper fast path that lets ref↔ref writes
+            //    through a `VolatileObject<T>`-style wrapper succeed for any
+            //    root (locals, arguments, statics included).
+            //
+            // The dispatcher routes:
+            //  * byte-renderable values: to the bytes-or-typed-cell writer.
+            //    For empty prefix the writer's typed-cell fast path can
+            //    preserve identity; for non-empty prefix the byte-scatter
+            //    fallback's `resolveCell` lifts back through trailing `Field`
+            //    projections to handle `Unsafe.Add`-style cross-cell writes.
+            //  * non-byte-renderable values: to the structural projection
+            //    writer, which is the only one that can preserve identity for
+            //    object references and tagged pointers over arbitrary roots.
+            //    Without BCT we lack the metadata to peel chained reinterprets;
+            //    legacy callers should use `writeManagedByrefWithBase`.
             let peeled : (ByrefProjection list * int) voption =
                 match baseClassTypes with
                 | Some bct -> peelTrailingByteView bct state projs
@@ -1920,19 +1934,37 @@ module IlMachineManagedByref =
                 | CliByteAddressability.ByteAddressable -> true
                 | CliByteAddressability.Rejected _ -> false
 
-            match peeled, baseClassTypes with
-            | ValueSome ([], _), Some bct -> writeManagedByrefBytesOrTypedCell bct state src newValue
-            | ValueSome (_ :: _, _), Some bct when valueIsByteRenderable ->
-                writeManagedByrefBytesOrTypedCell bct state src newValue
-            | ValueSome _, None ->
+            match peeled, baseClassTypes, valueIsByteRenderable with
+            | ValueSome _, Some bct, true -> writeManagedByrefBytesOrTypedCell bct state src newValue
+            | ValueSome ([], _), Some bct, false ->
+                // Non-byte-renderable empty-prefix peel: the bytes-or-typed-cell
+                // writer can precise-write for the byte-addressable storage
+                // roots (StackMemoryByte, NativeMemoryByte, HeapValue,
+                // HeapObjectField, ArrayElement, StringCharAt). For other roots
+                // its fallback hits `CliType.ToBytes`; route those through the
+                // structural path instead.
+                match root with
+                | ByrefRoot.StackMemoryByte _
+                | ByrefRoot.NativeMemoryByte _
+                | ByrefRoot.HeapValue _
+                | ByrefRoot.HeapObjectField _
+                | ByrefRoot.ArrayElement _
+                | ByrefRoot.StringCharAt _ -> writeManagedByrefBytesOrTypedCell bct state src newValue
+                | _ ->
+                    let rootValue = readRootValue state root
+
+                    match writeProjectedValueIfChanged baseClassTypes state rootValue projs newValue with
+                    | None -> state
+                    | Some updatedRoot -> writeRootValue state root updatedRoot
+            | ValueSome _, None, _ ->
                 // Trailing-suffix-only byte view; legacy callers without BCT
                 // pass through here. Routing without BCT means the bytes path
                 // cannot peel non-trailing reinterprets, but the old
                 // splitTrailingByteView contract is preserved.
                 failwith
                     "writeManagedByref: byte-view byref encountered without BaseClassTypes; call writeManagedByrefWithBase instead"
-            | ValueSome (_ :: _, _), Some _
-            | ValueNone, _ ->
+            | ValueSome (_ :: _, _), Some _, false
+            | ValueNone, _, _ ->
                 let rootValue = readRootValue state root
 
                 match writeProjectedValueIfChanged baseClassTypes state rootValue projs newValue with

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -865,8 +865,20 @@ module IlMachineManagedByref =
     /// never contains a `ReinterpretAs` by construction. A non-trailing
     /// `ByteOffset` (which the construction-site canonicaliser never
     /// produces) is an interpreter bug and is raised here.
+    ///
+    /// `baseClassTypes` is required only when the byte-view suffix navigates
+    /// through a `Field` projection (Field layout is resolved against the
+    /// current type template, which requires metadata). Metadata-light
+    /// callers (the BCT-less `writeManagedByref` entry point used by
+    /// primitive/external boundaries that do not currently carry type
+    /// metadata) may pass `None`; their canonical chain shapes are
+    /// `[..., ReinterpretAs T]` and `[..., ReinterpretAs T; ByteOffset n]`,
+    /// whose suffixes contain no `Field` and therefore need no template. A
+    /// BCT-less call with a `Field` in the byte-view suffix is an interpreter
+    /// bug (the construction site that emitted such a chain ought to carry
+    /// BCT) and is raised here with a descriptive message.
     let private peelTrailingByteView
-        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly> option)
         (state : IlMachineState)
         (projs : ByrefProjection list)
         : (ByrefProjection list * int) voption
@@ -885,36 +897,44 @@ module IlMachineManagedByref =
         | None -> ValueNone
         | Some (structuralPrefix, firstReinTy, afterReinterpret) ->
             // Walk forward through the byte-view suffix, accumulating byte
-            // offset. `currentTemplate` tracks the CliType of the storage we
-            // are currently navigating through: `Field` projections add the
-            // field's offset within that template; chained `ReinterpretAs`
-            // re-anchors the template to the new type; `ByteOffset` adds raw
-            // bytes and either terminates the walk or re-anchors via the
-            // immediately following `ReinterpretAs`. A `ByteOffset` followed
-            // by a `Field` would require navigating fields on a cursor with
-            // no type anchor and signals an interpreter bug at the
-            // construction site.
-            let rec walk (currentTemplate : CliType) (offset : int) (remaining : ByrefProjection list) : int =
+            // offset. The template anchoring the cursor is computed lazily
+            // via `templateThunk`: only `Field` projections consume it.
+            // Chained `ReinterpretAs` re-anchors the thunk to the new type;
+            // `ByteOffset` adds raw bytes and either terminates the walk or
+            // re-anchors via the immediately following `ReinterpretAs`. A
+            // `ByteOffset` followed by a `Field` would require navigating
+            // fields on a cursor with no type anchor and signals an
+            // interpreter bug at the construction site. Lazy evaluation
+            // means BCT is only consulted when a `Field` actually appears
+            // in the byte-view suffix, so the metadata-light call shapes
+            // (`[ReinterpretAs T]`, `[ReinterpretAs T; ByteOffset n]`) work
+            // with `baseClassTypes = None`.
+            let templateFor (ty : ConcreteType<ConcreteTypeHandle>) : CliType =
+                match baseClassTypes with
+                | Some bct -> zeroForConcreteType bct state ty
+                | None ->
+                    failwith
+                        $"peelTrailingByteView: BaseClassTypes required to navigate `Field` projection after `ReinterpretAs` %s{ty.Namespace}.%s{ty.Name} in projection chain: %A{projs} (metadata-light entry points cannot resolve Field layout; pass BaseClassTypes via writeManagedByrefWithBase)"
+
+            let rec walk (templateThunk : unit -> CliType) (offset : int) (remaining : ByrefProjection list) : int =
                 match remaining with
                 | [] -> offset
                 | ByrefProjection.Field field :: rest ->
-                    let fieldOffset, _ = CliType.getFieldLayoutById field currentTemplate
-                    let fieldTemplate = CliType.getFieldById field currentTemplate
-                    walk fieldTemplate (offset + fieldOffset) rest
-                | ByrefProjection.ReinterpretAs newReinTy :: rest ->
-                    let newTemplate = zeroForConcreteType baseClassTypes state newReinTy
-                    walk newTemplate offset rest
+                    let template = templateThunk ()
+                    let fieldOffset, _ = CliType.getFieldLayoutById field template
+                    let fieldTemplate = CliType.getFieldById field template
+                    walk (fun () -> fieldTemplate) (offset + fieldOffset) rest
+                | ByrefProjection.ReinterpretAs newReinTy :: rest -> walk (fun () -> templateFor newReinTy) offset rest
                 | ByrefProjection.ByteOffset n :: rest ->
                     match rest with
                     | [] -> offset + n
                     | ByrefProjection.ReinterpretAs _ :: _
-                    | ByrefProjection.ByteOffset _ :: _ -> walk currentTemplate (offset + n) rest
+                    | ByrefProjection.ByteOffset _ :: _ -> walk templateThunk (offset + n) rest
                     | ByrefProjection.Field _ :: _ ->
                         failwith
                             $"ByteOffset %d{n} followed by Field navigation without an intervening ReinterpretAs in projection chain: %A{projs} (this is an interpreter bug)"
 
-            let firstReinTemplate = zeroForConcreteType baseClassTypes state firstReinTy
-            let totalOffset = walk firstReinTemplate 0 afterReinterpret
+            let totalOffset = walk (fun () -> templateFor firstReinTy) 0 afterReinterpret
             ValueSome (structuralPrefix, totalOffset)
 
     let readManagedByrefBytesAs
@@ -952,7 +972,7 @@ module IlMachineManagedByref =
             // then `Volatile.Read` wrapping the result in `VolatileUInt32`)
             // is the load-bearing example.
             let byteViewShape : (ByrefProjection list * int) voption =
-                peelTrailingByteView baseClassTypes state outerProjs
+                peelTrailingByteView (Some baseClassTypes) state outerProjs
 
             match byteViewShape with
             | ValueSome (prefixProjs, byteOffset) ->
@@ -1479,8 +1499,8 @@ module IlMachineManagedByref =
         | CliByteAddressability.ByteAddressable -> None
         | CliByteAddressability.Rejected _ -> IlMachineThreadState.setArrayValue arr newValue index state |> Some
 
-    let writeManagedByrefBytesOrTypedCell
-        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+    let private writeManagedByrefBytesOrTypedCellCore
+        (baseClassTypes : BaseClassTypes<DumpedAssembly> option)
         (state : IlMachineState)
         (src : ManagedPointerSource)
         (newValue : CliType)
@@ -1745,6 +1765,20 @@ module IlMachineManagedByref =
                     | None -> state
                     | Some updatedRoot -> writeRootValue state outerRoot updatedRoot
 
+    /// Public BCT-aware entry point. Delegates to `writeManagedByrefBytesOrTypedCellCore`
+    /// with `Some baseClassTypes`; the core body lazily consults the BCT only when a
+    /// `Field` projection appears in the byte-view suffix, so the metadata-light shapes
+    /// `[ReinterpretAs T]` and `[ReinterpretAs T; ByteOffset n]` flow through
+    /// `writeManagedByrefCore` with `None` without forcing BCT lookups.
+    let writeManagedByrefBytesOrTypedCell
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (src : ManagedPointerSource)
+        (newValue : CliType)
+        : IlMachineState
+        =
+        writeManagedByrefBytesOrTypedCellCore (Some baseClassTypes) state src newValue
+
     let private splitFirstReinterpret
         (projs : ByrefProjection list)
         : (ByrefProjection list * ConcreteType<ConcreteTypeHandle> * ByrefProjection list) option
@@ -1940,14 +1974,13 @@ module IlMachineManagedByref =
             //  * non-byte-renderable values: to the structural projection
             //    writer, which is the only one that can preserve identity for
             //    object references and tagged pointers over arbitrary roots.
-            //    Without BCT we lack the metadata to peel chained reinterprets;
-            //    legacy callers should use `writeManagedByrefWithBase`.
+            //
+            // Both writers now accept an optional `BaseClassTypes`: the peel
+            // and the bytes-or-typed-cell writer only consult BCT when a
+            // `Field` projection appears in the byte-view suffix, which
+            // metadata-light callers do not produce.
             let peeled : (ByrefProjection list * int) voption =
-                match baseClassTypes with
-                | Some bct -> peelTrailingByteView bct state projs
-                | None ->
-                    splitTrailingByteView src
-                    |> ValueOption.map (fun (_root, prefixProjs, offset) -> prefixProjs, offset)
+                peelTrailingByteView baseClassTypes state projs
 
             let valueIsByteRenderable =
                 match CliType.ByteAddressability newValue with
@@ -1966,9 +1999,16 @@ module IlMachineManagedByref =
                 | None -> state
                 | Some updatedRoot -> writeRootValue state root updatedRoot
 
-            match peeled, baseClassTypes, valueIsByteRenderable with
-            | ValueSome (_, _), Some bct, true -> writeManagedByrefBytesOrTypedCell bct state src newValue
-            | ValueSome ([], _), Some bct, false ->
+            match peeled, valueIsByteRenderable with
+            | ValueSome (_, _), true ->
+                // Byte-renderable values flow through the bytes-or-typed-cell
+                // writer regardless of BCT availability. The metadata-light
+                // shapes `[ReinterpretAs T]` and `[ReinterpretAs T; ByteOffset n]`
+                // (used by primitive/external boundaries that don't carry type
+                // metadata) work here because the core never consults BCT
+                // unless a `Field` appears in the byte-view suffix.
+                writeManagedByrefBytesOrTypedCellCore baseClassTypes state src newValue
+            | ValueSome ([], _), false ->
                 // Non-byte-renderable empty-prefix peel: the bytes-or-typed-cell
                 // writer can precise-write for the byte-addressable storage
                 // roots (StackMemoryByte, NativeMemoryByte, HeapValue,
@@ -1981,17 +2021,8 @@ module IlMachineManagedByref =
                 | ByrefRoot.HeapValue _
                 | ByrefRoot.HeapObjectField _
                 | ByrefRoot.ArrayElement _
-                | ByrefRoot.StringCharAt _ -> writeManagedByrefBytesOrTypedCell bct state src newValue
+                | ByrefRoot.StringCharAt _ -> writeManagedByrefBytesOrTypedCellCore baseClassTypes state src newValue
                 | _ -> useStructuralWriter ()
-            | ValueSome _, None, _ ->
-                // Metadata-light caller hit a trailing byte view but cannot
-                // supply BCT for the forward-walk peel. The structural writer
-                // accepts an `Option<BaseClassTypes>` and degrades gracefully
-                // for the simple chain shapes the legacy
-                // `splitTrailingByteView` is tuned for. Callers that need
-                // bytewise writes through arbitrary residual reinterprets
-                // should migrate to `writeManagedByrefWithBase`.
-                useStructuralWriter ()
             | _ -> useStructuralWriter ()
 
     let writeManagedByref (state : IlMachineState) (src : ManagedPointerSource) (newValue : CliType) : IlMachineState =

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -1419,7 +1419,48 @@ module IlMachineManagedByref =
                 |> Some
         | _ -> None
 
+    /// Element-precise byte-view write for an array element: when the destination cell
+    /// is non-byte-addressable (object reference, runtime pointer) and the new value is
+    /// the same CLI constructor of the same size at exactly `byteOffset = 0`, update the
+    /// element directly. This is the array-element analogue of `tryWriteHeapValueFieldPrecise`
+    /// and exists for the same reason: the byte-scatter path
+    /// (`writeArrayBytes` → `withByteAddressableCellBytesAtIfChanged`) refuses
+    /// non-byte-addressable cells, but the typed-cell write preserves their identity.
+    /// The motivating case is `Volatile.Write(ref keys[index], key)`, whose lowering
+    /// builds a byref over the reference-typed array element with a trailing
+    /// `[ReinterpretAs VolatileObject; Field Value]` view.
+    let private tryWriteArrayElementPrecise
+        (state : IlMachineState)
+        (arr : ManagedHeapAddress)
+        (index : int)
+        (byteOffset : int)
+        (newValue : CliType)
+        : IlMachineState option
+        =
+        if byteOffset <> 0 then
+            None
+        else
+
+        let arrObj = state.ManagedHeap.Arrays.[arr]
+
+        if index < 0 || index >= arrObj.Length then
+            None
+        else
+
+        let existing = arrObj.Elements.[index]
+
+        if CliType.sizeOf existing <> CliType.sizeOf newValue then
+            None
+        else if not (sameCliConstructor existing newValue) then
+            None
+        else
+
+        match CliType.ByteAddressability existing with
+        | CliByteAddressability.ByteAddressable -> None
+        | CliByteAddressability.Rejected _ -> IlMachineThreadState.setArrayValue arr newValue index state |> Some
+
     let writeManagedByrefBytesOrTypedCell
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (state : IlMachineState)
         (src : ManagedPointerSource)
         (newValue : CliType)
@@ -1434,16 +1475,18 @@ module IlMachineManagedByref =
         // NullaryIlOp.fs's `stind` dispatcher and `Localloc`, which pushes
         // `EvalStackValue.NativeInt (NativeIntSource.ManagedPointer ...)`).
         // The same fast path also accepts a trailing byte view
-        // (`[ReinterpretAs ty]` / `[ReinterpretAs ty; ByteOffset n]`) when
-        // the value being written cannot be flattened to bytes; otherwise
-        // byte-view writes must continue to land in the `Bytes` overlay so
-        // that partial-cell semantics (`stind.i1` updating one byte of a
-        // wider cell, byte-by-byte initialisation of a stackalloc buffer)
-        // are preserved. The Span<IntPtr> pinning path that feeds
-        // RuntimeTypeHandle.GetFields produces a byte-view shape over
-        // localloc memory and writes `FieldHandlePtr`-tagged native ints
-        // through it; those are not byte-addressable, so the typed-cell
-        // path is the only one that can preserve them.
+        // (`[ReinterpretAs ty]` / `[ReinterpretAs ty; ByteOffset n]`,
+        // or a chained reinterpret followed by `Field`/`ByteOffset`
+        // segments that `peelTrailingByteView` collapses into a single
+        // byte offset) when the value being written cannot be flattened
+        // to bytes; otherwise byte-view writes must continue to land in
+        // the `Bytes` overlay so that partial-cell semantics (`stind.i1`
+        // updating one byte of a wider cell, byte-by-byte initialisation
+        // of a stackalloc buffer) are preserved. The Span<IntPtr> pinning
+        // path that feeds RuntimeTypeHandle.GetFields produces a byte-view
+        // shape over localloc memory and writes `FieldHandlePtr`-tagged
+        // native ints through it; those are not byte-addressable, so the
+        // typed-cell path is the only one that can preserve them.
         // We restrict the fast path to writes that are observably equivalent
         // to byte scatter: the new value must replace at most one existing
         // cell that starts exactly at `byteOffset` and has the same size as
@@ -1456,16 +1499,22 @@ module IlMachineManagedByref =
             match src with
             | ManagedPointerSource.Byref (ByrefRoot.StackMemoryByte (thread, frame, block, byteOffset), []) ->
                 ValueSome (thread, frame, block, byteOffset)
-            | ManagedPointerSource.Byref (ByrefRoot.StackMemoryByte _, _) ->
+            | ManagedPointerSource.Byref (ByrefRoot.StackMemoryByte (thread, frame, block, rootByteOffset), projs) ->
                 match CliType.ByteAddressability newValue with
                 | CliByteAddressability.ByteAddressable ->
                     // Byte-addressable byte-view writes follow the existing byte-scatter
                     // path below to preserve the `Bytes` overlay representation.
                     ValueNone
                 | CliByteAddressability.Rejected _ ->
-                    match splitTrailingByteView src with
-                    | ValueSome (ByrefRoot.StackMemoryByte (thread, frame, block, rootByteOffset), [], byteOffset) ->
-                        ValueSome (thread, frame, block, rootByteOffset + byteOffset)
+                    // Iterative peel mirrors the read side: a chained
+                    // byte-view (e.g. `[ReinterpretAs S, Field f, ReinterpretAs
+                    // T]`) reduces to a single byte offset over the
+                    // StackMemoryByte root, so the typed-cell fast path can
+                    // preserve the provenance of `newValue` rather than
+                    // hitting byte scatter (which would reject the
+                    // non-byte-addressable payload).
+                    match peelTrailingByteView baseClassTypes state projs with
+                    | ValueSome ([], byteOffset) -> ValueSome (thread, frame, block, rootByteOffset + byteOffset)
                     | _ -> ValueNone
             | _ -> ValueNone
 
@@ -1484,18 +1533,21 @@ module IlMachineManagedByref =
         | ValueNone ->
 
         // Same fast path for native-heap blocks. The pool is global on state, so we
-        // only need (block, byteOffset) here.
+        // only need (block, byteOffset) here. The iterative-peel mirror of the
+        // StackMemoryByte case above: chained byte-view shapes
+        // (`[ReinterpretAs S, Field f, ReinterpretAs T]` and similar) reduce to a
+        // single byte offset over the NativeMemoryByte root, allowing the typed-cell
+        // fast path to preserve `newValue`'s provenance.
         let nativeMemoryByteTarget =
             match src with
             | ManagedPointerSource.Byref (ByrefRoot.NativeMemoryByte (block, byteOffset), []) ->
                 ValueSome (block, byteOffset)
-            | ManagedPointerSource.Byref (ByrefRoot.NativeMemoryByte _, _) ->
+            | ManagedPointerSource.Byref (ByrefRoot.NativeMemoryByte (block, rootByteOffset), projs) ->
                 match CliType.ByteAddressability newValue with
                 | CliByteAddressability.ByteAddressable -> ValueNone
                 | CliByteAddressability.Rejected _ ->
-                    match splitTrailingByteView src with
-                    | ValueSome (ByrefRoot.NativeMemoryByte (block, rootByteOffset), [], byteOffset) ->
-                        ValueSome (block, rootByteOffset + byteOffset)
+                    match peelTrailingByteView baseClassTypes state projs with
+                    | ValueSome ([], byteOffset) -> ValueSome (block, rootByteOffset + byteOffset)
                     | _ -> ValueNone
             | _ -> ValueNone
 
@@ -1518,16 +1570,54 @@ module IlMachineManagedByref =
         // field cell rather than the byte-scatter path. This preserves identity for
         // object-reference and runtime-pointer fields, whose `CliType.ToBytes` is not
         // defined and which `writeHeapValueBytes` would refuse via byte addressability.
-        // Mirrors `tryReadHeapValueFieldPrecise` on the read path.
+        // Mirrors `tryReadHeapValueFieldPrecise` on the read path; uses the iterative
+        // peel for symmetry with the read-side classifier so a chained byte-view that
+        // lands on a precise field (e.g. `Volatile.Write` lowering of an object-typed
+        // field through an `Unsafe.As` view) still routes to the typed write.
+        //
+        // For non-byte-renderable values, `writeManagedByrefCore` routes chains whose
+        // peel result has a non-empty structural prefix through the structural
+        // projection writer (`writeProjectedValueIfChanged`), so this dispatcher
+        // typically only needs to handle the empty-prefix case. Direct callers of
+        // `writeManagedByrefBytesOrTypedCell` (e.g. property tests) may still pass a
+        // non-empty prefix for byte-renderable values; in that case the typed-cell
+        // fast path declines and the byte-scatter fallback below handles the chain.
         let heapFieldPreciseWrite =
             match src with
             | ManagedPointerSource.Byref (ByrefRoot.HeapValue addr, []) ->
                 tryWriteHeapValueFieldPrecise state addr 0 newValue
-            | ManagedPointerSource.Byref (ByrefRoot.HeapValue _, _) ->
-                match splitTrailingByteView src with
-                | ValueSome (ByrefRoot.HeapValue addr, [], byteOffset) ->
-                    tryWriteHeapValueFieldPrecise state addr byteOffset newValue
-                | _ -> None
+            | ManagedPointerSource.Byref (ByrefRoot.HeapValue addr, projs) ->
+                match peelTrailingByteView baseClassTypes state projs with
+                | ValueSome ([], byteOffset) -> tryWriteHeapValueFieldPrecise state addr byteOffset newValue
+                | ValueSome (_ :: _, _)
+                | ValueNone -> None
+            | ManagedPointerSource.Byref (ByrefRoot.HeapObjectField (addr, field), projs) ->
+                match peelTrailingByteView baseClassTypes state projs with
+                | ValueSome ([], byteOffset) ->
+                    // The named field's offset is the starting point inside the heap
+                    // object; the peel result lands at `byteOffset` beyond that. For an
+                    // exact whole-field overlap (`byteOffset = 0` matches the typed-cell
+                    // matcher's same-size predicate), the typed write preserves
+                    // identity for object-reference and runtime-pointer cells.
+                    let obj = ManagedHeap.get addr state.ManagedHeap
+                    let fieldOffset, _ = CliValueType.GetFieldLayoutById field obj.Contents
+                    tryWriteHeapValueFieldPrecise state addr (fieldOffset + byteOffset) newValue
+                | ValueSome (_ :: _, _)
+                | ValueNone -> None
+            | ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, index), []) ->
+                tryWriteArrayElementPrecise state arr index 0 newValue
+            | ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, index), projs) ->
+                match peelTrailingByteView baseClassTypes state projs with
+                | ValueSome ([], byteOffset) ->
+                    // `Volatile.Write(ref array[i], obj)` lowers to a byref over the
+                    // array element with a trailing `[ReinterpretAs VolatileObject;
+                    // Field Value]` view, which peels to `([], 0)`. Route to the
+                    // element-precise typed-cell write so that the destination
+                    // ObjectRef cell is preserved rather than scattered through the
+                    // byte-write path (which refuses non-byte-addressable cells).
+                    tryWriteArrayElementPrecise state arr index byteOffset newValue
+                | ValueSome (_ :: _, _)
+                | ValueNone -> None
             | _ -> None
 
         match heapFieldPreciseWrite with
@@ -1553,59 +1643,72 @@ module IlMachineManagedByref =
         | ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, index), []) ->
             writeArrayBytes state arr index 0 bytes
         | ManagedPointerSource.Byref (outerRoot, outerProjs) ->
-            match splitTrailingByteView src with
-            | ValueSome (ByrefRoot.StackMemoryByte (thread, frame, block, rootByteOffset), [], byteOffset) ->
-                // Byte-addressable byte-view writes through a localloc buffer
-                // intentionally fall through here (the typed-cell fast path
-                // above declines them so that the `Bytes` overlay
-                // representation is preserved for `stind.i1`-style partial
-                // updates).
-                writeStackMemoryBytesAt state thread frame block (rootByteOffset + byteOffset) bytes
-            | ValueSome (ByrefRoot.NativeMemoryByte (block, rootByteOffset), [], byteOffset) ->
-                // Same reasoning as the StackMemoryByte case above, but routed
-                // through the global NativeMemoryPool.
-                writeNativeMemoryBytesAt state block (rootByteOffset + byteOffset) bytes
-            | ValueSome (ByrefRoot.ArrayElement (arr, index), [], byteOffset) ->
-                writeArrayBytes state arr index byteOffset bytes
-            | ValueSome (ByrefRoot.StringCharAt (str, charIndex), [], byteOffset) ->
-                writeStringBytes state str charIndex byteOffset bytes
-            | ValueSome (ByrefRoot.HeapValue addr, [], byteOffset) -> writeHeapValueBytes state addr byteOffset bytes
-            | ValueSome (byteViewRoot, prefixProjs, byteOffset) ->
-                let rootValue = readRootValue state byteViewRoot
+            // Collapse any trailing byte-view segment of the projection
+            // chain into an accumulated byte offset. Mirrors
+            // `readManagedByrefBytesAs`: once a `ReinterpretAs` appears
+            // the underlying storage is being treated as raw bytes, so
+            // subsequent `ByteOffset`, `Field` (resolved against the most
+            // recent `ReinterpretAs` target), and chained `ReinterpretAs`
+            // projections are all bytewise. Peeling them exposes the
+            // residual structural prefix to the existing dispatchers.
+            let byteViewShape : (ByrefProjection list * int) voption =
+                peelTrailingByteView baseClassTypes state outerProjs
 
-                // Symmetric to the read path: when the byte write overflows
-                // the immediate cell, lift back through trailing `Field`
-                // projections so a write through e.g. `Unsafe.Add(ref s.A, 1)`
-                // updates the parent struct's sibling field.
-                let rec resolveCell
-                    (projs : ByrefProjection list)
-                    (offset : int)
-                    : ByrefProjection list * int * CliType
-                    =
-                    let cell = readProjectedValue rootValue projs
-                    let cellSize = byteAddressableCellSize $"single-cell byref %O{src}" cell
+            match byteViewShape with
+            | ValueSome (prefixProjs, byteOffset) ->
+                match outerRoot, prefixProjs with
+                | ByrefRoot.StackMemoryByte (thread, frame, block, rootByteOffset), [] ->
+                    // Byte-addressable byte-view writes through a localloc buffer
+                    // intentionally fall through here (the typed-cell fast path
+                    // above declines them so that the `Bytes` overlay
+                    // representation is preserved for `stind.i1`-style partial
+                    // updates).
+                    writeStackMemoryBytesAt state thread frame block (rootByteOffset + byteOffset) bytes
+                | ByrefRoot.NativeMemoryByte (block, rootByteOffset), [] ->
+                    // Same reasoning as the StackMemoryByte case above, but
+                    // routed through the global NativeMemoryPool.
+                    writeNativeMemoryBytesAt state block (rootByteOffset + byteOffset) bytes
+                | ByrefRoot.ArrayElement (arr, index), [] -> writeArrayBytes state arr index byteOffset bytes
+                | ByrefRoot.StringCharAt (str, charIndex), [] -> writeStringBytes state str charIndex byteOffset bytes
+                | ByrefRoot.HeapValue addr, [] -> writeHeapValueBytes state addr byteOffset bytes
+                | _, prefixProjs ->
+                    let rootValue = readRootValue state outerRoot
 
-                    if offset >= 0 && bytes.Length <= cellSize - offset then
-                        projs, offset, cell
-                    else
-                        match List.tryLast projs with
-                        | Some (ByrefProjection.Field field) ->
-                            let parentProjs = projs |> List.take (List.length projs - 1)
-                            let parentValue = readProjectedValue rootValue parentProjs
-                            let fieldOffset, _ = CliType.getFieldLayoutById field parentValue
-                            resolveCell parentProjs (offset + fieldOffset)
-                        | _ ->
-                            failwith
-                                $"TODO: byte-view write at offset %d{offset} for %d{bytes.Length} bytes does not fit in single primitive cell of size %d{cellSize}: %O{src}"
+                    // Symmetric to the read path: when the byte write overflows
+                    // the immediate cell, lift back through trailing `Field`
+                    // projections so a write through e.g. `Unsafe.Add(ref s.A, 1)`
+                    // updates the parent struct's sibling field.
+                    let rec resolveCell
+                        (projs : ByrefProjection list)
+                        (offset : int)
+                        : ByrefProjection list * int * CliType
+                        =
+                        let cell = readProjectedValue rootValue projs
+                        let cellSize = byteAddressableCellSize $"single-cell byref %O{src}" cell
 
-                let liftedProjs, finalOffset, cell = resolveCell prefixProjs byteOffset
+                        if offset >= 0 && bytes.Length <= cellSize - offset then
+                            projs, offset, cell
+                        else
+                            match List.tryLast projs with
+                            | Some (ByrefProjection.Field field) ->
+                                let parentProjs = projs |> List.take (List.length projs - 1)
+                                let parentValue = readProjectedValue rootValue parentProjs
+                                let fieldOffset, _ = CliType.getFieldLayoutById field parentValue
+                                resolveCell parentProjs (offset + fieldOffset)
+                            | _ ->
+                                failwith
+                                    $"TODO: byte-view write at offset %d{offset} for %d{bytes.Length} bytes does not fit in single primitive cell of size %d{cellSize}: %O{src}"
 
-                match withByteAddressableCellBytesAtIfChanged $"single-cell byref %O{src}" finalOffset bytes cell with
-                | None -> state
-                | Some updatedCell ->
-                    match applyProjectionsForWriteIfChanged rootValue liftedProjs updatedCell with
+                    let liftedProjs, finalOffset, cell = resolveCell prefixProjs byteOffset
+
+                    match
+                        withByteAddressableCellBytesAtIfChanged $"single-cell byref %O{src}" finalOffset bytes cell
+                    with
                     | None -> state
-                    | Some updatedRoot -> writeRootValue state byteViewRoot updatedRoot
+                    | Some updatedCell ->
+                        match applyProjectionsForWriteIfChanged rootValue liftedProjs updatedCell with
+                        | None -> state
+                        | Some updatedRoot -> writeRootValue state outerRoot updatedRoot
             | ValueNone ->
                 let rootValue = readRootValue state outerRoot
                 let cell = readProjectedValue rootValue outerProjs
@@ -1784,9 +1887,42 @@ module IlMachineManagedByref =
         | ManagedPointerSource.Null -> failwith "TODO: throw NullReferenceException"
         | ManagedPointerSource.Byref (root, []) -> writeRootValue state root newValue
         | ManagedPointerSource.Byref (root, projs) ->
-            match splitTrailingByteView src with
-            | ValueSome _ -> writeManagedByrefBytesOrTypedCell state src newValue
-            | ValueNone ->
+            // Mirror the read-side dispatch: when we have BaseClassTypes,
+            // use the iterative peel so chained byte views like
+            // `[ReinterpretAs S, Field f, ReinterpretAs T, Field g]`
+            // (e.g. `Volatile.Write` on a field of an `Unsafe.As`-projected
+            // struct view) route to the bytes-or-typed-cell writer. Without
+            // BCT, fall back to the trailing-suffix-only classifier.
+            //
+            // The bytes-or-typed-cell writer assumes it can target the cell at
+            // an absolute byte offset within the root: it works directly for
+            // chains whose peeled prefix is empty (bare StackMemoryByte /
+            // NativeMemoryByte / HeapValue / HeapObjectField roots). When peel collapses only a
+            // suffix and leaves a structural `Field` prefix, the typed-cell
+            // path can no longer reach the destination cell from the root
+            // alone; the structural projection writer (`writeProjectedValueIfChanged`)
+            // is the right path because it threads the write through
+            // `splitFirstReinterpret` / `writeReinterpretedStorageIfChanged`,
+            // which already handles the same byte-view tail and additionally
+            // walks the structural prefix.
+            let peeled : (ByrefProjection list * int) voption =
+                match baseClassTypes with
+                | Some bct -> peelTrailingByteView bct state projs
+                | None ->
+                    splitTrailingByteView src
+                    |> ValueOption.map (fun (_root, prefixProjs, offset) -> prefixProjs, offset)
+
+            match peeled, baseClassTypes with
+            | ValueSome ([], _), Some bct -> writeManagedByrefBytesOrTypedCell bct state src newValue
+            | ValueSome _, None ->
+                // Trailing-suffix-only byte view; legacy callers without BCT
+                // pass through here. Routing without BCT means the bytes path
+                // cannot peel non-trailing reinterprets, but the old
+                // splitTrailingByteView contract is preserved.
+                failwith
+                    "writeManagedByref: byte-view byref encountered without BaseClassTypes; call writeManagedByrefWithBase instead"
+            | ValueSome (_ :: _, _), _
+            | ValueNone, _ ->
                 let rootValue = readRootValue state root
 
                 match writeProjectedValueIfChanged baseClassTypes state rootValue projs newValue with
@@ -1893,17 +2029,17 @@ module IlMachineManagedByref =
                 let destSize = CliType.sizeOf newValue
 
                 if stackMemoryByteTypedWriteSafe pool block byteOffset destSize then
-                    writeManagedByrefBytesOrTypedCell state src newValue
+                    writeManagedByrefBytesOrTypedCell baseClassTypes state src newValue
                 else
                     failwith
                         $"TODO: primitive indirect store of %O{newValue} through byte-view byref %O{src} cannot preserve new value's %s{rejection.Description}"
-            | _ -> writeManagedByrefBytesOrTypedCell state src newValue
+            | _ -> writeManagedByrefBytesOrTypedCell baseClassTypes state src newValue
         | ManagedPointerSource.Byref (ByrefRoot.StackMemoryByte _, _) ->
             match byteAddressabilityRejection newValue with
             | Some rejection when isNumericProvenanceRejection rejection ->
                 failwith
                     $"TODO: primitive indirect store of %O{newValue} through byte-view byref %O{src} cannot preserve new value's %s{rejection.Description}"
-            | _ -> writeManagedByrefBytesOrTypedCell state src newValue
+            | _ -> writeManagedByrefBytesOrTypedCell baseClassTypes state src newValue
         | ManagedPointerSource.Byref (ByrefRoot.NativeMemoryByte (block, byteOffset), []) ->
             match byteAddressabilityRejection newValue with
             | Some rejection when isNumericProvenanceRejection rejection ->
@@ -1911,17 +2047,17 @@ module IlMachineManagedByref =
                 let destSize = CliType.sizeOf newValue
 
                 if nativeMemoryByteTypedWriteSafe pool block byteOffset destSize then
-                    writeManagedByrefBytesOrTypedCell state src newValue
+                    writeManagedByrefBytesOrTypedCell baseClassTypes state src newValue
                 else
                     failwith
                         $"TODO: primitive indirect store of %O{newValue} through byte-view byref %O{src} cannot preserve new value's %s{rejection.Description}"
-            | _ -> writeManagedByrefBytesOrTypedCell state src newValue
+            | _ -> writeManagedByrefBytesOrTypedCell baseClassTypes state src newValue
         | ManagedPointerSource.Byref (ByrefRoot.NativeMemoryByte _, _) ->
             match byteAddressabilityRejection newValue with
             | Some rejection when isNumericProvenanceRejection rejection ->
                 failwith
                     $"TODO: primitive indirect store of %O{newValue} through byte-view byref %O{src} cannot preserve new value's %s{rejection.Description}"
-            | _ -> writeManagedByrefBytesOrTypedCell state src newValue
+            | _ -> writeManagedByrefBytesOrTypedCell baseClassTypes state src newValue
         | ManagedPointerSource.Null -> failwith "TODO: throw NullReferenceException"
         | ManagedPointerSource.Byref _ ->
             let sourceRejection = byteAddressabilityRejection newValue
@@ -1937,7 +2073,7 @@ module IlMachineManagedByref =
                     None
             | _ ->
                 match splitTrailingByteView src with
-                | ValueSome _ -> writeManagedByrefBytesOrTypedCell state src newValue
+                | ValueSome _ -> writeManagedByrefBytesOrTypedCell baseClassTypes state src newValue
                 | ValueNone ->
                     // Even a byte-renderable payload may need a typed store
                     // when the destination cell carries non-byte-renderable
@@ -1953,4 +2089,4 @@ module IlMachineManagedByref =
                             newValue
                             $"destination's existing %s{rejection.Description}"
                             (Some existing)
-                    | _ -> writeManagedByrefBytesOrTypedCell state src newValue
+                    | _ -> writeManagedByrefBytesOrTypedCell baseClassTypes state src newValue

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -1985,10 +1985,12 @@ module IlMachineManagedByref =
                 | _ -> useStructuralWriter ()
             | ValueSome _, None, _ ->
                 // Metadata-light caller hit a trailing byte view but cannot
-                // supply BCT for the iterative peel. The structural writer is
-                // still safe: it accepts the option-typed BCT and only needs
-                // it for non-trailing `ReinterpretAs` chains, which the legacy
-                // `splitTrailingByteView` classifier never produces.
+                // supply BCT for the forward-walk peel. The structural writer
+                // accepts an `Option<BaseClassTypes>` and degrades gracefully
+                // for the simple chain shapes the legacy
+                // `splitTrailingByteView` is tuned for. Callers that need
+                // bytewise writes through arbitrary residual reinterprets
+                // should migrate to `writeManagedByrefWithBase`.
                 useStructuralWriter ()
             | _ -> useStructuralWriter ()
 

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -1977,12 +1977,12 @@ module IlMachineManagedByref =
                 | ByrefRoot.StringCharAt _ -> writeManagedByrefBytesOrTypedCell bct state src newValue
                 | _ -> useStructuralWriter ()
             | ValueSome _, None, _ ->
-                // Trailing-suffix-only byte view; legacy callers without BCT
-                // pass through here. Routing without BCT means the bytes path
-                // cannot peel non-trailing reinterprets, but the old
-                // splitTrailingByteView contract is preserved.
-                failwith
-                    "writeManagedByref: byte-view byref encountered without BaseClassTypes; call writeManagedByrefWithBase instead"
+                // Metadata-light caller hit a trailing byte view but cannot
+                // supply BCT for the iterative peel. The structural writer is
+                // still safe: it accepts the option-typed BCT and only needs
+                // it for non-trailing `ReinterpretAs` chains, which the legacy
+                // `splitTrailingByteView` classifier never produces.
+                useStructuralWriter ()
             | _ -> useStructuralWriter ()
 
     let writeManagedByref (state : IlMachineState) (src : ManagedPointerSource) (newValue : CliType) : IlMachineState =

--- a/WoofWare.PawPrint/IntrinsicHelpers.fs
+++ b/WoofWare.PawPrint/IntrinsicHelpers.fs
@@ -1126,7 +1126,7 @@ module internal IntrinsicHelpers =
                     let value =
                         IlMachineState.readManagedByrefBytesAs baseClassTypes state src byteTemplate
 
-                    state <- IlMachineState.writeManagedByrefBytesOrTypedCell state dest value
+                    state <- IlMachineState.writeManagedByrefBytesOrTypedCell baseClassTypes state dest value
 
                 state
 

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -1275,7 +1275,8 @@ module Intrinsics =
                     failwith
                         $"Unsafe.WriteUnaligned: coerced value has size %d{valueSize}, expected %d{tSize} for %O{valueAsCli}"
 
-                let state = IlMachineState.writeManagedByrefBytesOrTypedCell state src valueAsCli
+                let state =
+                    IlMachineState.writeManagedByrefBytesOrTypedCell baseClassTypes state src valueAsCli
 
                 let state = state |> IlMachineState.advanceProgramCounter currentThread
                 Some state
@@ -1304,7 +1305,8 @@ module Intrinsics =
                     failwith
                         $"Unsafe.WriteUnaligned(void*): coerced value has size %d{valueSize}, expected %d{tSize} for %O{valueAsCli}"
 
-                let state = IlMachineState.writeManagedByrefBytesOrTypedCell state src valueAsCli
+                let state =
+                    IlMachineState.writeManagedByrefBytesOrTypedCell baseClassTypes state src valueAsCli
 
                 let state = state |> IlMachineState.advanceProgramCounter currentThread
                 Some state

--- a/WoofWare.PawPrint/Native/NativeBuffer.fs
+++ b/WoofWare.PawPrint/Native/NativeBuffer.fs
@@ -26,8 +26,18 @@ module NativeBuffer =
         | CliType.Numeric (CliNumericType.UInt8 b) -> b
         | other -> failwith $"Buffer_MemMove: byte-view read returned non-byte value %O{other}"
 
-    let private writeByte (state : IlMachineState) (ptr : ManagedPointerSource) (value : byte) : IlMachineState =
-        IlMachineState.writeManagedByrefBytesOrTypedCell state ptr (CliType.Numeric (CliNumericType.UInt8 value))
+    let private writeByte
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (ptr : ManagedPointerSource)
+        (value : byte)
+        : IlMachineState
+        =
+        IlMachineState.writeManagedByrefBytesOrTypedCell
+            baseClassTypes
+            state
+            ptr
+            (CliType.Numeric (CliNumericType.UInt8 value))
 
     let private checkedByteCount (operation : string) (count : int64) : int =
         if count < 0L then
@@ -140,7 +150,7 @@ module NativeBuffer =
                     ManagedPointerByteView.addByteOffset baseClassTypes state byteConcreteType i dest
 
                 let value = readByte baseClassTypes state src
-                state <- writeByte state dest value
+                state <- writeByte baseClassTypes state dest value
         else
             for i = 0 to byteCount - 1 do
                 let src =
@@ -150,7 +160,7 @@ module NativeBuffer =
                     ManagedPointerByteView.addByteOffset baseClassTypes state byteConcreteType i dest
 
                 let value = readByte baseClassTypes state src
-                state <- writeByte state dest value
+                state <- writeByte baseClassTypes state dest value
 
         state
 

--- a/WoofWare.PawPrint/Native/NativeDependentHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeDependentHandle.fs
@@ -121,7 +121,11 @@ module NativeDependentHandle =
                 | other -> failwith $"%s{operation}: handle %O{handle} is %O{other}, not Dependent"
 
             let state =
-                IlMachineState.writeManagedByref state dependentOut (CliType.ObjectRef dependent)
+                IlMachineState.writeManagedByrefWithBase
+                    ctx.BaseClassTypes
+                    state
+                    dependentOut
+                    (CliType.ObjectRef dependent)
 
             let state = NativeCall.pushObjectTarget target ctx.Thread state
 

--- a/WoofWare.PawPrint/Native/NativeEventPipe.fs
+++ b/WoofWare.PawPrint/Native/NativeEventPipe.fs
@@ -221,7 +221,9 @@ module NativeEventPipe =
                 let zeroGuid, state =
                     IlMachineState.cliTypeZeroOfHandle state ctx.BaseClassTypes guidPtrHandle
 
-                let state = IlMachineState.writeManagedByref state activityIdPtr zeroGuid
+                let state =
+                    IlMachineState.writeManagedByrefWithBase ctx.BaseClassTypes state activityIdPtr zeroGuid
+
                 state |> pushInt32 0 ctx.Thread |> Some
             | 2u ->
                 failwith

--- a/WoofWare.PawPrint/Native/NativeKernel32.fs
+++ b/WoofWare.PawPrint/Native/NativeKernel32.fs
@@ -57,7 +57,7 @@ module NativeKernel32 =
         let ptr =
             ManagedPointerByteView.addByteOffset baseClassTypes state charConcreteType (charIndex * 2) ptr
 
-        IlMachineState.writeManagedByrefBytesOrTypedCell state ptr (CliType.ofChar value)
+        IlMachineState.writeManagedByrefBytesOrTypedCell baseClassTypes state ptr (CliType.ofChar value)
 
     let private writeNullTerminatedUtf16
         (operation : string)

--- a/WoofWare.PawPrint/UnaryMetadataMemoryOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataMemoryOps.fs
@@ -92,7 +92,7 @@ module internal UnaryMetadataMemoryOps =
             match src with
             | ManagedPointerSource.Byref (ByrefRoot.StackMemoryByte _, _)
             | ManagedPointerSource.Byref (ByrefRoot.NativeMemoryByte _, _) ->
-                IlMachineState.writeManagedByrefBytesOrTypedCell state src coerced
+                IlMachineState.writeManagedByrefBytesOrTypedCell baseClassTypes state src coerced
             | ManagedPointerSource.Byref _ -> IlMachineState.writeManagedByrefWithBase baseClassTypes state src coerced
             | ManagedPointerSource.Null -> failwith "unreachable: null Stobj target handled above"
 


### PR DESCRIPTION
## Summary

Extends the bytewise-write path through `ReinterpretAs` byref projections so that nested-field overlays survive a `Volatile.Write` / store into a reinterpreted view. The starting motivation is the `VolatileWriteNestedFieldNonZeroOffset` test pattern: `Unsafe.As<int, Outer>(ref arr[0])` followed by `Volatile.Write(ref view.I.Y, 456)` must write to the underlying `int[]` slot at offset 4, not crash the structural writer.

Key changes:

- **Forward-walk peel** (`peelTrailingByteView` in `IlMachineManagedByref.fs`) accumulates byte offsets across a `ReinterpretAs ... Field ... ByteOffset ... ReinterpretAs ...` chain, instead of the legacy right-to-left structural-only split. This is what lets `view.I.Y` resolve to a single byte offset on top of the `int[]` root.
- **Lazy template thunks** in the peel keep the `BaseClassTypes` dependency optional: BCT is only consulted when a `Field` projection appears in the byte-view suffix. Metadata-light callers that produce only `[ReinterpretAs T]` / `[ReinterpretAs T; ByteOffset n]` keep working without a BCT handle (restored after a regression earlier in the branch).
- **Dispatch in `writeManagedByrefCore`** now routes:
  - byte-renderable values with any valid peel → byte-scatter / typed-cell fast path
  - non-byte-renderable values with an empty peel prefix over byte-addressable roots → still byte-scatter (covers e.g. struct writes through a `ReinterpretAs` over an array element)
  - everything else → structural writer
- **Regression test** in `TestMethodTableProjection.fs` exercises the bare `[ReinterpretAs byte]` and `[ReinterpretAs byte; ByteOffset n]` shapes through the metadata-light entry point, locking in the legacy contract that the rebase had briefly broken.

`splitTrailingByteView` is retained for the 3 read-path callers that still need the structural-prefix + root + offset triple.

Codex `codex review --base main` came back clean over the final commit; all 782 tests pass after rebase onto current `main`.

## Test plan
- [x] `nix develop -c dotnet build WoofWare.PawPrint.slnx`
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` (782 / 782 passing)
- [x] `codex review --base main` reports no actionable correctness issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)