### PR TITLE
Name raw kernel errno constants via Errno module

### DIFF
--- a/WoofWare.PawPrint/Errno.fs
+++ b/WoofWare.PawPrint/Errno.fs
@@ -1,0 +1,20 @@
+namespace WoofWare.PawPrint
+
+/// Raw Unix kernel errno values, as defined in `<errno.h>` on every platform
+/// PawPrint models (Linux, Darwin, BSD). These are the values that land in
+/// `EmulatedKernel.LastSystemError` when a modelled `SystemNative_*` shim
+/// fails — i.e. exactly what `Marshal.GetLastSystemError` / the host's
+/// `errno` would return on the real syscall.
+///
+/// Note that this is *not* the same as the BCL's `Interop.Error` enum, whose
+/// values (e.g. `Interop.Error.EBADF = 0x10008`) are deliberately chosen
+/// outside the typical errno range. The BCL converts raw → PAL by calling
+/// `SystemNative_ConvertErrorPlatformToPal` before switching on the enum;
+/// guest code that reaches `LastSystemError` directly (via
+/// `Marshal.GetLastSystemError` or `Marshal.GetLastPInvokeError`) sees the
+/// raw kernel value stored here.
+[<RequireQualifiedAccess>]
+module Errno =
+    /// `EBADF` — Bad file descriptor. Returned by `dup`, `close`, `read`,
+    /// `write`, etc. when the supplied fd is not currently open.
+    let EBADF : int = 9

--- a/WoofWare.PawPrint/Native/NativeSystemNative.fs
+++ b/WoofWare.PawPrint/Native/NativeSystemNative.fs
@@ -160,10 +160,10 @@ module NativeSystemNative =
             // `dup(2)`: allocate the lowest non-negative fd not in use, sharing
             // the OFD of `oldFd`. On EBADF we return -1 and set errno=EBADF so
             // CoreLib's `Interop.CheckIo` raises an IOException, matching the
-            // libc behaviour `Interop.Sys.Dup` is written against. errno 9 is
-            // EBADF on every Unix kernel we model; tracked in GH issue #529
-            // for replacing with a proper `Interop.Error.EBADF` lookup once
-            // the BCL's Interop.Errors enum is wired through.
+            // libc behaviour `Interop.Sys.Dup` is written against. `LastSystemError`
+            // holds the raw kernel errno; the BCL converts it to the
+            // `Interop.Error` PAL enum via `SystemNative_ConvertErrorPlatformToPal`
+            // before `CheckIo` switches on it.
             let oldFd = fdArgument "SystemNative_Dup" instruction.Arguments.[0]
 
             let resultFd, state =
@@ -179,7 +179,7 @@ module NativeSystemNative =
                     -1L,
                     state.MapKernel (fun kernel ->
                         { kernel with
-                            LastSystemError = 9
+                            LastSystemError = Errno.EBADF
                         }
                     )
 

--- a/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
+++ b/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
@@ -21,6 +21,7 @@
     <Compile Include="CliType.fs" />
     <Compile Include="FieldIdentity.fs" />
     <Compile Include="GcHandleRegistry.fs" />
+    <Compile Include="Errno.fs" />
     <Compile Include="FileDescriptorRegistry.fs" />
     <Compile Include="TypeHandleRegistry.fs" />
     <Compile Include="FieldHandleRegistry.fs" />


### PR DESCRIPTION
## Summary
- Adds `WoofWare.PawPrint/Errno.fs`, a small module of raw Unix kernel errno values, with `Errno.EBADF = 9` as the initial entry.
- Replaces the magic `LastSystemError = 9` in `SystemNative_Dup`'s EBADF handler with `Errno.EBADF`.
- The module docstring spells out the raw-errno vs PAL (`Interop.Error`) distinction: PawPrint stores raw kernel errnos in `LastSystemError`; the BCL converts them to its `Interop.Error` PAL enum (e.g. `Interop.Error.EBADF = 0x10008`) via `SystemNative_ConvertErrorPlatformToPal` before `CheckIo` switches on the result. Naming the raw value avoids future confusion about which side of that boundary a number lives on.
- Updates the `SystemNative_Dup` site comment to drop the GH #529 tracking note and document the raw-vs-PAL flow inline.

Closes #529.

## Test plan
- [x] `nix develop -c dotnet build WoofWare.PawPrint/WoofWare.PawPrint.fsproj` — clean.
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 820/820 passing.
- [x] `nix develop -c dotnet fantomas .` — no changes.
- [x] `codex review --base main` — no blocking findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)