### PR TITLE
Park contended Monitor.Enter on SyncBlock AcquireQueue

### DIFF
--- a/WoofWare.PawPrint.App/DebuggerServer.fs
+++ b/WoofWare.PawPrint.App/DebuggerServer.fs
@@ -94,6 +94,11 @@ module DebuggerServer =
             writer.WriteString ("kind", "blockedOnMonitorWait")
             writer.WriteNumber ("monitor", monitor)
             writer.WriteEndObject ()
+        | ThreadStatus.BlockedOnSyncBlockAcquire lockObject ->
+            writer.WriteStartObject ()
+            writer.WriteString ("kind", "blockedOnSyncBlockAcquire")
+            writer.WriteNumber ("lockObject", heapAddressValue lockObject)
+            writer.WriteEndObject ()
         | ThreadStatus.Terminated -> writer.WriteStringValue "terminated"
 
     let private writeFrameProperties

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -91,6 +91,7 @@ module TestPureCases =
             "NoOp.cs", 1
             "BasicLock.cs", 1
             "MonitorEnterRefBool.cs", 1
+            "ContendedMonitorEnter.cs", 99
             "ExceptionWithNoOpFinally.cs", 3
             "ExceptionWithNoOpCatch.cs", 10
             "Threads.cs", 3

--- a/WoofWare.PawPrint.Test/sourcesPure/ContendedMonitorEnter.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/ContendedMonitorEnter.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+
+namespace HelloWorldApp
+{
+    class Program
+    {
+        static object locker = new object();
+        static int shared = 0;
+
+        static void Worker()
+        {
+            lock (locker)
+            {
+                shared = 99;
+            }
+        }
+
+        static int Main(string[] args)
+        {
+            Thread t = new Thread(Worker);
+            lock (locker)
+            {
+                t.Start();
+                shared = 7;
+            }
+            t.Join();
+            return shared;
+        }
+    }
+}

--- a/WoofWare.PawPrint/ExternImplementations/System.Threading.Monitor.fs
+++ b/WoofWare.PawPrint/ExternImplementations/System.Threading.Monitor.fs
@@ -17,11 +17,38 @@ module System_Threading_Monitor =
         |> IlMachineState.loadArgument currentThread argIndex
         |> IlMachineState.popEvalStack currentThread
 
+    /// Park `thread` at the FIFO tail of `addr`'s AcquireQueue and flip its status
+    /// to `BlockedOnSyncBlockAcquire`. Assumes `addr`'s SyncBlock is `Locked` by
+    /// some other thread (the caller has already checked self-vs-other). When the
+    /// owner's `Monitor.Exit` decrements the reentrancy count to zero, ownership
+    /// is handed directly to the FIFO head and the head flips back to `Runnable`
+    /// already holding the lock — mirroring `LowLevelMonitor`'s ownership-transfer
+    /// model so the IL after the `Enter` call site is correctly held.
+    let private parkOnAcquireQueue
+        (addr : ManagedHeapAddress)
+        (thread : ThreadId)
+        (locked : LockedSyncBlock)
+        (state : IlMachineState)
+        : IlMachineState
+        =
+        let locked =
+            { locked with
+                AcquireQueue = locked.AcquireQueue @ [ thread ]
+            }
+
+        state
+        |> IlMachineState.setSyncBlock addr (SyncBlock.Locked locked)
+        |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnSyncBlockAcquire addr)
+
     /// .NET 10 InternalCall: Monitor.TryEnter_FastPath(obj) -> bool.
-    /// Returns true if the lock can be acquired without contention; false routes the IL to
-    /// Monitor.Enter_Slowpath, which calls back into the QCall path. PawPrint runs each
-    /// thread to completion between scheduler points, so a "Locked by another thread"
-    /// SyncBlock represents real contention with no way to make progress in a fast path.
+    /// Backs `Monitor.Enter(obj)`: the BCL's IL is "if (!TryEnter_FastPath(obj)) Enter_Slowpath(obj)",
+    /// so returning false here routes the caller through the (unimplemented) `Enter_Slowpath` QCall.
+    /// PawPrint can answer Free / SelfHeld / OtherHeld directly from the SyncBlock and we know
+    /// contention precisely, so we collapse Enter's blocking semantics into this handler:
+    /// on contention we park the caller in `BlockedOnSyncBlockAcquire` at the FIFO tail of the
+    /// SyncBlock's `AcquireQueue` and push `true` — when the lock owner's Exit transfers
+    /// ownership to us the resumed thread's IL is already past this call site and observes
+    /// `true`, mirroring the `LowLevelMonitor` ownership-transfer model.
     let TryEnter_FastPath
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (currentThread : ThreadId)
@@ -30,27 +57,40 @@ module System_Threading_Monitor =
         =
         let lockObj, state = popOneObject currentThread 0 state
 
-        let acquired, state =
+        let state =
             match IlMachineState.evalStackValueToObjectRef baseClassTypes state lockObj with
             | None -> failwith "TODO: Monitor.TryEnter_FastPath should throw ArgumentNullException for null obj"
             | Some addr ->
                 match IlMachineState.getSyncBlock addr state with
                 | SyncBlock.Free ->
-                    let state =
-                        IlMachineState.setSyncBlock addr (SyncBlock.Locked (currentThread, 1)) state
-
-                    true, state
-                | SyncBlock.Locked (holder, count) ->
-                    if holder = currentThread then
-                        let state =
-                            IlMachineState.setSyncBlock addr (SyncBlock.Locked (holder, count + 1)) state
-
-                        true, state
+                    IlMachineState.setSyncBlock
+                        addr
+                        (SyncBlock.Locked
+                            {
+                                LockingThread = currentThread
+                                ReentrancyCount = 1
+                                AcquireQueue = []
+                            })
+                        state
+                | SyncBlock.Locked locked ->
+                    if locked.LockingThread = currentThread then
+                        IlMachineState.setSyncBlock
+                            addr
+                            (SyncBlock.Locked
+                                { locked with
+                                    ReentrancyCount = locked.ReentrancyCount + 1
+                                })
+                            state
                     else
-                        false, state
+                        // Locked by another thread: park at the FIFO tail of the AcquireQueue.
+                        // When ownership is transferred to us by the owner's Exit, the resumed
+                        // thread's IL is already past this call site and observes `true`, so the
+                        // BCL's `if (!TryEnter_FastPath(obj)) Enter_Slowpath(obj)` skips the
+                        // Slowpath. This collapses Monitor.Enter's blocking semantics into the
+                        // fast-path handler — PawPrint never needs the Enter_Slowpath QCall.
+                        parkOnAcquireQueue addr currentThread locked state
 
-        let state =
-            IlMachineState.pushToEvalStack (CliType.ofBool acquired) currentThread state
+        let state = IlMachineState.pushToEvalStack (CliType.ofBool true) currentThread state
 
         (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
 
@@ -58,6 +98,13 @@ module System_Threading_Monitor =
     /// Caller treats the result as: 0 (Contention) → return false; 1 (Entered) → return true;
     /// 2 (UseSlowPath) → call Monitor.TryEnter_Slowpath. We never need the slowpath because
     /// PawPrint can answer Free / SelfHeld / OtherHeld directly from the SyncBlock.
+    ///
+    /// Contention with a non-zero timeout parks the caller in `BlockedOnSyncBlockAcquire`
+    /// and pushes `1` (Entered) onto the stack: the IL pointer advances past this call
+    /// site as part of returning `Executed`, and when ownership is later transferred to
+    /// us the resumed thread already holds the lock. Finite non-zero timeouts fail loud
+    /// because PawPrint has no virtual clock yet — `LowLevelMonitor.timedWait` makes the
+    /// same call and we keep both posture-consistent.
     let TryEnter_FastPath_WithTimeout
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (currentThread : ThreadId)
@@ -80,26 +127,44 @@ module System_Threading_Monitor =
                 match IlMachineState.getSyncBlock addr state with
                 | SyncBlock.Free ->
                     let state =
-                        IlMachineState.setSyncBlock addr (SyncBlock.Locked (currentThread, 1)) state
+                        IlMachineState.setSyncBlock
+                            addr
+                            (SyncBlock.Locked
+                                {
+                                    LockingThread = currentThread
+                                    ReentrancyCount = 1
+                                    AcquireQueue = []
+                                })
+                            state
 
                     1, state
-                | SyncBlock.Locked (holder, count) ->
-                    if holder = currentThread then
+                | SyncBlock.Locked locked ->
+                    if locked.LockingThread = currentThread then
                         let state =
-                            IlMachineState.setSyncBlock addr (SyncBlock.Locked (holder, count + 1)) state
+                            IlMachineState.setSyncBlock
+                                addr
+                                (SyncBlock.Locked
+                                    { locked with
+                                        ReentrancyCount = locked.ReentrancyCount + 1
+                                    })
+                                state
 
                         1, state
                     elif timeout = 0 then
                         // Non-blocking poll: report contention without waiting.
                         0, state
+                    elif timeout = System.Threading.Timeout.Infinite then
+                        // Blocking acquire: park at the FIFO tail and push "Entered" —
+                        // when the scheduler resumes us, ownership has been transferred
+                        // and the IL pointer is already past this call site.
+                        let state = parkOnAcquireQueue addr currentThread locked state
+                        1, state
                     else
-                        // The deterministic scheduler runs the holding thread to a yield point
-                        // before the waiter resumes, so blocking on a foreign-held monitor would
-                        // require modelling cross-thread Monitor wait queues. Fail loud rather
-                        // than silently returning Contention, which would corrupt guest control
-                        // flow. Same envelope as the existing ReliableEnter handler.
+                        // Finite non-zero timeout would require a virtual clock to honour;
+                        // silently treating it as Infinite would hide guest bugs. Same
+                        // envelope as `LowLevelMonitor.timedWait`.
                         failwith
-                            "TODO: Monitor.TryEnter_FastPath_WithTimeout cross-thread blocking is not yet implemented"
+                            $"TODO: Monitor.TryEnter_FastPath_WithTimeout with finite non-zero timeout %d{timeout}ms requires a virtual clock; not yet implemented"
 
         let state =
             IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 result)) currentThread state
@@ -122,7 +187,7 @@ module System_Threading_Monitor =
             | Some addr ->
                 match IlMachineState.getSyncBlock addr state with
                 | SyncBlock.Free -> false
-                | SyncBlock.Locked (holder, _) -> holder = currentThread
+                | SyncBlock.Locked locked -> locked.LockingThread = currentThread
 
         let state =
             IlMachineState.pushToEvalStack (CliType.ofBool result) currentThread state
@@ -134,6 +199,12 @@ module System_Threading_Monitor =
     /// any non-zero value (Signal/Yield/Contention/Error) routes the IL through Exit_Slowpath.
     /// PawPrint can decrement the SyncBlock directly, so we always return None on success and
     /// fail loud if the unlock would have surfaced as Error in the real runtime.
+    ///
+    /// When the final `Exit` releases the lock and the `AcquireQueue` is non-empty, ownership
+    /// is transferred directly to the FIFO head: that thread's status flips back to `Runnable`
+    /// already holding the lock with a fresh `ReentrancyCount = 1`. Mirrors `LowLevelMonitor`'s
+    /// ownership-transfer model — the woken thread's IL resumes past `Enter` already owning
+    /// the lock, which is what the BCL contract requires.
     let Exit_FastPath
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (currentThread : ThreadId)
@@ -149,14 +220,34 @@ module System_Threading_Monitor =
                 match IlMachineState.getSyncBlock addr state with
                 | SyncBlock.Free ->
                     failwith "TODO: Monitor.Exit_FastPath on a Free SyncBlock should throw SynchronizationLockException"
-                | SyncBlock.Locked (holder, count) ->
-                    if holder <> currentThread then
+                | SyncBlock.Locked locked ->
+                    if locked.LockingThread <> currentThread then
                         failwith
                             "TODO: Monitor.Exit_FastPath by a non-owning thread should throw SynchronizationLockException"
-                    elif count = 1 then
-                        IlMachineState.setSyncBlock addr SyncBlock.Free state
+                    elif locked.ReentrancyCount > 1 then
+                        IlMachineState.setSyncBlock
+                            addr
+                            (SyncBlock.Locked
+                                { locked with
+                                    ReentrancyCount = locked.ReentrancyCount - 1
+                                })
+                            state
                     else
-                        IlMachineState.setSyncBlock addr (SyncBlock.Locked (holder, count - 1)) state
+                        // Last release. If anyone is queued, ownership transfers atomically
+                        // to the FIFO head; otherwise the block returns to Free.
+                        match locked.AcquireQueue with
+                        | [] -> IlMachineState.setSyncBlock addr SyncBlock.Free state
+                        | nextOwner :: rest ->
+                            state
+                            |> IlMachineState.setSyncBlock
+                                addr
+                                (SyncBlock.Locked
+                                    {
+                                        LockingThread = nextOwner
+                                        ReentrancyCount = 1
+                                        AcquireQueue = rest
+                                    })
+                            |> Scheduler.setThreadStatus nextOwner ThreadStatus.Runnable
 
         // LeaveHelperAction.None = 0 — caller's IL takes the early Ret branch.
         let state =

--- a/WoofWare.PawPrint/ManagedHeap.fs
+++ b/WoofWare.PawPrint/ManagedHeap.fs
@@ -2,9 +2,25 @@ namespace WoofWare.PawPrint
 
 open System.Collections.Immutable
 
+/// State carried by a `Locked` SyncBlock. `AcquireQueue` is the FIFO list of
+/// threads parked in `BlockedOnSyncBlockAcquire` waiting for ownership to be
+/// transferred to them when `LockingThread` calls `Monitor.Exit`. FIFO order
+/// is load-bearing for fairness: switching to LIFO or arbitrary order would
+/// change the observable interleaving for guests that race multiple threads
+/// into the same `lock` block.
+///
+/// `ReentrancyCount` is the depth of nested `Monitor.Enter` calls by
+/// `LockingThread` and must reach exactly zero before ownership can transfer.
+type LockedSyncBlock =
+    {
+        LockingThread : ThreadId
+        ReentrancyCount : int
+        AcquireQueue : ThreadId list
+    }
+
 type SyncBlock =
     | Free
-    | Locked of lockingThread : ThreadId * reentrancyCount : int
+    | Locked of LockedSyncBlock
 
 type AllocatedNonArrayObject =
     {

--- a/WoofWare.PawPrint/Scheduler.fs
+++ b/WoofWare.PawPrint/Scheduler.fs
@@ -132,6 +132,28 @@ module Scheduler =
             failwith
                 $"Thread {terminated} terminated while still owning {orphanedMonitors.Length} LowLevelMonitor(s) (%A{orphanedMonitors}); any thread parked in BlockedOnMonitorAcquire on those monitors would deadlock on a dead owner. The guest must Release before terminating."
 
+        // Same contract for managed SyncBlocks (Monitor.Enter / `lock`): a terminating
+        // thread must not still hold any SyncBlock, because any thread parked in
+        // BlockedOnSyncBlockAcquire on that object would wait forever for ownership
+        // transfer from a dead owner. Mirrors the LowLevelMonitor check above —
+        // RAII-style release is the guest's responsibility, and a loud failure is far
+        // easier to diagnose than a silent deadlock.
+        let orphanedSyncBlocks =
+            state.ManagedHeap.NonArrayObjects
+            |> Map.toSeq
+            |> Seq.choose (fun (addr, obj) ->
+                match obj.SyncBlock with
+                | SyncBlock.Locked locked when locked.LockingThread = terminated -> Some (addr, locked)
+                | _ -> None
+            )
+            |> Seq.toList
+
+        match orphanedSyncBlocks with
+        | [] -> ()
+        | _ ->
+            failwith
+                $"Thread {terminated} terminated while still holding {orphanedSyncBlocks.Length} SyncBlock(s) (%A{orphanedSyncBlocks}); any thread parked in BlockedOnSyncBlockAcquire on those objects would deadlock on a dead owner. The guest must Monitor.Exit before terminating."
+
         let threadState =
             state.ThreadState
             |> Map.change

--- a/WoofWare.PawPrint/ThreadState.fs
+++ b/WoofWare.PawPrint/ThreadState.fs
@@ -26,6 +26,14 @@ type ThreadStatus =
     /// to `BlockedOnMonitorAcquire`; reacquisition then runs through the normal
     /// acquire path.
     | BlockedOnMonitorWait of monitor : LowLevelMonitorId
+    /// This thread called `Monitor.Enter` (or its `TryEnter` cousin with a non-zero
+    /// timeout) on an object whose SyncBlock is `Locked` by a different thread, and
+    /// is parked at the SyncBlock's `AcquireQueue`. The lock owner's eventual
+    /// `Monitor.Exit` transfers ownership directly to the FIFO head of the queue,
+    /// flipping that thread back to `Runnable` already holding the lock — mirroring
+    /// the `LowLevelMonitor` ownership-transfer model so the resumed thread's IL
+    /// continues past the `Enter` call site already owning the SyncBlock.
+    | BlockedOnSyncBlockAcquire of lockObject : ManagedHeapAddress
     /// This thread has executed its final `ret`; it will never run again. Its state is kept
     /// only so other threads can observe termination (e.g. to satisfy Join).
     | Terminated

--- a/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
+++ b/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
@@ -75,10 +75,10 @@
         <ISystem_Environment>GenerateMock(false)</ISystem_Environment>
       </MyriadParams>
     </Compile>
-    <Compile Include="ExternImplementations\System.Threading.Monitor.fs" />
     <Compile Include="ExternImplementations\NativeImpls.fs" />
     <Compile Include="Scheduler.fs" />
     <Compile Include="LowLevelMonitor.fs" />
+    <Compile Include="ExternImplementations\System.Threading.Monitor.fs" />
     <Compile Include="Native\NativeCall.fs" />
     <Compile Include="Native\NativeEnvironment.fs" />
     <Compile Include="Native\NativeMonitor.fs" />


### PR DESCRIPTION
## Summary
- Extend the `Locked` SyncBlock with a FIFO `AcquireQueue` (named `LockedSyncBlock` record now that it has three fields, with the WaitQueue field landing in PR 2 for `Monitor.Wait`).
- Add `BlockedOnSyncBlockAcquire of ManagedHeapAddress` to `ThreadStatus`, with ownership transferred directly to the FIFO head on `Monitor.Exit` so the resumed thread's IL is already past the `Enter` call site — same model as `LowLevelMonitor`.
- Collapse `Monitor.Enter`'s blocking semantics into `TryEnter_FastPath`: contention parks the caller and pushes `true`, so the BCL's `if (!TryEnter_FastPath(obj)) Enter_Slowpath(obj)` skips the (unimplemented) Slowpath QCall entirely. `TryEnter_FastPath_WithTimeout` with `Infinite` uses the same path; finite non-zero timeouts still fail loud pending a virtual clock.
- `Scheduler.onThreadTerminated` gains the corresponding orphan check: a terminating thread that still holds any SyncBlock fails loud, mirroring the existing `LowLevelMonitor` orphan check.

This is PR 1 of 2 toward managed `Monitor.Wait`/`Pulse`/`PulseAll`; PR 2 will add `WaitQueue` plus the `Wait`/`Pulse`/`PulseAll` handlers and the parallel `SpuriousWakeupStrategy`.

## Test plan
- [x] Full test suite passes (836 tests, +1 for the new `ContendedMonitorEnter.cs` integration test).
- [x] `ContendedMonitorEnter.cs`: main thread holds the lock, spawns a worker, releases; worker takes ownership via FIFO transfer and writes `99` to `shared` before main's `Join` returns.
- [x] `BasicLock.cs` and `MonitorEnterRefBool.cs` (existing uncontended-lock tests) still pass.
- [x] `nix develop -c dotnet fantomas .`
- [x] `codex review --base main` — no actionable correctness issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)