### PR TITLE
Implement SystemNative_Write via FileDescriptorRegistry

### DIFF
--- a/WoofWare.PawPrint.App/Program.fs
+++ b/WoofWare.PawPrint.App/Program.fs
@@ -95,32 +95,43 @@ module AppProgram =
 
             let drainStandardStreams (state : IlMachineState) : unit =
                 // The interpreter never writes to host stdout/stderr during
-                // execution; instead `SystemNative_Write` appends bytes to
-                // the kernel's `StdoutAppended` / `StderrAppended` logs (and
+                // execution; instead `SystemNative_Write` appends each call
+                // as an `OutputLogEntry` to `state.Kernel.OutputLog` (and
                 // emits a `StepEffect.WroteToFd` for any consumer that wants
-                // to stream). Here, at the end of the run, drain those logs
+                // to stream). Here, at the end of the run, drain that log
                 // to the host's real standard streams so a user invoking
-                // `WoofWare.PawPrint.App` sees the guest's output. Order
-                // matches the run: stdout is drained before stderr.
+                // `WoofWare.PawPrint.App` sees the guest's output in the
+                // exact write order the guest produced — including across
+                // stdout/stderr — so a `Write(2,…)` followed by a
+                // `Write(1,…)` is replayed as `err`-then-`out`, matching
+                // what a real shell sees under `2>&1`.
                 //
                 // Streaming during execution would couple the functional
                 // core to an imperative sink; leaving it until the end keeps
                 // the interpreter deterministic and replayable. Programs
-                // that crash partway will lose nothing because the buffer
-                // is what's drained regardless of which `RunOutcome`
+                // that crash partway will lose nothing because the log is
+                // what's drained regardless of which `RunOutcome`
                 // terminates the run.
-                let stdout = state.Kernel.StdoutAppended
+                let log = state.Kernel.OutputLog
 
-                if stdout.Length > 0 then
+                if log.Length > 0 then
                     use out = System.Console.OpenStandardOutput ()
-                    out.Write (stdout.AsSpan ())
-                    out.Flush ()
-
-                let stderr = state.Kernel.StderrAppended
-
-                if stderr.Length > 0 then
                     use err = System.Console.OpenStandardError ()
-                    err.Write (stderr.AsSpan ())
+
+                    for entry in log do
+                        match entry.Role with
+                        | FileDescriptorRole.StandardOutput -> out.Write (entry.Bytes.AsSpan ())
+                        | FileDescriptorRole.StandardError -> err.Write (entry.Bytes.AsSpan ())
+                        | FileDescriptorRole.StandardInput ->
+                            // Unreachable: `SystemNative_Write` rejects stdin
+                            // with EBADF before appending. Exhaustiveness is
+                            // load-bearing here — a future writable role
+                            // (e.g. a regular file) will fail to compile
+                            // until its drain destination is decided.
+                            failwith
+                                "drainStandardStreams: OutputLog contains StandardInput entry (this is an interpreter bug)"
+
+                    out.Flush ()
                     err.Flush ()
 
             match Program.run loggerFactory (Some dllPath) fileStream dotnetRuntimes impls args with

--- a/WoofWare.PawPrint.App/Program.fs
+++ b/WoofWare.PawPrint.App/Program.fs
@@ -93,13 +93,46 @@ module AppProgram =
                 | [] -> failwith "Exiting thread returned void; expected an int32 exit code"
                 | other :: _ -> failwith $"Exiting thread had unexpected eval-stack top %O{other}; expected int32"
 
+            let drainStandardStreams (state : IlMachineState) : unit =
+                // The interpreter never writes to host stdout/stderr during
+                // execution; instead `SystemNative_Write` appends bytes to
+                // the kernel's `StdoutAppended` / `StderrAppended` logs (and
+                // emits a `StepEffect.WroteToFd` for any consumer that wants
+                // to stream). Here, at the end of the run, drain those logs
+                // to the host's real standard streams so a user invoking
+                // `WoofWare.PawPrint.App` sees the guest's output. Order
+                // matches the run: stdout is drained before stderr.
+                //
+                // Streaming during execution would couple the functional
+                // core to an imperative sink; leaving it until the end keeps
+                // the interpreter deterministic and replayable. Programs
+                // that crash partway will lose nothing because the buffer
+                // is what's drained regardless of which `RunOutcome`
+                // terminates the run.
+                let stdout = state.Kernel.StdoutAppended
+
+                if stdout.Length > 0 then
+                    use out = System.Console.OpenStandardOutput ()
+                    out.Write (stdout.AsSpan ())
+                    out.Flush ()
+
+                let stderr = state.Kernel.StderrAppended
+
+                if stderr.Length > 0 then
+                    use err = System.Console.OpenStandardError ()
+                    err.Write (stderr.AsSpan ())
+                    err.Flush ()
+
             match Program.run loggerFactory (Some dllPath) fileStream dotnetRuntimes impls args with
             | RunOutcome.NormalExit (state, thread)
-            | RunOutcome.ProcessExit (state, thread) -> exitCodeFromStack state thread
-            | RunOutcome.FailFast (_state, _thread, message) ->
+            | RunOutcome.ProcessExit (state, thread) ->
+                drainStandardStreams state
+                exitCodeFromStack state thread
+            | RunOutcome.FailFast (state, _thread, message) ->
                 // CoreCLR's Environment_FailFast calls HandleFatalError(COR_E_FAILFAST)
                 // and on Windows terminates with 0x80131623; on Unix it aborts via
                 // SIGABRT (exit code 128 + 6 = 134).
+                drainStandardStreams state
                 let msg = message |> Option.defaultValue "<no message>"
                 logger.LogCritical ("Guest called Environment.FailFast: {FailFastMessage}", msg)
 
@@ -108,6 +141,8 @@ module AppProgram =
                 else
                     134
             | RunOutcome.GuestUnhandledException (state, _thread, exn) ->
+                drainStandardStreams state
+
                 let exceptionTypeName =
                     match state.ManagedHeap.NonArrayObjects |> Map.tryFind exn.ExceptionObject with
                     | Some obj ->

--- a/WoofWare.PawPrint.Test/TestHarness.fs
+++ b/WoofWare.PawPrint.Test/TestHarness.fs
@@ -67,4 +67,12 @@ type EndToEndTestCase =
         ExpectedReturnCode : int
         NativeImpls : NativeImpls
         ExpectsUnhandledException : bool
+        /// Optional assertion run against the final PawPrint state once the
+        /// guest has exited. Used by impure tests that want to verify
+        /// interpreter-internal state (e.g. `state.Kernel.StdoutAppended`)
+        /// that isn't observable as an exit code. Pure tests, which run the
+        /// same source on the real CLR for cross-comparison, leave this
+        /// `None` — the real runtime has no analogous state to assert
+        /// against.
+        AssertTerminalState : (IlMachineState -> unit) option
     }

--- a/WoofWare.PawPrint.Test/TestHarness.fs
+++ b/WoofWare.PawPrint.Test/TestHarness.fs
@@ -69,8 +69,8 @@ type EndToEndTestCase =
         ExpectsUnhandledException : bool
         /// Optional assertion run against the final PawPrint state once the
         /// guest has exited. Used by impure tests that want to verify
-        /// interpreter-internal state (e.g. `state.Kernel.StdoutAppended`)
-        /// that isn't observable as an exit code. Pure tests, which run the
+        /// interpreter-internal state (e.g. `state.Kernel.OutputLog`) that
+        /// isn't observable as an exit code. Pure tests, which run the
         /// same source on the real CLR for cross-comparison, leave this
         /// `None` — the real runtime has no analogous state to assert
         /// against.

--- a/WoofWare.PawPrint.Test/TestImpureCases.fs
+++ b/WoofWare.PawPrint.Test/TestImpureCases.fs
@@ -82,12 +82,12 @@ module TestImpureCases =
                 // bytes at stdout. The pure-source test only covers the
                 // error paths (negative size, bad fd, zero size); the
                 // success path is impure because it appends to the
-                // interpreter's `StdoutAppended` buffer and we want to
-                // assert directly on those bytes rather than try to capture
-                // the test runner's real stdout. The guest returns 0 on
-                // success (positive return from `Write`), so a regression
-                // in the handler's return value or pointer decoding also
-                // surfaces as a wrong exit code.
+                // interpreter's `OutputLog` and we want to assert directly
+                // on those bytes rather than try to capture the test
+                // runner's real stdout. The guest returns 0 on success
+                // (positive return from `Write`), so a regression in the
+                // handler's return value or pointer decoding also surfaces
+                // as a wrong exit code.
                 FileName = "SystemNativeWriteSuccess.cs"
                 ExpectedReturnCode = 0
                 ExpectsUnhandledException = false
@@ -97,11 +97,13 @@ module TestImpureCases =
                         // The guest writes the literal "hi\n" (3 bytes) to
                         // fd 1. If the handler decoded the pointer wrong,
                         // we'd see garbage or fewer bytes here.
-                        state.Kernel.StdoutAppended
+                        OutputLogEntry.bytesFor FileDescriptorRole.StandardOutput state.Kernel.OutputLog
                         |> Seq.toArray
                         |> shouldEqual [| 0x68uy ; 0x69uy ; 0x0Auy |]
 
-                        state.Kernel.StderrAppended.Length |> shouldEqual 0
+                        OutputLogEntry.bytesFor FileDescriptorRole.StandardError state.Kernel.OutputLog
+                        |> fun bytes -> bytes.Length
+                        |> shouldEqual 0
                     )
             }
         ]

--- a/WoofWare.PawPrint.Test/TestImpureCases.fs
+++ b/WoofWare.PawPrint.Test/TestImpureCases.fs
@@ -19,16 +19,17 @@ module TestImpureCases =
         [
             // `Console.WriteLine("Hello, world!")` triggers lazy initialisation of `Console.Out`,
             // which descends Console::get_Out → ConsolePal::OpenStandardOutput → Interop+Sys::Dup.
-            // PawPrint now intercepts SystemNative_Dup via FileDescriptorRegistry, so the std-stream
-            // open path completes; the WriteLine flow now blocks downstream on the unimplemented
-            // libSystem.Globalization.Native P/Invoke `GlobalizationNative_LoadICU` during
-            // CultureInfo initialisation. Subsequent SystemNative_Write (the actual byte-emitting
-            // call) is also still unimplemented.
+            // PawPrint now intercepts SystemNative_Dup via FileDescriptorRegistry and
+            // SystemNative_Write via the same handler family, so both the std-stream open path and
+            // the actual byte-emitting call are implemented; the WriteLine flow now blocks
+            // downstream on the unimplemented libSystem.Globalization.Native P/Invoke
+            // `GlobalizationNative_LoadICU` during CultureInfo initialisation.
             {
                 FileName = "WriteLine.cs"
                 ExpectedReturnCode = 1
                 NativeImpls = NativeImpls.PassThru ()
                 ExpectsUnhandledException = false
+                AssertTerminalState = None
             }
         ]
 
@@ -38,6 +39,7 @@ module TestImpureCases =
                 FileName = "InstaQuit.cs"
                 ExpectedReturnCode = 1
                 ExpectsUnhandledException = false
+                AssertTerminalState = None
                 NativeImpls =
                     let mock = MockEnv.make ()
                     let env = mock.System_Environment
@@ -66,12 +68,41 @@ module TestImpureCases =
                 FileName = "ExitFromWorker.cs"
                 ExpectedReturnCode = 7
                 ExpectsUnhandledException = false
+                AssertTerminalState = None
                 NativeImpls =
                     let mock = MockEnv.make ()
 
                     { mock with
                         System_Environment = System_Environment.passThru
                     }
+            }
+            {
+                // Exercises the SystemNative_Write success path: a guest that
+                // DllImports SystemNative_Write directly and pushes a few
+                // bytes at stdout. The pure-source test only covers the
+                // error paths (negative size, bad fd, zero size); the
+                // success path is impure because it appends to the
+                // interpreter's `StdoutAppended` buffer and we want to
+                // assert directly on those bytes rather than try to capture
+                // the test runner's real stdout. The guest returns 0 on
+                // success (positive return from `Write`), so a regression
+                // in the handler's return value or pointer decoding also
+                // surfaces as a wrong exit code.
+                FileName = "SystemNativeWriteSuccess.cs"
+                ExpectedReturnCode = 0
+                ExpectsUnhandledException = false
+                NativeImpls = NativeImpls.PassThru ()
+                AssertTerminalState =
+                    Some (fun state ->
+                        // The guest writes the literal "hi\n" (3 bytes) to
+                        // fd 1. If the handler decoded the pointer wrong,
+                        // we'd see garbage or fewer bytes here.
+                        state.Kernel.StdoutAppended
+                        |> Seq.toArray
+                        |> shouldEqual [| 0x68uy ; 0x69uy ; 0x0Auy |]
+
+                        state.Kernel.StderrAppended.Length |> shouldEqual 0
+                    )
             }
         ]
 
@@ -109,6 +140,10 @@ module TestImpureCases =
                     | ret -> failwith $"expected program to return an int, but it returned %O{ret}"
 
             exitCode |> shouldEqual case.ExpectedReturnCode
+
+            match case.AssertTerminalState with
+            | None -> ()
+            | Some assertion -> assertion terminalState
         with _ ->
             for message in messages () do
                 System.Console.Error.WriteLine $"{message}"

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -438,6 +438,7 @@ class Program
             ExpectedReturnCode = 0
             NativeImpls = MockEnv.make ()
             ExpectsUnhandledException = false
+            AssertTerminalState = None
         }
         |> runTest
 
@@ -451,6 +452,7 @@ class Program
             ExpectedReturnCode = exitCode
             NativeImpls = MockEnv.make ()
             ExpectsUnhandledException = false
+            AssertTerminalState = None
         }
         |> runTest
 
@@ -461,6 +463,7 @@ class Program
             ExpectedReturnCode = 0
             NativeImpls = mock
             ExpectsUnhandledException = false
+            AssertTerminalState = None
         }
         |> runTest
 
@@ -472,6 +475,7 @@ class Program
             ExpectedReturnCode = 0 // not checked; both runtimes are expected to throw
             NativeImpls = MockEnv.make ()
             ExpectsUnhandledException = true
+            AssertTerminalState = None
         }
         |> runTest
 
@@ -496,6 +500,7 @@ class Program
             ExpectedReturnCode = 0
             NativeImpls = MockEnv.make ()
             ExpectsUnhandledException = false
+            AssertTerminalState = None
         }
         |> runTest
 
@@ -519,5 +524,6 @@ class Program
             ExpectedReturnCode = 0
             NativeImpls = mock
             ExpectsUnhandledException = false
+            AssertTerminalState = None
         }
         |> runTest

--- a/WoofWare.PawPrint.Test/sourcesImpure/SystemNativeWriteSuccess.cs
+++ b/WoofWare.PawPrint.Test/sourcesImpure/SystemNativeWriteSuccess.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Runtime.InteropServices;
+
+// Exercises the SystemNative_Write success path under PawPrint. This is in
+// `sourcesImpure` because the assertion is on PawPrint-internal state
+// (`EmulatedKernel.StdoutAppended`) rather than on the guest's exit code
+// alone; the test harness reads that buffer after the run terminates and
+// matches against the expected byte sequence.
+//
+// The pure-source `SystemNativeWrite.cs` covers the error paths (negative
+// size, bad fd, zero-size no-op) that can be asserted just on the return
+// value, since those don't pollute the real test runner's stdout.
+class Program
+{
+    [DllImport("libSystem.Native", EntryPoint = "SystemNative_Write")]
+    static extern unsafe int SystemNative_Write(IntPtr fd, byte* buffer, int bufferSize);
+
+    static unsafe int Main(string[] args)
+    {
+        // Write the literal three-byte sequence "hi\n" to fd 1 (stdout).
+        // PawPrint must decode the byte* argument correctly and the handler
+        // must return the number of bytes written (3); any deviation
+        // surfaces as a non-zero exit code below, before the harness even
+        // gets to inspect `StdoutAppended`.
+        byte[] msg = new byte[] { 0x68, 0x69, 0x0A };
+
+        fixed (byte* p = msg)
+        {
+            int written = SystemNative_Write((IntPtr)1, p, msg.Length);
+            if (written != msg.Length) return 1;
+        }
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesImpure/SystemNativeWriteSuccess.cs
+++ b/WoofWare.PawPrint.Test/sourcesImpure/SystemNativeWriteSuccess.cs
@@ -3,9 +3,9 @@ using System.Runtime.InteropServices;
 
 // Exercises the SystemNative_Write success path under PawPrint. This is in
 // `sourcesImpure` because the assertion is on PawPrint-internal state
-// (`EmulatedKernel.StdoutAppended`) rather than on the guest's exit code
-// alone; the test harness reads that buffer after the run terminates and
-// matches against the expected byte sequence.
+// (`EmulatedKernel.OutputLog`) rather than on the guest's exit code alone;
+// the test harness reads that log after the run terminates and matches
+// against the expected byte sequence.
 //
 // The pure-source `SystemNativeWrite.cs` covers the error paths (negative
 // size, bad fd, zero-size no-op) that can be asserted just on the return
@@ -21,7 +21,7 @@ class Program
         // PawPrint must decode the byte* argument correctly and the handler
         // must return the number of bytes written (3); any deviation
         // surfaces as a non-zero exit code below, before the harness even
-        // gets to inspect `StdoutAppended`.
+        // gets to inspect `OutputLog`.
         byte[] msg = new byte[] { 0x68, 0x69, 0x0A };
 
         fixed (byte* p = msg)

--- a/WoofWare.PawPrint.Test/sourcesPure/SystemNativeWrite.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/SystemNativeWrite.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Runtime.InteropServices;
+
+// Exercises the SystemNative_Write PawPrint handler directly via a P/Invoke
+// stub. The CLR runtime dispatches this to the real libSystem.Native shim;
+// PawPrint intercepts the call and routes it through FileDescriptorRegistry.
+//
+// This test must pass on both the real runtime and PawPrint, so it asserts
+// only invariants that hold on every Unix kernel AND that do not actually
+// emit bytes to the test runner's real stdout/stderr (which would corrupt
+// the test report). The cases here are therefore:
+//   * write of a negative byteCount returns -1 (PawPrint sets ERANGE; the
+//     real Common_Write does too)
+//   * write to a non-existent fd returns -1 (EBADF)
+//   * zero-byte write to stdout returns 0 and does not dereference the
+//     pointer (so passing IntPtr.Zero is safe)
+//
+// The success path with non-zero byte count is exercised separately by an
+// impure test that asserts on EmulatedKernel.StdoutAppended without ever
+// going through the real kernel.
+class Program
+{
+    [DllImport("libSystem.Native", EntryPoint = "SystemNative_Write")]
+    static extern unsafe int SystemNative_Write(IntPtr fd, byte* buffer, int bufferSize);
+
+    static unsafe int Main(string[] args)
+    {
+        byte b = 0;
+
+        // bufferSize < 0: Common_Write sets errno = ERANGE and returns -1
+        // before any dereference of `buffer`.
+        if (SystemNative_Write((IntPtr)1, &b, -1) != -1) return 1;
+
+        // fd that was never opened: write(2) returns -1 with errno = EBADF.
+        // -1 is never a live fd on any Unix.
+        if (SystemNative_Write((IntPtr)(-1), &b, 1) != -1) return 2;
+
+        // Zero-byte write to stdout: no-op, returns 0, must not dereference
+        // the buffer. Passing IntPtr.Zero deliberately to verify the
+        // short-circuit (a real write(fd, NULL, 0) is well-defined on Linux
+        // and Darwin and returns 0).
+        if (SystemNative_Write((IntPtr)1, (byte*)0, 0) != 0) return 3;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/SystemNativeWrite.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/SystemNativeWrite.cs
@@ -16,8 +16,8 @@ using System.Runtime.InteropServices;
 //     pointer (so passing IntPtr.Zero is safe)
 //
 // The success path with non-zero byte count is exercised separately by an
-// impure test that asserts on EmulatedKernel.StdoutAppended without ever
-// going through the real kernel.
+// impure test that asserts on EmulatedKernel.OutputLog without ever going
+// through the real kernel.
 class Program
 {
     [DllImport("libSystem.Native", EntryPoint = "SystemNative_Write")]
@@ -40,6 +40,14 @@ class Program
         // short-circuit (a real write(fd, NULL, 0) is well-defined on Linux
         // and Darwin and returns 0).
         if (SystemNative_Write((IntPtr)1, (byte*)0, 0) != 0) return 3;
+
+        // Zero-byte write to stdout with a non-null, non-managed bit
+        // pattern: same contract. write(2) does not dereference the
+        // buffer when count is zero, so the bit pattern is irrelevant.
+        // This guards against PawPrint regressing to eagerly decoding the
+        // pointer argument (which would crash on the verbatim 123) before
+        // checking bufferSize.
+        if (SystemNative_Write((IntPtr)1, (byte*)123, 0) != 0) return 4;
 
         return 0;
     }

--- a/WoofWare.PawPrint.Test/sourcesPure/SystemNativeWrite.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/SystemNativeWrite.cs
@@ -49,6 +49,15 @@ class Program
         // checking bufferSize.
         if (SystemNative_Write((IntPtr)1, (byte*)123, 0) != 0) return 4;
 
+        // Non-zero write to stdout with a NULL buffer: real write(2)
+        // returns -1 with errno = EFAULT and does not perform any I/O
+        // (POSIX guarantees the failure precedes any data emission, so
+        // this is safe to run on the real CLR without polluting test
+        // runner stdout). PawPrint must surface the same syscall
+        // failure rather than crashing the interpreter on a direct
+        // P/Invoke that bypasses the BCL's null guard in Stream.Write.
+        if (SystemNative_Write((IntPtr)1, (byte*)0, 5) != -1) return 5;
+
         return 0;
     }
 }

--- a/WoofWare.PawPrint/EmulatedKernel.fs
+++ b/WoofWare.PawPrint/EmulatedKernel.fs
@@ -123,6 +123,33 @@ type SyncBlockSpuriousWakeupStrategy =
     /// changes.
     | Scripted of wakeups : (int64 * ManagedHeapAddress * ThreadId) list
 
+/// One entry in `EmulatedKernel.OutputLog`: the role the guest targeted (a
+/// writable standard stream — stdout or stderr) and the byte payload of
+/// that single `SystemNative_Write` call. Chunks are not coalesced across
+/// calls because guest write boundaries matter for diagnostics (line
+/// boundaries, prompt boundaries) and for matching real-CLR observability.
+type OutputLogEntry =
+    {
+        Role : FileDescriptorRole
+        Bytes : ImmutableArray<byte>
+    }
+
+[<RequireQualifiedAccess>]
+module OutputLogEntry =
+    /// Concatenate every entry in `log` whose `Role` matches `role`,
+    /// preserving the original write order. Used by tests that want to
+    /// assert on the cumulative bytes the guest sent to a specific
+    /// standard stream (the equivalent of capturing one of host
+    /// stdout/stderr in isolation).
+    let bytesFor (role : FileDescriptorRole) (log : ImmutableArray<OutputLogEntry>) : ImmutableArray<byte> =
+        let builder = ImmutableArray.CreateBuilder<byte> ()
+
+        for entry in log do
+            if entry.Role = role then
+                builder.AddRange (entry.Bytes : ImmutableArray<byte>)
+
+        builder.ToImmutable ()
+
 /// Aggregates the slice of `IlMachineState` that models host-kernel /
 /// syscall-emulation state: process-wide last-error registers, the native
 /// heap pool backing `Marshal.AllocHGlobal`, the Unix file-descriptor table,
@@ -208,21 +235,25 @@ type EmulatedKernel =
         /// `Random()` ctor retries until it sees a non-zero seed, so a
         /// constant-zero substitute would hang at construction time.
         NonCryptoRandomState : uint64
-        /// Append-only log of every byte the guest has written to fd 1
-        /// (stdout) via `SystemNative_Write`. Acts as the canonical record
-        /// the driver's end-of-run host drain reads from, and is what
+        /// Ordered, append-only log of every write the guest has performed
+        /// against a writable standard stream via `SystemNative_Write`.
+        /// Each entry carries the destination `Role` and the exact byte
+        /// payload of that one call (chunks are not coalesced; ordering
+        /// across roles is preserved). Acts as the canonical record the
+        /// driver's end-of-run host drain reads from, and is what
         /// PawPrint-only tests assert on instead of trying to capture host
-        /// stdout. The buffer grows unboundedly: a guest that prints
+        /// stdout. The log grows unboundedly: a guest that prints
         /// gigabytes will pay the memory cost, but PawPrint is a slow
         /// deterministic interpreter and a guest of that scale is not in
         /// scope. Bound this with a streaming sink (consuming `StepEffect.
         /// WroteToFd` at each step) when a need arises.
-        StdoutAppended : ImmutableArray<byte>
-        /// Append-only log of every byte the guest has written to fd 2
-        /// (stderr) via `SystemNative_Write`. Same contract as
-        /// `StdoutAppended`; see that field for the unbounded-growth
-        /// caveat.
-        StderrAppended : ImmutableArray<byte>
+        ///
+        /// The single ordered log (rather than per-stream buffers)
+        /// preserves cross-stream ordering: a guest that writes
+        /// `err1, out1, err2` is replayed in that order under `2>&1`,
+        /// matching real-CLR behaviour. Per-stream views are derived in
+        /// `OutputLogEntry.bytesFor`.
+        OutputLog : ImmutableArray<OutputLogEntry>
     }
 
 /// Deterministic non-cryptographic PRNG that backs
@@ -299,6 +330,5 @@ module EmulatedKernel =
             SyncBlockSpuriousWakeup = SyncBlockSpuriousWakeupStrategy.Disabled
             StepCounter = 0L
             NonCryptoRandomState = NonCryptoRandom.initialState
-            StdoutAppended = ImmutableArray<byte>.Empty
-            StderrAppended = ImmutableArray<byte>.Empty
+            OutputLog = ImmutableArray<OutputLogEntry>.Empty
         }

--- a/WoofWare.PawPrint/EmulatedKernel.fs
+++ b/WoofWare.PawPrint/EmulatedKernel.fs
@@ -1,5 +1,7 @@
 namespace WoofWare.PawPrint
 
+open System.Collections.Immutable
+
 /// Deterministic model of a single `System.Threading.LowLevelMonitor`, as
 /// minted by `SystemNative_LowLevelMonitor_Create`. CoreCLR backs this with a
 /// `pthread_mutex_t` + `pthread_cond_t` pair on Unix; PawPrint reproduces the
@@ -206,6 +208,21 @@ type EmulatedKernel =
         /// `Random()` ctor retries until it sees a non-zero seed, so a
         /// constant-zero substitute would hang at construction time.
         NonCryptoRandomState : uint64
+        /// Append-only log of every byte the guest has written to fd 1
+        /// (stdout) via `SystemNative_Write`. Acts as the canonical record
+        /// the driver's end-of-run host drain reads from, and is what
+        /// PawPrint-only tests assert on instead of trying to capture host
+        /// stdout. The buffer grows unboundedly: a guest that prints
+        /// gigabytes will pay the memory cost, but PawPrint is a slow
+        /// deterministic interpreter and a guest of that scale is not in
+        /// scope. Bound this with a streaming sink (consuming `StepEffect.
+        /// WroteToFd` at each step) when a need arises.
+        StdoutAppended : ImmutableArray<byte>
+        /// Append-only log of every byte the guest has written to fd 2
+        /// (stderr) via `SystemNative_Write`. Same contract as
+        /// `StdoutAppended`; see that field for the unbounded-growth
+        /// caveat.
+        StderrAppended : ImmutableArray<byte>
     }
 
 /// Deterministic non-cryptographic PRNG that backs
@@ -282,4 +299,6 @@ module EmulatedKernel =
             SyncBlockSpuriousWakeup = SyncBlockSpuriousWakeupStrategy.Disabled
             StepCounter = 0L
             NonCryptoRandomState = NonCryptoRandom.initialState
+            StdoutAppended = ImmutableArray<byte>.Empty
+            StderrAppended = ImmutableArray<byte>.Empty
         }

--- a/WoofWare.PawPrint/Errno.fs
+++ b/WoofWare.PawPrint/Errno.fs
@@ -18,3 +18,11 @@ module Errno =
     /// `EBADF` — Bad file descriptor. Returned by `dup`, `close`, `read`,
     /// `write`, etc. when the supplied fd is not currently open.
     let EBADF : int = 9
+
+    /// `ERANGE` — Result too large / out of range. Used by PawPrint's
+    /// `SystemNative_Write` / `SystemNative_Read` shims when the caller
+    /// supplies a negative `bufferSize`, matching the behaviour of
+    /// `Common_Write` / `Common_Read` in `pal_io_common.h` (which set
+    /// `errno = ERANGE` and return -1 for negative sizes before the real
+    /// `read(2)` / `write(2)` is invoked).
+    let ERANGE : int = 34

--- a/WoofWare.PawPrint/Errno.fs
+++ b/WoofWare.PawPrint/Errno.fs
@@ -19,6 +19,17 @@ module Errno =
     /// `write`, etc. when the supplied fd is not currently open.
     let EBADF : int = 9
 
+    /// `EFAULT` — Bad address. Returned by `read(2)` / `write(2)` and friends
+    /// when the buffer pointer is outside the process's accessible address
+    /// space — most notably when the caller passes `NULL` (or any other
+    /// non-dereferenceable bit pattern) with a non-zero `bufferSize`. The
+    /// kernel performs no I/O for such a call. PawPrint maps a null /
+    /// non-managed buffer to this errno rather than crashing the
+    /// interpreter, so guests that issue a direct P/Invoke (skipping the
+    /// BCL's null-guard in `Stream.Write`) see the same error as on the
+    /// real runtime.
+    let EFAULT : int = 14
+
     /// `ERANGE` — Result too large / out of range. Used by PawPrint's
     /// `SystemNative_Write` / `SystemNative_Read` shims when the caller
     /// supplies a negative `bufferSize`, matching the behaviour of

--- a/WoofWare.PawPrint/IlMachineStateModel.fs
+++ b/WoofWare.PawPrint/IlMachineStateModel.fs
@@ -213,16 +213,16 @@ type StepEffect =
     /// the type level.
     | NoEffect
     /// The step accepted `bytes` for the file descriptor backing `role`, and
-    /// the bytes have already been appended to the canonical
-    /// `EmulatedKernel.StdoutAppended` / `StderrAppended` log (so the state
-    /// alone is sufficient to reconstruct the full output). Drivers that
-    /// want to stream output as it is produced — instead of waiting until
-    /// the end of the run and reading the buffer — should consume this
-    /// variant. The `role` is one of the standard-stream roles; PawPrint
-    /// does not currently model any other writable fd. `bytes` carries
-    /// exactly the bytes appended in this step (it is not the cumulative
-    /// log); a driver that streams therefore does not need to track an
-    /// offset.
+    /// the bytes have already been appended as a single entry to the
+    /// canonical `EmulatedKernel.OutputLog` (so the state alone is
+    /// sufficient to reconstruct the full output, in cross-stream order).
+    /// Drivers that want to stream output as it is produced — instead of
+    /// waiting until the end of the run and reading the log — should
+    /// consume this variant. The `role` is one of the standard-stream
+    /// roles; PawPrint does not currently model any other writable fd.
+    /// `bytes` carries exactly the bytes appended in this step (it is
+    /// not the cumulative log); a driver that streams therefore does not
+    /// need to track an offset.
     | WroteToFd of role : FileDescriptorRole * bytes : ImmutableArray<byte>
 
 type ExecutionResult =

--- a/WoofWare.PawPrint/IlMachineStateModel.fs
+++ b/WoofWare.PawPrint/IlMachineStateModel.fs
@@ -203,8 +203,8 @@ type WhatWeDid =
 /// world?" — i.e. it's input to the driver. A single step can do both (e.g.
 /// emit a `WroteToFd` effect *and* report `WhatWeDid.Executed`).
 ///
-/// Today the only variant is `NoEffect`; widening the contract up front lets
-/// us add `WroteToFd`, `ReadFromFd`, etc. in subsequent PRs without retouching
+/// Today the variants are `NoEffect` and `WroteToFd`; widening the contract
+/// up front lets us add `ReadFromFd` etc. in subsequent PRs without retouching
 /// the construction sites that don't emit effects.
 type StepEffect =
     /// The step had no externally-observable I/O effect. The overwhelming
@@ -212,6 +212,18 @@ type StepEffect =
     /// emitting handlers (`SystemNative_Write`, etc.) are distinguishable at
     /// the type level.
     | NoEffect
+    /// The step accepted `bytes` for the file descriptor backing `role`, and
+    /// the bytes have already been appended to the canonical
+    /// `EmulatedKernel.StdoutAppended` / `StderrAppended` log (so the state
+    /// alone is sufficient to reconstruct the full output). Drivers that
+    /// want to stream output as it is produced — instead of waiting until
+    /// the end of the run and reading the buffer — should consume this
+    /// variant. The `role` is one of the standard-stream roles; PawPrint
+    /// does not currently model any other writable fd. `bytes` carries
+    /// exactly the bytes appended in this step (it is not the cumulative
+    /// log); a driver that streams therefore does not need to track an
+    /// offset.
+    | WroteToFd of role : FileDescriptorRole * bytes : ImmutableArray<byte>
 
 type ExecutionResult =
     /// A single thread finished (its top frame hit `ret`). For the entry thread this means

--- a/WoofWare.PawPrint/Native/NativeSystemNative.fs
+++ b/WoofWare.PawPrint/Native/NativeSystemNative.fs
@@ -1,5 +1,7 @@
 namespace WoofWare.PawPrint
 
+open System.Collections.Immutable
+
 [<RequireQualifiedAccess>]
 module NativeSystemNative =
     let private trySystemNativeEntryPoint (ctx : NativeCallContext) : string option =
@@ -221,6 +223,140 @@ module NativeSystemNative =
             |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 resultCode) ctx.Thread
             |> Tuple.withRight WhatWeDid.Executed
             |> ExecutionResult.stepped
+            |> Some
+        | Some "SystemNative_Write",
+          [ ConcreteIntPtr state.ConcreteTypes
+            ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.Byte)
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32 ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
+            // `int32_t SystemNative_Write(intptr_t fd, const void* buffer, int32_t bufferSize)`
+            // delegates to `Common_Write` in `pal_io_common.h`. The C path:
+            //   * negative `bufferSize`            -> errno = ERANGE, return -1
+            //   * otherwise call real `write(2)`   -> may return short, may EINTR (retried)
+            // PawPrint models only the writable standard streams (fds 1 and
+            // 2) and never returns short, never returns EINTR, and never
+            // blocks: there is no kernel that could push back on our
+            // simulated process. A guest depending on EAGAIN / partial
+            // writes from a non-blocking socket would need new
+            // FileDescriptorRole entries; we'll add those when that need
+            // arises rather than guessing at the contract now.
+            let operation = "SystemNative_Write"
+
+            let fd = fdArgument operation instruction.Arguments.[0]
+
+            let buffer =
+                NativeCall.managedPointerOfPointerArgument operation "buffer" instruction.Arguments.[1]
+
+            let bufferSize = NativeCall.int32Argument operation instruction.Arguments.[2]
+
+            let setErrno (state : IlMachineState) (errno : int) : IlMachineState =
+                state.MapKernel (fun kernel ->
+                    { kernel with
+                        LastSystemError = errno
+                    }
+                )
+
+            let readBuffer (state : IlMachineState) : ImmutableArray<byte> =
+                // Drain `bufferSize` bytes from `buffer`. Called only after
+                // the bufferSize-> 0 and buffer-> non-null checks succeed.
+                let byteConcreteType =
+                    NativeCall.requiredByteConcreteType operation ctx.BaseClassTypes state
+
+                let builder = ImmutableArray.CreateBuilder<byte> bufferSize
+
+                for i = 0 to bufferSize - 1 do
+                    let src =
+                        ManagedPointerByteView.addByteOffset ctx.BaseClassTypes state byteConcreteType i buffer
+
+                    let cell =
+                        IlMachineState.readManagedByrefBytesAs
+                            ctx.BaseClassTypes
+                            state
+                            src
+                            (CliType.Numeric (CliNumericType.UInt8 0uy))
+
+                    match cell with
+                    | CliType.Numeric (CliNumericType.UInt8 b) -> builder.Add b
+                    | other ->
+                        failwith
+                            $"%s{operation}: byte read at offset %d{i} returned non-UInt8 cell %O{other} (this is an interpreter bug)"
+
+                builder.MoveToImmutable ()
+
+            let result, effect, state =
+                if bufferSize < 0 then
+                    // Matches `Common_Write`: refuse the call before any
+                    // dereference of `buffer`. CoreLib callers (`Interop.Sys.
+                    // Write`) never pass negative sizes, so this is a guest
+                    // misuse path; surface it through errno rather than
+                    // crashing so the guest's own error reporting runs.
+                    -1, StepEffect.NoEffect, setErrno state Errno.ERANGE
+                else
+                    match FileDescriptorRegistry.tryFind fd state.Kernel.FileDescriptors with
+                    | None ->
+                        // Unknown fd: report EBADF the same way `write(2)`
+                        // would.
+                        -1, StepEffect.NoEffect, setErrno state Errno.EBADF
+                    | Some entry ->
+                        match entry.Role with
+                        | FileDescriptorRole.StandardInput ->
+                            // `write(2)` on a read-only fd returns -1 + EBADF
+                            // on Linux (the fd's access mode is wrong for the
+                            // operation). Real stdin is opened O_RDONLY by
+                            // the shell, so this matches what guests would
+                            // observe on the host.
+                            -1, StepEffect.NoEffect, setErrno state Errno.EBADF
+                        | (FileDescriptorRole.StandardOutput | FileDescriptorRole.StandardError) as role ->
+                            if bufferSize = 0 then
+                                // `write(fd, _, 0)` is a no-op on every Unix
+                                // we model — no errno, no buffer
+                                // dereference, no observable effect. CoreLib
+                                // in principle never calls with
+                                // `bufferSize = 0` (it bails in
+                                // `Stream.Write`), but honour the C contract
+                                // so guests that DllImport directly behave
+                                // the same as on the host.
+                                0, StepEffect.NoEffect, state
+                            else
+                                match buffer with
+                                | ManagedPointerSource.Null ->
+                                    failwith
+                                        $"%s{operation}: refused to read %d{bufferSize} bytes through null buffer pointer (CoreLib should not invoke this entry point with a null source for a non-zero length)"
+                                | _ ->
+                                    let bytes = readBuffer state
+
+                                    let state =
+                                        state.MapKernel (fun kernel ->
+                                            match role with
+                                            | FileDescriptorRole.StandardOutput ->
+                                                { kernel with
+                                                    StdoutAppended =
+                                                        kernel.StdoutAppended.AddRange (bytes : ImmutableArray<byte>)
+                                                }
+                                            | FileDescriptorRole.StandardError ->
+                                                { kernel with
+                                                    StderrAppended =
+                                                        kernel.StderrAppended.AddRange (bytes : ImmutableArray<byte>)
+                                                }
+                                            | FileDescriptorRole.StandardInput ->
+                                                // Unreachable: matched the
+                                                // EBADF arm above. Threading
+                                                // the case here keeps `role`
+                                                // exhaustive so a future
+                                                // writable role (e.g. a
+                                                // regular file) fails to
+                                                // compile until its buffer
+                                                // destination is wired up.
+                                                failwith
+                                                    $"%s{operation}: write to StandardInput reached append path (this is an interpreter bug)"
+                                        )
+
+                                    bufferSize, StepEffect.WroteToFd (role, bytes), state
+
+            state
+            |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 result) ctx.Thread
+            |> Tuple.withRight WhatWeDid.Executed
+            |> ExecutionResult.steppedWith effect
             |> Some
         | Some "SystemNative_GetNonCryptographicallySecureRandomBytes",
           [ ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.Byte)

--- a/WoofWare.PawPrint/Native/NativeSystemNative.fs
+++ b/WoofWare.PawPrint/Native/NativeSystemNative.fs
@@ -339,10 +339,24 @@ module NativeSystemNative =
                                 // upstream) observes the same syscall
                                 // failure it would on the host.
                                 let dereferenceableBuffer : ManagedPointerSource option =
+                                    // `ManagedPointerSource.Null` is *also*
+                                    // non-dereferenceable — it can arrive
+                                    // wrapped in `CliRuntimePointer.Managed`
+                                    // when the guest passes e.g.
+                                    // `IntPtr.Zero` after a managed
+                                    // conversion, in addition to the
+                                    // verbatim-0 path. Collapse both kinds
+                                    // of null to EFAULT before `readBuffer`
+                                    // is asked to project from them.
+                                    let classifyManaged (ptr : ManagedPointerSource) =
+                                        match ptr with
+                                        | ManagedPointerSource.Null -> None
+                                        | _ -> Some ptr
+
                                     match CliType.unwrapPrimitiveLikeDeep instruction.Arguments.[1] with
-                                    | CliType.RuntimePointer (CliRuntimePointer.Managed ptr) -> Some ptr
+                                    | CliType.RuntimePointer (CliRuntimePointer.Managed ptr) -> classifyManaged ptr
                                     | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.ManagedPointer ptr)) ->
-                                        Some ptr
+                                        classifyManaged ptr
                                     | CliType.RuntimePointer (CliRuntimePointer.Verbatim _) ->
                                         // 0L is null; non-zero is a raw
                                         // unmapped address. Either way the

--- a/WoofWare.PawPrint/Native/NativeSystemNative.fs
+++ b/WoofWare.PawPrint/Native/NativeSystemNative.fs
@@ -244,9 +244,6 @@ module NativeSystemNative =
 
             let fd = fdArgument operation instruction.Arguments.[0]
 
-            let buffer =
-                NativeCall.managedPointerOfPointerArgument operation "buffer" instruction.Arguments.[1]
-
             let bufferSize = NativeCall.int32Argument operation instruction.Arguments.[2]
 
             let setErrno (state : IlMachineState) (errno : int) : IlMachineState =
@@ -256,7 +253,16 @@ module NativeSystemNative =
                     }
                 )
 
-            let readBuffer (state : IlMachineState) : ImmutableArray<byte> =
+            // Decoding the `buffer` pointer is deferred until we are
+            // genuinely about to dereference it. `Common_Write` is
+            // documented (in `pal_io_common.h`) to perform no dereference
+            // for `bufferSize < 0` (ERANGE bail) or `bufferSize = 0`
+            // (no-op on every Unix we model), so a guest calling e.g.
+            // `SystemNative_Write((IntPtr)1, (byte*)123, 0)` must succeed
+            // on PawPrint as it does on the real CLR — eagerly decoding
+            // `buffer` would crash here in `managedPointerOfPointerArgument`
+            // for any non-managed pointer literal.
+            let readBuffer (buffer : ManagedPointerSource) (state : IlMachineState) : ImmutableArray<byte> =
                 // Drain `bufferSize` bytes from `buffer`. Called only after
                 // the bufferSize-> 0 and buffer-> non-null checks succeed.
                 let byteConcreteType =
@@ -315,40 +321,36 @@ module NativeSystemNative =
                                 // `bufferSize = 0` (it bails in
                                 // `Stream.Write`), but honour the C contract
                                 // so guests that DllImport directly behave
-                                // the same as on the host.
+                                // the same as on the host. Crucially, do
+                                // NOT touch `buffer` here: the pointer is
+                                // permitted to be any bit pattern (incl.
+                                // garbage) because it is not dereferenced.
                                 0, StepEffect.NoEffect, state
                             else
+                                let buffer =
+                                    NativeCall.managedPointerOfPointerArgument
+                                        operation
+                                        "buffer"
+                                        instruction.Arguments.[1]
+
                                 match buffer with
                                 | ManagedPointerSource.Null ->
                                     failwith
                                         $"%s{operation}: refused to read %d{bufferSize} bytes through null buffer pointer (CoreLib should not invoke this entry point with a null source for a non-zero length)"
                                 | _ ->
-                                    let bytes = readBuffer state
+                                    let bytes = readBuffer buffer state
+
+                                    let logEntry =
+                                        {
+                                            OutputLogEntry.Role = role
+                                            OutputLogEntry.Bytes = bytes
+                                        }
 
                                     let state =
                                         state.MapKernel (fun kernel ->
-                                            match role with
-                                            | FileDescriptorRole.StandardOutput ->
-                                                { kernel with
-                                                    StdoutAppended =
-                                                        kernel.StdoutAppended.AddRange (bytes : ImmutableArray<byte>)
-                                                }
-                                            | FileDescriptorRole.StandardError ->
-                                                { kernel with
-                                                    StderrAppended =
-                                                        kernel.StderrAppended.AddRange (bytes : ImmutableArray<byte>)
-                                                }
-                                            | FileDescriptorRole.StandardInput ->
-                                                // Unreachable: matched the
-                                                // EBADF arm above. Threading
-                                                // the case here keeps `role`
-                                                // exhaustive so a future
-                                                // writable role (e.g. a
-                                                // regular file) fails to
-                                                // compile until its buffer
-                                                // destination is wired up.
-                                                failwith
-                                                    $"%s{operation}: write to StandardInput reached append path (this is an interpreter bug)"
+                                            { kernel with
+                                                OutputLog = kernel.OutputLog.Add logEntry
+                                            }
                                         )
 
                                     bufferSize, StepEffect.WroteToFd (role, bytes), state

--- a/WoofWare.PawPrint/Native/NativeSystemNative.fs
+++ b/WoofWare.PawPrint/Native/NativeSystemNative.fs
@@ -327,17 +327,38 @@ module NativeSystemNative =
                                 // garbage) because it is not dereferenced.
                                 0, StepEffect.NoEffect, state
                             else
-                                let buffer =
-                                    NativeCall.managedPointerOfPointerArgument
-                                        operation
-                                        "buffer"
-                                        instruction.Arguments.[1]
+                                // Try to decode `buffer` as a managed
+                                // pointer. Real `write(2)` returns -1 +
+                                // EFAULT for any non-dereferenceable
+                                // address (including NULL and unmapped
+                                // verbatim bit patterns); collapse both
+                                // those cases to EFAULT here rather than
+                                // crashing PawPrint, so a direct P/Invoke
+                                // that the BCL would never produce
+                                // (`Stream.Write` short-circuits null
+                                // upstream) observes the same syscall
+                                // failure it would on the host.
+                                let dereferenceableBuffer : ManagedPointerSource option =
+                                    match CliType.unwrapPrimitiveLikeDeep instruction.Arguments.[1] with
+                                    | CliType.RuntimePointer (CliRuntimePointer.Managed ptr) -> Some ptr
+                                    | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.ManagedPointer ptr)) ->
+                                        Some ptr
+                                    | CliType.RuntimePointer (CliRuntimePointer.Verbatim _) ->
+                                        // 0L is null; non-zero is a raw
+                                        // unmapped address. Either way the
+                                        // kernel cannot read from it.
+                                        None
+                                    | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim _)) -> None
+                                    | other ->
+                                        failwith
+                                            $"%s{operation}: expected buffer to be a managed pointer, raw verbatim address, or null literal, got %O{other} (this is an interpreter bug)"
 
-                                match buffer with
-                                | ManagedPointerSource.Null ->
-                                    failwith
-                                        $"%s{operation}: refused to read %d{bufferSize} bytes through null buffer pointer (CoreLib should not invoke this entry point with a null source for a non-zero length)"
-                                | _ ->
+                                match dereferenceableBuffer with
+                                | None ->
+                                    // EFAULT: bad address. Real kernels
+                                    // perform no I/O on this path.
+                                    -1, StepEffect.NoEffect, setErrno state Errno.EFAULT
+                                | Some buffer ->
                                     let bytes = readBuffer buffer state
 
                                     let logEntry =


### PR DESCRIPTION
## Summary

- Implement the `SystemNative_Write` shim through `FileDescriptorRegistry`. Negative `bufferSize` surfaces as `-1 + ERANGE`, unknown fd / stdin → `-1 + EBADF`, `bufferSize = 0` is a no-op (no buffer dereference), and writes to stdout/stderr append the bytes to a new canonical `EmulatedKernel.OutputLog` while emitting `StepEffect.WroteToFd`. Non-dereferenceable buffers (null in any shape, or unmapped verbatim addresses) with non-zero size produce `-1 + EFAULT`, matching real `write(2)`.
- `EmulatedKernel.StdoutAppended` / `StderrAppended` are replaced by a single ordered `OutputLog : ImmutableArray<OutputLogEntry>` so cross-stream write order is preserved (matters under `2>&1`). The App driver drains the log at end-of-run in insertion order; tests project per-stream views via `OutputLogEntry.bytesFor`.
- Test harness gains an optional `AssertTerminalState` hook so impure tests can assert against interpreter-internal state (e.g. `OutputLog`) without disrupting the pure / real-CLR cross-comparison runner. The pure `SystemNativeWrite.cs` covers all error paths (negative size, bad fd, zero-byte no-op, null buffer EFAULT, verbatim non-zero garbage pointer + zero size). The impure `SystemNativeWriteSuccess.cs` covers the success path by asserting the exact bytes recorded against the new `OutputLog`.
- New `Errno.EFAULT = 14` and `Errno.ERANGE = 34` constants, alongside the existing `EBADF`.

## Test plan

- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 893 / 893 passing
- [x] `nix develop -c dotnet fantomas .` — no changes
- [x] `codex review --base main` — clean ("No actionable correctness issues were found in the diff")

🤖 Generated with [Claude Code](https://claude.com/claude-code)