### PR TITLE
Implement managed Monitor.Wait/Pulse/PulseAll on SyncBlocks

### DIFF
--- a/WoofWare.PawPrint.App/DebuggerServer.fs
+++ b/WoofWare.PawPrint.App/DebuggerServer.fs
@@ -99,6 +99,11 @@ module DebuggerServer =
             writer.WriteString ("kind", "blockedOnSyncBlockAcquire")
             writer.WriteNumber ("lockObject", heapAddressValue lockObject)
             writer.WriteEndObject ()
+        | ThreadStatus.BlockedOnSyncBlockWait lockObject ->
+            writer.WriteStartObject ()
+            writer.WriteString ("kind", "blockedOnSyncBlockWait")
+            writer.WriteNumber ("lockObject", heapAddressValue lockObject)
+            writer.WriteEndObject ()
         | ThreadStatus.Terminated -> writer.WriteStringValue "terminated"
 
     let private writeFrameProperties

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -92,6 +92,7 @@ module TestPureCases =
             "BasicLock.cs", 1
             "MonitorEnterRefBool.cs", 1
             "ContendedMonitorEnter.cs", 99
+            "MonitorPulseWait.cs", 42
             "ExceptionWithNoOpFinally.cs", 3
             "ExceptionWithNoOpCatch.cs", 10
             "Threads.cs", 3

--- a/WoofWare.PawPrint.Test/sourcesPure/MonitorPulseWait.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/MonitorPulseWait.cs
@@ -1,0 +1,34 @@
+using System.Threading;
+
+namespace HelloWorldApp
+{
+    class Program
+    {
+        static object locker = new object();
+        static int produced = 0;
+
+        static void Worker()
+        {
+            lock (locker)
+            {
+                produced = 42;
+                Monitor.Pulse(locker);
+            }
+        }
+
+        static int Main(string[] args)
+        {
+            Thread t = new Thread(Worker);
+            lock (locker)
+            {
+                t.Start();
+                while (produced == 0)
+                {
+                    Monitor.Wait(locker);
+                }
+            }
+            t.Join();
+            return produced;
+        }
+    }
+}

--- a/WoofWare.PawPrint/EmulatedKernel.fs
+++ b/WoofWare.PawPrint/EmulatedKernel.fs
@@ -84,6 +84,43 @@ type SpuriousWakeupStrategy =
     /// underneath them changes.
     | Scripted of wakeups : (int64 * LowLevelMonitorId * ThreadId) list
 
+/// Parallel to `SpuriousWakeupStrategy`, but governs spurious wakeups out of
+/// the managed `Monitor.Wait` (i.e. the SyncBlock-backed condition variable)
+/// rather than the `LowLevelMonitor` primitive. CoreCLR's `Monitor.Wait` is
+/// permitted to return without a matching `Pulse` / `PulseAll`, which is why
+/// the documented usage pattern always wraps `Wait` in a predicate loop.
+/// This type is the deterministic knob for forcing those wakeups in PawPrint.
+///
+/// Kept structurally parallel-but-separate from `SpuriousWakeupStrategy` so
+/// a guest's LowLevelMonitor-level fuzz schedule and its SyncBlock-level
+/// schedule are independent dials: a single strategy covering both would
+/// either be hard to script (per-tick wakeups tagged by which queue family
+/// they target) or coarsely tied together (any waiter is fair game on a
+/// given tick), neither of which the user wants when they're trying to
+/// reproduce a specific managed-Monitor bug without disturbing the
+/// LowLevelMonitor schedule.
+[<RequireQualifiedAccess>]
+type SyncBlockSpuriousWakeupStrategy =
+    /// Default. Only `Pulse` / `PulseAll` wakes a waiter. Equivalent to a
+    /// `SyncBlock` implementation that never wakes spuriously: permitted by
+    /// the BCL contract but masks predicate-loop bugs.
+    | Disabled
+    /// Wake every waiter on every scheduler tick. Maximum fuzz pressure.
+    /// Guest code that uses `Monitor.Wait` outside a re-checking predicate
+    /// loop will produce wrong results — that is the point.
+    | AlwaysAll
+    /// Each (tick, lockObject, waiter) tuple wakes independently with the
+    /// given probability. Coin flip is deterministic over
+    /// `(seed, tick, lockObject, threadId)`. `probability` is rejected at
+    /// apply time if NaN or outside `[0.0, 1.0]`.
+    | Random of seed : uint64 * probability : float
+    /// Explicit `(tick, lockObject, threadId)` triples. Fully replayable.
+    /// A triple naming a thread not currently in the named SyncBlock's
+    /// `WaitQueue` at the named tick fails loudly — silent skip would let
+    /// scripts drift unnoticed when the interleaving underneath them
+    /// changes.
+    | Scripted of wakeups : (int64 * ManagedHeapAddress * ThreadId) list
+
 /// Aggregates the slice of `IlMachineState` that models host-kernel /
 /// syscall-emulation state: process-wide last-error registers, the native
 /// heap pool backing `Marshal.AllocHGlobal`, the Unix file-descriptor table,
@@ -145,6 +182,12 @@ type EmulatedKernel =
         /// via record-copy in tests) to inject wakeups for fuzz /
         /// correctness testing of guest condition-variable code.
         SpuriousWakeup : SpuriousWakeupStrategy
+        /// Deterministic strategy governing spurious wakeups out of the
+        /// managed `Monitor.Wait` (SyncBlock-backed condition variable).
+        /// Parallel-but-independent of `SpuriousWakeup` so a guest can fuzz
+        /// the two condvar primitives separately. Defaults to `Disabled` so
+        /// existing runs are bit-for-bit unchanged.
+        SyncBlockSpuriousWakeup : SyncBlockSpuriousWakeupStrategy
         /// Monotonically-advancing scheduler tick consumed by
         /// `SpuriousWakeupStrategy`. The driver loop applies the strategy
         /// against the current value and then increments by 1 before
@@ -236,6 +279,7 @@ module EmulatedKernel =
             NextLowLevelMonitorId = 1
             NextEventPipeId = 1L
             SpuriousWakeup = SpuriousWakeupStrategy.Disabled
+            SyncBlockSpuriousWakeup = SyncBlockSpuriousWakeupStrategy.Disabled
             StepCounter = 0L
             NonCryptoRandomState = NonCryptoRandom.initialState
         }

--- a/WoofWare.PawPrint/ExternImplementations/System.Threading.Monitor.fs
+++ b/WoofWare.PawPrint/ExternImplementations/System.Threading.Monitor.fs
@@ -17,27 +17,50 @@ module System_Threading_Monitor =
         |> IlMachineState.loadArgument currentThread argIndex
         |> IlMachineState.popEvalStack currentThread
 
-    /// Park `thread` at the FIFO tail of `addr`'s AcquireQueue and flip its status
-    /// to `BlockedOnSyncBlockAcquire`. Assumes `addr`'s SyncBlock is `Locked` by
-    /// some other thread (the caller has already checked self-vs-other). When the
-    /// owner's `Monitor.Exit` decrements the reentrancy count to zero, ownership
-    /// is handed directly to the FIFO head and the head flips back to `Runnable`
-    /// already holding the lock — mirroring `LowLevelMonitor`'s ownership-transfer
-    /// model so the IL after the `Enter` call site is correctly held.
+    /// Write back a SyncBlock whose `Lock` portion is freshly held by `owner`
+    /// at `depth`, preserving the existing `WaitQueue` and accepting a fresh
+    /// `AcquireQueue`. Used by the ownership-transfer paths in `Exit_FastPath`
+    /// (and re-used by `SyncBlockMonitor.pulse` indirectly via the same shape).
+    let private writeHeld
+        (addr : ManagedHeapAddress)
+        (waitQueue : (ThreadId * int) list)
+        (locked : LockedSyncBlock)
+        (state : IlMachineState)
+        : IlMachineState
+        =
+        IlMachineState.setSyncBlock
+            addr
+            {
+                Lock = SyncBlockLock.Held locked
+                WaitQueue = waitQueue
+            }
+            state
+
+    /// Park `thread` at the FIFO tail of `addr`'s AcquireQueue as a fresh entrant
+    /// (`None` snapshot — first `Enter` since `Free`, or a thread resumed from
+    /// `Monitor.Wait` would supply `Some prior-depth` via `SyncBlockMonitor.pulse`).
+    /// Flips status to `BlockedOnSyncBlockAcquire`. Assumes `addr`'s SyncBlock is
+    /// `Held` by some other thread (the caller has already checked self-vs-other).
+    /// When the owner's `Monitor.Exit` decrements the reentrancy count to zero,
+    /// ownership is handed directly to the FIFO head and the head flips back to
+    /// `Runnable` already holding the lock — mirroring `LowLevelMonitor`'s
+    /// ownership-transfer model so the IL after the `Enter` call site is correctly
+    /// held.
     let private parkOnAcquireQueue
         (addr : ManagedHeapAddress)
         (thread : ThreadId)
+        (block : SyncBlock)
         (locked : LockedSyncBlock)
         (state : IlMachineState)
         : IlMachineState
         =
         let locked =
             { locked with
-                AcquireQueue = locked.AcquireQueue @ [ thread ]
+                AcquireQueue = locked.AcquireQueue @ [ (thread, None) ]
             }
 
         state
-        |> IlMachineState.setSyncBlock addr (SyncBlock.Locked locked)
+        |> writeHeld addr block.WaitQueue locked
         |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnSyncBlockAcquire addr)
 
     /// .NET 10 InternalCall: Monitor.TryEnter_FastPath(obj) -> bool.
@@ -61,26 +84,26 @@ module System_Threading_Monitor =
             match IlMachineState.evalStackValueToObjectRef baseClassTypes state lockObj with
             | None -> failwith "TODO: Monitor.TryEnter_FastPath should throw ArgumentNullException for null obj"
             | Some addr ->
-                match IlMachineState.getSyncBlock addr state with
-                | SyncBlock.Free ->
-                    IlMachineState.setSyncBlock
-                        addr
-                        (SyncBlock.Locked
-                            {
-                                LockingThread = currentThread
-                                ReentrancyCount = 1
-                                AcquireQueue = []
-                            })
-                        state
-                | SyncBlock.Locked locked ->
+                let block = IlMachineState.getSyncBlock addr state
+
+                match block.Lock with
+                | SyncBlockLock.Free ->
+                    let locked =
+                        {
+                            LockingThread = currentThread
+                            ReentrancyCount = 1
+                            AcquireQueue = []
+                        }
+
+                    writeHeld addr block.WaitQueue locked state
+                | SyncBlockLock.Held locked ->
                     if locked.LockingThread = currentThread then
-                        IlMachineState.setSyncBlock
-                            addr
-                            (SyncBlock.Locked
-                                { locked with
-                                    ReentrancyCount = locked.ReentrancyCount + 1
-                                })
-                            state
+                        let locked =
+                            { locked with
+                                ReentrancyCount = locked.ReentrancyCount + 1
+                            }
+
+                        writeHeld addr block.WaitQueue locked state
                     else
                         // Locked by another thread: park at the FIFO tail of the AcquireQueue.
                         // When ownership is transferred to us by the owner's Exit, the resumed
@@ -88,7 +111,7 @@ module System_Threading_Monitor =
                         // BCL's `if (!TryEnter_FastPath(obj)) Enter_Slowpath(obj)` skips the
                         // Slowpath. This collapses Monitor.Enter's blocking semantics into the
                         // fast-path handler — PawPrint never needs the Enter_Slowpath QCall.
-                        parkOnAcquireQueue addr currentThread locked state
+                        parkOnAcquireQueue addr currentThread block locked state
 
         let state = IlMachineState.pushToEvalStack (CliType.ofBool true) currentThread state
 
@@ -124,31 +147,27 @@ module System_Threading_Monitor =
             | None ->
                 failwith "TODO: Monitor.TryEnter_FastPath_WithTimeout should throw ArgumentNullException for null obj"
             | Some addr ->
-                match IlMachineState.getSyncBlock addr state with
-                | SyncBlock.Free ->
-                    let state =
-                        IlMachineState.setSyncBlock
-                            addr
-                            (SyncBlock.Locked
-                                {
-                                    LockingThread = currentThread
-                                    ReentrancyCount = 1
-                                    AcquireQueue = []
-                                })
-                            state
+                let block = IlMachineState.getSyncBlock addr state
 
+                match block.Lock with
+                | SyncBlockLock.Free ->
+                    let locked =
+                        {
+                            LockingThread = currentThread
+                            ReentrancyCount = 1
+                            AcquireQueue = []
+                        }
+
+                    let state = writeHeld addr block.WaitQueue locked state
                     1, state
-                | SyncBlock.Locked locked ->
+                | SyncBlockLock.Held locked ->
                     if locked.LockingThread = currentThread then
-                        let state =
-                            IlMachineState.setSyncBlock
-                                addr
-                                (SyncBlock.Locked
-                                    { locked with
-                                        ReentrancyCount = locked.ReentrancyCount + 1
-                                    })
-                                state
+                        let locked =
+                            { locked with
+                                ReentrancyCount = locked.ReentrancyCount + 1
+                            }
 
+                        let state = writeHeld addr block.WaitQueue locked state
                         1, state
                     elif timeout = 0 then
                         // Non-blocking poll: report contention without waiting.
@@ -157,7 +176,7 @@ module System_Threading_Monitor =
                         // Blocking acquire: park at the FIFO tail and push "Entered" —
                         // when the scheduler resumes us, ownership has been transferred
                         // and the IL pointer is already past this call site.
-                        let state = parkOnAcquireQueue addr currentThread locked state
+                        let state = parkOnAcquireQueue addr currentThread block locked state
                         1, state
                     else
                         // Finite non-zero timeout would require a virtual clock to honour;
@@ -185,9 +204,9 @@ module System_Threading_Monitor =
             match IlMachineState.evalStackValueToObjectRef baseClassTypes state lockObj with
             | None -> failwith "TODO: Monitor.IsEnteredNative should throw ArgumentNullException for null obj"
             | Some addr ->
-                match IlMachineState.getSyncBlock addr state with
-                | SyncBlock.Free -> false
-                | SyncBlock.Locked locked -> locked.LockingThread = currentThread
+                match (IlMachineState.getSyncBlock addr state).Lock with
+                | SyncBlockLock.Free -> false
+                | SyncBlockLock.Held locked -> locked.LockingThread = currentThread
 
         let state =
             IlMachineState.pushToEvalStack (CliType.ofBool result) currentThread state
@@ -202,9 +221,13 @@ module System_Threading_Monitor =
     ///
     /// When the final `Exit` releases the lock and the `AcquireQueue` is non-empty, ownership
     /// is transferred directly to the FIFO head: that thread's status flips back to `Runnable`
-    /// already holding the lock with a fresh `ReentrancyCount = 1`. Mirrors `LowLevelMonitor`'s
-    /// ownership-transfer model — the woken thread's IL resumes past `Enter` already owning
-    /// the lock, which is what the BCL contract requires.
+    /// already holding the lock with `ReentrancyCount = 1` for fresh entrants (`None`
+    /// snapshot) or with its prior depth restored (`Some depth` snapshot, set when the head
+    /// was woken from `Monitor.Wait`). Mirrors `LowLevelMonitor`'s ownership-transfer model.
+    /// `WaitQueue` is preserved across every transition: waiters do not contend for the lock
+    /// until `Pulse` / `PulseAll` moves them onto `AcquireQueue`, and a fully-released lock
+    /// with a non-empty wait queue is a legitimate state (the SyncBlock stays present, just
+    /// with `Lock = Free`).
     let Exit_FastPath
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (currentThread : ThreadId)
@@ -217,36 +240,49 @@ module System_Threading_Monitor =
             match IlMachineState.evalStackValueToObjectRef baseClassTypes state lockObj with
             | None -> failwith "TODO: Monitor.Exit_FastPath should throw ArgumentNullException for null obj"
             | Some addr ->
-                match IlMachineState.getSyncBlock addr state with
-                | SyncBlock.Free ->
+                let block = IlMachineState.getSyncBlock addr state
+
+                match block.Lock with
+                | SyncBlockLock.Free ->
                     failwith "TODO: Monitor.Exit_FastPath on a Free SyncBlock should throw SynchronizationLockException"
-                | SyncBlock.Locked locked ->
+                | SyncBlockLock.Held locked ->
                     if locked.LockingThread <> currentThread then
                         failwith
                             "TODO: Monitor.Exit_FastPath by a non-owning thread should throw SynchronizationLockException"
                     elif locked.ReentrancyCount > 1 then
-                        IlMachineState.setSyncBlock
-                            addr
-                            (SyncBlock.Locked
-                                { locked with
-                                    ReentrancyCount = locked.ReentrancyCount - 1
-                                })
-                            state
+                        let locked =
+                            { locked with
+                                ReentrancyCount = locked.ReentrancyCount - 1
+                            }
+
+                        writeHeld addr block.WaitQueue locked state
                     else
-                        // Last release. If anyone is queued, ownership transfers atomically
-                        // to the FIFO head; otherwise the block returns to Free.
+                        // Last release. If anyone is queued for Enter, ownership transfers atomically
+                        // to the FIFO head; otherwise the lock becomes Free (but the SyncBlock
+                        // record persists so the WaitQueue is preserved across the transition).
                         match locked.AcquireQueue with
-                        | [] -> IlMachineState.setSyncBlock addr SyncBlock.Free state
-                        | nextOwner :: rest ->
-                            state
-                            |> IlMachineState.setSyncBlock
+                        | [] ->
+                            IlMachineState.setSyncBlock
                                 addr
-                                (SyncBlock.Locked
-                                    {
-                                        LockingThread = nextOwner
-                                        ReentrancyCount = 1
-                                        AcquireQueue = rest
-                                    })
+                                {
+                                    Lock = SyncBlockLock.Free
+                                    WaitQueue = block.WaitQueue
+                                }
+                                state
+                        | (nextOwner, snapshot) :: rest ->
+                            // `None` snapshot = fresh entrant from Monitor.Enter (ReentrancyCount = 1).
+                            // `Some depth` = waiter resumed from Monitor.Wait, restored to its prior depth.
+                            let restoredDepth = snapshot |> Option.defaultValue 1
+
+                            let nextLocked =
+                                {
+                                    LockingThread = nextOwner
+                                    ReentrancyCount = restoredDepth
+                                    AcquireQueue = rest
+                                }
+
+                            state
+                            |> writeHeld addr block.WaitQueue nextLocked
                             |> Scheduler.setThreadStatus nextOwner ThreadStatus.Runnable
 
         // LeaveHelperAction.None = 0 — caller's IL takes the early Ret branch.

--- a/WoofWare.PawPrint/IlMachineThreadState.fs
+++ b/WoofWare.PawPrint/IlMachineThreadState.fs
@@ -444,7 +444,7 @@ module IlMachineThreadState =
             {
                 Contents = fields
                 ConcreteType = ty
-                SyncBlock = SyncBlock.Free
+                SyncBlock = SyncBlock.Empty
             }
 
         let alloc, heap = state.ManagedHeap |> ManagedHeap.allocateNonArray o

--- a/WoofWare.PawPrint/ManagedHeap.fs
+++ b/WoofWare.PawPrint/ManagedHeap.fs
@@ -2,12 +2,25 @@ namespace WoofWare.PawPrint
 
 open System.Collections.Immutable
 
-/// State carried by a `Locked` SyncBlock. `AcquireQueue` is the FIFO list of
-/// threads parked in `BlockedOnSyncBlockAcquire` waiting for ownership to be
-/// transferred to them when `LockingThread` calls `Monitor.Exit`. FIFO order
-/// is load-bearing for fairness: switching to LIFO or arbitrary order would
-/// change the observable interleaving for guests that race multiple threads
-/// into the same `lock` block.
+/// State carried when an object's monitor is `Held` by some thread.
+/// `AcquireQueue` is the FIFO list of (thread, optional re-entry depth) pairs
+/// parked in `BlockedOnSyncBlockAcquire` waiting for ownership to be transferred
+/// to them when `LockingThread` calls `Monitor.Exit`. FIFO order is load-bearing
+/// for fairness: switching to LIFO or arbitrary order would change the
+/// observable interleaving for guests that race multiple threads into the same
+/// `lock` block.
+///
+/// The `int option` snapshot on each `AcquireQueue` entry distinguishes the
+/// two flavours of waiter:
+///   * `None` — a fresh entrant from `Monitor.Enter`. On ownership transfer it
+///     becomes the new owner with `ReentrancyCount = 1`.
+///   * `Some depth` — a waiter that was woken from `Monitor.Wait` by
+///     `Monitor.Pulse` / `PulseAll` (or a spurious wake). `Wait` snapshots its
+///     prior `ReentrancyCount` so that on re-acquire the depth it had before
+///     parking is restored verbatim. Storing the depth inline next to the
+///     thread keeps the "what's waiting and what depth do they need" coupling
+///     visible at every read site; a separate map would let a transition lose
+///     the pairing silently.
 ///
 /// `ReentrancyCount` is the depth of nested `Monitor.Enter` calls by
 /// `LockingThread` and must reach exactly zero before ownership can transfer.
@@ -15,12 +28,38 @@ type LockedSyncBlock =
     {
         LockingThread : ThreadId
         ReentrancyCount : int
-        AcquireQueue : ThreadId list
+        AcquireQueue : (ThreadId * int option) list
     }
 
-type SyncBlock =
+/// Ownership state of an object's monitor — distinct from its `WaitQueue`
+/// because `Monitor.Wait` fully releases the lock (`Free`) while leaving its
+/// caller parked in the SyncBlock's `WaitQueue`.
+type SyncBlockLock =
     | Free
-    | Locked of LockedSyncBlock
+    | Held of LockedSyncBlock
+
+/// Per-object monitor metadata. `Lock` describes ownership and FIFO of
+/// `Monitor.Enter` contenders. `WaitQueue` is the FIFO list of (thread,
+/// snapshot depth) pairs currently parked in `BlockedOnSyncBlockWait` from a
+/// `Monitor.Wait` call; they do NOT contend for the lock until a `Pulse` /
+/// `PulseAll` moves them onto `AcquireQueue` (FIFO tail), at which point they
+/// re-enter via the normal ownership-transfer path. The two fields are
+/// orthogonal: a non-empty `WaitQueue` can coexist with `Lock = Free` (the
+/// owner called `Wait`, releasing the lock, but the waiter is still parked).
+/// Pulse on an empty wait queue is a documented no-op (matches CoreCLR's
+/// `SyncBlock`).
+type SyncBlock =
+    {
+        Lock : SyncBlockLock
+        WaitQueue : (ThreadId * int) list
+    }
+
+    /// Initial state for a freshly-allocated object: lock free, no waiters.
+    static member Empty : SyncBlock =
+        {
+            Lock = SyncBlockLock.Free
+            WaitQueue = []
+        }
 
 type AllocatedNonArrayObject =
     {

--- a/WoofWare.PawPrint/Native/NativeMonitor.fs
+++ b/WoofWare.PawPrint/Native/NativeMonitor.fs
@@ -60,3 +60,135 @@ module NativeMonitor =
             System_Threading_Monitor.IsEnteredNative ctx.BaseClassTypes ctx.Thread state
             |> Some
         | _ -> None
+
+    /// Decode the ManagedHeapAddress carried by an `ObjectHandleOnStack` QCall
+    /// argument. Fails loud if the handle points at a null reference or anything
+    /// other than an object ref.
+    let private addressFromObjectHandle
+        (operation : string)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (arg : CliType)
+        : ManagedHeapAddress
+        =
+        let ptr = NativeCall.objectHandleOnStackTarget operation state "obj" arg
+
+        let value = IlMachineState.readManagedByref baseClassTypes state ptr
+
+        match value with
+        | CliType.ObjectRef (Some addr) -> addr
+        | CliType.ObjectRef None -> failwith $"%s{operation}: ObjectHandleOnStack pointed to a null object reference"
+        | other -> failwith $"%s{operation}: expected ObjectRef in ObjectHandleOnStack, got %O{other}"
+
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
+        let state = ctx.State
+        let instruction = ctx.Instruction
+
+        match
+            entryPoint,
+            ctx.TargetAssembly.Name.Name,
+            ctx.TargetType.Namespace,
+            ctx.TargetType.Name,
+            instruction.ExecutingMethod.Name,
+            instruction.ExecutingMethod.Signature.ParameterTypes,
+            instruction.ExecutingMethod.Signature.ReturnType
+        with
+        | "Monitor_Wait",
+          "System.Private.CoreLib",
+          "System.Threading",
+          "Monitor",
+          _,
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "ObjectHandleOnStack",
+                                              objectHandleGenerics)
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32 ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) when
+            objectHandleGenerics.IsEmpty
+            ->
+            // .NET 10 QCall: Monitor.Wait(ObjectHandleOnStack obj, int millisecondsTimeout) -> bool.
+            // Caller has already null-checked `obj` and clamped `timeout >= -1` in the managed
+            // wrapper. The return bool is `true` if a Pulse/PulseAll signalled us, `false` on
+            // timeout. We have no virtual clock, so finite non-zero timeouts fail loud; only
+            // -1 (Infinite) is supported. We always push `true` because in PawPrint a waiter
+            // can only be woken by a Pulse/PulseAll/spurious wake — never by a timeout.
+            let operation = "Monitor_Wait"
+
+            if instruction.Arguments.Length <> 2 then
+                failwith $"%s{operation}: expected two native arguments, got %d{instruction.Arguments.Length}"
+
+            let addr =
+                addressFromObjectHandle operation ctx.BaseClassTypes state instruction.Arguments.[0]
+
+            let timeout =
+                match instruction.Arguments.[1] |> CliType.unwrapPrimitiveLike with
+                | CliType.Numeric (CliNumericType.Int32 i) -> i
+                | other -> failwith $"%s{operation}: expected int32 timeout, got %O{other}"
+
+            if timeout <> System.Threading.Timeout.Infinite then
+                // CoreCLR honours finite timeouts; PawPrint has no virtual clock yet. Silently
+                // treating finite timeouts as Infinite would hide guest bugs that depend on
+                // timeout-based wakeups. Same envelope as `LowLevelMonitor.timedWait` and
+                // `TryEnter_FastPath_WithTimeout`.
+                failwith
+                    $"TODO: Monitor_Wait with non-Infinite timeout %d{timeout}ms requires a virtual clock; not yet implemented"
+
+            let state = SyncBlockMonitor.wait ctx.Thread addr state
+
+            // LibraryImport's `[return: MarshalAs(UnmanagedType.Bool)]` produces a 4-byte BOOL
+            // in the PInvoke signature, so the QCall returns int32 (not the managed bool ABI).
+            // Push 1: when the scheduler resumes this thread, the IL pointer is already past
+            // this call site and the return value is consumed by the caller as "signal received".
+            // Spurious wakeups also return 1 (matches CoreCLR's contract: spurious wakeups are
+            // documented; the boolean return is `signalReceived`, which is `true` for any
+            // non-timeout exit).
+            let state =
+                IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 1)) ctx.Thread state
+
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+
+        | "Monitor_Pulse",
+          "System.Private.CoreLib",
+          "System.Threading",
+          "Monitor",
+          _,
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "ObjectHandleOnStack",
+                                              objectHandleGenerics) ],
+          MethodReturnType.Void when objectHandleGenerics.IsEmpty ->
+            // .NET 10 QCall: Monitor.Pulse(ObjectHandleOnStack obj) -> void.
+            let operation = "Monitor_Pulse"
+
+            if instruction.Arguments.Length <> 1 then
+                failwith $"%s{operation}: expected one native argument, got %d{instruction.Arguments.Length}"
+
+            let addr =
+                addressFromObjectHandle operation ctx.BaseClassTypes state instruction.Arguments.[0]
+
+            let state = SyncBlockMonitor.pulse ctx.Thread addr state
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+
+        | "Monitor_PulseAll",
+          "System.Private.CoreLib",
+          "System.Threading",
+          "Monitor",
+          _,
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "ObjectHandleOnStack",
+                                              objectHandleGenerics) ],
+          MethodReturnType.Void when objectHandleGenerics.IsEmpty ->
+            // .NET 10 QCall: Monitor.PulseAll(ObjectHandleOnStack obj) -> void.
+            let operation = "Monitor_PulseAll"
+
+            if instruction.Arguments.Length <> 1 then
+                failwith $"%s{operation}: expected one native argument, got %d{instruction.Arguments.Length}"
+
+            let addr =
+                addressFromObjectHandle operation ctx.BaseClassTypes state instruction.Arguments.[0]
+
+            let state = SyncBlockMonitor.pulseAll ctx.Thread addr state
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+
+        | _ -> None

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -35,6 +35,9 @@ module NativeQCall =
             "ThreadNative_GetCurrentThread", NativeThreading.tryExecuteQCall "ThreadNative_GetCurrentThread"
             "ThreadNative_Initialize", NativeThreading.tryExecuteQCall "ThreadNative_Initialize"
             "ThreadNative_Join", NativeThreading.tryExecuteQCall "ThreadNative_Join"
+            "Monitor_Wait", NativeMonitor.tryExecuteQCall "Monitor_Wait"
+            "Monitor_Pulse", NativeMonitor.tryExecuteQCall "Monitor_Pulse"
+            "Monitor_PulseAll", NativeMonitor.tryExecuteQCall "Monitor_PulseAll"
             "DebugDebugger_IsManagedDebuggerAttached",
             NativeDebugger.tryExecuteQCall "DebugDebugger_IsManagedDebuggerAttached"
             "EventPipeInternal_Enable", NativeEventPipe.tryExecuteQCall "EventPipeInternal_Enable"

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -120,16 +120,23 @@ module Program =
         //     the oracle aligned. Environment.Exit from a worker still propagates as
         //     ProcessExit (handled below) before Main has a chance to return.
 
-        // Apply the spurious-wakeup strategy at the current tick, then
+        // Apply the spurious-wakeup strategies at the current tick, then
         // advance the counter so the next iteration sees a fresh tick.
-        // For the default (`Disabled`) strategy this is a fold over the
-        // identity and a single integer add — bit-for-bit identical to
-        // pre-feature behaviour.
+        // For the default (`Disabled`) strategy each application is a fold
+        // over the identity and a single integer add — bit-for-bit
+        // identical to pre-feature behaviour. The two layers (LowLevel and
+        // SyncBlock) are independent waiters on disjoint primitive types,
+        // so the order between them at a given tick is not load-bearing;
+        // we apply LowLevel first for parity with the pre-SyncBlock
+        // codepath.
         let state =
             LowLevelMonitor.applySpuriousWakeups
                 prepared.State.Kernel.SpuriousWakeup
                 prepared.State.Kernel.StepCounter
                 prepared.State
+
+        let state =
+            SyncBlockMonitor.applySpuriousWakeups state.Kernel.SyncBlockSpuriousWakeup state.Kernel.StepCounter state
 
         let prepared =
             { prepared with

--- a/WoofWare.PawPrint/Scheduler.fs
+++ b/WoofWare.PawPrint/Scheduler.fs
@@ -142,8 +142,8 @@ module Scheduler =
             state.ManagedHeap.NonArrayObjects
             |> Map.toSeq
             |> Seq.choose (fun (addr, obj) ->
-                match obj.SyncBlock with
-                | SyncBlock.Locked locked when locked.LockingThread = terminated -> Some (addr, locked)
+                match obj.SyncBlock.Lock with
+                | SyncBlockLock.Held locked when locked.LockingThread = terminated -> Some (addr, locked)
                 | _ -> None
             )
             |> Seq.toList

--- a/WoofWare.PawPrint/SyncBlockMonitor.fs
+++ b/WoofWare.PawPrint/SyncBlockMonitor.fs
@@ -1,0 +1,329 @@
+namespace WoofWare.PawPrint
+
+/// Deterministic state-machine for the `Monitor_Wait` / `Monitor_Pulse` /
+/// `Monitor_PulseAll` QCalls that back `System.Threading.Monitor`'s managed
+/// condition-variable surface. CoreCLR sits this on the `SyncBlock` /
+/// `AwareLock` / `CLREventBase` triple; we reproduce the observable semantics
+/// directly over `SyncBlock` (defined in `ManagedHeap.fs`) and three
+/// `ThreadStatus` cases (`Runnable`, `BlockedOnSyncBlockAcquire`,
+/// `BlockedOnSyncBlockWait`).
+///
+/// The module is pure: every transition is `IlMachineState -> IlMachineState`
+/// and never reads from a real clock, the host's mutex implementation, or any
+/// nondeterministic source. All ordering decisions are FIFO over the
+/// `AcquireQueue` / `WaitQueue`, which is load-bearing for fairness:
+/// deviating from FIFO changes the observable interleaving and is not a
+/// refactor.
+///
+/// Reentrancy: SyncBlocks ARE reentrant (unlike `LowLevelMonitor`).
+/// `Monitor.Wait` snapshots the caller's `ReentrancyCount`, fully releases
+/// the lock, parks the caller in `WaitQueue`, and — on subsequent wake-up
+/// via `Pulse` / `PulseAll` (or a spurious wake) — re-enters at the same
+/// snapshot depth via the `(ThreadId * int option) list` AcquireQueue: the
+/// `int option` carries the snapshot for resumed waiters and `None` for
+/// fresh `Monitor.Enter` entrants. `Exit_FastPath`'s ownership-transfer path
+/// reads the snapshot and restores the depth verbatim, so the IL after
+/// `Wait` resumes already owning the lock at the right depth.
+///
+/// Ownership transfer (same model as `LowLevelMonitor`): when `wait` gives
+/// up the lock and the AcquireQueue is non-empty, ownership is handed
+/// directly from the releaser to the FIFO head — the head's status flips to
+/// `Runnable` and its `ReentrancyCount` is set from the snapshot. The
+/// released thread does NOT briefly observe a free lock with a non-empty
+/// AcquireQueue; that intermediate state would mean the next thread resumes
+/// past its `Enter` site without owning the lock.
+///
+/// Pulse does NOT release the lock. The caller of `Monitor.Pulse` /
+/// `Monitor.PulseAll` keeps ownership; the woken waiter is moved to the
+/// AcquireQueue tail and only acquires when the current owner's eventual
+/// `Exit` transfers ownership to it (possibly after intervening fresh
+/// entrants). This mirrors CoreCLR exactly.
+///
+/// Spurious wakeups: injected from outside this module under control of
+/// `EmulatedKernel.SyncBlockSpuriousWakeup`. The transition is `spuriousWake`
+/// below; `applySpuriousWakeups` snapshots the wait-queue membership at entry
+/// and applies the strategy's wakeup list in deterministic order. Guest code
+/// that depends on the absence of spurious wakeups is incorrect against real
+/// CoreCLR; switching the strategy to `AlwaysAll` is the deterministic way
+/// to expose those bugs.
+[<RequireQualifiedAccess>]
+module SyncBlockMonitor =
+
+    /// Read the SyncBlock for `addr`, or fail loud. (The underlying heap
+    /// lookup raises if `addr` is not a non-array object, which is the only
+    /// failure mode we can hit here since Monitor.Wait/Pulse/PulseAll on a
+    /// missing object would have failed earlier at the `evalStackValueToObjectRef`
+    /// step.)
+    let private readBlock (addr : ManagedHeapAddress) (state : IlMachineState) : SyncBlock =
+        IlMachineState.getSyncBlock addr state
+
+    /// Write back a SyncBlock with the given `Lock` portion and `WaitQueue`.
+    let private writeBlock
+        (addr : ManagedHeapAddress)
+        (lockState : SyncBlockLock)
+        (waitQueue : (ThreadId * int) list)
+        (state : IlMachineState)
+        : IlMachineState
+        =
+        IlMachineState.setSyncBlock
+            addr
+            {
+                Lock = lockState
+                WaitQueue = waitQueue
+            }
+            state
+
+    /// `Monitor.Wait`: the caller must hold the lock; the call snapshots
+    /// the reentrancy depth, parks the caller on the WaitQueue (FIFO tail)
+    /// with the snapshot, and fully releases the lock (transferring
+    /// ownership to the AcquireQueue head if any, else setting Lock = Free).
+    /// Caller's status flips to `BlockedOnSyncBlockWait`. Resumption is
+    /// driven by `pulse` / `pulseAll` / `spuriousWake`, each of which moves
+    /// the waiter to the AcquireQueue carrying the snapshot for depth
+    /// restoration on re-acquire.
+    ///
+    /// Atomicity: from the guest's perspective, Wait is a single operation
+    /// — the caller cannot observe a state in which it has released the
+    /// lock but has not yet been parked, because both happen in one call.
+    let wait (thread : ThreadId) (addr : ManagedHeapAddress) (state : IlMachineState) : IlMachineState =
+        let block = readBlock addr state
+
+        let locked =
+            match block.Lock with
+            | SyncBlockLock.Free ->
+                failwith
+                    $"Monitor.Wait on object %O{addr}: SyncBlock is Free but Wait requires the caller to own the lock. The BCL would raise SynchronizationLockException; we fail loud."
+            | SyncBlockLock.Held l when l.LockingThread <> thread ->
+                failwith
+                    $"Monitor.Wait on object %O{addr}: caller %O{thread} does not own the lock (owner = %O{l.LockingThread}). The BCL would raise SynchronizationLockException."
+            | SyncBlockLock.Held l -> l
+
+        let snapshot = locked.ReentrancyCount
+        let newWaitQueue = block.WaitQueue @ [ (thread, snapshot) ]
+
+        // Atomically release the lock. If anyone is queued for Enter, transfer
+        // ownership; otherwise the lock becomes Free with the WaitQueue
+        // preserved.
+        let newLock, wakeNextOwner =
+            match locked.AcquireQueue with
+            | [] -> SyncBlockLock.Free, None
+            | (nextOwner, ackSnapshot) :: rest ->
+                // `None` snapshot = fresh entrant (depth 1); `Some d` = woken
+                // from an earlier Wait (depth d). Same rule Exit_FastPath uses.
+                let restoredDepth = ackSnapshot |> Option.defaultValue 1
+
+                let next =
+                    {
+                        LockingThread = nextOwner
+                        ReentrancyCount = restoredDepth
+                        AcquireQueue = rest
+                    }
+
+                SyncBlockLock.Held next, Some nextOwner
+
+        let state = writeBlock addr newLock newWaitQueue state
+
+        let state =
+            match wakeNextOwner with
+            | None -> state
+            | Some nextOwner -> Scheduler.setThreadStatus nextOwner ThreadStatus.Runnable state
+
+        Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnSyncBlockWait addr) state
+
+    /// `Monitor.Pulse`: caller must hold the lock; wakes at most one waiter
+    /// from the FIFO head of `WaitQueue`. The woken waiter is moved to the
+    /// FIFO tail of `AcquireQueue` carrying its snapshot depth as a
+    /// `Some depth` entry; its status flips from `BlockedOnSyncBlockWait`
+    /// to `BlockedOnSyncBlockAcquire`. The lock is NOT released — the
+    /// caller keeps ownership until its own `Exit`.
+    ///
+    /// Pulse on an empty wait queue is a documented no-op (CoreCLR exact).
+    let pulse (thread : ThreadId) (addr : ManagedHeapAddress) (state : IlMachineState) : IlMachineState =
+        let block = readBlock addr state
+
+        let locked =
+            match block.Lock with
+            | SyncBlockLock.Free ->
+                failwith
+                    $"Monitor.Pulse on object %O{addr}: SyncBlock is Free but Pulse requires the caller to own the lock. The BCL would raise SynchronizationLockException."
+            | SyncBlockLock.Held l when l.LockingThread <> thread ->
+                failwith
+                    $"Monitor.Pulse on object %O{addr}: caller %O{thread} does not own the lock (owner = %O{l.LockingThread}). The BCL would raise SynchronizationLockException."
+            | SyncBlockLock.Held l -> l
+
+        match block.WaitQueue with
+        | [] ->
+            // No waiter to wake. Pulse is a no-op (BCL contract).
+            state
+        | (waiter, depth) :: restWait ->
+            let locked =
+                { locked with
+                    AcquireQueue = locked.AcquireQueue @ [ (waiter, Some depth) ]
+                }
+
+            state
+            |> writeBlock addr (SyncBlockLock.Held locked) restWait
+            |> Scheduler.setThreadStatus waiter (ThreadStatus.BlockedOnSyncBlockAcquire addr)
+
+    /// `Monitor.PulseAll`: caller must hold the lock; drains the entire
+    /// `WaitQueue` onto the FIFO tail of `AcquireQueue`, preserving FIFO
+    /// order. Each woken waiter's status flips from `BlockedOnSyncBlockWait`
+    /// to `BlockedOnSyncBlockAcquire`. The lock is NOT released. PulseAll
+    /// on an empty wait queue is a no-op.
+    let pulseAll (thread : ThreadId) (addr : ManagedHeapAddress) (state : IlMachineState) : IlMachineState =
+        let block = readBlock addr state
+
+        let locked =
+            match block.Lock with
+            | SyncBlockLock.Free ->
+                failwith
+                    $"Monitor.PulseAll on object %O{addr}: SyncBlock is Free but PulseAll requires the caller to own the lock. The BCL would raise SynchronizationLockException."
+            | SyncBlockLock.Held l when l.LockingThread <> thread ->
+                failwith
+                    $"Monitor.PulseAll on object %O{addr}: caller %O{thread} does not own the lock (owner = %O{l.LockingThread}). The BCL would raise SynchronizationLockException."
+            | SyncBlockLock.Held l -> l
+
+        match block.WaitQueue with
+        | [] -> state
+        | waiters ->
+            let newEntries = waiters |> List.map (fun (tid, depth) -> tid, Some depth)
+
+            let locked =
+                { locked with
+                    AcquireQueue = locked.AcquireQueue @ newEntries
+                }
+
+            let state = writeBlock addr (SyncBlockLock.Held locked) [] state
+
+            waiters
+            |> List.fold
+                (fun acc (tid, _) -> Scheduler.setThreadStatus tid (ThreadStatus.BlockedOnSyncBlockAcquire addr) acc)
+                state
+
+    /// Pull `thread` out of `addr`'s `WaitQueue` and route it through the
+    /// same reacquire path that `pulse` would take. If the lock is currently
+    /// `Free`, the woken thread becomes the new owner directly (status
+    /// flips to `Runnable`, ReentrancyCount set to its snapshot depth); if
+    /// the lock is `Held`, the woken thread is parked at the AcquireQueue
+    /// tail carrying its snapshot as `Some depth` (status flips to
+    /// `BlockedOnSyncBlockAcquire`). In both cases the waiter eventually
+    /// resumes past its `Wait` call site already owning the lock at its
+    /// snapshot depth — the same shape `pulse` produces — so the QCall
+    /// handler does not need to distinguish signalled from spurious wakeups.
+    ///
+    /// Fails loudly if `thread` is not in `addr`'s `WaitQueue`. The only
+    /// caller is `applySpuriousWakeups`, which enumerates the waiters
+    /// itself; a miss indicates either a script that named a stale thread
+    /// (silent skip would let the script drift unnoticed) or a bug in the
+    /// strategy interpreter.
+    let spuriousWake (addr : ManagedHeapAddress) (thread : ThreadId) (state : IlMachineState) : IlMachineState =
+        let block = readBlock addr state
+
+        let entry = block.WaitQueue |> List.tryFind (fun (t, _) -> t = thread)
+
+        let depth =
+            match entry with
+            | Some (_, d) -> d
+            | None ->
+                failwith
+                    $"SyncBlockMonitor.spuriousWake: cannot spuriously wake thread %O{thread} on object %O{addr} because it is not in WaitQueue (queue: %A{block.WaitQueue})."
+
+        let newWaitQueue = block.WaitQueue |> List.filter (fun (t, _) -> t <> thread)
+
+        match block.Lock with
+        | SyncBlockLock.Free ->
+            // Uncontended: take ownership directly with the snapshot depth restored.
+            let locked =
+                {
+                    LockingThread = thread
+                    ReentrancyCount = depth
+                    AcquireQueue = []
+                }
+
+            state
+            |> writeBlock addr (SyncBlockLock.Held locked) newWaitQueue
+            |> Scheduler.setThreadStatus thread ThreadStatus.Runnable
+
+        | SyncBlockLock.Held locked ->
+            // Contended: park at the AcquireQueue tail. Ownership will be
+            // handed to us atomically when our predecessor releases, and
+            // ReentrancyCount will be set to our snapshot depth on transfer.
+            let locked =
+                { locked with
+                    AcquireQueue = locked.AcquireQueue @ [ (thread, Some depth) ]
+                }
+
+            state
+            |> writeBlock addr (SyncBlockLock.Held locked) newWaitQueue
+            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnSyncBlockAcquire addr)
+
+    /// SplitMix64-style hash, deriving a per-(tick, addr, thread) coin flip
+    /// in `[0.0, 1.0)`. Replayability comes from the function being a pure
+    /// hash with no mutable PRNG state.
+    let private coinFlip (seed : uint64) (tick : int64) (ManagedHeapAddress aid) (ThreadId tid) : float =
+        let mix (h : uint64) (x : uint64) : uint64 =
+            let h = h ^^^ x
+            h * 0x100000001B3UL
+
+        let finalise (h : uint64) : uint64 =
+            let h = h ^^^ (h >>> 33)
+            let h = h * 0xff51afd7ed558ccdUL
+            let h = h ^^^ (h >>> 33)
+            let h = h * 0xc4ceb9fe1a85ec53UL
+            h ^^^ (h >>> 33)
+
+        let h = seed
+        let h = mix h (uint64 tick)
+        let h = mix h (uint64 aid)
+        let h = mix h (uint64 tid)
+        let h = finalise h
+        float (h >>> 11) / float (1UL <<< 53)
+
+    /// Enumerate the spurious wakeups requested by `strategy` for `tick`
+    /// against the current managed-heap SyncBlock `WaitQueue` membership,
+    /// then apply each `spuriousWake` in deterministic order (ascending
+    /// `ManagedHeapAddress`, then FIFO position within the queue).
+    /// Snapshotting the (addr, thread) list first means strategy decisions
+    /// are computed against the state at entry — applying an earlier wake
+    /// never affects which later wakes the strategy would have chosen on
+    /// this tick.
+    ///
+    /// `Disabled` is the identity. `Random.probability` outside
+    /// `[0.0, 1.0]` (or NaN) is a programmer error and fails loud.
+    /// `Scripted` triples that name a thread not in the named SyncBlock's
+    /// `WaitQueue` at the named tick fail loud — silent skip would let
+    /// scripts drift when the underlying interleaving changes.
+    let applySpuriousWakeups
+        (strategy : SyncBlockSpuriousWakeupStrategy)
+        (tick : int64)
+        (state : IlMachineState)
+        : IlMachineState
+        =
+        match strategy with
+        | SyncBlockSpuriousWakeupStrategy.Disabled -> state
+
+        | SyncBlockSpuriousWakeupStrategy.AlwaysAll ->
+            state.ManagedHeap.NonArrayObjects
+            |> Map.toSeq
+            |> Seq.sortBy (fun (ManagedHeapAddress aid, _) -> aid)
+            |> Seq.collect (fun (addr, obj) -> obj.SyncBlock.WaitQueue |> List.map (fun (tid, _) -> addr, tid))
+            |> Seq.toList
+            |> List.fold (fun acc (addr, tid) -> spuriousWake addr tid acc) state
+
+        | SyncBlockSpuriousWakeupStrategy.Random (seed, probability) ->
+            if probability < 0.0 || probability > 1.0 || System.Double.IsNaN probability then
+                failwith
+                    $"SyncBlockSpuriousWakeupStrategy.Random: probability %f{probability} is outside [0.0, 1.0] (NaN or out of range)."
+
+            state.ManagedHeap.NonArrayObjects
+            |> Map.toSeq
+            |> Seq.sortBy (fun (ManagedHeapAddress aid, _) -> aid)
+            |> Seq.collect (fun (addr, obj) -> obj.SyncBlock.WaitQueue |> List.map (fun (tid, _) -> addr, tid))
+            |> Seq.filter (fun (addr, tid) -> coinFlip seed tick addr tid < probability)
+            |> Seq.toList
+            |> List.fold (fun acc (addr, tid) -> spuriousWake addr tid acc) state
+
+        | SyncBlockSpuriousWakeupStrategy.Scripted wakeups ->
+            wakeups
+            |> List.filter (fun (t, _, _) -> t = tick)
+            |> List.fold (fun acc (_, addr, tid) -> spuriousWake addr tid acc) state

--- a/WoofWare.PawPrint/ThreadState.fs
+++ b/WoofWare.PawPrint/ThreadState.fs
@@ -27,13 +27,24 @@ type ThreadStatus =
     /// acquire path.
     | BlockedOnMonitorWait of monitor : LowLevelMonitorId
     /// This thread called `Monitor.Enter` (or its `TryEnter` cousin with a non-zero
-    /// timeout) on an object whose SyncBlock is `Locked` by a different thread, and
+    /// timeout) on an object whose SyncBlock is `Held` by a different thread, and
     /// is parked at the SyncBlock's `AcquireQueue`. The lock owner's eventual
     /// `Monitor.Exit` transfers ownership directly to the FIFO head of the queue,
     /// flipping that thread back to `Runnable` already holding the lock — mirroring
     /// the `LowLevelMonitor` ownership-transfer model so the resumed thread's IL
     /// continues past the `Enter` call site already owning the SyncBlock.
     | BlockedOnSyncBlockAcquire of lockObject : ManagedHeapAddress
+    /// This thread called `Monitor.Wait` on an object's SyncBlock and is parked at
+    /// the SyncBlock's `WaitQueue` with the lock fully released. A subsequent
+    /// `Monitor.Pulse` / `PulseAll` from another thread (or a spurious wake)
+    /// transitions the head of the wait queue onto the SyncBlock's `AcquireQueue`
+    /// carrying its prior reentrancy depth as a `Some depth` snapshot; the resumed
+    /// thread becomes `BlockedOnSyncBlockAcquire` until the current owner's `Exit`
+    /// hands ownership over, at which point its `ReentrancyCount` is restored to
+    /// the snapshotted depth and the IL resumes past the `Wait` call site already
+    /// re-owning the lock. Parallel with `BlockedOnMonitorWait` but for managed
+    /// SyncBlocks rather than `LowLevelMonitor`.
+    | BlockedOnSyncBlockWait of lockObject : ManagedHeapAddress
     /// This thread has executed its final `ret`; it will never run again. Its state is kept
     /// only so other threads can observe termination (e.g. to satisfy Join).
     | Terminated

--- a/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
+++ b/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
@@ -78,6 +78,7 @@
     <Compile Include="ExternImplementations\NativeImpls.fs" />
     <Compile Include="Scheduler.fs" />
     <Compile Include="LowLevelMonitor.fs" />
+    <Compile Include="SyncBlockMonitor.fs" />
     <Compile Include="ExternImplementations\System.Threading.Monitor.fs" />
     <Compile Include="Native\NativeCall.fs" />
     <Compile Include="Native\NativeEnvironment.fs" />


### PR DESCRIPTION
## Summary

- Adds the `Monitor_Wait` / `Monitor_Pulse` / `Monitor_PulseAll` QCalls and a pure `SyncBlockMonitor` state-machine implementing condition-variable semantics on top of the SyncBlock model already used by `Monitor.Enter`/`Exit`.
- Reshapes `SyncBlock` into a record with orthogonal `Lock` and `WaitQueue` fields so a fully-released lock with parked waiters is representable; reentrancy depth snapshots travel inline on the AcquireQueue (`(ThreadId * int option) list`) so `Exit_FastPath`'s ownership-transfer path restores depth verbatim for woken waiters.
- Pulse keeps the caller's lock (CoreCLR-accurate); woken waiters are parked on the AcquireQueue tail and only acquire when the current owner's Exit transfers ownership. Wait fully releases the lock atomically, transferring to the AcquireQueue head if any, else setting `Lock = Free`.
- Adds a parallel `SyncBlockSpuriousWakeupStrategy` (Disabled / AlwaysAll / Random / Scripted) wired into `stepPrepared` alongside the existing `LowLevelMonitor` wakeup driver, and a `BlockedOnSyncBlockWait` `ThreadStatus` surfaced via the debugger server.
- New integration test `MonitorPulseWait.cs` exercises a producer/consumer between two threads through Wait/Pulse on a managed `lock`-style SyncBlock.

## Test plan

- [x] `nix develop -c dotnet build WoofWare.PawPrint.slnx` (clean, 0 warnings)
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` (892 / 892 pass)
- [x] `nix develop -c dotnet fantomas .`
- [x] `codex review --base main` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)