### PR TITLE
Extract EmulatedKernel sub-record from IlMachineState

### DIFF
--- a/WoofWare.PawPrint.Test/TestBinaryArithmetic.fs
+++ b/WoofWare.PawPrint.Test/TestBinaryArithmetic.fs
@@ -659,7 +659,7 @@ module TestBinaryArithmetic =
 
         // Write raw bytes directly into the native-memory pool, bypassing typed-cell stores.
         let pool =
-            NativeMemoryPool.writeBytes block 0 [| 0x44uy ; 0x33uy ; 0x22uy ; 0x11uy |] state.NativeMemoryPool
+            NativeMemoryPool.writeBytes block 0 [| 0x44uy ; 0x33uy ; 0x22uy ; 0x11uy |] state.Kernel.NativeMemoryPool
 
         let state = IlMachineState.setNativeMemoryPool pool state
 

--- a/WoofWare.PawPrint.Test/TestLowLevelMonitor.fs
+++ b/WoofWare.PawPrint.Test/TestLowLevelMonitor.fs
@@ -57,7 +57,7 @@ module TestLowLevelMonitor =
     let private statusOf (thread : ThreadId) (state : IlMachineState) : ThreadStatus = state.ThreadState.[thread].Status
 
     let private monitorOf (id : LowLevelMonitorId) (state : IlMachineState) : LowLevelMonitorState =
-        Map.find id state.LowLevelMonitors
+        Map.find id state.Kernel.LowLevelMonitors
 
     let private acquired (outcome : LowLevelMonitor.AcquireOutcome) : IlMachineState =
         match outcome with
@@ -268,7 +268,7 @@ module TestLowLevelMonitor =
         let id, state = LowLevelMonitor.create state
         let state = LowLevelMonitor.destroy id state
 
-        Map.containsKey id state.LowLevelMonitors |> shouldEqual false
+        Map.containsKey id state.Kernel.LowLevelMonitors |> shouldEqual false
 
     [<Test>]
     let ``destroy fails loud when the monitor is still owned`` () : unit =
@@ -300,9 +300,11 @@ module TestLowLevelMonitor =
             }
 
         let state =
-            { state with
-                LowLevelMonitors = state.LowLevelMonitors |> Map.add id corrupt
-            }
+            state.MapKernel (fun kernel ->
+                { kernel with
+                    LowLevelMonitors = kernel.LowLevelMonitors |> Map.add id corrupt
+                }
+            )
 
         let exn =
             Assert.Throws<System.Exception> (fun () -> LowLevelMonitor.destroy id state |> ignore)

--- a/WoofWare.PawPrint/EmulatedKernel.fs
+++ b/WoofWare.PawPrint/EmulatedKernel.fs
@@ -1,0 +1,114 @@
+namespace WoofWare.PawPrint
+
+/// Deterministic model of a single `System.Threading.LowLevelMonitor`, as
+/// minted by `SystemNative_LowLevelMonitor_Create`. CoreCLR backs this with a
+/// `pthread_mutex_t` + `pthread_cond_t` pair on Unix; PawPrint reproduces the
+/// observable semantics through three pieces of state owned by the kernel's
+/// `LowLevelMonitors` registry:
+///
+///   - `Owner` is `Some t` iff thread `t` currently holds the monitor;
+///     mutual exclusion is just the invariant "at most one thread is the
+///     `Owner` at any time."
+///   - `AcquireQueue` is the FIFO list of threads parked in
+///     `BlockedOnMonitorAcquire`. The head is the next thread that will
+///     receive ownership when the current owner releases. FIFO order is
+///     load-bearing for `LowLevelLock` fairness; switching to LIFO or
+///     arbitrary order would change the program's observable interleaving.
+///   - `WaitQueue` is the FIFO list of threads parked in
+///     `BlockedOnMonitorWait`. `Signal_Release` moves the head of this queue
+///     onto the tail of `AcquireQueue` (it must re-contend for the monitor
+///     before its `Wait` call returns), atomically with releasing the owner.
+///
+/// The monitor is non-reentrant, matching CoreCLR's `LowLevelMonitor` — a
+/// thread that holds the monitor and calls `Acquire` again deadlocks.
+/// Reentrancy is supplied at a higher level by `LowLevelLock`.
+///
+/// Spurious wakeups are not generated today, but the model is shaped so
+/// they can be inserted later by moving a thread from `WaitQueue` to
+/// `AcquireQueue` from outside `Signal_Release`. Any guest code that
+/// depends on the absence of spurious wakeups is incorrect on real CoreCLR.
+type LowLevelMonitorState =
+    {
+        Owner : ThreadId option
+        AcquireQueue : ThreadId list
+        WaitQueue : ThreadId list
+    }
+
+[<RequireQualifiedAccess>]
+module LowLevelMonitorState =
+    let empty : LowLevelMonitorState =
+        {
+            Owner = None
+            AcquireQueue = []
+            WaitQueue = []
+        }
+
+/// Aggregates the slice of `IlMachineState` that models host-kernel /
+/// syscall-emulation state: process-wide last-error registers, the native
+/// heap pool backing `Marshal.AllocHGlobal`, the Unix file-descriptor table,
+/// the `LowLevelMonitor` registry, and monotonic ID counters for opaque
+/// kernel handles. These are the pieces of interpreter state that exist
+/// because PawPrint refuses to use the host kernel; they don't belong in the
+/// CIL execution model proper.
+///
+/// Pulling them into a sub-record keeps `IlMachineState` from sprawling and
+/// makes it possible to swap the kernel implementation (e.g. for a Windows-
+/// shaped emulation) without disturbing the rest of the state model.
+type EmulatedKernel =
+    {
+        /// Last error reported by a modelled P/Invoke with SetLastError=true.
+        /// This is currently process-wide; model it per-thread when a guest
+        /// depends on thread-local last-error state.
+        LastPInvokeError : int
+        /// Last system error tracked separately from LastPInvokeError because
+        /// CoreLib wrappers can read this and then write LastPInvokeError.
+        /// This is currently process-wide; model it per-thread when a guest
+        /// depends on thread-local GetLastError or errno state.
+        LastSystemError : int
+        /// Globally-scoped pool of native-heap blocks allocated by
+        /// `Marshal.AllocHGlobal` / `NativeMemory.Alloc`. Freeing a block
+        /// deletes it from this pool, so any retained byref into the block
+        /// becomes a dangling reference that the simulator catches loudly at
+        /// the use site. Unlike `StackMemoryPool` (which lives on each method
+        /// frame and is reclaimed at frame exit), native-heap blocks outlive
+        /// the frames that allocate them.
+        NativeMemoryPool : NativeMemoryPool
+        /// In-memory model of the simulated process's Unix file descriptor
+        /// table. Pre-seeded at startup with stdin (0), stdout (1), stderr
+        /// (2), matching the kernel's behaviour of populating these slots
+        /// at `exec` time. SystemNative_Dup / Close / Read / Write etc.
+        /// route through this table; the host's real fds are never used.
+        FileDescriptors : FileDescriptorRegistry
+        /// Registry of `System.Threading.LowLevelMonitor` instances minted by
+        /// `SystemNative_LowLevelMonitor_Create`. The handle held by the
+        /// guest (as an `IntPtr` in `LowLevelMonitor._nativeMonitor`) is the
+        /// `LowLevelMonitorId` key; the value is the deterministic
+        /// owner / queue state. `Destroy` removes the entry so any retained
+        /// handle fails loudly at the next use rather than silently
+        /// referencing a recycled monitor.
+        LowLevelMonitors : Map<LowLevelMonitorId, LowLevelMonitorState>
+        /// Monotonic ID source for `LowLevelMonitorPtr`. Starts at 1 so the
+        /// guest's "create failed" check (`if _nativeMonitor == IntPtr.Zero`)
+        /// is never triggered for a successfully-minted monitor. IDs are
+        /// never reused; freeing a monitor leaves a gap.
+        NextLowLevelMonitorId : int
+        /// Monotonic ID source for opaque EventPipe provider/event handles
+        /// minted by the `EventPipeInternal_*` QCalls. PawPrint never opens a
+        /// tracing session, so the IDs are not stored in any registry; they
+        /// only need to be unique and non-zero (the BCL treats handle 0 as
+        /// "create failed" and throws OOM).
+        NextEventPipeId : int64
+    }
+
+[<RequireQualifiedAccess>]
+module EmulatedKernel =
+    let initial : EmulatedKernel =
+        {
+            LastPInvokeError = 0
+            LastSystemError = 0
+            NativeMemoryPool = NativeMemoryPool.empty
+            FileDescriptors = FileDescriptorRegistry.initial
+            LowLevelMonitors = Map.empty
+            NextLowLevelMonitorId = 1
+            NextEventPipeId = 1L
+        }

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -183,7 +183,7 @@ module IlMachineManagedByref =
         (byteCount : int)
         : byte[] voption
         =
-        NativeMemoryPool.tryReadBytes block byteOffset byteCount state.NativeMemoryPool
+        NativeMemoryPool.tryReadBytes block byteOffset byteCount state.Kernel.NativeMemoryPool
 
     let private readRootValue (state : IlMachineState) (root : ByrefRoot) : CliType =
         match root with
@@ -208,7 +208,7 @@ module IlMachineManagedByref =
         | ByrefRoot.NativeMemoryByte (block, byteOffset) ->
             // Mirror of the StackMemoryByte case. The native-heap pool is global on
             // IlMachineState; use-after-free is caught inside NativeMemoryPool.
-            match NativeMemoryPool.tryFindCellCovering block byteOffset state.NativeMemoryPool with
+            match NativeMemoryPool.tryFindCellCovering block byteOffset state.Kernel.NativeMemoryPool with
             | Some (cellOffset, cell) when cellOffset = byteOffset -> cell
             | Some (cellOffset, cell) ->
                 failwith
@@ -331,7 +331,7 @@ module IlMachineManagedByref =
             // Mirror of the StackMemoryByte write case but routed through the
             // global NativeMemoryPool. Use-after-free is caught inside the pool
             // when the block has been removed.
-            let pool = state.NativeMemoryPool
+            let pool = state.Kernel.NativeMemoryPool
 
             match NativeMemoryPool.tryFindCellCovering block byteOffset pool with
             | Some (cellOffset, cell) when cellOffset <> byteOffset ->
@@ -831,7 +831,7 @@ module IlMachineManagedByref =
             failwith
                 $"native-heap byte-view read at offset %d{byteOffset} in %O{block} is outside the block (negative offset)"
 
-        let pool = state.NativeMemoryPool
+        let pool = state.Kernel.NativeMemoryPool
         let blockData = NativeMemoryPool.getBlock block pool
 
         if int64 byteOffset + int64 targetSize > int64 blockData.Size then
@@ -1346,7 +1346,9 @@ module IlMachineManagedByref =
         | ValueSome existing when bytesEqual existing bytes -> state
         | _ ->
 
-        let pool = NativeMemoryPool.writeBytes block byteOffset bytes state.NativeMemoryPool
+        let pool =
+            NativeMemoryPool.writeBytes block byteOffset bytes state.Kernel.NativeMemoryPool
+
         IlMachineThreadState.setNativeMemoryPool pool state
 
     let private writeStringBytes
@@ -1639,7 +1641,7 @@ module IlMachineManagedByref =
 
         match nativeMemoryByteTarget with
         | ValueSome (block, byteOffset) ->
-            let pool = state.NativeMemoryPool
+            let pool = state.Kernel.NativeMemoryPool
             let destSize = CliType.sizeOf newValue
 
             let typedWriteSafe = nativeMemoryByteTypedWriteSafe pool block byteOffset destSize
@@ -2301,7 +2303,7 @@ module IlMachineManagedByref =
         | ManagedPointerSource.Byref (ByrefRoot.NativeMemoryByte (block, byteOffset), []) ->
             match byteAddressabilityRejection newValue with
             | Some rejection when isNumericProvenanceRejection rejection ->
-                let pool = state.NativeMemoryPool
+                let pool = state.Kernel.NativeMemoryPool
                 let destSize = CliType.sizeOf newValue
 
                 if nativeMemoryByteTypedWriteSafe pool block byteOffset destSize then

--- a/WoofWare.PawPrint/IlMachineStateModel.fs
+++ b/WoofWare.PawPrint/IlMachineStateModel.fs
@@ -7,49 +7,6 @@ open System.Reflection.Metadata
 open Microsoft.Extensions.Logging
 open Microsoft.FSharp.Core
 
-/// Deterministic model of a single `System.Threading.LowLevelMonitor`, as
-/// minted by `SystemNative_LowLevelMonitor_Create`. CoreCLR backs this with a
-/// `pthread_mutex_t` + `pthread_cond_t` pair on Unix; PawPrint reproduces the
-/// observable semantics through three pieces of state owned by the
-/// `IlMachineState.LowLevelMonitors` registry:
-///
-///   - `Owner` is `Some t` iff thread `t` currently holds the monitor;
-///     mutual exclusion is just the invariant "at most one thread is the
-///     `Owner` at any time."
-///   - `AcquireQueue` is the FIFO list of threads parked in
-///     `BlockedOnMonitorAcquire`. The head is the next thread that will
-///     receive ownership when the current owner releases. FIFO order is
-///     load-bearing for `LowLevelLock` fairness; switching to LIFO or
-///     arbitrary order would change the program's observable interleaving.
-///   - `WaitQueue` is the FIFO list of threads parked in
-///     `BlockedOnMonitorWait`. `Signal_Release` moves the head of this queue
-///     onto the tail of `AcquireQueue` (it must re-contend for the monitor
-///     before its `Wait` call returns), atomically with releasing the owner.
-///
-/// The monitor is non-reentrant, matching CoreCLR's `LowLevelMonitor` — a
-/// thread that holds the monitor and calls `Acquire` again deadlocks.
-/// Reentrancy is supplied at a higher level by `LowLevelLock`.
-///
-/// Spurious wakeups are not generated today, but the model is shaped so
-/// they can be inserted later by moving a thread from `WaitQueue` to
-/// `AcquireQueue` from outside `Signal_Release`. Any guest code that
-/// depends on the absence of spurious wakeups is incorrect on real CoreCLR.
-type LowLevelMonitorState =
-    {
-        Owner : ThreadId option
-        AcquireQueue : ThreadId list
-        WaitQueue : ThreadId list
-    }
-
-[<RequireQualifiedAccess>]
-module LowLevelMonitorState =
-    let empty : LowLevelMonitorState =
-        {
-            Owner = None
-            AcquireQueue = []
-            WaitQueue = []
-        }
-
 type IlMachineState =
     {
         ConcreteTypes : AllConcreteTypes
@@ -95,54 +52,28 @@ type IlMachineState =
         /// threads.  Starts at 2 because ID 0 is the CLR's "no managed thread" sentinel and
         /// ID 1 is reserved for the main thread (ThreadId 0).
         NextManagedThreadId : int
-        /// Last error reported by a modelled P/Invoke with SetLastError=true.
-        /// This is currently process-wide; model it per-thread when a guest
-        /// depends on thread-local last-error state.
-        LastPInvokeError : int
-        /// Last system error tracked separately from LastPInvokeError because
-        /// CoreLib wrappers can read this and then write LastPInvokeError.
-        /// This is currently process-wide; model it per-thread when a guest
-        /// depends on thread-local GetLastError or errno state.
-        LastSystemError : int
-        /// Monotonic ID source for opaque EventPipe provider/event handles
-        /// minted by the `EventPipeInternal_*` QCalls. PawPrint never opens a
-        /// tracing session, so the IDs are not stored in any registry; they
-        /// only need to be unique and non-zero (the BCL treats handle 0 as
-        /// "create failed" and throws OOM).
-        NextEventPipeId : int64
         /// Deterministic counter-assignment state for synthesised pointer
         /// hash bits. Each canonical pointer key gets a stable bit pattern
         /// derived from its registration order; distinct keys produce
         /// distinct bits with no collisions. See `PointerHashSynthesis`.
         PointerHashCounters : PointerHashCounters
-        /// Globally-scoped pool of native-heap blocks allocated by
-        /// `Marshal.AllocHGlobal` / `NativeMemory.Alloc`. Freeing a block
-        /// deletes it from this pool, so any retained byref into the block
-        /// becomes a dangling reference that the simulator catches loudly at
-        /// the use site. Unlike `StackMemoryPool` (which lives on each method
-        /// frame and is reclaimed at frame exit), native-heap blocks outlive
-        /// the frames that allocate them.
-        NativeMemoryPool : NativeMemoryPool
-        /// Registry of `System.Threading.LowLevelMonitor` instances minted by
-        /// `SystemNative_LowLevelMonitor_Create`. The handle held by the
-        /// guest (as an `IntPtr` in `LowLevelMonitor._nativeMonitor`) is the
-        /// `LowLevelMonitorId` key; the value is the deterministic
-        /// owner / queue state. `Destroy` removes the entry so any retained
-        /// handle fails loudly at the next use rather than silently
-        /// referencing a recycled monitor.
-        LowLevelMonitors : Map<LowLevelMonitorId, LowLevelMonitorState>
-        /// Monotonic ID source for `LowLevelMonitorPtr`. Starts at 1 so the
-        /// guest's "create failed" check (`if _nativeMonitor == IntPtr.Zero`)
-        /// is never triggered for a successfully-minted monitor. IDs are
-        /// never reused; freeing a monitor leaves a gap.
-        NextLowLevelMonitorId : int
-        /// In-memory model of the simulated process's Unix file descriptor
-        /// table. Pre-seeded at startup with stdin (0), stdout (1), stderr
-        /// (2), matching the kernel's behaviour of populating these slots
-        /// at `exec` time. SystemNative_Dup / Close / Read / Write etc.
-        /// route through this table; the host's real fds are never used.
-        FileDescriptors : FileDescriptorRegistry
+        /// Host-kernel / syscall-emulation state: last-error registers, native
+        /// heap pool, file-descriptor table, `LowLevelMonitor` registry, and
+        /// monotonic ID counters for opaque kernel handles. Bundled into a
+        /// sub-record because the rest of `IlMachineState` models the CIL
+        /// execution layer, not the kernel surface PawPrint refuses to use.
+        Kernel : EmulatedKernel
     }
+
+    member this.WithKernel (kernel : EmulatedKernel) : IlMachineState =
+        { this with
+            Kernel = kernel
+        }
+
+    member this.MapKernel (f : EmulatedKernel -> EmulatedKernel) : IlMachineState =
+        { this with
+            Kernel = f this.Kernel
+        }
 
     member this.WithTypeBeginInit (thread : ThreadId) (ty : ConcreteTypeHandle) =
         let concreteType = AllConcreteTypes.lookup ty this.ConcreteTypes |> Option.get

--- a/WoofWare.PawPrint/IlMachineThreadState.fs
+++ b/WoofWare.PawPrint/IlMachineThreadState.fs
@@ -305,14 +305,8 @@ module IlMachineThreadState =
                 RuntimeModuleObjects = ImmutableDictionary.Empty
                 ManagedThreadObjects = Map.empty
                 NextManagedThreadId = 2
-                LastPInvokeError = 0
-                LastSystemError = 0
-                NextEventPipeId = 1L
                 PointerHashCounters = PointerHashCounters.empty
-                NativeMemoryPool = NativeMemoryPool.empty
-                LowLevelMonitors = Map.empty
-                NextLowLevelMonitorId = 1
-                FileDescriptors = FileDescriptorRegistry.initial
+                Kernel = EmulatedKernel.initial
             }
 
         state.WithLoadedAssembly assyName entryAssembly
@@ -626,12 +620,14 @@ module IlMachineThreadState =
         : ManagedPointerSource * IlMachineState
         =
         let blockId, pool =
-            NativeMemoryPool.allocate initialization byteCount state.NativeMemoryPool
+            NativeMemoryPool.allocate initialization byteCount state.Kernel.NativeMemoryPool
 
         let state =
-            { state with
-                NativeMemoryPool = pool
-            }
+            state.MapKernel (fun kernel ->
+                { kernel with
+                    NativeMemoryPool = pool
+                }
+            )
 
         ManagedPointerSource.Byref (ByrefRoot.NativeMemoryByte (blockId, 0), []), state
 
@@ -639,16 +635,20 @@ module IlMachineThreadState =
     /// Use-after-free is caught later by `NativeMemoryPool.getBlock` when any
     /// retained byref into the block is dereferenced.
     let freeNativeMemory (blockId : NativeMemoryBlockId) (state : IlMachineState) : IlMachineState =
-        { state with
-            NativeMemoryPool = NativeMemoryPool.free blockId state.NativeMemoryPool
-        }
+        state.MapKernel (fun kernel ->
+            { kernel with
+                NativeMemoryPool = NativeMemoryPool.free blockId kernel.NativeMemoryPool
+            }
+        )
 
-    let getNativeMemoryPool (state : IlMachineState) : NativeMemoryPool = state.NativeMemoryPool
+    let getNativeMemoryPool (state : IlMachineState) : NativeMemoryPool = state.Kernel.NativeMemoryPool
 
     let setNativeMemoryPool (pool : NativeMemoryPool) (state : IlMachineState) : IlMachineState =
-        { state with
-            NativeMemoryPool = pool
-        }
+        state.MapKernel (fun kernel ->
+            { kernel with
+                NativeMemoryPool = pool
+            }
+        )
 
     let setSyncBlock
         (addr : ManagedHeapAddress)

--- a/WoofWare.PawPrint/LowLevelMonitor.fs
+++ b/WoofWare.PawPrint/LowLevelMonitor.fs
@@ -55,7 +55,7 @@ module LowLevelMonitor =
     /// outlives `destroy` lands here so use-after-free shows up at the use
     /// site rather than as a confusing null-handle bug elsewhere.
     let private lookup (id : LowLevelMonitorId) (state : IlMachineState) : LowLevelMonitorState =
-        match Map.tryFind id state.LowLevelMonitors with
+        match Map.tryFind id state.Kernel.LowLevelMonitors with
         | Some monitor -> monitor
         | None ->
             failwith
@@ -67,21 +67,25 @@ module LowLevelMonitor =
         (state : IlMachineState)
         : IlMachineState
         =
-        { state with
-            LowLevelMonitors = state.LowLevelMonitors |> Map.add id monitor
-        }
+        state.MapKernel (fun kernel ->
+            { kernel with
+                LowLevelMonitors = kernel.LowLevelMonitors |> Map.add id monitor
+            }
+        )
 
     /// Allocate a fresh monitor. Returns the new handle alongside the
     /// updated state. The handle is non-zero (counters start at 1) so the
     /// guest's "create failed → throw OOM" check does not fire.
     let create (state : IlMachineState) : LowLevelMonitorId * IlMachineState =
-        let id = LowLevelMonitorId state.NextLowLevelMonitorId
+        let id = LowLevelMonitorId state.Kernel.NextLowLevelMonitorId
 
         let state =
-            { state with
-                LowLevelMonitors = state.LowLevelMonitors |> Map.add id LowLevelMonitorState.empty
-                NextLowLevelMonitorId = state.NextLowLevelMonitorId + 1
-            }
+            state.MapKernel (fun kernel ->
+                { kernel with
+                    LowLevelMonitors = kernel.LowLevelMonitors |> Map.add id LowLevelMonitorState.empty
+                    NextLowLevelMonitorId = kernel.NextLowLevelMonitorId + 1
+                }
+            )
 
         id, state
 
@@ -115,9 +119,11 @@ module LowLevelMonitor =
             failwith
                 $"LowLevelMonitor %O{id}: refusing to Destroy a monitor with %d{List.length waiters} thread(s) parked in BlockedOnMonitorWait (%A{waiters})"
 
-        { state with
-            LowLevelMonitors = state.LowLevelMonitors |> Map.remove id
-        }
+        state.MapKernel (fun kernel ->
+            { kernel with
+                LowLevelMonitors = kernel.LowLevelMonitors |> Map.remove id
+            }
+        )
 
     /// Try to acquire the monitor on behalf of `thread`.
     ///

--- a/WoofWare.PawPrint/Native/NativeEventPipe.fs
+++ b/WoofWare.PawPrint/Native/NativeEventPipe.fs
@@ -6,12 +6,14 @@ module NativeEventPipe =
     /// these are not stored anywhere — they only need to be unique and non-zero (the BCL treats
     /// IntPtr.Zero from `CreateProvider`/`DefineEvent` as "create failed" and throws OOM).
     let private mintEventPipeId (state : IlMachineState) : int64 * IlMachineState =
-        let id = state.NextEventPipeId
+        let id = state.Kernel.NextEventPipeId
 
         let state =
-            { state with
-                NextEventPipeId = state.NextEventPipeId + 1L
-            }
+            state.MapKernel (fun kernel ->
+                { kernel with
+                    NextEventPipeId = kernel.NextEventPipeId + 1L
+                }
+            )
 
         id, state
 

--- a/WoofWare.PawPrint/Native/NativeKernel32.fs
+++ b/WoofWare.PawPrint/Native/NativeKernel32.fs
@@ -40,9 +40,11 @@ module NativeKernel32 =
     let private withKernel32LastSystemError (error : int) (state : IlMachineState) : IlMachineState =
         // CoreLib's generated P/Invoke wrapper clears and reads this
         // GetLastError slot, then writes LastPInvokeError itself.
-        { state with
-            LastSystemError = error
-        }
+        state.MapKernel (fun kernel ->
+            { kernel with
+                LastSystemError = error
+            }
+        )
 
     let private writeUtf16Char
         (operation : string)

--- a/WoofWare.PawPrint/Native/NativeMarshal.fs
+++ b/WoofWare.PawPrint/Native/NativeMarshal.fs
@@ -21,7 +21,7 @@ module NativeMarshal =
           [],
           MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
             state
-            |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 state.LastPInvokeError) ctx.Thread
+            |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 state.Kernel.LastPInvokeError) ctx.Thread
             |> Tuple.withRight WhatWeDid.Executed
             |> ExecutionResult.Stepped
             |> Some
@@ -32,7 +32,7 @@ module NativeMarshal =
           [],
           MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
             state
-            |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 state.LastSystemError) ctx.Thread
+            |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 state.Kernel.LastSystemError) ctx.Thread
             |> Tuple.withRight WhatWeDid.Executed
             |> ExecutionResult.Stepped
             |> Some
@@ -45,9 +45,11 @@ module NativeMarshal =
             let error =
                 NativeCall.int32Argument "Marshal.SetLastPInvokeError" instruction.Arguments.[0]
 
-            ({ state with
-                LastPInvokeError = error
-             },
+            (state.MapKernel (fun kernel ->
+                { kernel with
+                    LastPInvokeError = error
+                }
+             ),
              WhatWeDid.Executed)
             |> ExecutionResult.Stepped
             |> Some
@@ -60,9 +62,11 @@ module NativeMarshal =
             let error =
                 NativeCall.int32Argument "Marshal.SetLastSystemError" instruction.Arguments.[0]
 
-            ({ state with
-                LastSystemError = error
-             },
+            (state.MapKernel (fun kernel ->
+                { kernel with
+                    LastSystemError = error
+                }
+             ),
              WhatWeDid.Executed)
             |> ExecutionResult.Stepped
             |> Some

--- a/WoofWare.PawPrint/Native/NativeSystemNative.fs
+++ b/WoofWare.PawPrint/Native/NativeSystemNative.fs
@@ -90,16 +90,18 @@ module NativeSystemNative =
         | Some "SystemNative_GetErrNo",
           [],
           MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
-            pushInt32 state.LastSystemError ctx |> Some
+            pushInt32 state.Kernel.LastSystemError ctx |> Some
         | Some "SystemNative_SetErrNo",
           [ ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32 ],
           MethodReturnType.Void ->
             let error =
                 NativeCall.int32Argument "SystemNative_SetErrNo" instruction.Arguments.[0]
 
-            ({ state with
-                LastSystemError = error
-             },
+            (state.MapKernel (fun kernel ->
+                { kernel with
+                    LastSystemError = error
+                }
+             ),
              WhatWeDid.Executed)
             |> ExecutionResult.Stepped
             |> Some
@@ -165,17 +167,21 @@ module NativeSystemNative =
             let oldFd = fdArgument "SystemNative_Dup" instruction.Arguments.[0]
 
             let resultFd, state =
-                match FileDescriptorRegistry.dup oldFd state.FileDescriptors with
+                match FileDescriptorRegistry.dup oldFd state.Kernel.FileDescriptors with
                 | Ok (newFd, registry) ->
                     int64 newFd,
-                    { state with
-                        FileDescriptors = registry
-                    }
+                    state.MapKernel (fun kernel ->
+                        { kernel with
+                            FileDescriptors = registry
+                        }
+                    )
                 | Error FileDescriptorDupError.BadFd ->
                     -1L,
-                    { state with
-                        LastSystemError = 9
-                    }
+                    state.MapKernel (fun kernel ->
+                        { kernel with
+                            LastSystemError = 9
+                        }
+                    )
 
             state
             |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt (NativeIntSource.Verbatim resultFd)) ctx.Thread

--- a/WoofWare.PawPrint/Scheduler.fs
+++ b/WoofWare.PawPrint/Scheduler.fs
@@ -117,7 +117,7 @@ module Scheduler =
                 $"Thread {terminated} terminated while still the InProgress initializer of {orphanedInits.Length} type(s); the real CLR would raise TypeInitializationException into every waiter, which we don't yet synthesise."
 
         let orphanedMonitors =
-            state.LowLevelMonitors
+            state.Kernel.LowLevelMonitors
             |> Map.toSeq
             |> Seq.choose (fun (id, monitor) ->
                 match monitor.Owner with

--- a/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
+++ b/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
@@ -35,6 +35,7 @@
     <Compile Include="TypeResolution.fs" />
     <Compile Include="HardwareIntrinsicsProfile.fs" />
     <Compile Include="DebuggerState.fs" />
+    <Compile Include="EmulatedKernel.fs" />
     <Compile Include="IlMachineStateModel.fs" />
     <Compile Include="IlMachineTypeResolution.fs" />
     <Compile Include="IlMachineThreadState.fs" />


### PR DESCRIPTION
## Summary
- Bundles the host-kernel / syscall-emulation slice of `IlMachineState` (`LastPInvokeError`, `LastSystemError`, `NativeMemoryPool`, `FileDescriptors`, `LowLevelMonitors`, `NextLowLevelMonitorId`, `NextEventPipeId`) into a new `EmulatedKernel` record under `state.Kernel`.
- Adds `state.MapKernel` / `state.WithKernel` helpers so callsites mutate the kernel without nesting record copies.
- Moves `LowLevelMonitorState` (and its `empty` module) from `IlMachineStateModel.fs` into `EmulatedKernel.fs` since it is part of the kernel's state surface.
- Boot path drops six inline field initialisers in favour of `Kernel = EmulatedKernel.initial`.

This is a pure structural reshuffle: the CIL execution surface of `IlMachineState` is unchanged and 820/820 tests still pass. The motivation is to keep `IlMachineState` from sprawling and to make the kernel-emulation boundary explicit, so future kernel surface (file/socket I/O, signals, virtual clock) has an obvious home.

## Test plan
- [x] `nix develop -c dotnet fantomas .`
- [x] `nix develop -c dotnet build WoofWare.PawPrint.slnx` — clean build
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --verbosity normal` — 820/820 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)