### PR TITLE
Widen ExecutionResult.Stepped with orthogonal StepEffect channel

### DIFF
--- a/WoofWare.PawPrint.Test/TestFieldHandleRegistry.fs
+++ b/WoofWare.PawPrint.Test/TestFieldHandleRegistry.fs
@@ -575,7 +575,7 @@ public class DerivedWithField : BaseWithField
 
         let state =
             match NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_GetFields" ctx with
-            | Some (ExecutionResult.Stepped (state, WhatWeDid.Executed)) -> state
+            | Some (ExecutionResult.Stepped (state, WhatWeDid.Executed, _)) -> state
             | Some result -> failwith $"unexpected RuntimeTypeHandle_GetFields execution result: %O{result}"
             | None -> failwith "RuntimeTypeHandle_GetFields did not match"
 
@@ -647,7 +647,7 @@ public class DerivedWithField : BaseWithField
 
         let state =
             match NativeRuntimeFieldHandle.tryExecute ctx with
-            | Some (ExecutionResult.Stepped (state, WhatWeDid.Executed)) -> state
+            | Some (ExecutionResult.Stepped (state, WhatWeDid.Executed, _)) -> state
             | Some result -> failwith $"unexpected RuntimeFieldHandle.GetAttributes execution result: %O{result}"
             | None -> failwith "RuntimeFieldHandle.GetAttributes did not match"
 

--- a/WoofWare.PawPrint.Test/TestHarness.fs
+++ b/WoofWare.PawPrint.Test/TestHarness.fs
@@ -39,7 +39,7 @@ module MockEnv =
                             state
                             |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 1) thread
                             |> Tuple.withRight WhatWeDid.Executed
-                            |> ExecutionResult.Stepped
+                            |> ExecutionResult.stepped
                     GetCurrentManagedThreadId =
                         fun thread state ->
                             state
@@ -47,7 +47,7 @@ module MockEnv =
                                 (EvalStackValue.Int32 (IlMachineState.getCurrentManagedThreadId thread state))
                                 thread
                             |> Tuple.withRight WhatWeDid.Executed
-                            |> ExecutionResult.Stepped
+                            |> ExecutionResult.stepped
                     TryGetEnvironmentVariable = tryGetEnvironmentVariable
                     // Surface FailFast as the abort outcome instead of raising
                     // NotImplementedException from the generated mock; the test

--- a/WoofWare.PawPrint.Test/TestImpureCases.fs
+++ b/WoofWare.PawPrint.Test/TestImpureCases.fs
@@ -50,7 +50,7 @@ module TestImpureCases =
                                         let state =
                                             state |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 1) thread
 
-                                        (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+                                        (state, WhatWeDid.Executed) |> ExecutionResult.stepped
                                 GetCurrentManagedThreadId = env.GetCurrentManagedThreadId
                                 TryGetEnvironmentVariable = env.TryGetEnvironmentVariable
                                 _Exit =

--- a/WoofWare.PawPrint.Test/TestManifestResources.fs
+++ b/WoofWare.PawPrint.Test/TestManifestResources.fs
@@ -319,7 +319,7 @@ public static class Entry
 
         let state =
             match NativeRuntimeAssembly.tryExecuteQCall "AssemblyNative_GetResource" ctx with
-            | Some (ExecutionResult.Stepped (state, WhatWeDid.Executed)) -> state
+            | Some (ExecutionResult.Stepped (state, WhatWeDid.Executed, _)) -> state
             | Some result -> failwith $"unexpected AssemblyNative_GetResource execution result: %O{result}"
             | None -> failwith "AssemblyNative_GetResource QCall did not match"
 

--- a/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
+++ b/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
@@ -2373,7 +2373,7 @@ public unsafe struct PointerWrapper
 
         let state =
             match NullaryIlOp.execute loggerFactory bct state thread NullaryIlOp.Stind_I1 with
-            | ExecutionResult.Stepped (state, WhatWeDid.Executed) -> state
+            | ExecutionResult.Stepped (state, WhatWeDid.Executed, _) -> state
             | other -> failwith $"Expected Stind_I1 to step, got %O{other}"
 
         IlMachineState.readManagedByrefBytesAs bct state ptr (CliType.Numeric (CliNumericType.Int32 0))
@@ -2406,7 +2406,7 @@ public unsafe struct PointerWrapper
 
         let state =
             match NullaryIlOp.execute loggerFactory bct state thread NullaryIlOp.Stind_I1 with
-            | ExecutionResult.Stepped (state, WhatWeDid.Executed) -> state
+            | ExecutionResult.Stepped (state, WhatWeDid.Executed, _) -> state
             | other -> failwith $"Expected Stind_I1 to step, got %O{other}"
 
         IlMachineState.getArrayValue arrayAddr 0 state
@@ -2443,7 +2443,7 @@ public unsafe struct PointerWrapper
 
         let state =
             match NullaryIlOp.execute loggerFactory bct state thread NullaryIlOp.Stind_I with
-            | ExecutionResult.Stepped (state, WhatWeDid.Executed) -> state
+            | ExecutionResult.Stepped (state, WhatWeDid.Executed, _) -> state
             | other -> failwith $"Expected Stind_I to step, got %O{other}"
 
         IlMachineState.readManagedByref bct state ptr
@@ -2496,7 +2496,7 @@ public unsafe struct PointerWrapper
 
             let state =
                 match NullaryIlOp.execute loggerFactory bct state thread NullaryIlOp.Stind_I with
-                | ExecutionResult.Stepped (state, WhatWeDid.Executed) -> state
+                | ExecutionResult.Stepped (state, WhatWeDid.Executed, _) -> state
                 | other -> failwith $"Expected Stind_I to step, got %O{other}"
 
             IlMachineState.readManagedByref bct state ptr
@@ -2759,7 +2759,7 @@ public unsafe struct PointerWrapper
 
             let state =
                 match NullaryIlOp.execute loggerFactory bct state thread NullaryIlOp.Stind_I8 with
-                | ExecutionResult.Stepped (state, WhatWeDid.Executed) -> state
+                | ExecutionResult.Stepped (state, WhatWeDid.Executed, _) -> state
                 | other -> failwith $"Expected Stind_I8 to step, got %O{other}"
 
             IlMachineState.readManagedByref bct state ptr
@@ -2796,7 +2796,7 @@ public unsafe struct PointerWrapper
 
         let nativeIntState =
             match NullaryIlOp.execute nativeIntLoggerFactory bct nativeIntState nativeIntThread NullaryIlOp.Stind_I with
-            | ExecutionResult.Stepped (state, WhatWeDid.Executed) -> state
+            | ExecutionResult.Stepped (state, WhatWeDid.Executed, _) -> state
             | other -> failwith $"Expected Stind_I to step, got %O{other}"
 
         IlMachineState.getArrayValue int64ArrayAddr 0 nativeIntState
@@ -2829,7 +2829,7 @@ public unsafe struct PointerWrapper
 
         let int64State =
             match NullaryIlOp.execute int64LoggerFactory bct int64State int64Thread NullaryIlOp.Stind_I8 with
-            | ExecutionResult.Stepped (state, WhatWeDid.Executed) -> state
+            | ExecutionResult.Stepped (state, WhatWeDid.Executed, _) -> state
             | other -> failwith $"Expected Stind_I8 to step, got %O{other}"
 
         IlMachineState.getArrayValue nativeIntArrayAddr 0 int64State
@@ -2877,7 +2877,7 @@ public unsafe struct PointerWrapper
             |> IlMachineState.pushToEvalStack' EvalStackValue.NullObjectRef thread
 
         match NullaryIlOp.execute loggerFactory bct state thread NullaryIlOp.Stind_ref with
-        | ExecutionResult.Stepped (state, WhatWeDid.Executed) ->
+        | ExecutionResult.Stepped (state, WhatWeDid.Executed, _) ->
             let activeFrame = state.ThreadState.[thread].ActiveMethodState
             let frame = IlMachineThreadState.getFrame thread activeFrame state
 
@@ -2957,7 +2957,7 @@ public unsafe struct PointerWrapper
 
             let state =
                 match NullaryIlOp.execute loggerFactory bct state thread NullaryIlOp.Stind_ref with
-                | ExecutionResult.Stepped (state, WhatWeDid.Executed) -> state
+                | ExecutionResult.Stepped (state, WhatWeDid.Executed, _) -> state
                 | other -> failwith $"Expected Stind_ref to step for %s{caseName}, got %O{other}"
 
             IlMachineState.getArrayValue arrayAddr 0 state

--- a/WoofWare.PawPrint.Test/TestNativeEnum.fs
+++ b/WoofWare.PawPrint.Test/TestNativeEnum.fs
@@ -314,7 +314,7 @@ public static class Entry
 
         let state =
             match NativeQCall.tryExecute ctx with
-            | Some (ExecutionResult.Stepped (state, WhatWeDid.Executed)) -> state
+            | Some (ExecutionResult.Stepped (state, WhatWeDid.Executed, _)) -> state
             | Some result -> failwith $"unexpected Enum_GetValuesAndNames execution result: %O{result}"
             | None -> failwith "Enum_GetValuesAndNames QCall did not match"
 

--- a/WoofWare.PawPrint.Test/TestNativeMetadataImport.fs
+++ b/WoofWare.PawPrint.Test/TestNativeMetadataImport.fs
@@ -431,7 +431,7 @@ public class TypesWithMembers
             }
 
         match NativeMetadataImport.tryExecute ctx with
-        | Some (ExecutionResult.Stepped (state, WhatWeDid.Executed)) -> state
+        | Some (ExecutionResult.Stepped (state, WhatWeDid.Executed, _)) -> state
         | Some result -> failwith $"unexpected MetadataImport execution result: %O{result}"
         | None -> failwith "MetadataImport native method did not match"
 

--- a/WoofWare.PawPrint.Test/TestNativeSignature.fs
+++ b/WoofWare.PawPrint.Test/TestNativeSignature.fs
@@ -404,7 +404,7 @@ public sealed class GenericFieldHost<T>
 
         let state =
             match NativeSignature.tryExecuteQCall "Signature_Init" ctx with
-            | Some (ExecutionResult.Stepped (state, WhatWeDid.Executed)) -> state
+            | Some (ExecutionResult.Stepped (state, WhatWeDid.Executed, _)) -> state
             | Some result -> failwith $"unexpected Signature_Init execution result: %O{result}"
             | None -> failwith "Signature_Init did not match"
 

--- a/WoofWare.PawPrint.Test/TestNullaryIlOp.fs
+++ b/WoofWare.PawPrint.Test/TestNullaryIlOp.fs
@@ -358,7 +358,7 @@ module TestNullaryIlOp =
         let state, thread = stateWithNullary loggerFactory NullaryIlOp.Neg input
 
         match NullaryIlOp.execute loggerFactory baseClassTypes state thread NullaryIlOp.Neg with
-        | ExecutionResult.Stepped (state, whatWeDid) ->
+        | ExecutionResult.Stepped (state, whatWeDid, _) ->
             whatWeDid |> shouldEqual WhatWeDid.Executed
 
             let methodState = state.ThreadState.[thread].MethodState

--- a/WoofWare.PawPrint/AbstractMachine.fs
+++ b/WoofWare.PawPrint/AbstractMachine.fs
@@ -51,26 +51,26 @@ module AbstractMachine =
             | ExecutionResult.ProcessExit _ -> outcome
             | ExecutionResult.FailFast _ -> outcome
             | ExecutionResult.UnhandledException _ -> outcome
-            | ExecutionResult.Stepped (state, WhatWeDid.SuspendedForClassInit) ->
+            | ExecutionResult.Stepped (state, WhatWeDid.SuspendedForClassInit, effect) ->
                 // A cctor was pushed; the native frame must stay on the stack so the dispatch loop
                 // runs the cctor first, then re-enters this native method on the next step.
-                ExecutionResult.Stepped (state, WhatWeDid.SuspendedForClassInit)
-            | ExecutionResult.Stepped (state, WhatWeDid.SuspendedForManagedCall) ->
+                ExecutionResult.Stepped (state, WhatWeDid.SuspendedForClassInit, effect)
+            | ExecutionResult.Stepped (state, WhatWeDid.SuspendedForManagedCall, effect) ->
                 // The native handler pushed a managed callee on top of itself; the native frame
                 // must stay on the stack so the dispatch loop runs the callee, then re-enters this
                 // native method on the next step.
-                ExecutionResult.Stepped (state, WhatWeDid.SuspendedForManagedCall)
-            | ExecutionResult.Stepped (state, WhatWeDid.ThrowingTypeInitializationException) ->
+                ExecutionResult.Stepped (state, WhatWeDid.SuspendedForManagedCall, effect)
+            | ExecutionResult.Stepped (state, WhatWeDid.ThrowingTypeInitializationException, effect) ->
                 // Exception dispatch has already unwound past this native frame to the matching
                 // handler, so returnStackFrame would pop the wrong frame.
-                ExecutionResult.Stepped (state, WhatWeDid.ThrowingTypeInitializationException)
-            | ExecutionResult.Stepped (state, WhatWeDid.BlockedOnClassInit blockedBy) ->
+                ExecutionResult.Stepped (state, WhatWeDid.ThrowingTypeInitializationException, effect)
+            | ExecutionResult.Stepped (state, WhatWeDid.BlockedOnClassInit blockedBy, effect) ->
                 // Another thread owns this type's .cctor lock; the native frame must persist
                 // until that thread finishes, then we re-enter.
-                ExecutionResult.Stepped (state, WhatWeDid.BlockedOnClassInit blockedBy)
-            | ExecutionResult.Stepped (state, whatWeDid) ->
+                ExecutionResult.Stepped (state, WhatWeDid.BlockedOnClassInit blockedBy, effect)
+            | ExecutionResult.Stepped (state, whatWeDid, effect) ->
                 match IlMachineState.returnStackFrame loggerFactory baseClassTypes thread state with
-                | ReturnFrameResult.NormalReturn state -> ExecutionResult.Stepped (state, whatWeDid)
+                | ReturnFrameResult.NormalReturn state -> ExecutionResult.Stepped (state, whatWeDid, effect)
                 | result -> failwith $"unexpected ReturnFrameResult from extern method return: %A{result}"
 
         let dispatchDelegateCtor () =
@@ -78,7 +78,7 @@ module AbstractMachine =
             // can't advance the program counter here - there's no IL instructions executing!
             |> IlMachineState.returnStackFrame loggerFactory baseClassTypes thread
             |> function
-                | ReturnFrameResult.NormalReturn state -> (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+                | ReturnFrameResult.NormalReturn state -> (state, WhatWeDid.Executed) |> ExecutionResult.stepped
                 | result -> failwith $"unexpected ReturnFrameResult from delegate constructor: %A{result}"
 
         let dispatchDelegateInvoke () =
@@ -168,7 +168,7 @@ module AbstractMachine =
                     false
                     state
 
-            ExecutionResult.Stepped (state, WhatWeDid.Executed)
+            ExecutionResult.stepped (state, WhatWeDid.Executed)
 
         match instruction.ExecutingMethod.Body with
         | MethodBody.RuntimeProvided RuntimeBehaviour.DelegateCtor -> dispatchDelegateCtor ()
@@ -217,11 +217,11 @@ module AbstractMachine =
         match instructions.Locations.[instruction.IlOpIndex] with
         | IlOp.Nullary op -> NullaryIlOp.execute loggerFactory baseClassTypes state thread op
         | IlOp.UnaryConst unaryConstIlOp ->
-            UnaryConstIlOp.execute state thread unaryConstIlOp |> ExecutionResult.Stepped
+            UnaryConstIlOp.execute state thread unaryConstIlOp |> ExecutionResult.stepped
         | IlOp.UnaryMetadataToken (unaryMetadataTokenIlOp, bytes) ->
             UnaryMetadataIlOp.execute loggerFactory baseClassTypes unaryMetadataTokenIlOp bytes state thread
-            |> ExecutionResult.Stepped
-        | IlOp.Switch immutableArray -> SwitchIlOp.execute state thread immutableArray |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
+        | IlOp.Switch immutableArray -> SwitchIlOp.execute state thread immutableArray |> ExecutionResult.stepped
         | IlOp.UnaryStringToken (unaryStringTokenIlOp, stringHandle) ->
             UnaryStringTokenIlOp.execute loggerFactory baseClassTypes unaryStringTokenIlOp stringHandle state thread
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped

--- a/WoofWare.PawPrint/ExternImplementations/System.Environment.fs
+++ b/WoofWare.PawPrint/ExternImplementations/System.Environment.fs
@@ -28,7 +28,7 @@ module System_Environment =
                     currentThread
                     state
                 |> Tuple.withRight WhatWeDid.Executed
-                |> ExecutionResult.Stepped
+                |> ExecutionResult.stepped
 
             member _.GetCurrentManagedThreadId currentThread state =
                 IlMachineState.pushToEvalStack'
@@ -36,7 +36,7 @@ module System_Environment =
                     currentThread
                     state
                 |> Tuple.withRight WhatWeDid.Executed
-                |> ExecutionResult.Stepped
+                |> ExecutionResult.stepped
 
             member _.TryGetEnvironmentVariable variable =
                 // The production pass-through reflects the host process. Tests

--- a/WoofWare.PawPrint/ExternImplementations/System.Threading.Monitor.fs
+++ b/WoofWare.PawPrint/ExternImplementations/System.Threading.Monitor.fs
@@ -52,7 +52,7 @@ module System_Threading_Monitor =
         let state =
             IlMachineState.pushToEvalStack (CliType.ofBool acquired) currentThread state
 
-        (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+        (state, WhatWeDid.Executed) |> ExecutionResult.stepped
 
     /// .NET 10 InternalCall: Monitor.TryEnter_FastPath_WithTimeout(obj, int32) -> EnterHelperResult.
     /// Caller treats the result as: 0 (Contention) → return false; 1 (Entered) → return true;
@@ -104,7 +104,7 @@ module System_Threading_Monitor =
         let state =
             IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 result)) currentThread state
 
-        (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+        (state, WhatWeDid.Executed) |> ExecutionResult.stepped
 
     /// .NET 10 InternalCall: Monitor.IsEnteredNative(obj) -> bool.
     /// Returns true if the SyncBlock for `obj` is held by the current thread.
@@ -127,7 +127,7 @@ module System_Threading_Monitor =
         let state =
             IlMachineState.pushToEvalStack (CliType.ofBool result) currentThread state
 
-        (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+        (state, WhatWeDid.Executed) |> ExecutionResult.stepped
 
     /// .NET 10 InternalCall: Monitor.Exit_FastPath(obj) -> LeaveHelperAction.
     /// LeaveHelperAction.None (0) means the unlock fully succeeded and IL skips the slowpath;
@@ -162,4 +162,4 @@ module System_Threading_Monitor =
         let state =
             IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 0)) currentThread state
 
-        (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+        (state, WhatWeDid.Executed) |> ExecutionResult.stepped

--- a/WoofWare.PawPrint/IlMachineStateModel.fs
+++ b/WoofWare.PawPrint/IlMachineStateModel.fs
@@ -191,6 +191,28 @@ type WhatWeDid =
     /// The state has already been updated with exception dispatch (handler search and frame unwinding).
     | ThrowingTypeInitializationException
 
+/// An externally-observable side-effect that a single interpreter step requests
+/// from the driver (the imperative shell around the functional core). The
+/// interpreter never performs host I/O directly; it emits a data description
+/// of the effect alongside the new machine state, and the shell decides what
+/// (if anything) to do with it.
+///
+/// `StepEffect` is orthogonal to `WhatWeDid`: `WhatWeDid` answers "did this
+/// step make progress, suspend, or block?" — i.e. it's input to the
+/// scheduler. `StepEffect` answers "did this step want to talk to the outside
+/// world?" — i.e. it's input to the driver. A single step can do both (e.g.
+/// emit a `WroteToFd` effect *and* report `WhatWeDid.Executed`).
+///
+/// Today the only variant is `NoEffect`; widening the contract up front lets
+/// us add `WroteToFd`, `ReadFromFd`, etc. in subsequent PRs without retouching
+/// the construction sites that don't emit effects.
+type StepEffect =
+    /// The step had no externally-observable I/O effect. The overwhelming
+    /// majority of IL steps land here; the variant exists so that effect-
+    /// emitting handlers (`SystemNative_Write`, etc.) are distinguishable at
+    /// the type level.
+    | NoEffect
+
 type ExecutionResult =
     /// A single thread finished (its top frame hit `ret`). For the entry thread this means
     /// the whole program exits; for a worker it just means that thread is done.
@@ -212,7 +234,7 @@ type ExecutionResult =
     /// and so callers can surface the abort to the host (logs, non-zero exit) rather than
     /// reporting a clean exit.
     | FailFast of IlMachineState * abortingThread : ThreadId * message : string option
-    | Stepped of IlMachineState * WhatWeDid
+    | Stepped of IlMachineState * WhatWeDid * StepEffect
     | UnhandledException of
         IlMachineState *
         terminatingThread : ThreadId *
@@ -259,3 +281,19 @@ type StateLoadResult =
     | FirstLoadThis of IlMachineState
     /// The type's .cctor previously failed. A TypeInitializationException has been dispatched into the guest.
     | ThrowingTypeInitializationException of IlMachineState
+
+[<RequireQualifiedAccess>]
+module ExecutionResult =
+    /// Construct a `Stepped` result that emits no externally-observable effect.
+    /// Use this for the overwhelming majority of step outcomes; reserve
+    /// `steppedWith` for handlers that genuinely want the driver to do
+    /// something (e.g. `SystemNative_Write` emitting `StepEffect.WroteToFd`
+    /// once that variant exists).
+    let stepped ((state, whatWeDid) : IlMachineState * WhatWeDid) : ExecutionResult =
+        ExecutionResult.Stepped (state, whatWeDid, StepEffect.NoEffect)
+
+    /// Construct a `Stepped` result that emits the supplied effect. Argument
+    /// order matches `stepped` so existing pipelines can swap one for the
+    /// other by inserting `|> steppedWith effect` in place of `|> stepped`.
+    let steppedWith (effect : StepEffect) ((state, whatWeDid) : IlMachineState * WhatWeDid) : ExecutionResult =
+        ExecutionResult.Stepped (state, whatWeDid, effect)

--- a/WoofWare.PawPrint/Native/NativeArray.fs
+++ b/WoofWare.PawPrint/Native/NativeArray.fs
@@ -140,5 +140,5 @@ module NativeArray =
                     retArray
                     (CliType.ObjectRef (Some arrayAddr))
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeBuffer.fs
+++ b/WoofWare.PawPrint/Native/NativeBuffer.fs
@@ -215,7 +215,7 @@ module NativeBuffer =
                 else
                     copy ctx.BaseClassTypes state dest src byteCount
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | _ -> None
 
     /// Dispatches the InternalCall (FCall) variants of `System.Buffer` that
@@ -281,5 +281,5 @@ module NativeBuffer =
                 else
                     copy ctx.BaseClassTypes state dest src byteCount
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeDebugger.fs
+++ b/WoofWare.PawPrint/Native/NativeDebugger.fs
@@ -29,7 +29,7 @@ module NativeDebugger =
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 isAttached)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | _ -> None
 
     let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
@@ -57,5 +57,5 @@ module NativeDebugger =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ofBool isAttached) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeDependentHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeDependentHandle.fs
@@ -42,7 +42,7 @@ module NativeDependentHandle =
 
             let state = NativeCall.pushGcHandleAddress handle ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System.Runtime",
           "DependentHandle",
@@ -58,7 +58,7 @@ module NativeDependentHandle =
 
             let state = NativeCall.pushObjectTarget target ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System.Runtime",
           "DependentHandle",
@@ -88,7 +88,7 @@ module NativeDependentHandle =
 
             let state = NativeCall.pushObjectTarget dependent ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System.Runtime",
           "DependentHandle",
@@ -129,7 +129,7 @@ module NativeDependentHandle =
 
             let state = NativeCall.pushObjectTarget target ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System.Runtime",
           "DependentHandle",
@@ -154,7 +154,7 @@ module NativeDependentHandle =
                     GcHandles = state.GcHandles |> GcHandleRegistry.setDependent handle dependent
                 }
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System.Runtime",
           "DependentHandle",
@@ -171,7 +171,7 @@ module NativeDependentHandle =
                     GcHandles = state.GcHandles |> GcHandleRegistry.setTarget handle None
                 }
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System.Runtime",
           "DependentHandle",
@@ -192,5 +192,5 @@ module NativeDependentHandle =
             // PawPrint has no GC and free always succeeds, so we report true.
             let state = IlMachineState.pushToEvalStack (CliType.ofBool true) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeEnum.fs
+++ b/WoofWare.PawPrint/Native/NativeEnum.fs
@@ -323,5 +323,5 @@ module NativeEnum =
                 else
                     state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeEventPipe.fs
+++ b/WoofWare.PawPrint/Native/NativeEventPipe.fs
@@ -44,35 +44,35 @@ module NativeEventPipe =
         state
         |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt (NativeIntSource.Verbatim 0L)) thread
         |> Tuple.withRight WhatWeDid.Executed
-        |> ExecutionResult.Stepped
+        |> ExecutionResult.stepped
 
     let private pushProviderHandle (id : int64) (thread : ThreadId) (state : IlMachineState) : ExecutionResult =
         state
         |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt (NativeIntSource.EventPipeProviderPtr id)) thread
         |> Tuple.withRight WhatWeDid.Executed
-        |> ExecutionResult.Stepped
+        |> ExecutionResult.stepped
 
     let private pushEventHandle (id : int64) (thread : ThreadId) (state : IlMachineState) : ExecutionResult =
         state
         |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt (NativeIntSource.EventPipeEventPtr id)) thread
         |> Tuple.withRight WhatWeDid.Executed
-        |> ExecutionResult.Stepped
+        |> ExecutionResult.stepped
 
     let private pushUInt64Zero (thread : ThreadId) (state : IlMachineState) : ExecutionResult =
         // The CLI evaluation stack stores UInt64 in the same Int64 cell, two's-complement.
         state
         |> IlMachineState.pushToEvalStack' (EvalStackValue.Int64 (Int64Source.Verbatim 0L)) thread
         |> Tuple.withRight WhatWeDid.Executed
-        |> ExecutionResult.Stepped
+        |> ExecutionResult.stepped
 
     let private pushInt32 (value : int32) (thread : ThreadId) (state : IlMachineState) : ExecutionResult =
         state
         |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 value) thread
         |> Tuple.withRight WhatWeDid.Executed
-        |> ExecutionResult.Stepped
+        |> ExecutionResult.stepped
 
     let private justStep (state : IlMachineState) : ExecutionResult =
-        (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+        (state, WhatWeDid.Executed) |> ExecutionResult.stepped
 
     let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
         let state = ctx.State

--- a/WoofWare.PawPrint/Native/NativeException.fs
+++ b/WoofWare.PawPrint/Native/NativeException.fs
@@ -64,5 +64,5 @@ module NativeException =
                     retString
                     (CliType.ObjectRef (Some messageAddr))
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeGcHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeGcHandle.fs
@@ -49,7 +49,7 @@ module NativeGcHandle =
 
             let state = NativeCall.pushGcHandleAddress handle ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "QCall_FreeGCHandleForTypeHandle",
           "System.Private.CoreLib",
           "System",
@@ -79,12 +79,12 @@ module NativeGcHandle =
                 }
 
             match returnType with
-            | MethodReturnType.Void -> (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            | MethodReturnType.Void -> (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
             | MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr) ->
                 state
                 |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt (NativeIntSource.Verbatim 0L)) ctx.Thread
                 |> Tuple.withRight WhatWeDid.Executed
-                |> ExecutionResult.Stepped
+                |> ExecutionResult.stepped
                 |> Some
             | other -> failwith $"%s{operation}: unexpected return type %O{other}"
         | _ -> None
@@ -134,7 +134,7 @@ module NativeGcHandle =
 
             let state = NativeCall.pushGcHandleAddress handle ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System.Runtime.InteropServices",
           "GCHandle",
@@ -153,7 +153,7 @@ module NativeGcHandle =
 
             let state = IlMachineState.pushToEvalStack (CliType.ofBool true) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System.Runtime.InteropServices",
           "GCHandle",
@@ -170,7 +170,7 @@ module NativeGcHandle =
                     GcHandles = state.GcHandles |> GcHandleRegistry.free handle
                 }
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System.Runtime.InteropServices",
           "GCHandle",
@@ -193,7 +193,7 @@ module NativeGcHandle =
                     GcHandles = state.GcHandles |> GcHandleRegistry.setTarget handle target
                 }
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System.Runtime.InteropServices",
           "GCHandle",
@@ -227,5 +227,5 @@ module NativeGcHandle =
 
             let state = NativeCall.pushObjectTarget oldTarget ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeKernel32.fs
+++ b/WoofWare.PawPrint/Native/NativeKernel32.fs
@@ -109,7 +109,7 @@ module NativeKernel32 =
         state
         |> IlMachineState.pushToEvalStack (NativeCall.cliUInt32 value) thread
         |> Tuple.withRight WhatWeDid.Executed
-        |> ExecutionResult.Stepped
+        |> ExecutionResult.stepped
 
     let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
         let state = ctx.State

--- a/WoofWare.PawPrint/Native/NativeLowLevelMonitor.fs
+++ b/WoofWare.PawPrint/Native/NativeLowLevelMonitor.fs
@@ -50,7 +50,7 @@ module NativeLowLevelMonitor =
                 (EvalStackValue.NativeInt (NativeIntSource.LowLevelMonitorPtr id))
                 ctx.Thread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
             |> Some
 
         | Some "SystemNative_LowLevelMonitor_Destroy",
@@ -59,7 +59,7 @@ module NativeLowLevelMonitor =
             let operation = "SystemNative_LowLevelMonitor_Destroy"
             let id = monitorOfArgument operation instruction.Arguments.[0]
             let state = LowLevelMonitor.destroy id state
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
 
         | Some "SystemNative_LowLevelMonitor_Acquire",
           [ ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr ],
@@ -78,7 +78,7 @@ module NativeLowLevelMonitor =
                 | LowLevelMonitor.AcquireOutcome.Acquired state
                 | LowLevelMonitor.AcquireOutcome.Blocked state -> state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
 
         | Some "SystemNative_LowLevelMonitor_Release",
           [ ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr ],
@@ -86,7 +86,7 @@ module NativeLowLevelMonitor =
             let operation = "SystemNative_LowLevelMonitor_Release"
             let id = monitorOfArgument operation instruction.Arguments.[0]
             let state = LowLevelMonitor.release ctx.Thread id state
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
 
         | Some "SystemNative_LowLevelMonitor_Wait",
           [ ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr ],
@@ -94,7 +94,7 @@ module NativeLowLevelMonitor =
             let operation = "SystemNative_LowLevelMonitor_Wait"
             let id = monitorOfArgument operation instruction.Arguments.[0]
             let state = LowLevelMonitor.wait ctx.Thread id state
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
 
         | Some "SystemNative_LowLevelMonitor_TimedWait",
           [ ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr
@@ -121,6 +121,6 @@ module NativeLowLevelMonitor =
             let operation = "SystemNative_LowLevelMonitor_Signal_Release"
             let id = monitorOfArgument operation instruction.Arguments.[0]
             let state = LowLevelMonitor.signalRelease ctx.Thread id state
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
 
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeMarshal.fs
+++ b/WoofWare.PawPrint/Native/NativeMarshal.fs
@@ -23,7 +23,7 @@ module NativeMarshal =
             state
             |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 state.Kernel.LastPInvokeError) ctx.Thread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
             |> Some
         | "System.Private.CoreLib",
           "System.Runtime.InteropServices",
@@ -34,7 +34,7 @@ module NativeMarshal =
             state
             |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 state.Kernel.LastSystemError) ctx.Thread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
             |> Some
         | "System.Private.CoreLib",
           "System.Runtime.InteropServices",
@@ -51,7 +51,7 @@ module NativeMarshal =
                 }
              ),
              WhatWeDid.Executed)
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
             |> Some
         | "System.Private.CoreLib",
           "System.Runtime.InteropServices",
@@ -68,7 +68,7 @@ module NativeMarshal =
                 }
              ),
              WhatWeDid.Executed)
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
             |> Some
         | _ -> None
 
@@ -119,5 +119,5 @@ module NativeMarshal =
                 let state =
                     IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 size.Size)) ctx.Thread state
 
-                (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+                (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeMetadataImport.fs
+++ b/WoofWare.PawPrint/Native/NativeMetadataImport.fs
@@ -410,7 +410,7 @@ module NativeMetadataImport =
                     ctx.Thread
                     state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System.Reflection",
           "MetadataImport",
@@ -482,7 +482,7 @@ module NativeMetadataImport =
 
             let state = writeInt32AtPointer ctx.BaseClassTypes state lengthOut values.Length
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System.Reflection",
           "MetadataImport",
@@ -517,7 +517,7 @@ module NativeMetadataImport =
             let state =
                 IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System.Reflection",
           "MetadataImport",
@@ -549,7 +549,7 @@ module NativeMetadataImport =
             let state =
                 IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System.Reflection",
           "MetadataImport",
@@ -608,7 +608,7 @@ module NativeMetadataImport =
             let state =
                 IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System.Reflection",
           "MetadataImport",
@@ -661,7 +661,7 @@ module NativeMetadataImport =
             let state =
                 IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System.Reflection",
           "MetadataImport",
@@ -801,7 +801,7 @@ module NativeMetadataImport =
             let state =
                 IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System.Reflection",
           "MetadataImport",
@@ -837,5 +837,5 @@ module NativeMetadataImport =
             let state =
                 IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeMetadataUpdater.fs
+++ b/WoofWare.PawPrint/Native/NativeMetadataUpdater.fs
@@ -27,5 +27,5 @@ module NativeMetadataUpdater =
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 0)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeRuntimeAssembly.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeAssembly.fs
@@ -85,7 +85,7 @@ module NativeRuntimeAssembly =
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 mdAssemblyToken)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System.Reflection",
           "RuntimeAssembly",
@@ -117,7 +117,7 @@ module NativeRuntimeAssembly =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ObjectRef (Some runtimeModuleAddr)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | _ -> None
 
     let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
@@ -203,7 +203,7 @@ module NativeRuntimeAssembly =
                     failwith
                         $"TODO: %s{operation} does not support assembly-forwarded manifest resource %s{actualResourceName} in %s{assemblyFullName} forwarded to %s{assemblyReference.Name.FullName}"
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "AssemblyNative_GetTypeCore",
           "System.Private.CoreLib",
           "System.Reflection",
@@ -344,7 +344,7 @@ module NativeRuntimeAssembly =
 
                 // Caller's local was preinitialized to null (Type? type = null);
                 // leaving retType untouched preserves that.
-                (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+                (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
             | Some typeInfo ->
                 let runtimeTypeAddr, state =
                     if typeInfo.Generics.IsEmpty then
@@ -371,5 +371,5 @@ module NativeRuntimeAssembly =
                         retType
                         (CliType.ObjectRef (Some runtimeTypeAddr))
 
-                (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+                (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeRuntimeFieldHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeFieldHandle.fs
@@ -101,7 +101,7 @@ module NativeRuntimeFieldHandle =
             let state =
                 IlMachineState.pushToEvalStack' (EvalStackValue.ManagedPointer namePtr) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeFieldHandle",
@@ -129,7 +129,7 @@ module NativeRuntimeFieldHandle =
                     ctx.Thread
                     state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | _ -> None
 
     let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
@@ -197,5 +197,5 @@ module NativeRuntimeFieldHandle =
 
                             state |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 1) ctx.Thread
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeRuntimeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeHelpers.fs
@@ -47,7 +47,7 @@ module NativeRuntimeHelpers =
                 | ConcreteTypeHandle.Array _ ->
                     // Pointer, byref, fnptr, and array type descriptors have no .cctor;
                     // CoreCLR treats this as a no-op. Return immediately.
-                    (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+                    (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
                 | ConcreteTypeHandle.Concrete _ ->
                     let state, typeInit =
                         IlMachineStateExecution.ensureTypeInitialised
@@ -58,7 +58,7 @@ module NativeRuntimeHelpers =
                             state
 
                     match typeInit with
-                    | WhatWeDid.Executed -> (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+                    | WhatWeDid.Executed -> (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
                     | WhatWeDid.SuspendedForClassInit ->
                         // The cctor was pushed as a new frame. We must NOT go through the normal
                         // returnStackFrame path (which would pop the cctor frame we just pushed).
@@ -66,17 +66,17 @@ module NativeRuntimeHelpers =
                         // When the cctor finishes, returnStackFrame pops it, bringing us back to
                         // this native method frame. executeOneStep re-enters here and
                         // ensureTypeInitialised will return Executed.
-                        ExecutionResult.Stepped (state, WhatWeDid.SuspendedForClassInit) |> Some
+                        ExecutionResult.stepped (state, WhatWeDid.SuspendedForClassInit) |> Some
                     | WhatWeDid.SuspendedForManagedCall ->
                         failwith "logic error: ensureTypeInitialised cannot suspend for an arbitrary managed call"
                     | WhatWeDid.ThrowingTypeInitializationException ->
                         (state, WhatWeDid.ThrowingTypeInitializationException)
-                        |> ExecutionResult.Stepped
+                        |> ExecutionResult.stepped
                         |> Some
                     | WhatWeDid.BlockedOnClassInit blockedBy ->
                         // Another thread owns this type's .cctor lock. Yield so the scheduler
                         // can run that thread to completion before re-entering.
-                        ExecutionResult.Stepped (state, WhatWeDid.BlockedOnClassInit blockedBy) |> Some
+                        ExecutionResult.stepped (state, WhatWeDid.BlockedOnClassInit blockedBy) |> Some
         | _ -> None
 
     /// Identity hash for a managed object reference. Heap addresses are positive and
@@ -115,7 +115,7 @@ module NativeRuntimeHelpers =
             let state =
                 IlMachineState.pushToEvalStack' (EvalStackValue.Int32 hash) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System.Runtime.CompilerServices",
           "RuntimeHelpers",
@@ -138,5 +138,5 @@ module NativeRuntimeHelpers =
             let state =
                 IlMachineState.pushToEvalStack' (EvalStackValue.Int32 hash) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeRuntimeMethodHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeMethodHandle.fs
@@ -75,7 +75,7 @@ module NativeRuntimeMethodHandle =
             let state =
                 IlMachineState.pushToEvalStack' (EvalStackValue.ManagedPointer namePtr) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeMethodHandle",
@@ -105,7 +105,7 @@ module NativeRuntimeMethodHandle =
                     ctx.Thread
                     state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeMethodHandle",
@@ -217,7 +217,7 @@ module NativeRuntimeMethodHandle =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ValueType returnValue) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeMethodHandle",
@@ -257,5 +257,5 @@ module NativeRuntimeMethodHandle =
 
             let state = IlMachineState.pushToEvalStack (CliType.ObjectRef None) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeRuntimeType.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeType.fs
@@ -1805,7 +1805,7 @@ module NativeRuntimeType =
                     retString
                     (CliType.ObjectRef (Some nameAddr))
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "TypeHandle_GetCorElementType",
           "System.Private.CoreLib",
           "System.Runtime.CompilerServices",
@@ -1828,7 +1828,7 @@ module NativeRuntimeType =
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 elementType)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "TypeHandle_CanCastTo_NoCacheLookup",
           "System.Private.CoreLib",
           "System.Runtime.CompilerServices",
@@ -1892,7 +1892,7 @@ module NativeRuntimeType =
                 let ret = if isAssignable then 1 else 0
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 ret)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "MethodTable_CanCompareBitsOrUseFastGetHashCode",
           "System.Private.CoreLib",
           "System",
@@ -1924,7 +1924,7 @@ module NativeRuntimeType =
 
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 ret)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "RuntimeTypeHandle_Instantiate",
           "System.Private.CoreLib",
           "System",
@@ -2002,7 +2002,7 @@ module NativeRuntimeType =
                         ctx.Thread
                         state
 
-                ExecutionResult.Stepped (state, WhatWeDid.SuspendedForManagedCall) |> Some
+                ExecutionResult.stepped (state, WhatWeDid.SuspendedForManagedCall) |> Some
             | None ->
 
             let instantiatedHandle, state =
@@ -2028,7 +2028,7 @@ module NativeRuntimeType =
                     retType
                     (CliType.ObjectRef (Some runtimeTypeAddr))
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "RuntimeTypeHandle_GetInstantiation",
           "System.Private.CoreLib",
           "System",
@@ -2112,7 +2112,7 @@ module NativeRuntimeType =
             // Empty: leave the caller's local null. RuntimeType.GetGenericArguments handles
             // null via `?? EmptyTypes`, matching native CopyRuntimeTypeHandles for 0 args.
             if genericArgumentTargets.IsEmpty then
-                (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+                (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
             else
                 let elementTypeName = if asRuntimeTypeArray then "RuntimeType" else "Type"
 
@@ -2150,7 +2150,7 @@ module NativeRuntimeType =
                         retTypes
                         (CliType.ObjectRef (Some arrayAddr))
 
-                (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+                (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "RuntimeTypeHandle_GetConstraints",
           "System.Private.CoreLib",
           "System",
@@ -2295,7 +2295,7 @@ module NativeRuntimeType =
                     // CopyRuntimeTypeHandles writes NULL when count = 0; the managed wrapper turns
                     // the resulting null into Type.EmptyTypes via `?? EmptyTypes`. Leave the
                     // caller's local null untouched.
-                    (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+                    (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
                 else
                     // CopyRuntimeTypeHandles allocates Type[] (CLASS__TYPE) — not RuntimeType[].
                     let state, _, typeHandle =
@@ -2332,7 +2332,7 @@ module NativeRuntimeType =
                             retTypes
                             (CliType.ObjectRef (Some arrayAddr))
 
-                    (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+                    (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
 
             | RuntimeTypeHandleTarget.MethodGenericParameter (declaringType, declaringMethod, position) ->
                 failwith
@@ -2400,7 +2400,7 @@ module NativeRuntimeType =
                         outHandle
                         (CliType.ObjectRef (Some addr))
 
-                (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+                (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
             | [] ->
                 let typeHandleTarget =
                     NativeCall.qCallTypeHandleToRuntimeTypeHandleTarget
@@ -2441,11 +2441,11 @@ module NativeRuntimeType =
 
                 match typeInit with
                 | WhatWeDid.SuspendedForClassInit ->
-                    ExecutionResult.Stepped (state, WhatWeDid.SuspendedForClassInit) |> Some
+                    ExecutionResult.stepped (state, WhatWeDid.SuspendedForClassInit) |> Some
                 | WhatWeDid.BlockedOnClassInit blockedBy ->
-                    ExecutionResult.Stepped (state, WhatWeDid.BlockedOnClassInit blockedBy) |> Some
+                    ExecutionResult.stepped (state, WhatWeDid.BlockedOnClassInit blockedBy) |> Some
                 | WhatWeDid.ThrowingTypeInitializationException ->
-                    ExecutionResult.Stepped (state, WhatWeDid.ThrowingTypeInitializationException)
+                    ExecutionResult.stepped (state, WhatWeDid.ThrowingTypeInitializationException)
                     |> Some
                 | WhatWeDid.SuspendedForManagedCall ->
                     failwith "logic error: ensureTypeInitialised cannot suspend for an arbitrary managed call"
@@ -2530,7 +2530,7 @@ module NativeRuntimeType =
                         false
                         state
 
-                ExecutionResult.Stepped (state, WhatWeDid.SuspendedForManagedCall) |> Some
+                ExecutionResult.stepped (state, WhatWeDid.SuspendedForManagedCall) |> Some
             | other ->
                 failwith
                     $"%s{operation}: expected at most one re-entry marker on the eval stack, got %d{other.Length} value(s): %A{other}"
@@ -2616,7 +2616,7 @@ module NativeRuntimeType =
             let state =
                 IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt returnSource) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "RuntimeTypeHandle_GetDeclaringTypeHandleForGenericVariable",
           "System.Private.CoreLib",
           "System",
@@ -2691,7 +2691,7 @@ module NativeRuntimeType =
                     ctx.Thread
                     state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "ModuleHandle_ResolveType",
           "System.Private.CoreLib",
           "System",
@@ -2845,7 +2845,7 @@ module NativeRuntimeType =
                     retType
                     (CliType.ObjectRef (Some runtimeTypeAddr))
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "ModuleHandle_ResolveMethod",
           "System.Private.CoreLib",
           "System",
@@ -3069,7 +3069,7 @@ module NativeRuntimeType =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ValueType handleValue) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "RuntimeTypeHandle_GetFields",
           "System.Private.CoreLib",
           "System",
@@ -3164,7 +3164,7 @@ module NativeRuntimeType =
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 result)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "RuntimeTypeHandle_GetInterfaces",
           "System.Private.CoreLib",
           "System",
@@ -3297,7 +3297,7 @@ module NativeRuntimeType =
 
             if List.isEmpty interfaceHandles then
                 // Mirror CoreCLR: skip the allocation and leave the caller's `[]` local intact.
-                (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+                (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
             else
                 let state, _, runtimeTypeElementHandle =
                     concretizeNonGenericCorelibType ctx.LoggerFactory ctx.BaseClassTypes state "System" "RuntimeType"
@@ -3337,7 +3337,7 @@ module NativeRuntimeType =
                         retArray
                         (CliType.ObjectRef (Some arrayAddr))
 
-                (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+                (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | _ -> None
 
     let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
@@ -3369,7 +3369,7 @@ module NativeRuntimeType =
             let state =
                 IlMachineState.pushToEvalStack (NativeCall.cliUInt32 bytes) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System.Runtime.CompilerServices",
           "MethodTable",
@@ -3392,7 +3392,7 @@ module NativeRuntimeType =
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 elementType)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -3455,7 +3455,7 @@ module NativeRuntimeType =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ofBool (count <= capacity)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -3483,7 +3483,7 @@ module NativeRuntimeType =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ObjectRef (Some arrayAddr)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -3507,7 +3507,7 @@ module NativeRuntimeType =
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 elementType)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -3529,7 +3529,7 @@ module NativeRuntimeType =
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 token)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -3555,7 +3555,7 @@ module NativeRuntimeType =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ofBool isGenericVariable) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -3587,7 +3587,7 @@ module NativeRuntimeType =
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 index)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -3615,7 +3615,7 @@ module NativeRuntimeType =
             | RuntimeTypeHandleTarget.Closed _ ->
                 // Type-level generic parameters and non-parameter targets return null.
                 let state = NativeCall.pushObjectTarget None ctx.Thread state
-                (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+                (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
             | RuntimeTypeHandleTarget.MethodGenericParameter (declaringType, declaringMethod, position) ->
                 failwith
                     $"TODO: %s{operation} for method generic parameter #%i{position} of method %O{declaringMethod.Get} on %O{declaringType.TypeDefinition.Get}; need to allocate/return IRuntimeMethodInfo"
@@ -3642,7 +3642,7 @@ module NativeRuntimeType =
 
             let state = NativeCall.pushObjectTarget declaringTypeAddr ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -3662,7 +3662,7 @@ module NativeRuntimeType =
 
             let state = IlMachineState.pushToEvalStack (CliType.ofBool result) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -3686,7 +3686,7 @@ module NativeRuntimeType =
 
             let state = NativeCall.pushObjectTarget baseTypeAddr ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -3710,7 +3710,7 @@ module NativeRuntimeType =
 
             let state = NativeCall.pushObjectTarget elementTypeAddr ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -3738,7 +3738,7 @@ module NativeRuntimeType =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ObjectRef (Some addr)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -3766,7 +3766,7 @@ module NativeRuntimeType =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ObjectRef (Some addr)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -3797,7 +3797,7 @@ module NativeRuntimeType =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ObjectRef (Some addr)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -3826,7 +3826,7 @@ module NativeRuntimeType =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ObjectRef (Some addr)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -3863,7 +3863,7 @@ module NativeRuntimeType =
             let state =
                 IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt elementTypeSource) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -3950,7 +3950,7 @@ module NativeRuntimeType =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ofBool isAssignable) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -4025,7 +4025,7 @@ module NativeRuntimeType =
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 attributes)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -4053,7 +4053,7 @@ module NativeRuntimeType =
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 count)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -4120,7 +4120,7 @@ module NativeRuntimeType =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ValueType returnValue) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -4215,5 +4215,5 @@ module NativeRuntimeType =
                     methodPtr
                     (CliType.ValueType nextValue)
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeSignature.fs
+++ b/WoofWare.PawPrint/Native/NativeSignature.fs
@@ -221,7 +221,7 @@ module NativeSignature =
                     "_sig"
                     state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | _ -> None
 
     let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
@@ -306,5 +306,5 @@ module NativeSignature =
                     "m_sig"
                     state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeString.fs
+++ b/WoofWare.PawPrint/Native/NativeString.fs
@@ -75,7 +75,7 @@ module NativeString =
 
             state
             |> allocateAndPushBlankString ctx length
-            |> fun state -> (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            |> fun state -> (state, WhatWeDid.Executed) |> ExecutionResult.stepped
             |> Some
         | "System.Private.CoreLib",
           "System",
@@ -112,7 +112,7 @@ module NativeString =
 
             state
             |> allocateAndPushBlankString ctx length
-            |> fun state -> (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            |> fun state -> (state, WhatWeDid.Executed) |> ExecutionResult.stepped
             |> Some
         | "System.Private.CoreLib",
           "System",
@@ -245,7 +245,7 @@ module NativeString =
             // the placeholder allocated by executeNewobj is left as garbage.
             state
             |> IlMachineState.withReplacedConstructedObject newAddr ctx.Thread
-            |> fun state -> (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            |> fun state -> (state, WhatWeDid.Executed) |> ExecutionResult.stepped
             |> Some
         | "System.Private.CoreLib",
           "System",
@@ -295,6 +295,6 @@ module NativeString =
             // the placeholder allocated by executeNewobj is left as garbage.
             state
             |> IlMachineState.withReplacedConstructedObject newAddr ctx.Thread
-            |> fun state -> (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            |> fun state -> (state, WhatWeDid.Executed) |> ExecutionResult.stepped
             |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeSystemNative.fs
+++ b/WoofWare.PawPrint/Native/NativeSystemNative.fs
@@ -11,7 +11,7 @@ module NativeSystemNative =
         ctx.State
         |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 value) ctx.Thread
         |> Tuple.withRight WhatWeDid.Executed
-        |> ExecutionResult.Stepped
+        |> ExecutionResult.stepped
 
     /// Decode an `nint`-shaped Unix file-descriptor argument. CoreLib passes
     /// fds across the SystemNative boundary as plain `IntPtr` values (the low
@@ -103,7 +103,7 @@ module NativeSystemNative =
                 }
              ),
              WhatWeDid.Executed)
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
             |> Some
         | Some "SystemNative_Malloc",
           [ ConcreteUIntPtr state.ConcreteTypes ],
@@ -123,7 +123,7 @@ module NativeSystemNative =
             state
             |> IlMachineState.pushToEvalStack' (EvalStackValue.ManagedPointer ptrSrc) ctx.Thread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
             |> Some
         | Some "SystemNative_Calloc",
           [ ConcreteUIntPtr state.ConcreteTypes ; ConcreteUIntPtr state.ConcreteTypes ],
@@ -152,7 +152,7 @@ module NativeSystemNative =
             state
             |> IlMachineState.pushToEvalStack' (EvalStackValue.ManagedPointer ptrSrc) ctx.Thread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
             |> Some
         | Some "SystemNative_Dup",
           [ ConcreteIntPtr state.ConcreteTypes ],
@@ -186,7 +186,7 @@ module NativeSystemNative =
             state
             |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt (NativeIntSource.Verbatim resultFd)) ctx.Thread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
             |> Some
         | Some "SystemNative_Close",
           [ ConcreteIntPtr state.ConcreteTypes ],
@@ -220,7 +220,7 @@ module NativeSystemNative =
             state
             |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 resultCode) ctx.Thread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
             |> Some
         | Some "SystemNative_GetNonCryptographicallySecureRandomBytes",
           [ ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.Byte)
@@ -295,7 +295,7 @@ module NativeSystemNative =
                             }
                         )
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | Some "SystemNative_Free", [ ConcretePointer _ ], MethodReturnType.Void ->
             let ptr =
                 NativeCall.managedPointerOfPointerArgument "SystemNative_Free" "ptr" instruction.Arguments.[0]
@@ -331,5 +331,5 @@ module NativeSystemNative =
                     failwith
                         $"SystemNative_Free: expected null or native-heap pointer, got %O{other} (only pointers from SystemNative_Malloc/Calloc may be freed here)"
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeThreading.fs
+++ b/WoofWare.PawPrint/Native/NativeThreading.fs
@@ -168,7 +168,7 @@ module NativeThreading =
                     threadOut
                     (CliType.ObjectRef (Some addr))
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "ThreadNative_Initialize",
           "System.Private.CoreLib",
           "System.Threading",
@@ -199,7 +199,7 @@ module NativeThreading =
                 | other -> failwith $"%s{operation}: expected ObjectRef in ObjectHandleOnStack, got %O{other}"
 
             let state = initializeThreadObject threadAddr state
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "ThreadNative_Join",
           "System.Private.CoreLib",
           "System.Threading",
@@ -247,7 +247,7 @@ module NativeThreading =
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 resultInt)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | _ -> None
 
     let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
@@ -277,7 +277,7 @@ module NativeThreading =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ObjectRef (Some addr)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib", "System.Threading", "Thread", "Initialize", [], MethodReturnType.Void ->
             // Pre-.NET 10 InternalCall backing `new Thread(...)` constructor. .NET 10 routes the
             // same logic through the ThreadNative_Initialize QCall above.
@@ -290,7 +290,7 @@ module NativeThreading =
                 | other -> failwith $"Thread.Initialize: expected ObjectRef for 'this', got %O{other}"
 
             let state = initializeThreadObject threadAddr state
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib", "System.Threading", "Thread", "StartInternal", _, MethodReturnType.Void ->
             // StartInternal (ThreadHandle t, int stackSize, int priority, Interop.BOOL isThreadPool, char* pThreadName) -> void
             // We don't yet model stack size / priority / thread-pool / native name; we recover the
@@ -493,7 +493,7 @@ module NativeThreading =
 
             let state = Scheduler.onWorkerSpawned newThreadId workerInitOutcome state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib",
           "System.Threading",
           "Thread",
@@ -520,5 +520,5 @@ module NativeThreading =
 
             let state = IlMachineState.pushToEvalStack (CliType.ofBool result) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped |> Some
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | _ -> None

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -400,7 +400,7 @@ module NullaryIlOp =
                 corelib.NullReferenceException
                 currentThread
                 state
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | _ ->
 
         let targetCliType = getTargetLdindCliType targetType
@@ -432,7 +432,7 @@ module NullaryIlOp =
             |> IlMachineState.pushToEvalStack coercedValue currentThread
             |> IlMachineState.advanceProgramCounter currentThread
 
-        (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+        (state, WhatWeDid.Executed) |> ExecutionResult.stepped
 
     let private stind
         (loggerFactory : ILoggerFactory)
@@ -455,7 +455,7 @@ module NullaryIlOp =
                 corelib.NullReferenceException
                 currentThread
                 state
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | _ ->
 
         let state =
@@ -486,7 +486,7 @@ module NullaryIlOp =
         state
         |> IlMachineState.advanceProgramCounter currentThread
         |> Tuple.withRight WhatWeDid.Executed
-        |> ExecutionResult.Stepped
+        |> ExecutionResult.stepped
 
     let internal getArrayElt
         (index : EvalStackValue)
@@ -590,7 +590,7 @@ module NullaryIlOp =
             |> IlMachineState.setArrayValue arrAddr (EvalStackValue.toCliTypeCoerced targetCliTypeZero value) index
             |> IlMachineState.advanceProgramCounter currentThread
 
-        ExecutionResult.Stepped (state, WhatWeDid.Executed)
+        ExecutionResult.stepped (state, WhatWeDid.Executed)
 
     let internal execute
         (loggerFactory : ILoggerFactory)
@@ -603,31 +603,31 @@ module NullaryIlOp =
         match op with
         | Nop ->
             (IlMachineState.advanceProgramCounter currentThread state, WhatWeDid.Executed)
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | LdArg0 ->
             state
             |> IlMachineState.loadArgument currentThread 0
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | LdArg1 ->
             state
             |> IlMachineState.loadArgument currentThread 1
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | LdArg2 ->
             state
             |> IlMachineState.loadArgument currentThread 2
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | LdArg3 ->
             state
             |> IlMachineState.loadArgument currentThread 3
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Ldloc_0 ->
             let localVar = state.ThreadState.[currentThread].MethodState.LocalVariables.[0]
 
@@ -635,7 +635,7 @@ module NullaryIlOp =
             |> IlMachineState.pushToEvalStack localVar currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Ldloc_1 ->
             let localVar = state.ThreadState.[currentThread].MethodState.LocalVariables.[1]
 
@@ -643,7 +643,7 @@ module NullaryIlOp =
             |> IlMachineState.pushToEvalStack localVar currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Ldloc_2 ->
             let localVar = state.ThreadState.[currentThread].MethodState.LocalVariables.[2]
 
@@ -651,7 +651,7 @@ module NullaryIlOp =
             |> IlMachineState.pushToEvalStack localVar currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Ldloc_3 ->
             let localVar = state.ThreadState.[currentThread].MethodState.LocalVariables.[3]
 
@@ -659,13 +659,13 @@ module NullaryIlOp =
             |> IlMachineState.pushToEvalStack localVar currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Pop ->
             IlMachineState.popEvalStack currentThread state
             |> snd
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Dup ->
             let topValue =
                 match IlMachineState.peekEvalStack currentThread state with
@@ -676,11 +676,11 @@ module NullaryIlOp =
             |> IlMachineState.pushToEvalStack' topValue currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Ret ->
             match IlMachineState.returnStackFrame loggerFactory corelib currentThread state with
             | ReturnFrameResult.NoFrameToReturn -> ExecutionResult.Terminated (state, currentThread)
-            | ReturnFrameResult.NormalReturn state -> (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            | ReturnFrameResult.NormalReturn state -> (state, WhatWeDid.Executed) |> ExecutionResult.stepped
             | ReturnFrameResult.DispatchException (state, exnAddr, exnType) ->
                 // The ctor has run; now overwrite _HResult with the CLR's mapped value,
                 // matching EEException::CreateThrowable's SetHResult(GetHR()) post-ctor step.
@@ -690,7 +690,7 @@ module NullaryIlOp =
                 match
                     ExceptionDispatching.throwExceptionObject loggerFactory corelib state currentThread exnAddr exnType
                 with
-                | ExceptionDispatchResult.HandlerFound state -> (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+                | ExceptionDispatchResult.HandlerFound state -> (state, WhatWeDid.Executed) |> ExecutionResult.stepped
                 | ExceptionDispatchResult.ExceptionUnhandled (state, exn) ->
                     ExecutionResult.UnhandledException (state, currentThread, exn)
         | LdcI4_0 ->
@@ -698,68 +698,68 @@ module NullaryIlOp =
             |> IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 0)) currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | LdcI4_1 ->
             state
             |> IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 1)) currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | LdcI4_2 ->
             state
             |> IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 2)) currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | LdcI4_3 ->
             state
             |> IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 3)) currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | LdcI4_4 ->
             state
             |> IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 4)) currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | LdcI4_5 ->
             state
             |> IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 5)) currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | LdcI4_6 ->
             state
             |> IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 6)) currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | LdcI4_7 ->
             state
             |> IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 7)) currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | LdcI4_8 ->
             state
             |> IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 8)) currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | LdcI4_m1 ->
             state
             |> IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 -1)) currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | LdNull ->
             let state =
                 state
                 |> IlMachineState.pushToEvalStack' EvalStackValue.NullObjectRef currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Ceq ->
             let var2, state = state |> IlMachineState.popEvalStack currentThread
             let var1, state = state |> IlMachineState.popEvalStack currentThread
@@ -770,7 +770,7 @@ module NullaryIlOp =
             |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 comparisonResult) currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Cgt ->
             let var2, state = state |> IlMachineState.popEvalStack currentThread
             let var1, state = state |> IlMachineState.popEvalStack currentThread
@@ -781,7 +781,7 @@ module NullaryIlOp =
             |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 comparisonResult) currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Cgt_un ->
             let var2, state = state |> IlMachineState.popEvalStack currentThread
             let var1, state = state |> IlMachineState.popEvalStack currentThread
@@ -792,7 +792,7 @@ module NullaryIlOp =
             |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 comparisonResult) currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Clt ->
             let var2, state = state |> IlMachineState.popEvalStack currentThread
             let var1, state = state |> IlMachineState.popEvalStack currentThread
@@ -803,7 +803,7 @@ module NullaryIlOp =
             |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 comparisonResult) currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Clt_un ->
             let var2, state = state |> IlMachineState.popEvalStack currentThread
             let var1, state = state |> IlMachineState.popEvalStack currentThread
@@ -814,31 +814,31 @@ module NullaryIlOp =
             |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 comparisonResult) currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Stloc_0 ->
             state
             |> IlMachineState.popFromStackToLocalVariable currentThread 0
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Stloc_1 ->
             state
             |> IlMachineState.popFromStackToLocalVariable currentThread 1
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Stloc_2 ->
             state
             |> IlMachineState.popFromStackToLocalVariable currentThread 2
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Stloc_3 ->
             state
             |> IlMachineState.popFromStackToLocalVariable currentThread 3
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Sub ->
             let val2, state = IlMachineState.popEvalStack currentThread state
             let val1, state = IlMachineState.popEvalStack currentThread state
@@ -850,7 +850,7 @@ module NullaryIlOp =
             |> IlMachineState.pushToEvalStack' result currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Sub_ovf -> failwith "TODO: Sub_ovf unimplemented"
         | Sub_ovf_un -> failwith "TODO: Sub_ovf_un unimplemented"
         | Add ->
@@ -864,7 +864,7 @@ module NullaryIlOp =
             |> IlMachineState.pushToEvalStack' result currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Add_ovf ->
             let val2, state = IlMachineState.popEvalStack currentThread state
             let val1, state = IlMachineState.popEvalStack currentThread state
@@ -881,7 +881,7 @@ module NullaryIlOp =
                 |> IlMachineState.pushToEvalStack' result currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
                 |> Tuple.withRight WhatWeDid.Executed
-                |> ExecutionResult.Stepped
+                |> ExecutionResult.stepped
             | Error _ ->
                 IlMachineStateExecution.raiseRuntimeException
                     loggerFactory
@@ -889,7 +889,7 @@ module NullaryIlOp =
                     corelib.OverflowException
                     currentThread
                     state
-                |> ExecutionResult.Stepped
+                |> ExecutionResult.stepped
         | Add_ovf_un -> failwith "TODO: Add_ovf_un unimplemented"
         | Mul ->
             let val2, state = IlMachineState.popEvalStack currentThread state
@@ -902,7 +902,7 @@ module NullaryIlOp =
             |> IlMachineState.pushToEvalStack' result currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Mul_ovf ->
             let val2, state = IlMachineState.popEvalStack currentThread state
             let val1, state = IlMachineState.popEvalStack currentThread state
@@ -919,7 +919,7 @@ module NullaryIlOp =
                 |> IlMachineState.pushToEvalStack' result currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
                 |> Tuple.withRight WhatWeDid.Executed
-                |> ExecutionResult.Stepped
+                |> ExecutionResult.stepped
             | Error _ ->
                 IlMachineStateExecution.raiseRuntimeException
                     loggerFactory
@@ -927,7 +927,7 @@ module NullaryIlOp =
                     corelib.OverflowException
                     currentThread
                     state
-                |> ExecutionResult.Stepped
+                |> ExecutionResult.stepped
         | Mul_ovf_un ->
             let val2, state = IlMachineState.popEvalStack currentThread state
             let val1, state = IlMachineState.popEvalStack currentThread state
@@ -944,7 +944,7 @@ module NullaryIlOp =
                 |> IlMachineState.pushToEvalStack' result currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
                 |> Tuple.withRight WhatWeDid.Executed
-                |> ExecutionResult.Stepped
+                |> ExecutionResult.stepped
             | Error _ ->
                 IlMachineStateExecution.raiseRuntimeException
                     loggerFactory
@@ -952,7 +952,7 @@ module NullaryIlOp =
                     corelib.OverflowException
                     currentThread
                     state
-                |> ExecutionResult.Stepped
+                |> ExecutionResult.stepped
         | Div ->
             let val2, state = IlMachineState.popEvalStack currentThread state
             let val1, state = IlMachineState.popEvalStack currentThread state
@@ -968,7 +968,7 @@ module NullaryIlOp =
                 |> IlMachineState.pushToEvalStack' result currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
                 |> Tuple.withRight WhatWeDid.Executed
-                |> ExecutionResult.Stepped
+                |> ExecutionResult.stepped
             | Error _ ->
                 IlMachineStateExecution.raiseRuntimeException
                     loggerFactory
@@ -976,7 +976,7 @@ module NullaryIlOp =
                     corelib.OverflowException
                     currentThread
                     state
-                |> ExecutionResult.Stepped
+                |> ExecutionResult.stepped
         | Div_un ->
             let v2, state = IlMachineState.popEvalStack currentThread state
             let v1, state = IlMachineState.popEvalStack currentThread state
@@ -987,7 +987,7 @@ module NullaryIlOp =
             |> IlMachineState.pushToEvalStack' result currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Shr ->
             let shift, state = IlMachineState.popEvalStack currentThread state
             let number, state = IlMachineState.popEvalStack currentThread state
@@ -1018,7 +1018,7 @@ module NullaryIlOp =
                 |> IlMachineState.pushToEvalStack' result currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Shr_un ->
             let shift, state = IlMachineState.popEvalStack currentThread state
             let number, state = IlMachineState.popEvalStack currentThread state
@@ -1052,7 +1052,7 @@ module NullaryIlOp =
                 |> IlMachineState.pushToEvalStack' result currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Shl ->
             let shift, state = IlMachineState.popEvalStack currentThread state
             let number, state = IlMachineState.popEvalStack currentThread state
@@ -1083,7 +1083,7 @@ module NullaryIlOp =
                 |> IlMachineState.pushToEvalStack' result currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | And ->
             let v2, state = IlMachineState.popEvalStack currentThread state
             let v1, state = IlMachineState.popEvalStack currentThread state
@@ -1147,7 +1147,7 @@ module NullaryIlOp =
                 |> IlMachineState.pushToEvalStack' result currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Or ->
             let v2, state = IlMachineState.popEvalStack currentThread state
             let v1, state = IlMachineState.popEvalStack currentThread state
@@ -1184,7 +1184,7 @@ module NullaryIlOp =
                 |> IlMachineState.pushToEvalStack' result currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Xor ->
             let v2, state = IlMachineState.popEvalStack currentThread state
             let v1, state = IlMachineState.popEvalStack currentThread state
@@ -1221,7 +1221,7 @@ module NullaryIlOp =
                 |> IlMachineState.pushToEvalStack' result currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Conv_I ->
             let popped, state = IlMachineState.popEvalStack currentThread state
             let converted = EvalStackValue.toNativeInt popped
@@ -1247,7 +1247,7 @@ module NullaryIlOp =
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Conv_I1 ->
             let popped, state = IlMachineState.popEvalStack currentThread state
             let converted = EvalStackValue.convToInt8 popped
@@ -1261,7 +1261,7 @@ module NullaryIlOp =
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Conv_I2 ->
             let popped, state = IlMachineState.popEvalStack currentThread state
             let converted = EvalStackValue.convToInt16 popped
@@ -1275,7 +1275,7 @@ module NullaryIlOp =
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Conv_I4 ->
             let popped, state = IlMachineState.popEvalStack currentThread state
             let converted = EvalStackValue.convToInt32 popped
@@ -1289,7 +1289,7 @@ module NullaryIlOp =
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Conv_I8 ->
             let popped, state = IlMachineState.popEvalStack currentThread state
             let converted = EvalStackValue.convToInt64 popped
@@ -1303,7 +1303,7 @@ module NullaryIlOp =
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Conv_R4 ->
             let popped, state = IlMachineState.popEvalStack currentThread state
             let converted = EvalStackValue.convToFloat32 popped
@@ -1317,7 +1317,7 @@ module NullaryIlOp =
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Conv_R8 ->
             let popped, state = IlMachineState.popEvalStack currentThread state
             let converted = EvalStackValue.convToFloat64 popped
@@ -1331,7 +1331,7 @@ module NullaryIlOp =
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Conv_U ->
             let popped, state = IlMachineState.popEvalStack currentThread state
             let converted = EvalStackValue.toUnsignedNativeInt popped
@@ -1366,7 +1366,7 @@ module NullaryIlOp =
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Conv_U1 ->
             let popped, state = IlMachineState.popEvalStack currentThread state
             let converted = EvalStackValue.convToUInt8 popped
@@ -1380,7 +1380,7 @@ module NullaryIlOp =
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Conv_U2 ->
             let popped, state = IlMachineState.popEvalStack currentThread state
             let converted = EvalStackValue.convToUInt16 popped
@@ -1394,7 +1394,7 @@ module NullaryIlOp =
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Conv_U4 ->
             let popped, state = IlMachineState.popEvalStack currentThread state
             let converted = EvalStackValue.convToUInt32 popped
@@ -1408,7 +1408,7 @@ module NullaryIlOp =
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Conv_U8 ->
             let popped, state = IlMachineState.popEvalStack currentThread state
             let converted = EvalStackValue.convToUInt64 popped
@@ -1422,7 +1422,7 @@ module NullaryIlOp =
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | LdLen ->
             let popped, state = IlMachineState.popEvalStack currentThread state
 
@@ -1437,7 +1437,7 @@ module NullaryIlOp =
             IlMachineState.pushToEvalStack' (EvalStackValue.Int32 popped.Length) currentThread state
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Endfilter ->
             let filterResult, state = IlMachineState.popEvalStack currentThread state
             let filterAccepted = endfilterAccepts filterResult
@@ -1478,7 +1478,7 @@ module NullaryIlOp =
                         continuation.CurrentFilter.HandlerOffset
                         continuation.CliException
                     |> Tuple.withRight WhatWeDid.Executed
-                    |> ExecutionResult.Stepped
+                    |> ExecutionResult.stepped
                 else
                     let newMethodState = methodStateWithoutFilter |> MethodState.clearEvalStack
 
@@ -1507,7 +1507,7 @@ module NullaryIlOp =
                             skippedFilters
                     with
                     | ExceptionDispatchResult.HandlerFound state ->
-                        (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+                        (state, WhatWeDid.Executed) |> ExecutionResult.stepped
                     | ExceptionDispatchResult.ExceptionUnhandled (state, exn) ->
                         ExecutionResult.UnhandledException (state, currentThread, exn)
             | Some frame, _ ->
@@ -1530,7 +1530,7 @@ module NullaryIlOp =
                 state
                 |> IlMachineState.advanceProgramCounter currentThread
                 |> Tuple.withRight WhatWeDid.Executed
-                |> ExecutionResult.Stepped
+                |> ExecutionResult.stepped
             | Some {
                        Scope = ExceptionContinuationScope.FinallyHandler _
                        Continuation = ExceptionContinuation.ResumeAfterFinally targetPC
@@ -1547,7 +1547,7 @@ module NullaryIlOp =
                     ThreadState = state.ThreadState |> Map.add currentThread newThreadState
                 }
                 |> Tuple.withRight WhatWeDid.Executed
-                |> ExecutionResult.Stepped
+                |> ExecutionResult.stepped
             | Some {
                        Scope = scope
                        Continuation = ExceptionContinuation.PropagatingException exn
@@ -1577,7 +1577,7 @@ module NullaryIlOp =
                         exn
                         heapObject.ConcreteType
                 with
-                | ExceptionDispatchResult.HandlerFound state -> (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+                | ExceptionDispatchResult.HandlerFound state -> (state, WhatWeDid.Executed) |> ExecutionResult.stepped
                 | ExceptionDispatchResult.ExceptionUnhandled (state, exn) ->
                     ExecutionResult.UnhandledException (state, currentThread, exn)
             | Some {
@@ -1611,7 +1611,7 @@ module NullaryIlOp =
                         cliException
                         exceptionType
                 with
-                | ExceptionDispatchResult.HandlerFound state -> (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+                | ExceptionDispatchResult.HandlerFound state -> (state, WhatWeDid.Executed) |> ExecutionResult.stepped
                 | ExceptionDispatchResult.ExceptionUnhandled (state, exn) ->
                     ExecutionResult.UnhandledException (state, currentThread, exn)
         | Throw ->
@@ -1627,7 +1627,7 @@ module NullaryIlOp =
                     corelib.NullReferenceException
                     currentThread
                     state
-                |> ExecutionResult.Stepped
+                |> ExecutionResult.stepped
             | _ ->
 
             let addr =
@@ -1651,7 +1651,7 @@ module NullaryIlOp =
                     addr
                     heapObject.ConcreteType
             with
-            | ExceptionDispatchResult.HandlerFound state -> (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            | ExceptionDispatchResult.HandlerFound state -> (state, WhatWeDid.Executed) |> ExecutionResult.stepped
             | ExceptionDispatchResult.ExceptionUnhandled (state, exn) ->
                 ExecutionResult.UnhandledException (state, currentThread, exn)
 
@@ -1695,7 +1695,7 @@ module NullaryIlOp =
                 currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Stind_I ->
             stind
                 loggerFactory
@@ -1737,7 +1737,7 @@ module NullaryIlOp =
             |> IlMachineState.pushToEvalStack' result currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Rem_un ->
             let val2, state = IlMachineState.popEvalStack currentThread state
             let val1, state = IlMachineState.popEvalStack currentThread state
@@ -1749,7 +1749,7 @@ module NullaryIlOp =
             |> IlMachineState.pushToEvalStack' result currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Volatile ->
             // `volatile.` constrains host memory reordering. PawPrint's
             // deterministic execution model has no host reordering to model,
@@ -1757,7 +1757,7 @@ module NullaryIlOp =
             state
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Tail -> failwith "TODO: Tail unimplemented"
         | Conv_ovf_i_un -> failwith "TODO: Conv_ovf_i_un unimplemented"
         | Conv_ovf_u_un -> failwith "TODO: Conv_ovf_u_un unimplemented"
@@ -1773,7 +1773,7 @@ module NullaryIlOp =
             |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 converted) currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Conv_ovf_u4_un -> failwith "TODO: Conv_ovf_u4_un unimplemented"
         | Conv_ovf_i8_un -> failwith "TODO: Conv_ovf_i8_un unimplemented"
         | Conv_ovf_u8_un -> failwith "TODO: Conv_ovf_u8_un unimplemented"
@@ -1792,7 +1792,7 @@ module NullaryIlOp =
             |> IlMachineState.pushToEvalStack' result currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Not ->
             let val1, state = IlMachineState.popEvalStack currentThread state
 
@@ -1815,7 +1815,7 @@ module NullaryIlOp =
             |> IlMachineState.pushToEvalStack' result currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Ldind_ref ->
             let addr, state = IlMachineState.popEvalStack currentThread state
 
@@ -1829,7 +1829,7 @@ module NullaryIlOp =
                     corelib.NullReferenceException
                     currentThread
                     state
-                |> ExecutionResult.Stepped
+                |> ExecutionResult.stepped
             | _ ->
 
             let referenced =
@@ -1847,7 +1847,7 @@ module NullaryIlOp =
                 | _ -> failwith $"Unexpected non-reference {referenced}"
                 |> IlMachineState.advanceProgramCounter currentThread
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Stind_ref ->
             let value, state = IlMachineState.popEvalStack currentThread state
             let addr, state = IlMachineState.popEvalStack currentThread state
@@ -1862,7 +1862,7 @@ module NullaryIlOp =
                     corelib.NullReferenceException
                     currentThread
                     state
-                |> ExecutionResult.Stepped
+                |> ExecutionResult.stepped
             | _ ->
 
             let state =
@@ -1879,7 +1879,7 @@ module NullaryIlOp =
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Ldelem_i ->
             let index, state = IlMachineState.popEvalStack currentThread state
             let arr, state = IlMachineState.popEvalStack currentThread state
@@ -1895,7 +1895,7 @@ module NullaryIlOp =
                 |> IlMachineState.pushToEvalStack value currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
 
-            ExecutionResult.Stepped (state, WhatWeDid.Executed)
+            ExecutionResult.stepped (state, WhatWeDid.Executed)
         | Ldelem_i1 ->
             let index, state = IlMachineState.popEvalStack currentThread state
             let arr, state = IlMachineState.popEvalStack currentThread state
@@ -1913,7 +1913,7 @@ module NullaryIlOp =
                 |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 value) currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
 
-            ExecutionResult.Stepped (state, WhatWeDid.Executed)
+            ExecutionResult.stepped (state, WhatWeDid.Executed)
         | Ldelem_u1 ->
             let index, state = IlMachineState.popEvalStack currentThread state
             let arr, state = IlMachineState.popEvalStack currentThread state
@@ -1931,7 +1931,7 @@ module NullaryIlOp =
                 |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 value) currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
 
-            ExecutionResult.Stepped (state, WhatWeDid.Executed)
+            ExecutionResult.stepped (state, WhatWeDid.Executed)
         | Ldelem_i2 ->
             let index, state = IlMachineState.popEvalStack currentThread state
             let arr, state = IlMachineState.popEvalStack currentThread state
@@ -1949,7 +1949,7 @@ module NullaryIlOp =
                 |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 value) currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
 
-            ExecutionResult.Stepped (state, WhatWeDid.Executed)
+            ExecutionResult.stepped (state, WhatWeDid.Executed)
         | Ldelem_u2 ->
             let index, state = IlMachineState.popEvalStack currentThread state
             let arr, state = IlMachineState.popEvalStack currentThread state
@@ -1968,7 +1968,7 @@ module NullaryIlOp =
                 |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 value) currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
 
-            ExecutionResult.Stepped (state, WhatWeDid.Executed)
+            ExecutionResult.stepped (state, WhatWeDid.Executed)
         | Ldelem_i4 ->
             let index, state = IlMachineState.popEvalStack currentThread state
             let arr, state = IlMachineState.popEvalStack currentThread state
@@ -1984,7 +1984,7 @@ module NullaryIlOp =
                 |> IlMachineState.pushToEvalStack value currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
 
-            ExecutionResult.Stepped (state, WhatWeDid.Executed)
+            ExecutionResult.stepped (state, WhatWeDid.Executed)
         | Ldelem_u4 ->
             let index, state = IlMachineState.popEvalStack currentThread state
             let arr, state = IlMachineState.popEvalStack currentThread state
@@ -2000,7 +2000,7 @@ module NullaryIlOp =
                 |> IlMachineState.pushToEvalStack value currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
 
-            ExecutionResult.Stepped (state, WhatWeDid.Executed)
+            ExecutionResult.stepped (state, WhatWeDid.Executed)
         | Ldelem_i8 ->
             let index, state = IlMachineState.popEvalStack currentThread state
             let arr, state = IlMachineState.popEvalStack currentThread state
@@ -2016,7 +2016,7 @@ module NullaryIlOp =
                 |> IlMachineState.pushToEvalStack value currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
 
-            ExecutionResult.Stepped (state, WhatWeDid.Executed)
+            ExecutionResult.stepped (state, WhatWeDid.Executed)
         | Ldelem_u8 -> failwith "TODO: Ldelem_u8 unimplemented"
         | Ldelem_r4 ->
             let index, state = IlMachineState.popEvalStack currentThread state
@@ -2033,7 +2033,7 @@ module NullaryIlOp =
                 |> IlMachineState.pushToEvalStack value currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
 
-            ExecutionResult.Stepped (state, WhatWeDid.Executed)
+            ExecutionResult.stepped (state, WhatWeDid.Executed)
         | Ldelem_r8 ->
             let index, state = IlMachineState.popEvalStack currentThread state
             let arr, state = IlMachineState.popEvalStack currentThread state
@@ -2049,7 +2049,7 @@ module NullaryIlOp =
                 |> IlMachineState.pushToEvalStack value currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
 
-            ExecutionResult.Stepped (state, WhatWeDid.Executed)
+            ExecutionResult.stepped (state, WhatWeDid.Executed)
         | Ldelem_ref ->
             let index, state = IlMachineState.popEvalStack currentThread state
             let arr, state = IlMachineState.popEvalStack currentThread state
@@ -2066,7 +2066,7 @@ module NullaryIlOp =
                 |> IlMachineState.pushToEvalStack value currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
 
-            ExecutionResult.Stepped (state, WhatWeDid.Executed)
+            ExecutionResult.stepped (state, WhatWeDid.Executed)
         | Stelem_i ->
             let value, state = IlMachineState.popEvalStack currentThread state
             let index, state = IlMachineState.popEvalStack currentThread state
@@ -2149,7 +2149,7 @@ module NullaryIlOp =
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.Stepped
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Arglist -> failwith "TODO: Arglist unimplemented"
         | Ckfinite -> failwith "TODO: Ckfinite unimplemented"
         | Readonly ->
@@ -2174,5 +2174,5 @@ module NullaryIlOp =
                 )
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.Stepped
+            |> ExecutionResult.stepped
         | Refanytype -> failwith "TODO: Refanytype unimplemented"

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -169,7 +169,7 @@ module Program =
                 ProgramStepOutcome.Completed (RunOutcome.FailFast (state, abortingThread, message))
             | ExecutionResult.UnhandledException (state, terminatingThread, exn) ->
                 ProgramStepOutcome.Completed (RunOutcome.GuestUnhandledException (state, terminatingThread, exn))
-            | ExecutionResult.Stepped (state, whatWeDid) ->
+            | ExecutionResult.Stepped (state, whatWeDid, _) ->
                 logStepOutcome logger state nextThread whatWeDid
 
                 let state = Scheduler.onStepOutcome nextThread whatWeDid state


### PR DESCRIPTION
## Summary
- Add `StepEffect` DU (only variant: `NoEffect`) as a third component of `ExecutionResult.Stepped`, orthogonal to the existing `WhatWeDid` scheduler signal.
- Add `ExecutionResult.stepped` / `steppedWith` helpers so the ~250 construction sites that emit no effect just lowercase the case constructor at the end of their pipelines.
- Propagate whichever effect a native callee emitted in `AbstractMachine.dispatchNative` as we walk back up the native frame return.

This widening is a deliberate no-op: every existing site emits `NoEffect` and behaviour is unchanged. The point is to land the contract change ahead of `SystemNative_Write` / `SystemNative_Read` so those PRs can add effect variants without retouching the rest of the interpreter. `WhatWeDid` answers "did this step make progress, suspend, or block?" (input to the scheduler); `StepEffect` will answer "did this step want to talk to the outside world?" (input to the driver). A single step can do both.

## Test plan
- [x] `nix develop -c dotnet build WoofWare.PawPrint.slnx` clean
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --no-build` — all 835 tests pass
- [x] `nix develop -c dotnet fantomas .` clean
- [x] `codex review --base main` — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)