### PR TITLE
Intercept System.Numerics.Vector.get_IsHardwareAccelerated

### DIFF
--- a/WoofWare.PawPrint.Test/TestHardwareIntrinsicsProfile.fs
+++ b/WoofWare.PawPrint.Test/TestHardwareIntrinsicsProfile.fs
@@ -89,6 +89,25 @@ class Program
         |> shouldEqual 0
 
     [<Test>]
+    let ``Default virtual hardware profile reports System.Numerics.Vector unavailable`` () : unit =
+        let source =
+            """
+using System.Numerics;
+
+class Program
+{
+    static int Main(string[] args)
+    {
+        return Vector.IsHardwareAccelerated ? 1 : 0;
+    }
+}
+"""
+
+        runSource "NumericsVectorIsHardwareAccelerated.cs" source
+        |> exitCodeOfRunOutcome
+        |> shouldEqual 0
+
+    [<Test>]
     let ``Scalar-only profile reports Arm Rdm unavailable`` () : unit =
         let source =
             """

--- a/WoofWare.PawPrint/IntrinsicHelpers.fs
+++ b/WoofWare.PawPrint/IntrinsicHelpers.fs
@@ -397,6 +397,11 @@ module internal IntrinsicHelpers =
         | "Vector128" -> profile.Vector128
         | "Vector256" -> profile.Vector256
         | "Vector512" -> profile.Vector512
+        // System.Numerics.Vector.IsHardwareAccelerated is the JIT capability query for the
+        // non-generic numerics helper (and is the value Vector<T>.IsHardwareAccelerated forwards
+        // to via its static interface impl). CoreCLR reports it true iff the JIT can accelerate
+        // at least 128-bit SIMD, so it shares the Vector128 bit on PawPrint's profile.
+        | "Vector" -> profile.Vector128
         | other -> failwith $"Unexpected vector intrinsic type name: %s{other}"
 
     // PawPrint emulates a deterministic scalar virtual CPU: every hardware-intrinsic

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -110,10 +110,17 @@ module Intrinsics =
             isSpanHelpersByteSequenceEqual state methodToCall
             ->
             spanHelpersSequenceEqual baseClassTypes currentThread methodToCall state |> Some
-        | "System.Private.CoreLib", ("Vector128" | "Vector256" | "Vector512"), "get_IsHardwareAccelerated" ->
-            // System.Runtime.Intrinsics.Vector{128,256,512}.IsHardwareAccelerated are JIT
-            // intrinsic capability queries. PawPrint models a deterministic virtual CPU profile;
-            // the default scalar-only profile reports them unavailable without consulting the host.
+        | "System.Private.CoreLib", ("Vector128" | "Vector256" | "Vector512"), "get_IsHardwareAccelerated"
+        | "System.Private.CoreLib", "Vector", "get_IsHardwareAccelerated" when
+            // System.Runtime.Intrinsics.Vector{128,256,512}.IsHardwareAccelerated and
+            // System.Numerics.Vector.IsHardwareAccelerated are JIT intrinsic capability queries
+            // whose IL bodies are recursive self-calls the JIT replaces with a constant. PawPrint
+            // models a deterministic virtual CPU profile; the default scalar-only profile reports
+            // them unavailable without consulting the host. The fully-qualified-name guard on the
+            // "Vector" arm rejects any unrelated CoreLib type that happens to share the short name.
+            methodToCall.DeclaringType.Name <> "Vector"
+            || intrinsicKey.DeclaringTypeFullName = "System.Numerics.Vector"
+            ->
             match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
             | [], MethodReturnType.Returns (ConcreteBool state.ConcreteTypes) -> ()
             | _ ->


### PR DESCRIPTION
## Summary

- `System.Numerics.Vector.get_IsHardwareAccelerated` is a JIT intrinsic whose managed body is the self-recursive stub `get => IsHardwareAccelerated;` (see [Vector.cs:20-24](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector.cs#L20-L24)). Without explicit interception PawPrint stack-overflows on first use, just as it would for the sibling `Vector128/256/512` getters that we already intercept.
- Extend the existing intrinsic match arm to also handle declaring type `Vector`, guarded on the fully qualified name `System.Numerics.Vector` so we don't misfire on any unrelated CoreLib type sharing the short name.
- Route the result through `vectorAccelerationAvailable` keyed on `"Vector"`, which maps to `profile.Vector128`. CoreCLR sets `Vector.IsHardwareAccelerated` true iff the JIT can accelerate at least 128-bit SIMD, so reusing the existing `Vector128` bit on `HardwareIntrinsicsProfile` is semantically faithful and keeps the scalar-only default at `false`.

## Test plan

- [x] New test ``Default virtual hardware profile reports System.Numerics.Vector unavailable`` in `TestHardwareIntrinsicsProfile.fs` covers the new path.
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --filter "Name~HardwareIntrinsicsProfile"` — 8/8 pass.
- [x] Full suite: `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 910/910 pass.
- [x] `nix develop -c dotnet fantomas .` — no further diff.
- [x] `codex review --base main` — no actionable findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)