### PR TITLE
Intercept SystemNative_Close via FileDescriptorRegistry

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/SystemNativeClose.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/SystemNativeClose.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Runtime.InteropServices;
+
+// Exercises the SystemNative_Close PawPrint handler directly via a P/Invoke
+// stub, without depending on `SafeFileHandle` marshalling. The CLR runtime
+// dispatches this to the real libSystem.Native shim; PawPrint intercepts the
+// call and routes it through FileDescriptorRegistry.
+//
+// This test must pass on both the real runtime and PawPrint, so it asserts
+// only invariants that hold on every Unix kernel:
+//   * close of an invalid fd returns -1
+//   * close of a freshly-duped fd returns 0
+//   * a second close of the same fd returns -1 (the slot is gone)
+//   * after close-then-dup, the freed fd is the one POSIX allocates next
+//     (lowest non-negative integer not in use)
+//
+// The test deliberately never closes fd 0/1/2 — on the real CLR that would
+// detach the test process from its stdin/stdout/stderr and corrupt the test
+// runner's output. The registry unit tests in TestFileDescriptorRegistry
+// cover close semantics over std-stream fds directly.
+class Program
+{
+    [DllImport("libSystem.Native", EntryPoint = "SystemNative_Close")]
+    static extern int SystemNative_Close(IntPtr fd);
+
+    [DllImport("libSystem.Native", EntryPoint = "SystemNative_Dup")]
+    static extern IntPtr SystemNative_Dup(IntPtr oldfd);
+
+    static int Main(string[] args)
+    {
+        // -1 is never a live fd on any Unix; close(2) returns -1 (EBADF).
+        if (SystemNative_Close((IntPtr)(-1)) != -1) return 1;
+
+        // dup stdin to a fresh fd; close must succeed and return 0.
+        IntPtr duped = SystemNative_Dup((IntPtr)0);
+        if ((long)duped < 3L) return 2;
+        if (SystemNative_Close(duped) != 0) return 3;
+
+        // A second close of the same fd hits the now-empty slot and must
+        // return -1 (EBADF). This is the load-bearing case: closing the
+        // table entry actually removed it, so the slot is gone.
+        if (SystemNative_Close(duped) != -1) return 4;
+
+        // POSIX requires dup to allocate the lowest non-negative fd not in
+        // use, so after the close above the next dup of stdin must reuse
+        // the fd we just freed. This exercises the gap-fill at the handler
+        // boundary, not just the registry unit.
+        IntPtr reused = SystemNative_Dup((IntPtr)0);
+        if ((long)reused != (long)duped) return 5;
+
+        // Tidy up so the test doesn't leave a dangling table entry behind.
+        if (SystemNative_Close(reused) != 0) return 6;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/FileDescriptorRegistry.fs
+++ b/WoofWare.PawPrint/FileDescriptorRegistry.fs
@@ -124,11 +124,12 @@ module FileDescriptorRegistry =
             )
 
     /// Remove an entry from the table. Mirrors `close(2)`: returns
-    /// `Error BadFd` (= `EBADF`) when `fd` is not currently live. The
-    /// SystemNative_Close handler isn't wired up yet; this is defined so
-    /// the registry contract is closed under the operations it will need,
-    /// and so property tests can drive close+dup cycles to exercise the
-    /// `lowestFree` invariant against the gap structure that close produces.
+    /// `Error BadFd` (= `EBADF`) when `fd` is not currently live. Wired
+    /// into the interpreter via the `SystemNative_Close` handler in
+    /// `NativeSystemNative.fs`; the in-house property tests drive
+    /// close+dup cycles directly against this function to exercise the
+    /// `lowestFree` invariant against the gap structure that close
+    /// produces.
     let close
         (fd : int)
         (registry : FileDescriptorRegistry)

--- a/WoofWare.PawPrint/Native/NativeSystemNative.fs
+++ b/WoofWare.PawPrint/Native/NativeSystemNative.fs
@@ -188,6 +188,40 @@ module NativeSystemNative =
             |> Tuple.withRight WhatWeDid.Executed
             |> ExecutionResult.Stepped
             |> Some
+        | Some "SystemNative_Close",
+          [ ConcreteIntPtr state.ConcreteTypes ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
+            // `close(2)`: remove the fd from the per-process table and return 0.
+            // On EBADF (fd not currently live) return -1 and set errno=EBADF, so
+            // CoreLib's `Interop.CheckIo` raises an IOException, matching the
+            // libc behaviour `Interop.Sys.Close` is written against. The native
+            // shim silently retries EINTR (`pal_io.c` treats EINTR-on-close as
+            // success); PawPrint doesn't model signals, so EINTR is unreachable
+            // here. Per Unix convention, errno is left untouched on success.
+            let fd = fdArgument "SystemNative_Close" instruction.Arguments.[0]
+
+            let resultCode, state =
+                match FileDescriptorRegistry.close fd state.Kernel.FileDescriptors with
+                | Ok registry ->
+                    0,
+                    state.MapKernel (fun kernel ->
+                        { kernel with
+                            FileDescriptors = registry
+                        }
+                    )
+                | Error FileDescriptorCloseError.BadFd ->
+                    -1,
+                    state.MapKernel (fun kernel ->
+                        { kernel with
+                            LastSystemError = Errno.EBADF
+                        }
+                    )
+
+            state
+            |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 resultCode) ctx.Thread
+            |> Tuple.withRight WhatWeDid.Executed
+            |> ExecutionResult.Stepped
+            |> Some
         | Some "SystemNative_Free", [ ConcretePointer _ ], MethodReturnType.Void ->
             let ptr =
                 NativeCall.managedPointerOfPointerArgument "SystemNative_Free" "ptr" instruction.Arguments.[0]


### PR DESCRIPTION
## Summary
- Wires `SystemNative_Close` through the per-process fd table in `NativeSystemNative.fs`, mirroring the recently-landed `SystemNative_Dup` handler. Returns 0 on success, `-1` with `LastSystemError = Errno.EBADF` on a missing fd. EINTR is unreachable for PawPrint (we don't model signals; the native shim treats EINTR-on-close as success), and per Unix convention errno is left untouched on success.
- `FileDescriptorRegistry.close` already existed and is property-tested against close+dup cycles in `TestFileDescriptorRegistry`. Updates its docstring to drop the "isn't wired up yet" caveat.
- New `SystemNativeClose.cs` pure-source test exercises the handler end-to-end via direct P/Invoke. It asserts only invariants that hold on every Unix kernel so the same source passes on the real CLR: close of an invalid fd returns -1, close of a freshly-duped fd returns 0, double-close returns -1, and POSIX's lowest-free rule causes a subsequent dup to reuse the freed slot.
- The test deliberately never closes fd 0/1/2 — doing so on the real CLR would detach the test runner from its stdin/stdout/stderr. The std-stream close path is already covered by registry unit tests in `TestFileDescriptorRegistry`.

## Test plan
- [x] `nix develop -c dotnet build WoofWare.PawPrint/WoofWare.PawPrint.fsproj` — clean.
- [x] `nix develop -c dotnet test ... --filter "Name~SystemNative"` — both Dup and Close pure tests pass.
- [x] `nix develop -c dotnet test ...` (full suite) — 821/821 passing (was 820 + new SystemNativeClose test).
- [x] `nix develop -c dotnet fantomas .` — no changes.
- [x] `codex review --base main` — no blocking findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)