### PR TITLE
Intercept SystemNative_Dup via FileDescriptorRegistry

### DIFF
--- a/WoofWare.PawPrint.Test/TestFileDescriptorRegistry.fs
+++ b/WoofWare.PawPrint.Test/TestFileDescriptorRegistry.fs
@@ -1,0 +1,218 @@
+namespace WoofWare.PawPrint.Test
+
+open FsCheck
+open FsCheck.FSharp
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestFileDescriptorRegistry =
+
+    let private propertyConfig : Config = Config.QuickThrowOnFailure.WithMaxTest 500
+
+    [<Test>]
+    let ``initial seeds stdin, stdout, stderr with OwnsResource = false`` () : unit =
+        FileDescriptorRegistry.tryFind 0 FileDescriptorRegistry.initial
+        |> shouldEqual (
+            Some
+                {
+                    Role = FileDescriptorRole.StandardInput
+                    OwnsResource = false
+                }
+        )
+
+        FileDescriptorRegistry.tryFind 1 FileDescriptorRegistry.initial
+        |> shouldEqual (
+            Some
+                {
+                    Role = FileDescriptorRole.StandardOutput
+                    OwnsResource = false
+                }
+        )
+
+        FileDescriptorRegistry.tryFind 2 FileDescriptorRegistry.initial
+        |> shouldEqual (
+            Some
+                {
+                    Role = FileDescriptorRole.StandardError
+                    OwnsResource = false
+                }
+        )
+
+    [<Test>]
+    let ``initial has no entries outside 0/1/2`` () : unit =
+        for fd in [ -2 ; -1 ; 3 ; 4 ; 100 ; System.Int32.MaxValue ] do
+            FileDescriptorRegistry.tryFind fd FileDescriptorRegistry.initial
+            |> shouldEqual None
+
+    [<Test>]
+    let ``dup of unknown fd returns BadFd`` () : unit =
+        FileDescriptorRegistry.dup 3 FileDescriptorRegistry.initial
+        |> shouldEqual (Error FileDescriptorDupError.BadFd)
+
+        FileDescriptorRegistry.dup -1 FileDescriptorRegistry.initial
+        |> shouldEqual (Error FileDescriptorDupError.BadFd)
+
+        FileDescriptorRegistry.dup System.Int32.MaxValue FileDescriptorRegistry.initial
+        |> shouldEqual (Error FileDescriptorDupError.BadFd)
+
+    [<Test>]
+    let ``dup of stdin/stdout/stderr returns fresh fd 3 with matching role`` () : unit =
+        let assertDupAllocatesFd3WithRole (sourceFd : int) (expectedRole : FileDescriptorRole) : unit =
+            match FileDescriptorRegistry.dup sourceFd FileDescriptorRegistry.initial with
+            | Ok (newFd, registry) ->
+                newFd |> shouldEqual 3
+
+                FileDescriptorRegistry.tryFind newFd registry
+                |> shouldEqual (
+                    Some
+                        {
+                            Role = expectedRole
+                            OwnsResource = true
+                        }
+                )
+
+                // Source fd is unaffected — the table still resolves it to its
+                // original entry. dup is non-destructive on the source.
+                FileDescriptorRegistry.tryFind sourceFd registry
+                |> shouldEqual (FileDescriptorRegistry.tryFind sourceFd FileDescriptorRegistry.initial)
+            | Error e -> failwith $"unexpected dup error: %O{e}"
+
+        assertDupAllocatesFd3WithRole 0 FileDescriptorRole.StandardInput
+        assertDupAllocatesFd3WithRole 1 FileDescriptorRole.StandardOutput
+        assertDupAllocatesFd3WithRole 2 FileDescriptorRole.StandardError
+
+    [<Test>]
+    let ``repeated dup allocates strictly increasing fds starting at 3`` () : unit =
+        let assertDupYields (registry : FileDescriptorRegistry) (expectedFd : int) : FileDescriptorRegistry =
+            match FileDescriptorRegistry.dup 1 registry with
+            | Ok (newFd, registry) ->
+                newFd |> shouldEqual expectedFd
+                registry
+            | Error e -> failwith $"unexpected dup error: %O{e}"
+
+        FileDescriptorRegistry.initial
+        |> fun r -> assertDupYields r 3
+        |> fun r -> assertDupYields r 4
+        |> fun r -> assertDupYields r 5
+        |> fun r -> assertDupYields r 6
+        |> ignore
+
+    /// Reference implementation: the lowest non-negative integer not in `used`.
+    let private referenceLowestFree (used : Set<int>) : int =
+        let rec scan candidate =
+            if Set.contains candidate used then
+                scan (candidate + 1)
+            else
+                candidate
+
+        scan 0
+
+    [<Test>]
+    let ``dup always allocates the lowest non-negative fd not already in use`` () : unit =
+        // Generate a sequence of dup and close operations against the registry,
+        // tracking the expected live set as a Set<int> in parallel. After each
+        // dup the newly allocated fd must equal the lowest non-negative
+        // integer not currently live; closes punch holes that subsequent dups
+        // must fill before extending past the existing maximum.
+        let mutable observedDups = 0
+        let mutable observedCloses = 0
+        let mutable observedHoleFills = 0
+
+        let property (NonNegativeInt seed : NonNegativeInt) : unit =
+            let rng = System.Random (seed)
+            let steps = rng.Next (1, 30)
+
+            let mutable registry = FileDescriptorRegistry.initial
+            let mutable live : Set<int> = Set.ofList [ 0 ; 1 ; 2 ]
+
+            for _ in 1..steps do
+                let liveList = Set.toList live
+                // 70% dup, 30% close, biased toward dup so the table grows
+                // on average and we observe gap-filling rather than only
+                // catastrophic shrinkage.
+                let doClose = rng.Next 10 < 3 && liveList.Length > 3
+
+                if doClose then
+                    let pickIndex = rng.Next (liveList.Length)
+                    let chosen = liveList.[pickIndex]
+
+                    match FileDescriptorRegistry.close chosen registry with
+                    | Ok registry' ->
+                        live <- Set.remove chosen live
+                        registry <- registry'
+                        observedCloses <- observedCloses + 1
+                    | Error e -> failwith $"unexpected close error: %O{e}"
+                else
+                    let pickIndex = rng.Next (liveList.Length)
+                    let chosen = liveList.[pickIndex]
+
+                    match FileDescriptorRegistry.dup chosen registry with
+                    | Ok (newFd, registry') ->
+                        let expected = referenceLowestFree live
+                        newFd |> shouldEqual expected
+
+                        // Track whether the allocation filled a gap below the
+                        // existing maximum (the load-bearing case for the
+                        // lowest-free contract) versus extending past the top.
+                        let liveMaxBefore = Set.maxElement live
+
+                        if newFd < liveMaxBefore then
+                            observedHoleFills <- observedHoleFills + 1
+
+                        live <- Set.add newFd live
+                        registry <- registry'
+                        observedDups <- observedDups + 1
+                    | Error e -> failwith $"unexpected dup error: %O{e}"
+
+        Check.One (propertyConfig, property)
+
+        // Distribution check: the test is only load-bearing if it exercises
+        // the gap-filling case. If observedHoleFills were 0, the property
+        // could be satisfied by a buggy `max + 1` implementation, so assert
+        // we observe gap-fills frequently enough that a regression would be
+        // caught. With 500 iterations of ~20 steps each, biased 70/30 toward
+        // dup, we expect on the order of thousands of dups and hundreds of
+        // hole-fills; require at least 30 to keep the false-negative
+        // probability comfortably below 1e-11.
+        observedDups |> shouldBeGreaterThan 0
+        observedCloses |> shouldBeGreaterThan 0
+        observedHoleFills |> shouldBeGreaterThan 30
+
+    [<Test>]
+    let ``dup preserves the role of the source fd across the new fd`` () : unit =
+        let property (NonNegativeInt seed : NonNegativeInt) : unit =
+            let rng = System.Random (seed)
+            let steps = rng.Next (1, 15)
+
+            let mutable registry = FileDescriptorRegistry.initial
+
+            for _ in 1..steps do
+                let liveList =
+                    [ 0 ; 1 ; 2 ; 3 ; 4 ; 5 ; 6 ; 7 ; 8 ; 9 ]
+                    |> List.choose (fun fd ->
+                        FileDescriptorRegistry.tryFind fd registry
+                        |> Option.map (fun entry -> fd, entry)
+                    )
+
+                let pickIndex = rng.Next (liveList.Length)
+                let sourceFd, sourceEntry = liveList.[pickIndex]
+
+                match FileDescriptorRegistry.dup sourceFd registry with
+                | Ok (newFd, registry') ->
+                    match FileDescriptorRegistry.tryFind newFd registry' with
+                    | Some newEntry ->
+                        newEntry.Role |> shouldEqual sourceEntry.Role
+                        // Any fd minted by SystemNative_Dup is owned by the
+                        // simulated process and must be closed (when Close
+                        // lands) to reclaim the slot. Inherited fds 0/1/2 are
+                        // the only un-owned entries.
+                        newEntry.OwnsResource |> shouldEqual true
+                    | None -> failwith $"newly-allocated fd %d{newFd} not findable"
+
+                    registry <- registry'
+                | Error e -> failwith $"unexpected dup error: %O{e}"
+
+        Check.One (propertyConfig, property)

--- a/WoofWare.PawPrint.Test/TestImpureCases.fs
+++ b/WoofWare.PawPrint.Test/TestImpureCases.fs
@@ -18,11 +18,12 @@ module TestImpureCases =
     let unimplemented =
         [
             // `Console.WriteLine("Hello, world!")` triggers lazy initialisation of `Console.Out`,
-            // which descends Console::get_Out → ConsolePal::OpenStandardOutput → Interop+Sys::Dup
-            // (a libSystem.Native P/Invoke). PawPrint deliberately avoids native execution, so this
-            // path needs a managed replacement for `SystemNative_Dup` (and likely several sibling
-            // file-descriptor primitives) wired through `ExternImplementations` before WriteLine
-            // can complete.
+            // which descends Console::get_Out → ConsolePal::OpenStandardOutput → Interop+Sys::Dup.
+            // PawPrint now intercepts SystemNative_Dup via FileDescriptorRegistry, so the std-stream
+            // open path completes; the WriteLine flow now blocks downstream on the unimplemented
+            // libSystem.Globalization.Native P/Invoke `GlobalizationNative_LoadICU` during
+            // CultureInfo initialisation. Subsequent SystemNative_Write (the actual byte-emitting
+            // call) is also still unimplemented.
             {
                 FileName = "WriteLine.cs"
                 ExpectedReturnCode = 1

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -49,6 +49,7 @@
     <Compile Include="TestFunctionPointerConcretization.fs" />
     <Compile Include="TestGenericParamConstraints.fs" />
     <Compile Include="TestGcHandleRegistry.fs" />
+    <Compile Include="TestFileDescriptorRegistry.fs" />
     <Compile Include="TestPrimitiveLikeStructRegistry.fs" />
     <Compile Include="TestEvalStackPrimitiveLikeBoundary.fs" />
     <Compile Include="TestCliValueTypeCoerceFrom.fs" />

--- a/WoofWare.PawPrint.Test/sourcesPure/SystemNativeDup.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/SystemNativeDup.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Runtime.InteropServices;
+
+// Exercises the SystemNative_Dup PawPrint handler directly via a P/Invoke
+// stub, without depending on `SafeFileHandle` marshalling or `Console`'s
+// initialisation chain. The CLR runtime would dispatch this to the real
+// libSystem.Native shim; PawPrint intercepts the call and routes it through
+// FileDescriptorRegistry.
+//
+// This test must pass on both the real runtime and PawPrint, so it asserts
+// only invariants that hold on every Unix kernel:
+//   * dup of an invalid fd returns -1
+//   * dup of a live fd returns a non-negative fd in the "user" range (>= 3,
+//     since 0/1/2 are reserved for stdin/stdout/stderr at exec time and dup
+//     is required by POSIX to allocate the lowest free fd)
+//   * two consecutive dups return distinct fds
+// The specific fd numbers PawPrint allocates (3, 4, 5, ...) are validated
+// separately in TestFileDescriptorRegistry, where determinism is in scope.
+class Program
+{
+    [DllImport("libSystem.Native", EntryPoint = "SystemNative_Dup")]
+    static extern IntPtr SystemNative_Dup(IntPtr oldfd);
+
+    static int Main(string[] args)
+    {
+        // -1 is never a live fd on any Unix; dup(2) returns -1 (EBADF).
+        IntPtr bad = SystemNative_Dup((IntPtr)(-1));
+        if ((long)bad != -1L) return 1;
+
+        // stdin (fd 0) is guaranteed to be live at process start. dup must
+        // return a fresh fd >= 3 (POSIX reserves 0/1/2 for std streams).
+        IntPtr first = SystemNative_Dup((IntPtr)0);
+        if ((long)first < 3L) return 2;
+
+        // A second dup of stdin must allocate a different fd: dup(2) is
+        // defined to return a fresh slot, never re-aliasing the source.
+        IntPtr second = SystemNative_Dup((IntPtr)0);
+        if ((long)second < 3L) return 3;
+        if ((long)second == (long)first) return 4;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/FileDescriptorRegistry.fs
+++ b/WoofWare.PawPrint/FileDescriptorRegistry.fs
@@ -1,0 +1,143 @@
+namespace WoofWare.PawPrint
+
+/// Underlying "open file description" that a file descriptor points at.
+/// POSIX distinguishes between fds (per-process table entries) and OFDs
+/// (the underlying object the fd references). `dup` allocates a fresh fd
+/// pointing at the same OFD; that's why we keep this concept explicit even
+/// though the current set of roles is closed and small.
+[<RequireQualifiedAccess>]
+type FileDescriptorRole =
+    | StandardInput
+    | StandardOutput
+    | StandardError
+
+type FileDescriptorEntry =
+    {
+        Role : FileDescriptorRole
+        /// True if PawPrint owns the underlying resource and `close` should
+        /// release it. False for fds 0/1/2 that the simulated process
+        /// inherits at startup (the host owns those, as real Unix would).
+        OwnsResource : bool
+    }
+
+/// In-memory model of a Unix per-process file descriptor table. Stdin/
+/// stdout/stderr (fds 0/1/2) are pre-seeded at machine boot, matching the
+/// kernel's behaviour of populating these slots at `exec` time. `dup`
+/// allocates the lowest non-negative integer not currently in use,
+/// matching `dup(2)`.
+type FileDescriptorRegistry =
+    private
+        {
+            Entries : Map<int, FileDescriptorEntry>
+        }
+
+[<RequireQualifiedAccess>]
+type FileDescriptorDupError =
+    /// The supplied fd is not a live entry in the table. `dup(2)` reports
+    /// this as `EBADF`; the SystemNative_Dup handler translates this into
+    /// a -1 return and `LastSystemError = EBADF`.
+    | BadFd
+
+[<RequireQualifiedAccess>]
+type FileDescriptorCloseError =
+    /// The supplied fd is not a live entry in the table. `close(2)` reports
+    /// this as `EBADF`.
+    | BadFd
+
+[<RequireQualifiedAccess>]
+module FileDescriptorRegistry =
+    let private stdinEntry : FileDescriptorEntry =
+        {
+            Role = FileDescriptorRole.StandardInput
+            OwnsResource = false
+        }
+
+    let private stdoutEntry : FileDescriptorEntry =
+        {
+            Role = FileDescriptorRole.StandardOutput
+            OwnsResource = false
+        }
+
+    let private stderrEntry : FileDescriptorEntry =
+        {
+            Role = FileDescriptorRole.StandardError
+            OwnsResource = false
+        }
+
+    /// Empty registry seeded with stdin (fd 0), stdout (fd 1), stderr
+    /// (fd 2). The host owns these descriptors, so `OwnsResource = false`.
+    let initial : FileDescriptorRegistry =
+        {
+            Entries =
+                Map.empty
+                |> Map.add 0 stdinEntry
+                |> Map.add 1 stdoutEntry
+                |> Map.add 2 stderrEntry
+        }
+
+    let tryFind (fd : int) (registry : FileDescriptorRegistry) : FileDescriptorEntry option =
+        Map.tryFind fd registry.Entries
+
+    /// Lowest non-negative integer not currently used as a key in `entries`.
+    /// O(n) in the number of live fds, which is fine: process fd tables are
+    /// small (typically a handful, rarely more than a few hundred), and the
+    /// interpreter is not a performance-critical workload.
+    let private lowestFree (entries : Map<int, FileDescriptorEntry>) : int =
+        let rec scan (candidate : int) =
+            if Map.containsKey candidate entries then
+                scan (candidate + 1)
+            else
+                candidate
+
+        scan 0
+
+    /// Mirrors `dup(2)`: allocate the lowest non-negative fd not in use,
+    /// sharing the role of `oldFd`. A duplicate is independent of its
+    /// source for close purposes — the new entry has `OwnsResource = true`
+    /// because the simulated process is the one that minted it (the host's
+    /// underlying stream is not duplicated; only the table entry is). When
+    /// `oldFd` is not a live entry, returns `Error BadFd`, matching the
+    /// `EBADF` behaviour of `dup(2)`.
+    let dup
+        (oldFd : int)
+        (registry : FileDescriptorRegistry)
+        : Result<int * FileDescriptorRegistry, FileDescriptorDupError>
+        =
+        match Map.tryFind oldFd registry.Entries with
+        | None -> Error FileDescriptorDupError.BadFd
+        | Some source ->
+            let newFd = lowestFree registry.Entries
+
+            let newEntry =
+                {
+                    Role = source.Role
+                    OwnsResource = true
+                }
+
+            let entries = Map.add newFd newEntry registry.Entries
+
+            Ok (
+                newFd,
+                {
+                    Entries = entries
+                }
+            )
+
+    /// Remove an entry from the table. Mirrors `close(2)`: returns
+    /// `Error BadFd` (= `EBADF`) when `fd` is not currently live. The
+    /// SystemNative_Close handler isn't wired up yet; this is defined so
+    /// the registry contract is closed under the operations it will need,
+    /// and so property tests can drive close+dup cycles to exercise the
+    /// `lowestFree` invariant against the gap structure that close produces.
+    let close
+        (fd : int)
+        (registry : FileDescriptorRegistry)
+        : Result<FileDescriptorRegistry, FileDescriptorCloseError>
+        =
+        if Map.containsKey fd registry.Entries then
+            Ok
+                { registry with
+                    Entries = Map.remove fd registry.Entries
+                }
+        else
+            Error FileDescriptorCloseError.BadFd

--- a/WoofWare.PawPrint/IlMachineStateModel.fs
+++ b/WoofWare.PawPrint/IlMachineStateModel.fs
@@ -136,6 +136,12 @@ type IlMachineState =
         /// is never triggered for a successfully-minted monitor. IDs are
         /// never reused; freeing a monitor leaves a gap.
         NextLowLevelMonitorId : int
+        /// In-memory model of the simulated process's Unix file descriptor
+        /// table. Pre-seeded at startup with stdin (0), stdout (1), stderr
+        /// (2), matching the kernel's behaviour of populating these slots
+        /// at `exec` time. SystemNative_Dup / Close / Read / Write etc.
+        /// route through this table; the host's real fds are never used.
+        FileDescriptors : FileDescriptorRegistry
     }
 
     member this.WithTypeBeginInit (thread : ThreadId) (ty : ConcreteTypeHandle) =

--- a/WoofWare.PawPrint/IlMachineThreadState.fs
+++ b/WoofWare.PawPrint/IlMachineThreadState.fs
@@ -312,6 +312,7 @@ module IlMachineThreadState =
                 NativeMemoryPool = NativeMemoryPool.empty
                 LowLevelMonitors = Map.empty
                 NextLowLevelMonitorId = 1
+                FileDescriptors = FileDescriptorRegistry.initial
             }
 
         state.WithLoadedAssembly assyName entryAssembly

--- a/WoofWare.PawPrint/Native/NativeSystemNative.fs
+++ b/WoofWare.PawPrint/Native/NativeSystemNative.fs
@@ -13,6 +13,29 @@ module NativeSystemNative =
         |> Tuple.withRight WhatWeDid.Executed
         |> ExecutionResult.Stepped
 
+    /// Decode an `nint`-shaped Unix file-descriptor argument. CoreLib passes
+    /// fds across the SystemNative boundary as plain `IntPtr` values (the low
+    /// 32 bits of `SafeFileHandle.handle`); PawPrint represents these as
+    /// `NativeIntSource.Verbatim`. Refuses non-verbatim sources because their
+    /// provenance encodes something other than an fd integer, which the
+    /// FileDescriptorRegistry has no way to interpret.
+    let private fdArgument (operation : string) (arg : CliType) : int =
+        match CliType.unwrapPrimitiveLikeDeep arg with
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim value)) ->
+            if value < int64 System.Int32.MinValue || value > int64 System.Int32.MaxValue then
+                // fds are int32-bounded on every Unix kernel we model. A
+                // value outside that range cannot correspond to a live fd in
+                // the registry; return a sentinel that will miss the table
+                // and produce EBADF, rather than silently truncating to a
+                // potentially-live fd.
+                System.Int32.MinValue
+            else
+                int value
+        | CliType.Numeric (CliNumericType.NativeInt source) ->
+            failwith
+                $"%s{operation}: expected verbatim IntPtr file descriptor, got tagged native-int source %O{source} (fd integers should arrive as plain numeric values across the SystemNative boundary)"
+        | other -> failwith $"%s{operation}: expected IntPtr file descriptor, got %O{other}"
+
     /// Decode an `nuint`-shaped allocation size argument to an `int` byte count.
     /// Returns `ValueNone` for values that a real `malloc`/`calloc` would treat
     /// as unsatisfiable (negative-as-nuint, or larger than the interpreter's
@@ -126,6 +149,36 @@ module NativeSystemNative =
 
             state
             |> IlMachineState.pushToEvalStack' (EvalStackValue.ManagedPointer ptrSrc) ctx.Thread
+            |> Tuple.withRight WhatWeDid.Executed
+            |> ExecutionResult.Stepped
+            |> Some
+        | Some "SystemNative_Dup",
+          [ ConcreteIntPtr state.ConcreteTypes ],
+          MethodReturnType.Returns (ConcreteIntPtr state.ConcreteTypes) ->
+            // `dup(2)`: allocate the lowest non-negative fd not in use, sharing
+            // the OFD of `oldFd`. On EBADF we return -1 and set errno=EBADF so
+            // CoreLib's `Interop.CheckIo` raises an IOException, matching the
+            // libc behaviour `Interop.Sys.Dup` is written against. errno 9 is
+            // EBADF on every Unix kernel we model; tracked in GH issue #529
+            // for replacing with a proper `Interop.Error.EBADF` lookup once
+            // the BCL's Interop.Errors enum is wired through.
+            let oldFd = fdArgument "SystemNative_Dup" instruction.Arguments.[0]
+
+            let resultFd, state =
+                match FileDescriptorRegistry.dup oldFd state.FileDescriptors with
+                | Ok (newFd, registry) ->
+                    int64 newFd,
+                    { state with
+                        FileDescriptors = registry
+                    }
+                | Error FileDescriptorDupError.BadFd ->
+                    -1L,
+                    { state with
+                        LastSystemError = 9
+                    }
+
+            state
+            |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt (NativeIntSource.Verbatim resultFd)) ctx.Thread
             |> Tuple.withRight WhatWeDid.Executed
             |> ExecutionResult.Stepped
             |> Some

--- a/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
+++ b/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
@@ -21,6 +21,7 @@
     <Compile Include="CliType.fs" />
     <Compile Include="FieldIdentity.fs" />
     <Compile Include="GcHandleRegistry.fs" />
+    <Compile Include="FileDescriptorRegistry.fs" />
     <Compile Include="TypeHandleRegistry.fs" />
     <Compile Include="FieldHandleRegistry.fs" />
     <Compile Include="MethodHandleRegistry.fs" />


### PR DESCRIPTION
## Summary
- Adds an in-memory `FileDescriptorRegistry` modelling the simulated process's Unix fd table, pre-seeded with stdin/stdout/stderr at machine boot.
- Routes `SystemNative_Dup` through the registry: allocates the lowest non-negative fd not already in use (matching `dup(2)`), returns -1 with errno=EBADF when the source fd is unknown.
- Unblocks `Console.WriteLine`'s std-stream open path. WriteLine remains in `unimplemented`, now blocked downstream on `GlobalizationNative_LoadICU` and `SystemNative_Write`.
- Hardcoded `errno = 9` for EBADF is tracked in #529 for replacement with a symbolic `Interop.Error.EBADF` lookup.

## Test plan
- [x] `TestFileDescriptorRegistry` property tests cover the seed invariant, `lowestFree` against a reference implementation under randomised dup/close cycles (with distribution checks asserting gap-fills are observed), and role/ownership preservation across dup.
- [x] `sourcesPure/SystemNativeDup.cs` exercises the handler end-to-end via raw `[DllImport]` (no SafeFileHandle dependency). Assertions are intentionally limited to cross-runtime invariants — dup of -1 returns -1; dup of stdin returns ≥3; two consecutive dups return distinct fds — so the test passes on both PawPrint (deterministic 3/4) and the real runtime (kernel-allocated, host-dependent).
- [x] Full suite: 771/771 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)