### PR TITLE
Add FriendAssemblyName.matchesDef ref-vs-def matcher

### DIFF
--- a/WoofWare.PawPrint.Domain/FriendAssemblies.fs
+++ b/WoofWare.PawPrint.Domain/FriendAssemblies.fs
@@ -187,6 +187,203 @@ module FriendAssemblyName =
             | FriendPublicKey.NotStrongNamed
             | FriendPublicKey.FullPublicKey _ -> Ok ()
 
+    let private bytesEqual (a : byte[]) (b : byte[]) : bool =
+        if isNull a || isNull b then
+            isNull a && isNull b
+        elif a.Length <> b.Length then
+            false
+        else
+            let mutable eq = true
+            let mutable i = 0
+
+            while eq && i < a.Length do
+                if a.[i] <> b.[i] then
+                    eq <- false
+
+                i <- i + 1
+
+            eq
+
+    /// Compute the eight-byte public key token from a full public key blob,
+    /// delegating to the host BCL's <c>AssemblyName.GetPublicKeyToken</c>.
+    /// Per ECMA-335 II.6.3 this is the low eight bytes of SHA-1 of the key,
+    /// reversed. The computation is pure (input bytes -> output bytes) so
+    /// the host's BCL agrees with what the guest's BCL would compute.
+    let private computeTokenFromPublicKey (publicKey : byte[]) : byte[] =
+        let an = AssemblyName ()
+        an.SetPublicKey publicKey
+        an.GetPublicKeyToken ()
+
+    let private namesEqual (a : string) (b : string) : bool =
+        if isNull a || isNull b then
+            isNull a && isNull b
+        else
+            String.Equals (a, b, StringComparison.OrdinalIgnoreCase)
+
+    /// Faithful port of CoreCLR's <c>BaseAssemblySpec::RefMatchesDef</c>
+    /// composed with <c>CompareRefToDef</c>. Treats the
+    /// <c>FriendAssemblyName</c> as the ref and the supplied
+    /// <c>AssemblyName</c> as the def.
+    let matchesDef (ref : FriendAssemblyName) (def : AssemblyName) : bool =
+        // RefMatchesDef: if ref is not strong-named, only compare names.
+        match ref.PublicKey with
+        | FriendPublicKey.NotStrongNamed -> namesEqual ref.Name def.Name
+        | _ ->
+
+        // Strong-named ref: def must also be strong-named. Inspect the
+        // AssemblyName fields directly rather than calling
+        // GetPublicKeyToken(), which derives the token (and throws
+        // SecurityException on a structurally malformed full-key blob)
+        // when the def carries a key but no explicit token. We use
+        // AssemblyNameFlags.PublicKey to distinguish: when the flag is set
+        // the def has a full key (GetPublicKeyToken would derive on
+        // demand); when clear, GetPublicKeyToken returns the literal
+        // stored token bytes (no derivation, no validation).
+        let defKey = def.GetPublicKey ()
+        let defHasFullKey = not (isNull defKey) && defKey.Length > 0
+
+        let defHasFullKeyFlag =
+            (def.Flags &&& AssemblyNameFlags.PublicKey) <> AssemblyNameFlags.None
+
+        let defStoredToken : byte[] =
+            if defHasFullKeyFlag then
+                // Stored-token field is unused when the full-key flag is
+                // set; defer the derivation to the token-ref branch
+                // below, which is the only branch that needs the token.
+                Array.empty
+            else
+                let t = def.GetPublicKeyToken ()
+                if isNull t then Array.empty else t
+
+        let defIsStrongNamed = defHasFullKey || defStoredToken.Length > 0
+
+        if not defIsStrongNamed then
+            false
+        else if
+
+            // CompareRefToDef name comparison.
+            not (namesEqual ref.Name def.Name)
+        then
+            false
+        else
+
+        // CompareRefToDef public key / token comparison.
+        // CoreCLR stores a single m_pbPublicKeyOrToken blob per spec and a
+        // flag that says whether it's a full key or a token; CompareRefToDef
+        // is a length+memcmp on those bytes. RefMatchesDef branches on the
+        // ref:
+        //   - Full-key ref: CompareRefToDef runs directly. If the def
+        //     carries only a token (smaller bytes), the length mismatch
+        //     fails the comparison; checkFriendRestrictions has already
+        //     guaranteed no Friend ref is token-only, but a def populated
+        //     from a token-only display name is possible. Model this
+        //     faithfully by requiring def to expose a full key. CoreCLR
+        //     additionally compares the afPublicKey flag in its
+        //     masked-flags strict-equality check, so we also require the
+        //     def's PublicKey flag bit to be set; otherwise a manually
+        //     constructed def with bytes set via SetPublicKey but the
+        //     flag cleared (the AssemblyName.Flags setter is mutable)
+        //     would spuriously match. The comparison is over raw bytes,
+        //     so a structurally malformed full-key blob is fine —
+        //     CoreCLR does not validate the blob during the comparison
+        //     either.
+        //   - Token-only ref: CoreCLR copies the def and calls
+        //     ConvertPublicKeyToToken before CompareRefToDef, so a full-key
+        //     def is reduced to its token first. We derive the token here
+        //     when needed.
+        let keysMatch =
+            match ref.PublicKey with
+            | FriendPublicKey.NotStrongNamed -> false
+            | FriendPublicKey.FullPublicKey k ->
+                if defHasFullKey && defHasFullKeyFlag then
+                    bytesEqual k defKey
+                else
+                    false
+            | FriendPublicKey.PublicKeyToken t ->
+                let defTokenMaterialised =
+                    if defStoredToken.Length > 0 then defStoredToken
+                    elif defHasFullKey then computeTokenFromPublicKey defKey
+                    else Array.empty
+
+                bytesEqual t defTokenMaterialised
+
+        if not keysMatch then
+            false
+        else
+
+        // CompareRefToDef Retargetable comparison. CoreCLR includes
+        // Retargetable in the masked-flags strict-equality check, so the
+        // ref's flag must equal the def's. (ProcessorArchitecture is masked
+        // out and ignored; ContentType is handled separately below.)
+        let defIsRetargetable =
+            (def.Flags &&& AssemblyNameFlags.Retargetable) <> AssemblyNameFlags.None
+
+        if ref.HasRetargetable <> defIsRetargetable then
+            false
+        else
+
+        // CompareRefToDef ContentType comparison. Optional in the ref: if
+        // the ref's content type is Default, the def's is unconstrained;
+        // otherwise it must equal the def's exactly.
+        let contentTypeMatch =
+            ref.ContentType = AssemblyContentType.Default
+            || ref.ContentType = def.ContentType
+
+        if not contentTypeMatch then
+            false
+        else
+
+        // CompareRefToDef cascading version comparison; -1 in any component
+        // means "unspecified, do not constrain lower components". The
+        // AssemblyName surface uses Version objects so we approximate by
+        // looking at the structured fields.
+        let versionMatch =
+            match ref.Version with
+            | None -> true
+            | Some refV ->
+                let defV = def.Version
+
+                if isNull defV then
+                    false
+                else
+                    let cmp (refField : int) (defField : int) (lower : (unit -> bool) option) : bool =
+                        if refField < 0 then
+                            true
+                        elif refField <> defField then
+                            false
+                        else
+                            match lower with
+                            | None -> true
+                            | Some f -> f ()
+
+                    cmp
+                        refV.Major
+                        defV.Major
+                        (Some (fun () ->
+                            cmp
+                                refV.Minor
+                                defV.Minor
+                                (Some (fun () ->
+                                    cmp refV.Build defV.Build (Some (fun () -> cmp refV.Revision defV.Revision None))
+                                ))
+                        ))
+
+        if not versionMatch then
+            false
+        else
+
+        // CompareRefToDef locale comparison. CoreCLR uses strcmp, i.e.
+        // case-sensitive ordinal.
+        match ref.Culture with
+        | None -> true
+        | Some refCulture ->
+            let defCulture =
+                let c = def.CultureName
+
+                if isNull c then "" else c
+
+            String.Equals (refCulture, defCulture, StringComparison.Ordinal)
+
 /// <summary>
 /// The set of friend assemblies declared on a given assembly. Friend access
 /// is granted through <c>InternalsVisibleToAttribute</c> (callers may see

--- a/WoofWare.PawPrint.Test/TestFriendAssemblies.fs
+++ b/WoofWare.PawPrint.Test/TestFriendAssemblies.fs
@@ -416,6 +416,362 @@ module TestFriendAssemblies =
 
         FriendAssemblyName.checkFriendRestrictions fan |> shouldEqual (Ok ())
 
+    let private makeDef
+        (name : string)
+        (publicKey : byte[] option)
+        (version : Version option)
+        (culture : string option)
+        : AssemblyName
+        =
+        let an = AssemblyName ()
+        an.Name <- name
+
+        match publicKey with
+        | Some k -> an.SetPublicKey k
+        | None -> ()
+
+        match version with
+        | Some v -> an.Version <- v
+        | None -> ()
+
+        match culture with
+        | Some c -> an.CultureName <- c
+        | None -> ()
+
+        an
+
+    let private withRetargetable (an : AssemblyName) : AssemblyName =
+        an.Flags <- an.Flags ||| AssemblyNameFlags.Retargetable
+        an
+
+    let private withContentType (ct : AssemblyContentType) (an : AssemblyName) : AssemblyName =
+        an.ContentType <- ct
+        an
+
+    let private baseRef =
+        {
+            Name = "FriendAsm"
+            PublicKey = FriendPublicKey.NotStrongNamed
+            Version = None
+            Culture = None
+            HasProcessorArchitecture = false
+            HasRetargetable = false
+            ContentType = AssemblyContentType.Default
+        }
+
+    [<Test>]
+    let ``matchesDef: non-strong-named ref matches by name only (case-insensitive)`` () : unit =
+        let ref =
+            {
+                Name = "FriendAsm"
+                PublicKey = FriendPublicKey.NotStrongNamed
+                Version = None
+                Culture = None
+                HasProcessorArchitecture = false
+                HasRetargetable = false
+                ContentType = AssemblyContentType.Default
+            }
+
+        let def = makeDef "friendasm" None None None
+
+        FriendAssemblyName.matchesDef ref def |> shouldEqual true
+
+    [<Test>]
+    let ``matchesDef: non-strong-named ref with wrong name fails`` () : unit =
+        let ref =
+            {
+                Name = "FriendAsm"
+                PublicKey = FriendPublicKey.NotStrongNamed
+                Version = None
+                Culture = None
+                HasProcessorArchitecture = false
+                HasRetargetable = false
+                ContentType = AssemblyContentType.Default
+            }
+
+        let def = makeDef "Other" None None None
+
+        FriendAssemblyName.matchesDef ref def |> shouldEqual false
+
+    [<Test>]
+    let ``matchesDef: non-strong-named ref matches even strong-named def`` () : unit =
+        let ref =
+            {
+                Name = "FriendAsm"
+                PublicKey = FriendPublicKey.NotStrongNamed
+                Version = None
+                Culture = None
+                HasProcessorArchitecture = false
+                HasRetargetable = false
+                ContentType = AssemblyContentType.Default
+            }
+
+        let def = makeDef "FriendAsm" (Some fakePublicKey) None None
+
+        FriendAssemblyName.matchesDef ref def |> shouldEqual true
+
+    [<Test>]
+    let ``matchesDef: strong-named ref against non-strong-named def fails`` () : unit =
+        let ref =
+            {
+                Name = "FriendAsm"
+                PublicKey = FriendPublicKey.FullPublicKey fakePublicKey
+                Version = None
+                Culture = None
+                HasProcessorArchitecture = false
+                HasRetargetable = false
+                ContentType = AssemblyContentType.Default
+            }
+
+        let def = makeDef "FriendAsm" None None None
+
+        FriendAssemblyName.matchesDef ref def |> shouldEqual false
+
+    [<Test>]
+    let ``matchesDef: strong-named ref with matching full key matches def`` () : unit =
+        let ref =
+            {
+                Name = "FriendAsm"
+                PublicKey = FriendPublicKey.FullPublicKey fakePublicKey
+                Version = None
+                Culture = None
+                HasProcessorArchitecture = false
+                HasRetargetable = false
+                ContentType = AssemblyContentType.Default
+            }
+
+        let def = makeDef "FriendAsm" (Some fakePublicKey) None None
+
+        FriendAssemblyName.matchesDef ref def |> shouldEqual true
+
+    [<Test>]
+    let ``matchesDef: strong-named ref with full key does not match token-only def`` () : unit =
+        // CoreCLR's RefMatchesDef branches on the ref. When the ref carries a
+        // full key it calls CompareRefToDef directly, which compares
+        // m_pbPublicKeyOrToken bytes by length+memcmp; a token-only def has
+        // shorter bytes than a full key, so the comparison fails. We must
+        // NOT shortcut by deriving the ref's token: that would falsely grant
+        // friend access to an identity that never supplied the full key.
+        let ref =
+            {
+                Name = "FriendAsm"
+                PublicKey = FriendPublicKey.FullPublicKey fakePublicKey
+                Version = None
+                Culture = None
+                HasProcessorArchitecture = false
+                HasRetargetable = false
+                ContentType = AssemblyContentType.Default
+            }
+
+        let def = AssemblyName ()
+        def.Name <- "FriendAsm"
+        def.SetPublicKeyToken fakePublicKeyToken
+
+        FriendAssemblyName.matchesDef ref def |> shouldEqual false
+
+    [<Test>]
+    let ``matchesDef: strong-named ref with wrong key fails`` () : unit =
+        let otherKey =
+            let k = Array.copy fakePublicKey
+            k.[0] <- k.[0] ^^^ 0xFFuy
+            k
+
+        let ref =
+            {
+                Name = "FriendAsm"
+                PublicKey = FriendPublicKey.FullPublicKey fakePublicKey
+                Version = None
+                Culture = None
+                HasProcessorArchitecture = false
+                HasRetargetable = false
+                ContentType = AssemblyContentType.Default
+            }
+
+        let def = makeDef "FriendAsm" (Some otherKey) None None
+
+        FriendAssemblyName.matchesDef ref def |> shouldEqual false
+
+    [<Test>]
+    let ``matchesDef: full-key ref does not match def with cleared PublicKey flag`` () : unit =
+        // CoreCLR's CompareRefToDef includes afPublicKey in its masked-flags
+        // strict-equality check, so a def whose bytes equal the ref's full
+        // key but whose PublicKey flag is clear must NOT match. AssemblyName
+        // exposes a mutable Flags property, so this inconsistent state is
+        // constructible by a caller.
+        let ref =
+            {
+                Name = "FriendAsm"
+                PublicKey = FriendPublicKey.FullPublicKey fakePublicKey
+                Version = None
+                Culture = None
+                HasProcessorArchitecture = false
+                HasRetargetable = false
+                ContentType = AssemblyContentType.Default
+            }
+
+        let def = AssemblyName ()
+        def.Name <- "FriendAsm"
+        def.SetPublicKey fakePublicKey
+        def.Flags <- def.Flags &&& (~~~AssemblyNameFlags.PublicKey)
+
+        FriendAssemblyName.matchesDef ref def |> shouldEqual false
+
+    [<Test>]
+    let ``matchesDef: ref version unspecified accepts any def version`` () : unit =
+        let ref =
+            {
+                Name = "FriendAsm"
+                PublicKey = FriendPublicKey.NotStrongNamed
+                Version = None
+                Culture = None
+                HasProcessorArchitecture = false
+                HasRetargetable = false
+                ContentType = AssemblyContentType.Default
+            }
+
+        let def = makeDef "FriendAsm" None (Some (Version (9, 9, 9, 9))) None
+
+        FriendAssemblyName.matchesDef ref def |> shouldEqual true
+
+    [<Test>]
+    let ``matchesDef: ref version exact match`` () : unit =
+        // Need strong-named for version comparison to be visible
+        // (with non-strong-named ref, RefMatchesDef short-circuits on name only)
+        let ref =
+            {
+                Name = "FriendAsm"
+                PublicKey = FriendPublicKey.FullPublicKey fakePublicKey
+                Version = Some (Version (1, 2, 3, 4))
+                Culture = None
+                HasProcessorArchitecture = false
+                HasRetargetable = false
+                ContentType = AssemblyContentType.Default
+            }
+
+        let def =
+            makeDef "FriendAsm" (Some fakePublicKey) (Some (Version (1, 2, 3, 4))) None
+
+        FriendAssemblyName.matchesDef ref def |> shouldEqual true
+
+    [<Test>]
+    let ``matchesDef: ref version mismatch fails`` () : unit =
+        let ref =
+            {
+                Name = "FriendAsm"
+                PublicKey = FriendPublicKey.FullPublicKey fakePublicKey
+                Version = Some (Version (1, 2, 3, 4))
+                Culture = None
+                HasProcessorArchitecture = false
+                HasRetargetable = false
+                ContentType = AssemblyContentType.Default
+            }
+
+        let def =
+            makeDef "FriendAsm" (Some fakePublicKey) (Some (Version (1, 2, 3, 5))) None
+
+        FriendAssemblyName.matchesDef ref def |> shouldEqual false
+
+    // Retargetable and ContentType only participate in matching when the ref is
+    // strong-named: CoreCLR's RefMatchesDef short-circuits non-strong-named refs
+    // on name alone.
+
+    let private strongRef =
+        { baseRef with
+            PublicKey = FriendPublicKey.FullPublicKey fakePublicKey
+        }
+
+    [<Test>]
+    let ``matchesDef: retargetable ref matches retargetable def`` () : unit =
+        let ref =
+            { strongRef with
+                HasRetargetable = true
+            }
+
+        let def = makeDef "FriendAsm" (Some fakePublicKey) None None |> withRetargetable
+
+        FriendAssemblyName.matchesDef ref def |> shouldEqual true
+
+    [<Test>]
+    let ``matchesDef: retargetable ref does not match non-retargetable def`` () : unit =
+        let ref =
+            { strongRef with
+                HasRetargetable = true
+            }
+
+        let def = makeDef "FriendAsm" (Some fakePublicKey) None None
+        FriendAssemblyName.matchesDef ref def |> shouldEqual false
+
+    [<Test>]
+    let ``matchesDef: non-retargetable ref does not match retargetable def`` () : unit =
+        // CoreCLR's masked-flags strict equality: Retargetable must agree.
+        let ref = strongRef
+
+        let def = makeDef "FriendAsm" (Some fakePublicKey) None None |> withRetargetable
+
+        FriendAssemblyName.matchesDef ref def |> shouldEqual false
+
+    [<Test>]
+    let ``matchesDef: ContentType=Default ref matches def with any ContentType`` () : unit =
+        // Optional in ref: Default means "do not constrain def's ContentType".
+        let ref = strongRef
+
+        let def =
+            makeDef "FriendAsm" (Some fakePublicKey) None None
+            |> withContentType AssemblyContentType.WindowsRuntime
+
+        FriendAssemblyName.matchesDef ref def |> shouldEqual true
+
+    [<Test>]
+    let ``matchesDef: ContentType=WindowsRuntime ref requires matching def`` () : unit =
+        let ref =
+            { strongRef with
+                ContentType = AssemblyContentType.WindowsRuntime
+            }
+
+        let defMatch =
+            makeDef "FriendAsm" (Some fakePublicKey) None None
+            |> withContentType AssemblyContentType.WindowsRuntime
+
+        let defDefault = makeDef "FriendAsm" (Some fakePublicKey) None None
+        FriendAssemblyName.matchesDef ref defMatch |> shouldEqual true
+        FriendAssemblyName.matchesDef ref defDefault |> shouldEqual false
+
+    [<Test>]
+    let ``matchesDef: full-key ref with malformed bytes matches def with same malformed bytes`` () : unit =
+        // CoreCLR's CompareRefToDef does a length+memcmp on the raw key
+        // blob; the bytes are not validated. The host BCL's
+        // GetPublicKeyToken() does try to derive a token from a full key
+        // and throws SecurityException on a malformed blob, but matchesDef
+        // must not call it on the full-key path.
+        let malformed = [| 0x00uy ; 0x11uy |]
+
+        let ref =
+            { baseRef with
+                PublicKey = FriendPublicKey.FullPublicKey malformed
+            }
+
+        let def = AssemblyName ()
+        def.Name <- "FriendAsm"
+        def.SetPublicKey malformed
+
+        FriendAssemblyName.matchesDef ref def |> shouldEqual true
+
+    [<Test>]
+    let ``matchesDef: full-key ref with malformed bytes does not match def with different bytes`` () : unit =
+        let malformed = [| 0x00uy ; 0x11uy |]
+        let other = [| 0x22uy ; 0x33uy |]
+
+        let ref =
+            { baseRef with
+                PublicKey = FriendPublicKey.FullPublicKey malformed
+            }
+
+        let def = AssemblyName ()
+        def.Name <- "FriendAsm"
+        def.SetPublicKey other
+
+        FriendAssemblyName.matchesDef ref def |> shouldEqual false
+
     [<Test>]
     let ``scan: assembly with no IVT returns empty`` () : unit =
         let source =


### PR DESCRIPTION
## Summary

Second slice of friend-assembly support, layered on the parser/scan slice already in main (#537). Implements `FriendAssemblyName.matchesDef`, a port of CoreCLR's `BaseAssemblySpec::RefMatchesDef` + `CompareRefToDef` for the friend-assembly case.

- **Strong-naming**: `NotStrongNamed` refs short-circuit to a name-only match; `FullPublicKey` refs require the def to expose a full public key (both `GetPublicKey()` bytes and the `AssemblyNameFlags.PublicKey` bit, because CoreCLR's masked-flags strict-equality in `CompareRefToDef` covers `afPublicKey`); `PublicKeyToken` refs derive the def's token only when needed and compare bytes.
- **Retargetable / ContentType / Version / Locale**: ports the rest of `CompareRefToDef`'s comparisons (masked-flags equality for `Retargetable`, optional-in-ref `ContentType`, cascading version with -1 wildcards, `strcmp` on locale).
- **Token derivation is deferred** until a `PublicKeyToken`-ref is actually being matched. A structurally malformed `FullPublicKey` blob on the def (which `GetPublicKeyToken()` would throw `SecurityException` on) no longer surfaces when it could never have matched anyway.

The diff was reviewed by Codex; the only finding (P2 on the full-key flag check) has been addressed and a regression test covers it.

## Test plan

- [x] `nix develop -c dotnet build WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj`
- [x] `nix develop -c dotnet test ... --filter "FullyQualifiedName~TestFriendAssemblies"` (62 pass)
- [x] `codex review --base main` returned no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)