### PR TITLE
Add AccessCheck domain module (canAccessClass / canAccessMethod)

### DIFF
--- a/WoofWare.PawPrint.Domain/AccessCheck.fs
+++ b/WoofWare.PawPrint.Domain/AccessCheck.fs
@@ -1,0 +1,162 @@
+namespace WoofWare.PawPrint
+
+open System.Reflection
+
+/// <summary>
+/// Per-level visibility input for <c>AccessCheck.canAccessClass</c>'s walk
+/// over a type's enclosing-type chain. We project this out of
+/// <c>TypeInfo</c> so that AccessCheck has no dependency on the larger
+/// type-info surface (which is generic over a name encoding).
+/// </summary>
+type AccessLevelInfo =
+    {
+        /// The type's <c>TypeAttributes</c>; AccessCheck looks at the
+        /// <c>VisibilityMask</c> bits only.
+        Visibility : TypeAttributes
+        /// The type's name. Used solely for diagnostic messages when a
+        /// not-yet-ported visibility flag triggers a loud failure.
+        Name : string
+    }
+
+/// <summary>
+/// One side of an access-check decision. CoreCLR's
+/// <c>ClassLoader::CanAccess*</c> family threads an <c>AccessCheckContext</c>
+/// describing the accessing side; we make both sides symmetric so the same
+/// record describes either the accessor or the target.
+/// </summary>
+type AccessParty =
+    {
+        /// Type-nesting chain. <c>Head</c>: the immediate type whose
+        /// visibility we are deciding about. <c>Tail</c>: the chain of
+        /// enclosing types, up to and including the outermost (whose
+        /// <c>Visibility</c> is one of <c>Public</c> / <c>NotPublic</c>).
+        /// For a top-level type, this list has a single element.
+        TypeChain : AccessLevelInfo list
+        /// The assembly identity used by <c>FriendAssemblyName.matchesDef</c>
+        /// to decide whether the other side's IVT / IgnoresAccessChecksTo
+        /// declarations grant cross-assembly visibility.
+        Assembly : AssemblyName
+        /// The IVT / IgnoresAccessChecksTo declarations parsed from
+        /// assembly-level custom attributes on this party's assembly.
+        Friends : FriendAssemblies
+    }
+
+[<RequireQualifiedAccess>]
+module AccessCheck =
+
+    /// Run an IVT / IgnoresAccessChecksTo list against a candidate identity:
+    /// the match succeeds if any entry in the list is a friend-ref that
+    /// matches the candidate def (per CoreCLR's
+    /// <c>BaseAssemblySpec::RefMatchesDef</c>, ported as
+    /// <c>FriendAssemblyName.matchesDef</c>).
+    let private friendDeclares (friends : FriendAssemblyName array) (candidate : AssemblyName) : bool =
+        friends
+        |> Array.exists (fun friendRef -> FriendAssemblyName.matchesDef friendRef candidate)
+
+    /// Mirrors CoreCLR's <c>ClassLoader::AssemblyOrFriendAccessAllowed</c>:
+    /// <list type="number">
+    /// <item>If the two parties are the same assembly, access is granted.</item>
+    /// <item>If the accessor's <c>IgnoresAccessChecksTo</c> list names the
+    /// target's assembly, access is granted (the accessor has opted out of
+    /// the target's visibility checks; this is the standard mechanism the
+    /// "PrivateProxy" / "InternalsVisibleTo"-by-attacker tooling relies
+    /// on).</item>
+    /// <item>If the target's <c>InternalsVisibleTo</c> list names the
+    /// accessor's assembly, access is granted (the target has granted
+    /// friend status to the accessor).</item>
+    /// <item>Otherwise access is denied.</item>
+    /// </list>
+    let private assemblyOrFriendAccessAllowed
+        (sameAssembly : bool)
+        (accessor : AccessParty)
+        (target : AccessParty)
+        : bool
+        =
+        sameAssembly
+        || friendDeclares accessor.Friends.IgnoresAccessChecksTo target.Assembly
+        || friendDeclares target.Friends.InternalsVisibleTo accessor.Assembly
+
+    /// Decide visibility of a single type-chain level. <c>Public</c> /
+    /// <c>NestedPublic</c> is unconditional; <c>NotPublic</c> /
+    /// <c>NestedAssembly</c> routes through
+    /// <c>assemblyOrFriendAccessAllowed</c>. The family-style and private
+    /// nested flags raise <c>failwith</c>: porting them requires
+    /// <c>CanAccessFamily</c>'s subclass-walk and chain-equality checks,
+    /// which are out of scope for this slice and would silently grant
+    /// (or deny) access if guessed at.
+    let private levelIsVisible
+        (sameAssembly : bool)
+        (accessor : AccessParty)
+        (target : AccessParty)
+        (level : AccessLevelInfo)
+        : bool
+        =
+        let vis = level.Visibility &&& TypeAttributes.VisibilityMask
+
+        match vis with
+        | TypeAttributes.Public
+        | TypeAttributes.NestedPublic -> true
+        | TypeAttributes.NotPublic
+        | TypeAttributes.NestedAssembly -> assemblyOrFriendAccessAllowed sameAssembly accessor target
+        | TypeAttributes.NestedPrivate ->
+            failwithf
+                "AccessCheck: NestedPrivate visibility on type '%s' is not implemented in this slice (would require CanAccessFamily-style chain-equality check)"
+                level.Name
+        | TypeAttributes.NestedFamily
+        | TypeAttributes.NestedFamORAssem
+        | TypeAttributes.NestedFamANDAssem ->
+            failwithf
+                "AccessCheck: family-style nested-type visibility (%A) on type '%s' is not implemented in this slice (would require CanAccessFamily subclass walk)"
+                vis
+                level.Name
+        | _ -> failwithf "AccessCheck: unrecognised TypeAttributes visibility 0x%x on type '%s'" (int vis) level.Name
+
+    /// Mirrors <c>ClassLoader::CanAccessClass</c> for the visibility flags
+    /// supported by this slice: a target type is visible to the accessor
+    /// iff every level in the target's nesting chain (from innermost up to
+    /// the outermost top-level type) is visible. Generic-instantiation
+    /// argument visibility (<c>CanAccessClass</c>'s recursive walk over
+    /// the target's generic arguments) is deliberately not modelled here:
+    /// the caller in slice 4 only ever asks about a non-generic custom
+    /// attribute type.
+    let canAccessClass (sameAssembly : bool) (accessor : AccessParty) (target : AccessParty) : bool =
+        target.TypeChain |> List.forall (levelIsVisible sameAssembly accessor target)
+
+    /// Mirrors the visibility portion of <c>ClassLoader::CanAccess</c> /
+    /// <c>CheckAccessMember</c> for a method member: access requires both
+    /// <c>canAccessClass</c> on the declaring type and the method's own
+    /// visibility bit to admit the accessor.
+    /// <c>MethodAttributes.Public</c> is unconditional;
+    /// <c>MethodAttributes.Assembly</c> routes through
+    /// <c>assemblyOrFriendAccessAllowed</c>. The family-style flags and
+    /// <c>Private</c> / <c>PrivateScope</c> raise <c>failwith</c>: they
+    /// would require <c>CanAccessFamily</c> and chain-equality logic that
+    /// is not ported in this slice.
+    let canAccessMethod
+        (sameAssembly : bool)
+        (accessor : AccessParty)
+        (target : AccessParty)
+        (targetMethodAttrs : MethodAttributes)
+        : bool
+        =
+        if not (canAccessClass sameAssembly accessor target) then
+            false
+        else
+            let memberAccess = targetMethodAttrs &&& MethodAttributes.MemberAccessMask
+
+            match memberAccess with
+            | MethodAttributes.Public -> true
+            | MethodAttributes.Assembly -> assemblyOrFriendAccessAllowed sameAssembly accessor target
+            | MethodAttributes.Private ->
+                failwith
+                    "AccessCheck: Private member access is not implemented in this slice (would require CanAccessFamily-style chain-equality check)"
+            | MethodAttributes.Family
+            | MethodAttributes.FamANDAssem
+            | MethodAttributes.FamORAssem ->
+                failwithf
+                    "AccessCheck: family-style member visibility (%A) is not implemented in this slice (would require CanAccessFamily subclass walk)"
+                    memberAccess
+            | MethodAttributes.PrivateScope ->
+                failwith
+                    "AccessCheck: PrivateScope (compiler-controlled) member access is not implemented in this slice"
+            | _ -> failwithf "AccessCheck: unrecognised MethodAttributes member access flag 0x%x" (int memberAccess)

--- a/WoofWare.PawPrint.Domain/WoofWare.PawPrint.Domain.fsproj
+++ b/WoofWare.PawPrint.Domain/WoofWare.PawPrint.Domain.fsproj
@@ -34,6 +34,7 @@
         <Compile Include="TypeSpec.fs" />
         <Compile Include="Assembly.fs" />
         <Compile Include="FriendAssemblies.fs" />
+        <Compile Include="AccessCheck.fs" />
         <Compile Include="IlFormatting.fs" />
         <Compile Include="TypeConcretisation.fs" />
     </ItemGroup>

--- a/WoofWare.PawPrint.Test/TestAccessCheck.fs
+++ b/WoofWare.PawPrint.Test/TestAccessCheck.fs
@@ -1,0 +1,389 @@
+namespace WoofWare.PawPrint.Test
+
+open System.Reflection
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestAccessCheck =
+
+    let private level (vis : TypeAttributes) (name : string) : AccessLevelInfo =
+        {
+            Visibility = vis
+            Name = name
+        }
+
+    let private party
+        (chain : AccessLevelInfo list)
+        (assemblyName : string)
+        (ivt : string list)
+        (ignoresAccessChecksTo : string list)
+        : AccessParty
+        =
+        let toFriends (xs : string list) : FriendAssemblyName array =
+            xs
+            |> List.map (fun s ->
+                match FriendAssemblyName.parse s with
+                | Ok fan -> fan
+                | Error e -> failwithf "test setup: parse %s failed: %s" s e
+            )
+            |> List.toArray
+
+        {
+            TypeChain = chain
+            Assembly = AssemblyName assemblyName
+            Friends =
+                {
+                    InternalsVisibleTo = toFriends ivt
+                    IgnoresAccessChecksTo = toFriends ignoresAccessChecksTo
+                }
+        }
+
+    // ----- canAccessClass: top-level visibility -----
+
+    [<Test>]
+    let ``canAccessClass: Public top-level type is visible cross-assembly`` () : unit =
+        let target = party [ level TypeAttributes.Public "T" ] "TargetAsm" [] []
+        let accessor = party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] []
+
+        AccessCheck.canAccessClass false accessor target |> shouldEqual true
+
+    [<Test>]
+    let ``canAccessClass: NotPublic top-level type is visible same-assembly`` () : unit =
+        let target = party [ level TypeAttributes.NotPublic "T" ] "Asm" [] []
+        let accessor = party [ level TypeAttributes.Public "A" ] "Asm" [] []
+
+        AccessCheck.canAccessClass true accessor target |> shouldEqual true
+
+    [<Test>]
+    let ``canAccessClass: NotPublic top-level type is not visible cross-assembly without friend`` () : unit =
+        let target = party [ level TypeAttributes.NotPublic "T" ] "TargetAsm" [] []
+        let accessor = party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] []
+
+        AccessCheck.canAccessClass false accessor target |> shouldEqual false
+
+    [<Test>]
+    let ``canAccessClass: NotPublic top-level type is visible via target's IVT`` () : unit =
+        let target =
+            party [ level TypeAttributes.NotPublic "T" ] "TargetAsm" [ "AccessorAsm" ] []
+
+        let accessor = party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] []
+
+        AccessCheck.canAccessClass false accessor target |> shouldEqual true
+
+    [<Test>]
+    let ``canAccessClass: NotPublic top-level type is visible via accessor's IgnoresAccessChecksTo`` () : unit =
+        let target = party [ level TypeAttributes.NotPublic "T" ] "TargetAsm" [] []
+
+        let accessor =
+            party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] [ "TargetAsm" ]
+
+        AccessCheck.canAccessClass false accessor target |> shouldEqual true
+
+    [<Test>]
+    let ``canAccessClass: NotPublic is not visible when IVT names a different assembly`` () : unit =
+        let target =
+            party [ level TypeAttributes.NotPublic "T" ] "TargetAsm" [ "WrongAsm" ] []
+
+        let accessor = party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] []
+
+        AccessCheck.canAccessClass false accessor target |> shouldEqual false
+
+    // ----- canAccessClass: nested chains -----
+
+    [<Test>]
+    let ``canAccessClass: NestedPublic in Public outer is visible cross-assembly`` () : unit =
+        let target =
+            party
+                [
+                    level TypeAttributes.NestedPublic "Inner"
+                    level TypeAttributes.Public "Outer"
+                ]
+                "TargetAsm"
+                []
+                []
+
+        let accessor = party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] []
+
+        AccessCheck.canAccessClass false accessor target |> shouldEqual true
+
+    [<Test>]
+    let ``canAccessClass: NestedAssembly in Public outer is not visible cross-assembly`` () : unit =
+        let target =
+            party
+                [
+                    level TypeAttributes.NestedAssembly "Inner"
+                    level TypeAttributes.Public "Outer"
+                ]
+                "TargetAsm"
+                []
+                []
+
+        let accessor = party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] []
+
+        AccessCheck.canAccessClass false accessor target |> shouldEqual false
+
+    [<Test>]
+    let ``canAccessClass: NestedAssembly in Public outer is visible cross-assembly with IVT`` () : unit =
+        let target =
+            party
+                [
+                    level TypeAttributes.NestedAssembly "Inner"
+                    level TypeAttributes.Public "Outer"
+                ]
+                "TargetAsm"
+                [ "AccessorAsm" ]
+                []
+
+        let accessor = party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] []
+
+        AccessCheck.canAccessClass false accessor target |> shouldEqual true
+
+    [<Test>]
+    let ``canAccessClass: NestedPublic in NotPublic outer is not visible cross-assembly`` () : unit =
+        // The outer wraps the chain: an inner NestedPublic does not rescue
+        // a non-friend cross-assembly access if the enclosing top-level type
+        // is internal.
+        let target =
+            party
+                [
+                    level TypeAttributes.NestedPublic "Inner"
+                    level TypeAttributes.NotPublic "Outer"
+                ]
+                "TargetAsm"
+                []
+                []
+
+        let accessor = party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] []
+
+        AccessCheck.canAccessClass false accessor target |> shouldEqual false
+
+    [<Test>]
+    let ``canAccessClass: NestedPublic in NotPublic outer is visible cross-assembly via IVT`` () : unit =
+        let target =
+            party
+                [
+                    level TypeAttributes.NestedPublic "Inner"
+                    level TypeAttributes.NotPublic "Outer"
+                ]
+                "TargetAsm"
+                [ "AccessorAsm" ]
+                []
+
+        let accessor = party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] []
+
+        AccessCheck.canAccessClass false accessor target |> shouldEqual true
+
+    // ----- canAccessClass: loud failures -----
+
+    [<Test>]
+    let ``canAccessClass: NestedPrivate raises with diagnostic`` () : unit =
+        let target = party [ level TypeAttributes.NestedPrivate "Secret" ] "TargetAsm" [] []
+        let accessor = party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] []
+
+        let ex =
+            Assert.Throws (fun () -> AccessCheck.canAccessClass false accessor target |> ignore)
+
+        ex.Message |> shouldContainText "NestedPrivate"
+        ex.Message |> shouldContainText "Secret"
+
+    [<Test>]
+    let ``canAccessClass: NestedFamily raises with diagnostic`` () : unit =
+        let target = party [ level TypeAttributes.NestedFamily "FamType" ] "TargetAsm" [] []
+        let accessor = party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] []
+
+        let ex =
+            Assert.Throws (fun () -> AccessCheck.canAccessClass false accessor target |> ignore)
+
+        ex.Message |> shouldContainText "family"
+        ex.Message |> shouldContainText "FamType"
+
+    [<Test>]
+    let ``canAccessClass: NestedFamORAssem raises with diagnostic`` () : unit =
+        let target = party [ level TypeAttributes.NestedFamORAssem "T" ] "TargetAsm" [] []
+
+        let accessor = party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] []
+
+        let ex =
+            Assert.Throws (fun () -> AccessCheck.canAccessClass false accessor target |> ignore)
+
+        ex.Message |> shouldContainText "family"
+
+    [<Test>]
+    let ``canAccessClass: NestedFamANDAssem raises with diagnostic`` () : unit =
+        let target = party [ level TypeAttributes.NestedFamANDAssem "T" ] "TargetAsm" [] []
+
+        let accessor = party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] []
+
+        let ex =
+            Assert.Throws (fun () -> AccessCheck.canAccessClass false accessor target |> ignore)
+
+        ex.Message |> shouldContainText "family"
+
+    [<Test>]
+    let ``canAccessClass: family flag deep in chain still raises`` () : unit =
+        // The walk must reach every level: a family-flagged level even
+        // beneath a Public outer must still raise rather than be silently
+        // accepted.
+        let target =
+            party
+                [
+                    level TypeAttributes.NestedFamily "Inner"
+                    level TypeAttributes.Public "Outer"
+                ]
+                "TargetAsm"
+                []
+                []
+
+        let accessor = party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] []
+
+        Assert.Throws (fun () -> AccessCheck.canAccessClass false accessor target |> ignore)
+        |> ignore
+
+    // ----- canAccessMethod: visibility flags -----
+
+    [<Test>]
+    let ``canAccessMethod: Public method on Public class is visible cross-assembly`` () : unit =
+        let target = party [ level TypeAttributes.Public "T" ] "TargetAsm" [] []
+        let accessor = party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] []
+
+        AccessCheck.canAccessMethod false accessor target MethodAttributes.Public
+        |> shouldEqual true
+
+    [<Test>]
+    let ``canAccessMethod: Assembly method on Public class is visible same-assembly`` () : unit =
+        let target = party [ level TypeAttributes.Public "T" ] "Asm" [] []
+        let accessor = party [ level TypeAttributes.Public "A" ] "Asm" [] []
+
+        AccessCheck.canAccessMethod true accessor target MethodAttributes.Assembly
+        |> shouldEqual true
+
+    [<Test>]
+    let ``canAccessMethod: Assembly method on Public class is not visible cross-assembly without friend`` () : unit =
+        let target = party [ level TypeAttributes.Public "T" ] "TargetAsm" [] []
+        let accessor = party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] []
+
+        AccessCheck.canAccessMethod false accessor target MethodAttributes.Assembly
+        |> shouldEqual false
+
+    [<Test>]
+    let ``canAccessMethod: Assembly method on Public class is visible cross-assembly via IVT`` () : unit =
+        let target =
+            party [ level TypeAttributes.Public "T" ] "TargetAsm" [ "AccessorAsm" ] []
+
+        let accessor = party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] []
+
+        AccessCheck.canAccessMethod false accessor target MethodAttributes.Assembly
+        |> shouldEqual true
+
+    [<Test>]
+    let ``canAccessMethod: Assembly method on Public class is visible via IgnoresAccessChecksTo`` () : unit =
+        let target = party [ level TypeAttributes.Public "T" ] "TargetAsm" [] []
+
+        let accessor =
+            party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] [ "TargetAsm" ]
+
+        AccessCheck.canAccessMethod false accessor target MethodAttributes.Assembly
+        |> shouldEqual true
+
+    [<Test>]
+    let ``canAccessMethod: Public method on NotPublic class without friend yields false`` () : unit =
+        // Class inaccessibility short-circuits regardless of the method's
+        // own flag.
+        let target = party [ level TypeAttributes.NotPublic "T" ] "TargetAsm" [] []
+        let accessor = party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] []
+
+        AccessCheck.canAccessMethod false accessor target MethodAttributes.Public
+        |> shouldEqual false
+
+    [<Test>]
+    let ``canAccessMethod: Public method on NotPublic class with IVT yields true`` () : unit =
+        let target =
+            party [ level TypeAttributes.NotPublic "T" ] "TargetAsm" [ "AccessorAsm" ] []
+
+        let accessor = party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] []
+
+        AccessCheck.canAccessMethod false accessor target MethodAttributes.Public
+        |> shouldEqual true
+
+    // ----- canAccessMethod: loud failures -----
+
+    [<Test>]
+    let ``canAccessMethod: Private raises with diagnostic`` () : unit =
+        let target = party [ level TypeAttributes.Public "T" ] "TargetAsm" [] []
+        let accessor = party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] []
+
+        let ex =
+            Assert.Throws (fun () ->
+                AccessCheck.canAccessMethod false accessor target MethodAttributes.Private
+                |> ignore
+            )
+
+        ex.Message |> shouldContainText "Private"
+
+    [<Test>]
+    let ``canAccessMethod: Family raises with diagnostic`` () : unit =
+        let target = party [ level TypeAttributes.Public "T" ] "TargetAsm" [] []
+        let accessor = party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] []
+
+        let ex =
+            Assert.Throws (fun () ->
+                AccessCheck.canAccessMethod false accessor target MethodAttributes.Family
+                |> ignore
+            )
+
+        ex.Message |> shouldContainText "family"
+
+    [<Test>]
+    let ``canAccessMethod: FamORAssem raises with diagnostic`` () : unit =
+        let target = party [ level TypeAttributes.Public "T" ] "TargetAsm" [] []
+        let accessor = party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] []
+
+        let ex =
+            Assert.Throws (fun () ->
+                AccessCheck.canAccessMethod false accessor target MethodAttributes.FamORAssem
+                |> ignore
+            )
+
+        ex.Message |> shouldContainText "family"
+
+    [<Test>]
+    let ``canAccessMethod: FamANDAssem raises with diagnostic`` () : unit =
+        let target = party [ level TypeAttributes.Public "T" ] "TargetAsm" [] []
+        let accessor = party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] []
+
+        let ex =
+            Assert.Throws (fun () ->
+                AccessCheck.canAccessMethod false accessor target MethodAttributes.FamANDAssem
+                |> ignore
+            )
+
+        ex.Message |> shouldContainText "family"
+
+    [<Test>]
+    let ``canAccessMethod: PrivateScope raises with diagnostic`` () : unit =
+        let target = party [ level TypeAttributes.Public "T" ] "TargetAsm" [] []
+        let accessor = party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] []
+
+        let ex =
+            Assert.Throws (fun () ->
+                AccessCheck.canAccessMethod false accessor target MethodAttributes.PrivateScope
+                |> ignore
+            )
+
+        ex.Message |> shouldContainText "PrivateScope"
+
+    [<Test>]
+    let ``canAccessMethod: inaccessible class short-circuits before raising on private member`` () : unit =
+        // If the target class is itself inaccessible cross-assembly, the
+        // class check fails first and we never reach the unimplemented
+        // member-visibility branch. This means callers paying a loud-fail
+        // tax only see it when access would otherwise have been granted by
+        // the class check.
+        let target = party [ level TypeAttributes.NotPublic "T" ] "TargetAsm" [] []
+        let accessor = party [ level TypeAttributes.Public "A" ] "AccessorAsm" [] []
+
+        AccessCheck.canAccessMethod false accessor target MethodAttributes.Private
+        |> shouldEqual false

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="TestAssemblyReadCache.fs" />
     <Compile Include="TestCustomAttributeBlob.fs" />
     <Compile Include="TestFriendAssemblies.fs" />
+    <Compile Include="TestAccessCheck.fs" />
     <Compile Include="RealRuntime.fs" />
     <Compile Include="TestHarness.fs"/>
     <Compile Include="CrossAssemblyHarness.fs" />


### PR DESCRIPTION
## Summary

Third slice of the `IsCAVisibleFromDecoratedType` plumbing. Ports the subset of CoreCLR's `ClassLoader::CanAccess` family that the QCall actually exercises.

- **`canAccessClass`**: walks a target type's nesting chain. Each level's `TypeAttributes` visibility decides whether that level is reachable: `Public` / `NestedPublic` unconditionally, `NotPublic` / `NestedAssembly` via `assemblyOrFriendAccessAllowed`.
- **`canAccessMethod`**: combines `canAccessClass` on the declaring type with a `MethodAttributes` member-access check; `Public` unconditional, `Assembly` via `assemblyOrFriendAccessAllowed`.
- **`assemblyOrFriendAccessAllowed` (private)**: same-assembly OR accessor's `IgnoresAccessChecksTo` names the target OR target's `InternalsVisibleTo` names the accessor (delegating to `FriendAssemblyName.matchesDef` from #540).

Family-style flags and `Private` / `PrivateScope` / `NestedPrivate` raise `failwith` with a diagnostic identifying the flag and the type/method. Porting these would require CoreCLR's `CanAccessFamily` (subclass walk) plus chain-equality logic that this slice does not introduce; the loud failure ensures a future caller relying on these flags hits a clear error rather than a wrong boolean.

`sameAssembly` is a `bool` input pre-computed by the caller rather than derived from `AssemblyName` comparison — the eventual caller in slice 4 lives in `IlMachineState` and already knows the answer from its own assembly indexes. AccessCheck consumes its own minimal `AccessLevelInfo` / `AccessParty` records rather than `TypeInfo<_>` so it stays decoupled from the broader generic type-info surface (functional core, dependency rejection).

## Test plan

- [x] 29 new unit tests in `TestAccessCheck.fs` covering each handled visibility flag, each loud-fail flag (with diagnostic-content assertions), nested-chain interactions, IVT/IgnoresAccessChecksTo positive and negative cases, and class-check-short-circuits-loud-fail
- [x] `nix develop -c dotnet build WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj`
- [x] `nix develop -c dotnet test ... --filter "FullyQualifiedName~TestAccessCheck"` (29 pass)
- [x] `codex review --base main` returned no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)