### PR TITLE
Inject deterministic spurious wakeups into LowLevelMonitor

### DIFF
--- a/WoofWare.PawPrint.Test/TestLowLevelMonitor.fs
+++ b/WoofWare.PawPrint.Test/TestLowLevelMonitor.fs
@@ -470,3 +470,298 @@ module TestLowLevelMonitor =
             && threads |> List.forall (fun t -> statusOf t state = ThreadStatus.Runnable)
 
         Check.One (config, property)
+
+    // -------------------------------------------------------------------
+    // Spurious-wakeup injection
+    // -------------------------------------------------------------------
+
+    /// Helper: drive `thread` through Acquire+Wait on `id`, leaving it in
+    /// `WaitQueue` and the monitor unowned (provided no later thread
+    /// claims it). Caller is responsible for the ordering invariant —
+    /// callers that drive multiple threads must do so sequentially so
+    /// each Wait observes the monitor as currently owned.
+    let private parkInWait (thread : ThreadId) (id : LowLevelMonitorId) (state : IlMachineState) : IlMachineState =
+        let state = LowLevelMonitor.acquire thread id state |> acquired
+        LowLevelMonitor.wait thread id state
+
+    [<Test>]
+    let ``spuriousWake on free monitor grants ownership to the woken thread`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = LowLevelMonitor.create state
+        let state = state |> parkInWait t0 id
+
+        // Pre: t0 parked, monitor unowned.
+        (monitorOf id state).Owner |> shouldEqual None
+        (monitorOf id state).WaitQueue |> shouldEqual [ t0 ]
+
+        let state = LowLevelMonitor.spuriousWake id t0 state
+
+        let m = monitorOf id state
+        m.Owner |> shouldEqual (Some t0)
+        m.AcquireQueue |> shouldEqual []
+        m.WaitQueue |> shouldEqual []
+        statusOf t0 state |> shouldEqual ThreadStatus.Runnable
+
+    [<Test>]
+    let ``spuriousWake on held monitor parks the waiter at the AcquireQueue tail`` () : unit =
+        // t0 waits, t1 then owns; spurious-waking t0 must queue it behind
+        // t1, not steal the monitor.
+        let state = baseState () |> withThreads [ t0 ; t1 ]
+        let id, state = LowLevelMonitor.create state
+        let state = state |> parkInWait t0 id
+        let state = LowLevelMonitor.acquire t1 id state |> acquired
+
+        let state = LowLevelMonitor.spuriousWake id t0 state
+
+        let m = monitorOf id state
+        m.Owner |> shouldEqual (Some t1)
+        m.AcquireQueue |> shouldEqual [ t0 ]
+        m.WaitQueue |> shouldEqual []
+        statusOf t0 state |> shouldEqual (ThreadStatus.BlockedOnMonitorAcquire id)
+        statusOf t1 state |> shouldEqual ThreadStatus.Runnable
+
+    [<Test>]
+    let ``spuriousWake fails loud when the thread is not in WaitQueue`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = LowLevelMonitor.create state
+        let state = LowLevelMonitor.acquire t0 id state |> acquired
+        // t0 currently owns; not in WaitQueue.
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> LowLevelMonitor.spuriousWake id t0 state |> ignore)
+
+        exn.Message |> shouldContainText "WaitQueue"
+
+    /// Snapshot of just the parts of `IlMachineState` that
+    /// `applySpuriousWakeups` is allowed to touch. ThreadState as a whole
+    /// is not equality-comparable (it embeds MethodStates with structural
+    /// non-equality), so we compare what we care about explicitly.
+    let private wakeupVisibleState (state : IlMachineState) =
+        let monitors = state.Kernel.LowLevelMonitors
+        let statuses = state.ThreadState |> Map.map (fun _ ts -> ts.Status)
+        monitors, statuses
+
+    [<Test>]
+    let ``applySpuriousWakeups Disabled is bit-identical to the input state`` () : unit =
+        let state = baseState () |> withThreads [ t0 ; t1 ]
+        let id, state = LowLevelMonitor.create state
+        let state = state |> parkInWait t0 id
+        let state = state |> parkInWait t1 id
+        // Both waiters parked; Owner = None; WaitQueue = [t0; t1].
+
+        let state' =
+            LowLevelMonitor.applySpuriousWakeups SpuriousWakeupStrategy.Disabled 42L state
+
+        wakeupVisibleState state' |> shouldEqual (wakeupVisibleState state)
+
+    [<Test>]
+    let ``applySpuriousWakeups AlwaysAll drains the WaitQueue in FIFO order`` () : unit =
+        let state = baseState () |> withThreads [ t0 ; t1 ; t2 ]
+        let id, state = LowLevelMonitor.create state
+        let state = state |> parkInWait t0 id
+        let state = state |> parkInWait t1 id
+        let state = state |> parkInWait t2 id
+        // WaitQueue = [t0; t1; t2], Owner = None.
+
+        let state =
+            LowLevelMonitor.applySpuriousWakeups SpuriousWakeupStrategy.AlwaysAll 0L state
+
+        let m = monitorOf id state
+        // FIFO: t0 wakes first into a free monitor and takes ownership.
+        // t1 and t2 then queue behind t0.
+        m.Owner |> shouldEqual (Some t0)
+        m.AcquireQueue |> shouldEqual [ t1 ; t2 ]
+        m.WaitQueue |> shouldEqual []
+        statusOf t0 state |> shouldEqual ThreadStatus.Runnable
+        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnMonitorAcquire id)
+        statusOf t2 state |> shouldEqual (ThreadStatus.BlockedOnMonitorAcquire id)
+
+    [<Test>]
+    let ``applySpuriousWakeups AlwaysAll processes monitors in ascending id order`` () : unit =
+        // Two independent monitors. Order of monitor processing is
+        // observable through which owner each ends up with, but more
+        // importantly we want to know the iteration is deterministic.
+        let state = baseState () |> withThreads [ t0 ; t1 ; t2 ; t3 ]
+        let id1, state = LowLevelMonitor.create state
+        let id2, state = LowLevelMonitor.create state
+        let state = state |> parkInWait t0 id1
+        let state = state |> parkInWait t1 id1
+        let state = state |> parkInWait t2 id2
+        let state = state |> parkInWait t3 id2
+
+        let state =
+            LowLevelMonitor.applySpuriousWakeups SpuriousWakeupStrategy.AlwaysAll 0L state
+
+        let m1 = monitorOf id1 state
+        let m2 = monitorOf id2 state
+        m1.Owner |> shouldEqual (Some t0)
+        m1.AcquireQueue |> shouldEqual [ t1 ]
+        m1.WaitQueue |> shouldEqual []
+        m2.Owner |> shouldEqual (Some t2)
+        m2.AcquireQueue |> shouldEqual [ t3 ]
+        m2.WaitQueue |> shouldEqual []
+
+    [<Test>]
+    let ``applySpuriousWakeups Scripted only fires at the named tick`` () : unit =
+        let state = baseState () |> withThreads [ t0 ; t1 ]
+        let id, state = LowLevelMonitor.create state
+        let state = state |> parkInWait t0 id
+        let state = state |> parkInWait t1 id
+
+        let script = SpuriousWakeupStrategy.Scripted [ 5L, id, t1 ]
+
+        // At tick 0: nothing scripted; state passes through.
+        let state0 = LowLevelMonitor.applySpuriousWakeups script 0L state
+        (monitorOf id state0).WaitQueue |> shouldEqual [ t0 ; t1 ]
+
+        // At tick 5: only t1 wakes (and takes ownership because monitor
+        // is free).
+        let state5 = LowLevelMonitor.applySpuriousWakeups script 5L state
+        let m = monitorOf id state5
+        m.WaitQueue |> shouldEqual [ t0 ]
+        m.Owner |> shouldEqual (Some t1)
+        statusOf t1 state5 |> shouldEqual ThreadStatus.Runnable
+        statusOf t0 state5 |> shouldEqual (ThreadStatus.BlockedOnMonitorWait id)
+
+    [<Test>]
+    let ``applySpuriousWakeups Scripted fails loud on a stale waiter`` () : unit =
+        // Script names a thread that is not in any WaitQueue; the
+        // interpreter must reject this so scripts can't silently drift.
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = LowLevelMonitor.create state
+        let script = SpuriousWakeupStrategy.Scripted [ 0L, id, t0 ]
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> LowLevelMonitor.applySpuriousWakeups script 0L state |> ignore)
+
+        exn.Message |> shouldContainText "WaitQueue"
+
+    [<Test>]
+    let ``applySpuriousWakeups Random with probability 0.0 is a no-op`` () : unit =
+        let state = baseState () |> withThreads [ t0 ; t1 ]
+        let id, state = LowLevelMonitor.create state
+        let state = state |> parkInWait t0 id
+        let state = state |> parkInWait t1 id
+
+        let state' =
+            LowLevelMonitor.applySpuriousWakeups (SpuriousWakeupStrategy.Random (42UL, 0.0)) 7L state
+
+        wakeupVisibleState state' |> shouldEqual (wakeupVisibleState state)
+
+    [<Test>]
+    let ``applySpuriousWakeups Random with probability 1.0 matches AlwaysAll`` () : unit =
+        // probability=1.0 should wake every (mid, tid) regardless of
+        // seed, producing the same state as AlwaysAll.
+        let state = baseState () |> withThreads [ t0 ; t1 ; t2 ]
+        let id, state = LowLevelMonitor.create state
+        let state = state |> parkInWait t0 id
+        let state = state |> parkInWait t1 id
+        let state = state |> parkInWait t2 id
+
+        let always =
+            LowLevelMonitor.applySpuriousWakeups SpuriousWakeupStrategy.AlwaysAll 0L state
+
+        let random =
+            LowLevelMonitor.applySpuriousWakeups (SpuriousWakeupStrategy.Random (0UL, 1.0)) 0L state
+
+        wakeupVisibleState random |> shouldEqual (wakeupVisibleState always)
+
+    [<Test>]
+    let ``applySpuriousWakeups Random is deterministic in (seed, tick)`` () : unit =
+        // Identical inputs must produce identical outputs — the whole
+        // point of a deterministic strategy is replayability.
+        let state = baseState () |> withThreads [ t0 ; t1 ; t2 ; t3 ]
+        let id, state = LowLevelMonitor.create state
+        let state = state |> parkInWait t0 id
+        let state = state |> parkInWait t1 id
+        let state = state |> parkInWait t2 id
+        let state = state |> parkInWait t3 id
+
+        let strategy = SpuriousWakeupStrategy.Random (123UL, 0.5)
+
+        let r1 = LowLevelMonitor.applySpuriousWakeups strategy 17L state
+        let r2 = LowLevelMonitor.applySpuriousWakeups strategy 17L state
+
+        wakeupVisibleState r1 |> shouldEqual (wakeupVisibleState r2)
+
+    [<Test>]
+    let ``applySpuriousWakeups Random rejects NaN probability`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = LowLevelMonitor.create state
+        let state = state |> parkInWait t0 id
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () ->
+                LowLevelMonitor.applySpuriousWakeups (SpuriousWakeupStrategy.Random (1UL, System.Double.NaN)) 0L state
+                |> ignore
+            )
+
+        exn.Message |> shouldContainText "NaN"
+
+    [<Test>]
+    let ``applySpuriousWakeups preserves the Owner/AcquireQueue invariant on a contended monitor`` () : unit =
+        // Pre-existing acquirer + multiple waiters + AlwaysAll wake — the
+        // hard case for the invariant `Owner = None iff AcquireQueue = []`.
+        let state = baseState () |> withThreads [ t0 ; t1 ; t2 ; t3 ]
+        let id, state = LowLevelMonitor.create state
+        // t0 owns; t1 contends.
+        let state = LowLevelMonitor.acquire t0 id state |> acquired
+        let state = LowLevelMonitor.acquire t1 id state |> blocked
+        // t0 waits — t1 inherits ownership; t0 joins the WaitQueue.
+        let state = LowLevelMonitor.wait t0 id state
+        // t1 waits — Owner becomes None, WaitQueue = [t0; t1].
+        let state = LowLevelMonitor.wait t1 id state
+
+        let state =
+            LowLevelMonitor.applySpuriousWakeups SpuriousWakeupStrategy.AlwaysAll 0L state
+
+        let m = monitorOf id state
+        m.WaitQueue |> shouldEqual []
+        // Invariant: Owner = None implies AcquireQueue = [].
+        match m.Owner, m.AcquireQueue with
+        | None, _ :: _ -> failwith "invariant violated: AcquireQueue non-empty with no Owner"
+        | _ -> ()
+        // And specifically: t0 took ownership, t1 queued behind.
+        m.Owner |> shouldEqual (Some t0)
+        m.AcquireQueue |> shouldEqual [ t1 ]
+
+    [<Test>]
+    let ``Property: applySpuriousWakeups preserves invariants for AlwaysAll on randomly parked waiters`` () : unit =
+        // Park a random number of threads via Acquire+Wait, then apply
+        // AlwaysAll. Final state must satisfy:
+        //   1. WaitQueue is empty on the affected monitor.
+        //   2. Owner = None implies AcquireQueue = [] (the directional
+        //      invariant).
+        //   3. The set of (Owner ++ AcquireQueue) equals the original
+        //      WaitQueue (no thread lost or duplicated).
+        let property (PositiveInt n) : bool =
+            let n = min 6 n
+            let threads = [ 0 .. n - 1 ] |> List.map ThreadId
+            let state = baseState () |> withThreads threads
+            let id, state = LowLevelMonitor.create state
+
+            let state = threads |> List.fold (fun s tid -> parkInWait tid id s) state
+
+            let beforeWaiters = (monitorOf id state).WaitQueue
+
+            let state =
+                LowLevelMonitor.applySpuriousWakeups SpuriousWakeupStrategy.AlwaysAll 0L state
+
+            let m = monitorOf id state
+
+            let owners =
+                match m.Owner with
+                | Some o -> [ o ]
+                | None -> []
+
+            // The forbidden state is Owner = None with non-empty queue.
+            let invariantHolds =
+                match m.Owner, m.AcquireQueue with
+                | None, _ :: _ -> false
+                | _ -> true
+
+            m.WaitQueue = []
+            && invariantHolds
+            && Set.ofList (owners @ m.AcquireQueue) = Set.ofList beforeWaiters
+
+        Check.One (config, property)

--- a/WoofWare.PawPrint/EmulatedKernel.fs
+++ b/WoofWare.PawPrint/EmulatedKernel.fs
@@ -23,10 +23,13 @@ namespace WoofWare.PawPrint
 /// thread that holds the monitor and calls `Acquire` again deadlocks.
 /// Reentrancy is supplied at a higher level by `LowLevelLock`.
 ///
-/// Spurious wakeups are not generated today, but the model is shaped so
-/// they can be inserted later by moving a thread from `WaitQueue` to
-/// `AcquireQueue` from outside `Signal_Release`. Any guest code that
-/// depends on the absence of spurious wakeups is incorrect on real CoreCLR.
+/// Spurious wakeups are injected externally according to
+/// `EmulatedKernel.SpuriousWakeup` — the model exposes a transition
+/// (`LowLevelMonitor.spuriousWake`) that moves a thread from `WaitQueue`
+/// through the same reacquire path that `Signal_Release` uses. Any guest
+/// code that depends on the absence of spurious wakeups is incorrect on
+/// real CoreCLR; the `SpuriousWakeup` field is the deterministic knob
+/// for exposing those bugs.
 type LowLevelMonitorState =
     {
         Owner : ThreadId option
@@ -42,6 +45,44 @@ module LowLevelMonitorState =
             AcquireQueue = []
             WaitQueue = []
         }
+
+/// Deterministic policy the driver consults each scheduler step to
+/// decide whether to inject spurious wakeups for threads parked in
+/// `BlockedOnMonitorWait`. Real CoreCLR (via pthread `cond_wait`) is
+/// allowed to return from `Wait` without a matching `Signal_Release`,
+/// which is why guest code is required to wrap `Wait` in a predicate
+/// loop. This type drives that contract: a strategy other than
+/// `Disabled` causes PawPrint to wake waiters according to a
+/// deterministic recipe so guest predicate-loop bugs surface as failing
+/// runs rather than latent races.
+///
+/// The strategy is data, not a closure, so it can be printed, diffed,
+/// and replayed across runs. Each variant is independently
+/// deterministic given the current `EmulatedKernel.StepCounter`.
+[<RequireQualifiedAccess>]
+type SpuriousWakeupStrategy =
+    /// Default. Only `Signal_Release` wakes a waiter. Equivalent to a
+    /// pthread implementation that never returns from `cond_wait`
+    /// spuriously: permitted by POSIX but masks predicate-loop bugs.
+    | Disabled
+    /// Wake every waiter on every scheduler tick. Maximum fuzz
+    /// pressure. Guest code that uses `Monitor.Wait` outside a
+    /// re-checking predicate loop will produce wrong results — that is
+    /// the point.
+    | AlwaysAll
+    /// Each (tick, monitor, waiter) tuple wakes independently with the
+    /// given probability. The coin flip is a deterministic function of
+    /// `(seed, tick, monitorId, threadId)`, so the same seed reproduces
+    /// the same wakeup sequence across runs. `probability` is rejected
+    /// at apply time if it is NaN or outside `[0.0, 1.0]` — values
+    /// outside that range are a programmer error and fail loud.
+    | Random of seed : uint64 * probability : float
+    /// Explicit `(tick, monitorId, threadId)` triples. Fully
+    /// replayable. A triple naming a thread that is not in the named
+    /// monitor's `WaitQueue` at the named tick fails loudly — silent
+    /// skip would let scripts drift unnoticed when the interleaving
+    /// underneath them changes.
+    | Scripted of wakeups : (int64 * LowLevelMonitorId * ThreadId) list
 
 /// Aggregates the slice of `IlMachineState` that models host-kernel /
 /// syscall-emulation state: process-wide last-error registers, the native
@@ -98,6 +139,20 @@ type EmulatedKernel =
         /// only need to be unique and non-zero (the BCL treats handle 0 as
         /// "create failed" and throws OOM).
         NextEventPipeId : int64
+        /// Deterministic strategy governing spurious wakeups out of
+        /// `LowLevelMonitor.Wait`. Defaults to `Disabled` so existing runs
+        /// are bit-for-bit unchanged. Set this at construction time (or
+        /// via record-copy in tests) to inject wakeups for fuzz /
+        /// correctness testing of guest condition-variable code.
+        SpuriousWakeup : SpuriousWakeupStrategy
+        /// Monotonically-advancing scheduler tick consumed by
+        /// `SpuriousWakeupStrategy`. The driver loop applies the strategy
+        /// against the current value and then increments by 1 before
+        /// calling `Scheduler.chooseNext`. Threading the tick through state
+        /// (rather than as a side argument to the scheduler) keeps the
+        /// pure model self-contained and means tests can drive the strategy
+        /// without spinning up a real driver.
+        StepCounter : int64
     }
 
 [<RequireQualifiedAccess>]
@@ -111,4 +166,6 @@ module EmulatedKernel =
             LowLevelMonitors = Map.empty
             NextLowLevelMonitorId = 1
             NextEventPipeId = 1L
+            SpuriousWakeup = SpuriousWakeupStrategy.Disabled
+            StepCounter = 0L
         }

--- a/WoofWare.PawPrint/LowLevelMonitor.fs
+++ b/WoofWare.PawPrint/LowLevelMonitor.fs
@@ -24,10 +24,13 @@ namespace WoofWare.PawPrint
 /// scheduler later picks the woken thread, it resumes past the call site
 /// and must already own the monitor for subsequent guest code to be sound.
 ///
-/// Invariant: `Owner = None` iff `AcquireQueue = []`. A non-empty queue with
-/// no owner would mean the head is "next in line" but holds nothing, leaving
+/// Invariant: `Owner = None` implies `AcquireQueue = []` (equivalently,
+/// `AcquireQueue ≠ []` implies `Owner = Some _`). A non-empty queue with no
+/// owner would mean the head is "next in line" but holds nothing, leaving
 /// `Release` to fire as unowned when the resumed thread eventually runs.
-/// Every transition below preserves this invariant; `destroy` asserts it.
+/// Uncontended ownership (`Owner = Some _`, `AcquireQueue = []`) is normal
+/// and not forbidden by this invariant. Every transition below preserves
+/// the implication; `destroy` asserts it.
 ///
 /// Reentrancy: a monitor is non-reentrant, matching CoreCLR. A thread that
 /// already owns the monitor and calls `acquire` again is deadlocking guest
@@ -42,12 +45,15 @@ namespace WoofWare.PawPrint
 /// Calls to `timedWait` therefore fail loud; see the P/Invoke handler in
 /// `NativeLowLevelMonitor.fs` for the failure site.
 ///
-/// Spurious wakeups: not generated. Guest code that depends on the absence
-/// of spurious wakeups is incorrect against real CoreCLR, but adding them
-/// would amplify nondeterminism we are not yet prepared to control. The
-/// model is shaped to make insertion straightforward in future: moving a
-/// thread from `WaitQueue` to `AcquireQueue` from outside `signalRelease`
-/// is structurally the same operation.
+/// Spurious wakeups: injected from outside this module under control of
+/// `EmulatedKernel.SpuriousWakeup`. The transition is `spuriousWake`
+/// below, which routes a waiter through the same reacquire path as
+/// `signalRelease` (take ownership if the monitor is free; otherwise park
+/// at the tail of the acquire queue). The driver applies
+/// `applySpuriousWakeups` once per scheduler tick. Guest code that
+/// depends on the absence of spurious wakeups is incorrect against real
+/// CoreCLR; switching the strategy to `AlwaysAll` is the deterministic
+/// way to expose those bugs.
 [<RequireQualifiedAccess>]
 module LowLevelMonitor =
 
@@ -96,10 +102,10 @@ module LowLevelMonitor =
     /// guest bug that would otherwise present as a use-after-free later.
     ///
     /// The AcquireQueue check is also a defensive assertion of the
-    /// owner/queue invariant (`Owner = None` iff `AcquireQueue = []`): a
-    /// non-empty queue with no owner means a transition somewhere violated
-    /// the invariant, and surfacing that here is cheaper than chasing it
-    /// from a downstream symptom.
+    /// owner/queue invariant (`Owner = None` implies `AcquireQueue = []`):
+    /// a non-empty queue with no owner means a transition somewhere
+    /// violated the invariant, and surfacing that here is cheaper than
+    /// chasing it from a downstream symptom.
     let destroy (id : LowLevelMonitorId) (state : IlMachineState) : IlMachineState =
         let monitor = lookup id state
 
@@ -326,3 +332,130 @@ module LowLevelMonitor =
                 |> Scheduler.setThreadStatus waiter (ThreadStatus.BlockedOnMonitorAcquire id)
 
             release thread id state
+
+    /// Pull `thread` out of `id`'s `WaitQueue` and route it through the
+    /// same reacquire path that `signalRelease` would take. By the
+    /// Owner/AcquireQueue invariant, an unowned monitor has an empty
+    /// acquire queue, so a spurious wake of a free monitor grants
+    /// ownership directly to the woken thread (status flips to
+    /// `Runnable`); a held monitor parks the woken thread at the
+    /// AcquireQueue tail (status flips to `BlockedOnMonitorAcquire`).
+    /// In both cases the waiter eventually resumes past its `Wait` call
+    /// site already owning the monitor — the same shape `signalRelease`
+    /// produces — so the native handler does not need to distinguish
+    /// signalled from spurious wakeups.
+    ///
+    /// Fails loudly if `thread` is not in `id`'s `WaitQueue`. The only
+    /// caller is `applySpuriousWakeups`, which enumerates the waiters
+    /// itself; a miss indicates either a script that named a stale
+    /// thread (silent skip would let the script drift unnoticed) or a
+    /// bug in the strategy interpreter.
+    let spuriousWake (id : LowLevelMonitorId) (thread : ThreadId) (state : IlMachineState) : IlMachineState =
+        let monitor = lookup id state
+
+        if not (List.contains thread monitor.WaitQueue) then
+            failwith
+                $"LowLevelMonitor %O{id}: cannot spuriously wake thread %O{thread} because it is not in WaitQueue (queue: %A{monitor.WaitQueue})."
+
+        let newWaitQueue = monitor.WaitQueue |> List.filter (fun t -> t <> thread)
+
+        match monitor.Owner with
+        | None ->
+            // Uncontended: the invariant guarantees AcquireQueue is empty,
+            // so we take ownership directly and become Runnable.
+            let monitor =
+                { monitor with
+                    Owner = Some thread
+                    WaitQueue = newWaitQueue
+                }
+
+            state
+            |> writeMonitor id monitor
+            |> Scheduler.setThreadStatus thread ThreadStatus.Runnable
+
+        | Some _ ->
+            // Contended: park at the AcquireQueue tail. Ownership will be
+            // handed to us atomically when our predecessor releases.
+            let monitor =
+                { monitor with
+                    AcquireQueue = monitor.AcquireQueue @ [ thread ]
+                    WaitQueue = newWaitQueue
+                }
+
+            state
+            |> writeMonitor id monitor
+            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnMonitorAcquire id)
+
+    /// SplitMix64-style hash, used to derive a deterministic per-waiter
+    /// coin flip in `[0.0, 1.0)` from `(seed, tick, monitorId, threadId)`.
+    /// Replayability comes from the function being a pure hash with no
+    /// mutable PRNG state — distinct ticks/waiters never share entropy.
+    let private coinFlip (seed : uint64) (tick : int64) (LowLevelMonitorId mid) (ThreadId tid) : float =
+        let mix (h : uint64) (x : uint64) : uint64 =
+            let h = h ^^^ x
+            h * 0x100000001B3UL
+
+        let finalise (h : uint64) : uint64 =
+            let h = h ^^^ (h >>> 33)
+            let h = h * 0xff51afd7ed558ccdUL
+            let h = h ^^^ (h >>> 33)
+            let h = h * 0xc4ceb9fe1a85ec53UL
+            h ^^^ (h >>> 33)
+
+        let h = seed
+        let h = mix h (uint64 tick)
+        let h = mix h (uint64 mid)
+        let h = mix h (uint64 tid)
+        let h = finalise h
+        // Top 53 bits as a float in [0, 1). Matches the common
+        // "uniform double from uint64" recipe; precision loss in the low
+        // bits is irrelevant for a fuzz-probability threshold.
+        float (h >>> 11) / float (1UL <<< 53)
+
+    /// Enumerate the spurious wakeups requested by `strategy` for `tick`
+    /// against the current `WaitQueue` membership, then apply each
+    /// `spuriousWake` in deterministic order (ascending monitor id, then
+    /// FIFO position within `WaitQueue`). Snapshotting the (monitor,
+    /// thread) list first means strategy decisions are computed against
+    /// the state at entry — applying an earlier wake never affects which
+    /// later wakes the strategy would have chosen on this tick.
+    ///
+    /// `Disabled` is the identity. `Random.probability` outside
+    /// `[0.0, 1.0]` is a programmer error and fails loud. `Scripted`
+    /// triples that name a thread not in the named monitor's WaitQueue
+    /// at the named tick fail loud — silent skip would let scripts drift
+    /// when the underlying interleaving changes.
+    let applySpuriousWakeups
+        (strategy : SpuriousWakeupStrategy)
+        (tick : int64)
+        (state : IlMachineState)
+        : IlMachineState
+        =
+        match strategy with
+        | SpuriousWakeupStrategy.Disabled -> state
+
+        | SpuriousWakeupStrategy.AlwaysAll ->
+            state.Kernel.LowLevelMonitors
+            |> Map.toSeq
+            |> Seq.sortBy (fun (LowLevelMonitorId i, _) -> i)
+            |> Seq.collect (fun (mid, monitor) -> monitor.WaitQueue |> List.map (fun tid -> mid, tid))
+            |> Seq.toList
+            |> List.fold (fun acc (mid, tid) -> spuriousWake mid tid acc) state
+
+        | SpuriousWakeupStrategy.Random (seed, probability) ->
+            if probability < 0.0 || probability > 1.0 || System.Double.IsNaN probability then
+                failwith
+                    $"SpuriousWakeupStrategy.Random: probability %f{probability} is outside [0.0, 1.0] (NaN or out of range)."
+
+            state.Kernel.LowLevelMonitors
+            |> Map.toSeq
+            |> Seq.sortBy (fun (LowLevelMonitorId i, _) -> i)
+            |> Seq.collect (fun (mid, monitor) -> monitor.WaitQueue |> List.map (fun tid -> mid, tid))
+            |> Seq.filter (fun (mid, tid) -> coinFlip seed tick mid tid < probability)
+            |> Seq.toList
+            |> List.fold (fun acc (mid, tid) -> spuriousWake mid tid acc) state
+
+        | SpuriousWakeupStrategy.Scripted wakeups ->
+            wakeups
+            |> List.filter (fun (t, _, _) -> t = tick)
+            |> List.fold (fun acc (_, mid, tid) -> spuriousWake mid tid acc) state

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -119,6 +119,28 @@ module Program =
         //     for foreground workers, so matching that behaviour keeps PawPrint and
         //     the oracle aligned. Environment.Exit from a worker still propagates as
         //     ProcessExit (handled below) before Main has a chance to return.
+
+        // Apply the spurious-wakeup strategy at the current tick, then
+        // advance the counter so the next iteration sees a fresh tick.
+        // For the default (`Disabled`) strategy this is a fold over the
+        // identity and a single integer add — bit-for-bit identical to
+        // pre-feature behaviour.
+        let state =
+            LowLevelMonitor.applySpuriousWakeups
+                prepared.State.Kernel.SpuriousWakeup
+                prepared.State.Kernel.StepCounter
+                prepared.State
+
+        let prepared =
+            { prepared with
+                State =
+                    state.MapKernel (fun kernel ->
+                        { kernel with
+                            StepCounter = kernel.StepCounter + 1L
+                        }
+                    )
+            }
+
         match Scheduler.chooseNext prepared.LastRan prepared.State with
         | None ->
             // No Runnable threads and the entry thread didn't hit its ret. Every


### PR DESCRIPTION
## Summary

- Adds `SpuriousWakeupStrategy` DU (`Disabled` / `AlwaysAll` / `Random` / `Scripted`) plus `StepCounter` to `IlMachineState`; the driver applies the strategy each scheduler tick before `Scheduler.chooseNext`. Default is `Disabled`, so existing runs are bit-for-bit unchanged.
- New `LowLevelMonitor.spuriousWake` transition pulls a thread out of `WaitQueue` and routes it through the same reacquire path `signalRelease` uses (take ownership if free, park at AcquireQueue tail otherwise). `applySpuriousWakeups` is the interpreter over the strategy DU; `Random` uses a SplitMix64 hash of `(seed, tick, monitorId, threadId)` so the same seed reproduces the same wakeup sequence.
- Corrects a long-standing docstring error: the Owner/AcquireQueue invariant is one-directional (`Owner = None` implies `AcquireQueue = []`), not biconditional — uncontended ownership is normal.
- 14 new tests covering `spuriousWake` (free/held/missing), each strategy variant (Disabled/AlwaysAll/Scripted/Random with extremes 0.0, 1.0, NaN, determinism, ordering, stale-thread failure), plus a property test asserting the invariant survives random AlwaysAll wakeups.

Why: real CoreCLR (via pthread `cond_wait`) is allowed to return from `Monitor.Wait` spuriously, so guest code must wrap `Wait` in a predicate loop. PawPrint previously never generated spurious wakeups, which masked that contract. The strategy is data (not a closure) so it prints, diffs, and replays cleanly across runs — fits the deterministic-simulation goal of the project.

## Test plan

- [x] `dotnet build WoofWare.PawPrint.Test`
- [x] `dotnet test --filter "Name~LowLevelMonitor"` (39/39 pass, including 3 property tests at 200 cases each)
- [x] Full suite: `dotnet test WoofWare.PawPrint.Test` (824/824 pass)
- [x] `dotnet fantomas .`
- [x] `codex review --base main` (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)