### PR TITLE
Implement SystemNative_GetNonCryptographicallySecureRandomBytes

### DIFF
--- a/WoofWare.PawPrint.Test/TestNonCryptoRandom.fs
+++ b/WoofWare.PawPrint.Test/TestNonCryptoRandom.fs
@@ -1,0 +1,142 @@
+namespace WoofWare.PawPrint.Test
+
+open FsCheck
+open FsCheck.FSharp
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestNonCryptoRandom =
+
+    let private propertyConfig : Config = Config.QuickThrowOnFailure.WithMaxTest 500
+
+    [<Test>]
+    let ``initial state is non-zero`` () : unit =
+        // splitmix64 starting from zero produces a non-zero output on the
+        // first step, but a non-zero initial state matches the published
+        // reference implementation and avoids the easy-to-misread "the
+        // seed is zero" question for anyone debugging a deterministic run.
+        NonCryptoRandom.initialState |> shouldNotEqual 0UL
+
+    [<Test>]
+    let ``step is pure`` () : unit =
+        // Same input state ⇒ same (output, newState). This is what makes
+        // the whole runtime reproducible: replaying the same trace must
+        // produce identical PRNG draws.
+        let property (state : uint64) : bool =
+            NonCryptoRandom.step state = NonCryptoRandom.step state
+
+        Check.One (propertyConfig, property)
+
+    [<Test>]
+    let ``step changes state (no fixed points)`` () : unit =
+        // splitmix64's weyl increment is odd, so adding it to any 64-bit
+        // state must change the state — there is no fixed point. This
+        // matters because a fixed point would freeze the PRNG and turn
+        // every subsequent draw into the same bytes.
+        let property (state : uint64) : bool =
+            let _, newState = NonCryptoRandom.step state
+            newState <> state
+
+        Check.One (propertyConfig, property)
+
+    [<Test>]
+    let ``drawBytes is deterministic in the starting state`` () : unit =
+        let property (count : int) (state : uint64) : bool =
+            let count = abs count % 64
+            let bytesA, stateA = NonCryptoRandom.drawBytes count state
+            let bytesB, stateB = NonCryptoRandom.drawBytes count state
+            bytesA = bytesB && stateA = stateB
+
+        Check.One (propertyConfig, property)
+
+    [<Test>]
+    let ``drawBytes 0 is a no-op on state`` () : unit =
+        // The dispatch arm short-circuits on length=0 so it never even
+        // dereferences the buffer pointer; the helper must agree, otherwise
+        // the empty-buffer path silently advances the PRNG and desynchronises
+        // it from the dispatch arm's accounting.
+        let property (state : uint64) : bool =
+            let bytes, newState = NonCryptoRandom.drawBytes 0 state
+            bytes.Length = 0 && newState = state
+
+        Check.One (propertyConfig, property)
+
+    [<Test>]
+    let ``drawBytes returns exactly the requested count`` () : unit =
+        let property (count : int) (state : uint64) : bool =
+            let count = abs count % 256
+            let bytes, _ = NonCryptoRandom.drawBytes count state
+            bytes.Length = count
+
+        Check.One (propertyConfig, property)
+
+    [<Test>]
+    let ``drawBytes negative count fails loudly`` () : unit =
+        // A negative count is a caller bug. Silently returning an empty
+        // buffer would hide guest-visible underflow at the SystemNative
+        // boundary, where `(size_t)length` would otherwise interpret -1
+        // as ~2^64.
+        (fun () -> NonCryptoRandom.drawBytes -1 0UL |> ignore) |> shouldFail<exn>
+
+    [<Test>]
+    let ``drawBytes 8 matches a single splitmix64 step in little-endian order`` () : unit =
+        // Pin the byte order: callers may reinterpret the buffer as
+        // `ulong*` (`Random.Xoshiro256StarStarImpl`, `Marvin.DefaultSeed`,
+        // etc.) and we don't want a later refactor to silently flip from
+        // little-endian to big-endian.
+        let property (state : uint64) : bool =
+            let bytes, newState = NonCryptoRandom.drawBytes 8 state
+            let output, expectedNewState = NonCryptoRandom.step state
+
+            let expectedBytes = [| for j in 0..7 -> byte (output >>> (8 * j)) |]
+
+            bytes = expectedBytes && newState = expectedNewState
+
+        Check.One (propertyConfig, property)
+
+    [<Test>]
+    let ``drawBytes is incremental: prefix-then-rest equals one big draw`` () : unit =
+        // The dispatch arm computes one buffer of length N and writes it.
+        // If a future caller draws in chunks instead, the byte stream
+        // must be identical, otherwise a refactor that splits a buffer
+        // fill across two calls silently changes the PRNG output. (Note:
+        // this only holds because our `drawBytes` consumes a fresh
+        // 64-bit step every 8 bytes — partial-step leftover bits are
+        // discarded between calls, so the prefix length is rounded up
+        // to a multiple of 8 for this property.)
+        let property (state : uint64) : bool =
+            let prefix = 8
+            let total = 24
+            let big, _ = NonCryptoRandom.drawBytes total state
+            let first, midState = NonCryptoRandom.drawBytes prefix state
+            let rest, _ = NonCryptoRandom.drawBytes (total - prefix) midState
+            big = Array.append first rest
+
+        Check.One (propertyConfig, property)
+
+    [<Test>]
+    let ``distinct seeds eventually diverge`` () : unit =
+        // Sanity check that splitmix64 is doing *something* — two
+        // different seeds should produce different output streams within
+        // a few steps. (Stronger statistical properties are not claimed:
+        // splitmix64 is a non-crypto mixer.)
+        let property (seedA : uint64) (seedB : uint64) : bool =
+            if seedA = seedB then
+                true
+            else
+                let bytesA, _ = NonCryptoRandom.drawBytes 64 seedA
+                let bytesB, _ = NonCryptoRandom.drawBytes 64 seedB
+                bytesA <> bytesB
+
+        Check.One (propertyConfig, property)
+
+    [<Test>]
+    let ``EmulatedKernel.initial seeds NonCryptoRandomState from NonCryptoRandom.initialState`` () : unit =
+        // The kernel default is the only seed observable from a fresh
+        // run; pin it so a regression here is detected before it changes
+        // the bytes every Guid.NewGuid/Random/HashCode draws.
+        EmulatedKernel.initial.NonCryptoRandomState
+        |> shouldEqual NonCryptoRandom.initialState

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -50,6 +50,7 @@
     <Compile Include="TestGenericParamConstraints.fs" />
     <Compile Include="TestGcHandleRegistry.fs" />
     <Compile Include="TestFileDescriptorRegistry.fs" />
+    <Compile Include="TestNonCryptoRandom.fs" />
     <Compile Include="TestPrimitiveLikeStructRegistry.fs" />
     <Compile Include="TestEvalStackPrimitiveLikeBoundary.fs" />
     <Compile Include="TestCliValueTypeCoerceFrom.fs" />

--- a/WoofWare.PawPrint/EmulatedKernel.fs
+++ b/WoofWare.PawPrint/EmulatedKernel.fs
@@ -153,7 +153,76 @@ type EmulatedKernel =
         /// pure model self-contained and means tests can drive the strategy
         /// without spinning up a real driver.
         StepCounter : int64
+        /// Deterministic state for the splitmix64 PRNG that backs
+        /// `SystemNative_GetNonCryptographicallySecureRandomBytes`. Real
+        /// CoreCLR fills this buffer from `arc4random_buf` /
+        /// `BCryptGenRandom` / `/dev/urandom`; PawPrint refuses host
+        /// entropy because the whole point of the runtime is bit-for-bit
+        /// reproducibility. A seeded PRNG is the closest deterministic
+        /// substitute that still survives downstream consumers: the BCL's
+        /// `Random()` ctor retries until it sees a non-zero seed, so a
+        /// constant-zero substitute would hang at construction time.
+        NonCryptoRandomState : uint64
     }
+
+/// Deterministic non-cryptographic PRNG that backs
+/// `SystemNative_GetNonCryptographicallySecureRandomBytes`. This is the
+/// `splitmix64` step from Vigna's reference at
+/// <http://prng.di.unimi.it/splitmix64.c>: stateful, full-period over the
+/// 2^64 64-bit states, and famously fine for *seeding* other PRNGs (which
+/// is exactly what the BCL does here — it feeds the buffer into
+/// `Random.XoshiroImpl`, `Marvin.DefaultSeed`, `HashCode`'s seed, etc.).
+///
+/// Quality is intentionally non-cryptographic; that matches the entry-point
+/// name. The state being non-zero is preserved across the step (splitmix64
+/// has no fixed points other than `0 -> 0x9E3779B97F4A7C15`-style transient
+/// behaviour from a zero start, which is why `initial` seeds with the
+/// golden-ratio constant rather than zero).
+[<RequireQualifiedAccess>]
+module NonCryptoRandom =
+    /// `floor(2^64 / phi)`, the same constant the reference splitmix64 uses
+    /// as its weyl increment. Picked as the default initial state so a
+    /// fresh interpreter doesn't start from zero (which would still produce
+    /// a non-zero output after one step, but is the documented degenerate
+    /// input for splitmix64-style mixers).
+    let initialState : uint64 = 0x9E3779B97F4A7C15UL
+
+    /// Advance the splitmix64 state by one step and return the 64-bit
+    /// output drawn from the new state. Reference implementation:
+    /// <http://prng.di.unimi.it/splitmix64.c>. Pure: same input state
+    /// produces the same `(output, newState)` pair on every call.
+    let step (state : uint64) : uint64 * uint64 =
+        let newState = state + 0x9E3779B97F4A7C15UL
+        let mutable z = newState
+        z <- (z ^^^ (z >>> 30)) * 0xBF58476D1CE4E5B9UL
+        z <- (z ^^^ (z >>> 27)) * 0x94D049BB133111EBUL
+        z <- z ^^^ (z >>> 31)
+        z, newState
+
+    /// Draw `count` pseudo-random bytes from the splitmix64 state. Returns
+    /// the bytes in little-endian unpack order from each 64-bit step, plus
+    /// the new state. `count` must be non-negative; a negative count is a
+    /// caller bug and the function will fail loudly.
+    let drawBytes (count : int) (state : uint64) : byte[] * uint64 =
+        if count < 0 then
+            failwith $"NonCryptoRandom.drawBytes: byte count %d{count} is negative"
+
+        let buffer = Array.zeroCreate<byte> count
+        let mutable state = state
+        let mutable i = 0
+
+        while i < count do
+            let output, newState = step state
+            state <- newState
+            let remaining = count - i
+            let chunk = if remaining > 8 then 8 else remaining
+
+            for j = 0 to chunk - 1 do
+                buffer.[i + j] <- byte (output >>> (8 * j))
+
+            i <- i + chunk
+
+        buffer, state
 
 [<RequireQualifiedAccess>]
 module EmulatedKernel =
@@ -168,4 +237,5 @@ module EmulatedKernel =
             NextEventPipeId = 1L
             SpuriousWakeup = SpuriousWakeupStrategy.Disabled
             StepCounter = 0L
+            NonCryptoRandomState = NonCryptoRandom.initialState
         }

--- a/WoofWare.PawPrint/Native/NativeCall.fs
+++ b/WoofWare.PawPrint/Native/NativeCall.fs
@@ -229,7 +229,7 @@ module NativeCall =
 
             loop 0 []
 
-    let private requiredByteConcreteType
+    let requiredByteConcreteType
         (operation : string)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (state : IlMachineState)

--- a/WoofWare.PawPrint/Native/NativeSystemNative.fs
+++ b/WoofWare.PawPrint/Native/NativeSystemNative.fs
@@ -222,6 +222,80 @@ module NativeSystemNative =
             |> Tuple.withRight WhatWeDid.Executed
             |> ExecutionResult.Stepped
             |> Some
+        | Some "SystemNative_GetNonCryptographicallySecureRandomBytes",
+          [ ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.Byte)
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32 ],
+          MethodReturnType.Void ->
+            // CoreCLR fills this buffer from the host's non-crypto PRNG
+            // (`arc4random_buf` on BSD/macOS, BCrypt on Windows,
+            // `/dev/urandom` XOR'd with `lrand48()` on Linux — see
+            // minipal/random.c). PawPrint refuses host entropy because the
+            // whole runtime is built around bit-for-bit reproducibility,
+            // so we substitute a seeded splitmix64 step kept in
+            // `EmulatedKernel.NonCryptoRandomState`. That is *strictly*
+            // more deterministic than the real CLR (where each Random
+            // ctor, Guid.NewGuid, Marvin seed, and HashCode seed is
+            // unreproducible) and is what enables time-travel
+            // debugging across runs that touch any of those paths.
+            //
+            // Returning a constant (e.g. all zeros) is not viable: the
+            // BCL's Random ctor at Random.Xoshiro{128,256}StarStarImpl
+            // explicitly retries until the buffer is non-zero, so a
+            // constant-zero substitute hangs at `new Random()`.
+            let operation = "SystemNative_GetNonCryptographicallySecureRandomBytes"
+
+            let buffer =
+                NativeCall.managedPointerOfPointerArgument operation "buffer" instruction.Arguments.[0]
+
+            let length = NativeCall.int32Argument operation instruction.Arguments.[1]
+
+            if length < 0 then
+                // CoreCLR's `pal_random.c` does not validate `bufferLength`;
+                // a negative value would underflow `(size_t)bufferLength` in
+                // the C call. CoreLib callers never pass negative lengths,
+                // so seeing one here means a guest bug we want to surface
+                // rather than a silently truncated buffer.
+                failwith $"%s{operation}: bufferLength %d{length} is negative"
+
+            let state =
+                if length = 0 then
+                    // Match the C behaviour of `arc4random_buf(buf, 0)` /
+                    // `read(fd, buf, 0)`: no-op, do not even dereference
+                    // `buffer` (which CoreLib may pass as a null pointer
+                    // for an empty span).
+                    state
+                else
+                    match buffer with
+                    | ManagedPointerSource.Null ->
+                        failwith
+                            $"%s{operation}: refused to fill %d{length} bytes through null buffer pointer (CoreLib should not invoke this entry point with a null destination for a non-zero length)"
+                    | _ ->
+                        let bytes, newPrngState =
+                            NonCryptoRandom.drawBytes length state.Kernel.NonCryptoRandomState
+
+                        let byteConcreteType =
+                            NativeCall.requiredByteConcreteType operation ctx.BaseClassTypes state
+
+                        let mutable state = state
+
+                        for i = 0 to length - 1 do
+                            let dest =
+                                ManagedPointerByteView.addByteOffset ctx.BaseClassTypes state byteConcreteType i buffer
+
+                            state <-
+                                IlMachineState.writeManagedByrefBytesOrTypedCell
+                                    ctx.BaseClassTypes
+                                    state
+                                    dest
+                                    (CliType.Numeric (CliNumericType.UInt8 bytes.[i]))
+
+                        state.MapKernel (fun kernel ->
+                            { kernel with
+                                NonCryptoRandomState = newPrngState
+                            }
+                        )
+
+            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
         | Some "SystemNative_Free", [ ConcretePointer _ ], MethodReturnType.Void ->
             let ptr =
                 NativeCall.managedPointerOfPointerArgument "SystemNative_Free" "ptr" instruction.Arguments.[0]


### PR DESCRIPTION
## Summary

- Add the `SystemNative_GetNonCryptographicallySecureRandomBytes` dispatch arm in `NativeSystemNative.fs`, decoding `(buffer : byte*, length : int32) -> void` and writing pseudo-random bytes via the existing managed-byref byte writer.
- Back it with a deterministic splitmix64 PRNG kept in `EmulatedKernel.NonCryptoRandomState`. Seeded from a non-zero golden-ratio constant so the BCL's `Random.Xoshiro{128,256}StarStarImpl` non-zero-seed retry loop terminates immediately.
- Cover the PRNG with FsCheck properties for determinism, byte order, prefix-equivalence, and the kernel default seed.

## Why a seeded PRNG (and not "just return zeros")

CoreCLR fills this buffer from host entropy (`arc4random_buf` / BCrypt / `/dev/urandom` xor'd with `lrand48` — see `minipal/random.c`). PawPrint refuses host entropy because the whole runtime targets bit-for-bit reproducibility. A constant-zero substitute would hang `new Random()`: `Random.Xoshiro256StarStarImpl` (and the 128-bit variant) explicitly loops on `Interop.GetRandomBytes` until the seed is non-zero. Seeding splitmix64 from a fixed non-zero constant is *strictly more deterministic* than CoreCLR, where `Random` / `Guid.NewGuid` / `Marvin` / `HashCode` are all unreproducible across runs.

## Test plan

- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` (846 / 846 pass)
- [x] 11 new FsCheck-driven unit tests in `TestNonCryptoRandom.fs` cover the splitmix64 helper and the kernel default seed
- [x] `codex review --base main` — no actionable correctness issues reported
- [ ] Follow-up: end-to-end test exercising the entry point through CoreLib (likely blocked downstream on other unimplemented intrinsics; deferred per AGENTS.md "small reviewable chunks")

🤖 Generated with [Claude Code](https://claude.com/claude-code)