### PR TITLE
Seed guest environment with invariant globalization

### DIFF
--- a/WoofWare.PawPrint.App/DebuggerServer.fs
+++ b/WoofWare.PawPrint.App/DebuggerServer.fs
@@ -268,12 +268,13 @@ module DebuggerServer =
         (dllPath : string)
         (dotnetRuntimeDirs : ImmutableArray<string>)
         (impls : NativeImpls)
+        (env : Map<string, string>)
         (argv : string list)
         : SessionState
         =
         use fileStream = new FileStream (dllPath, FileMode.Open, FileAccess.Read)
 
-        match Program.prepare loggerFactory (Some dllPath) fileStream dotnetRuntimeDirs impls argv with
+        match Program.prepare loggerFactory (Some dllPath) fileStream dotnetRuntimeDirs impls env argv with
         | Program.ProgramStartResult.Ready prepared -> SessionState.Running (prepared, 0L)
         | Program.ProgramStartResult.CompletedBeforeMain outcome -> SessionState.Finished (outcome, 0L)
 
@@ -883,6 +884,7 @@ module DebuggerServer =
         (dllPath : string)
         (dotnetRuntimeDirs : ImmutableArray<string>)
         (impls : NativeImpls)
+        (env : Map<string, string>)
         (argv : string list)
         (token : string)
         (configureWebHost : IWebHostBuilder -> unit)
@@ -891,7 +893,7 @@ module DebuggerServer =
         let logger = loggerFactory.CreateLogger "WoofWare.PawPrint.App.DebuggerServer"
 
         let mutable session =
-            prepareSession loggerFactory dllPath dotnetRuntimeDirs impls argv
+            prepareSession loggerFactory dllPath dotnetRuntimeDirs impls env argv
 
         let sessionLock = obj ()
         let stopStateLock = obj ()
@@ -1120,7 +1122,8 @@ module DebuggerServer =
                                             |> responseOnly
                                         | _ -> responseOnly (textResponse 400 $"Invalid heap address: %s{rawAddress}")
                                     | "POST", [ "reset" ] ->
-                                        session <- prepareSession loggerFactory dllPath dotnetRuntimeDirs impls argv
+                                        session <-
+                                            prepareSession loggerFactory dllPath dotnetRuntimeDirs impls env argv
 
                                         jsonResponse
                                             200
@@ -1163,13 +1166,14 @@ module DebuggerServer =
         (dllPath : string)
         (dotnetRuntimeDirs : ImmutableArray<string>)
         (impls : NativeImpls)
+        (env : Map<string, string>)
         (argv : string list)
         : int
         =
         let token = generateBearerToken ()
 
         let app, stopCts =
-            createApp loggerFactory dllPath dotnetRuntimeDirs impls argv token configureLoopbackEphemeralPort
+            createApp loggerFactory dllPath dotnetRuntimeDirs impls env argv token configureLoopbackEphemeralPort
 
         use _stopCts = stopCts
 

--- a/WoofWare.PawPrint.App/Program.fs
+++ b/WoofWare.PawPrint.App/Program.fs
@@ -74,6 +74,22 @@ module AppProgram =
 
         let logger = loggerFactory.CreateLogger "WoofWare.PawPrint.App"
 
+        // Snapshot the host process's environment once at startup. Layered on top
+        // of `EmulatedKernel.defaultEnvironment`, so any host-set value wins over
+        // the seeded `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` default, while
+        // unset keys still get the default. This is the production analogue of
+        // tests passing an explicit env map to `Program.run`.
+        let hostEnvironment : Map<string, string> =
+            let dict = System.Environment.GetEnvironmentVariables ()
+
+            let mutable acc = Map.empty
+
+            for entry in dict do
+                let entry = entry :?> System.Collections.DictionaryEntry
+                acc <- Map.add (entry.Key :?> string) (entry.Value :?> string) acc
+
+            acc
+
         let runNormal (dllPath : string) (args : string list) : int =
             let dotnetRuntimes =
                 DotnetRuntime.SelectForDll dllPath |> ImmutableArray.CreateRange
@@ -134,7 +150,7 @@ module AppProgram =
                     out.Flush ()
                     err.Flush ()
 
-            match Program.run loggerFactory (Some dllPath) fileStream dotnetRuntimes impls args with
+            match Program.run loggerFactory (Some dllPath) fileStream dotnetRuntimes impls hostEnvironment args with
             | RunOutcome.NormalExit (state, thread)
             | RunOutcome.ProcessExit (state, thread) ->
                 drainStandardStreams state
@@ -177,7 +193,7 @@ module AppProgram =
 
             let impls = NativeImpls.PassThru ()
 
-            DebuggerServer.run loggerFactory dllPath dotnetRuntimes impls args
+            DebuggerServer.run loggerFactory dllPath dotnetRuntimes impls hostEnvironment args
 
         match mode with
         | AppMode.RunGuest (dllPath, args) -> runNormal dllPath args

--- a/WoofWare.PawPrint.Performance/Program.fs
+++ b/WoofWare.PawPrint.Performance/Program.fs
@@ -165,6 +165,7 @@ type StackHeavyProgramBenchmarks () =
                 peImage
                 dotnetRuntimeDirs
                 nativeImpls
+                Map.empty
                 []
         with
         | RunOutcome.NormalExit (terminalState, terminatingThread)

--- a/WoofWare.PawPrint.Test/CrossAssemblyHarness.fs
+++ b/WoofWare.PawPrint.Test/CrossAssemblyHarness.fs
@@ -99,7 +99,7 @@ module CrossAssemblyHarness =
 
         try
             let terminalState, terminatingThread =
-                match Program.run loggerFactory (Some entryPath) peImage dotnetRuntimeDirs nativeImpls [] with
+                match Program.run loggerFactory (Some entryPath) peImage dotnetRuntimeDirs nativeImpls Map.empty [] with
                 | RunOutcome.GuestUnhandledException (_, _, exn) ->
                     failwith $"Guest threw unhandled exception: %O{exn.ExceptionObject}"
                 | RunOutcome.FailFast (_, _, message) ->

--- a/WoofWare.PawPrint.Test/TestDebuggerServer.fs
+++ b/WoofWare.PawPrint.Test/TestDebuggerServer.fs
@@ -139,6 +139,7 @@ class Program
                 dllPath
                 dotnetRuntimes
                 impls
+                Map.empty
                 []
                 token
                 DebuggerServer.configureLoopbackEphemeralPort

--- a/WoofWare.PawPrint.Test/TestDebuggerState.fs
+++ b/WoofWare.PawPrint.Test/TestDebuggerState.fs
@@ -41,7 +41,7 @@ module TestDebuggerState =
         use peImage = new MemoryStream (image)
 
         try
-            Program.run loggerFactory (Some sourceFileName) peImage dotnetRuntimes (MockEnv.make ()) []
+            Program.run loggerFactory (Some sourceFileName) peImage dotnetRuntimes (MockEnv.make ()) Map.empty []
         with _ ->
             for message in messages () do
                 System.Console.Error.WriteLine $"{message}"

--- a/WoofWare.PawPrint.Test/TestHardwareIntrinsicsProfile.fs
+++ b/WoofWare.PawPrint.Test/TestHardwareIntrinsicsProfile.fs
@@ -41,7 +41,7 @@ module TestHardwareIntrinsicsProfile =
         use peImage = new MemoryStream (image)
 
         try
-            Program.run loggerFactory (Some sourceFileName) peImage dotnetRuntimes (MockEnv.make ()) []
+            Program.run loggerFactory (Some sourceFileName) peImage dotnetRuntimes (MockEnv.make ()) Map.empty []
         with _ ->
             for message in messages () do
                 System.Console.Error.WriteLine $"{message}"

--- a/WoofWare.PawPrint.Test/TestHarness.fs
+++ b/WoofWare.PawPrint.Test/TestHarness.fs
@@ -19,18 +19,12 @@ type RunResult =
 
 [<RequireQualifiedAccess>]
 module MockEnv =
-    let private invariantGlobalizationEnv : Map<string, string> =
-        [ "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "1" ] |> Map.ofList
-
-    let makeWithEnvironment (environment : Map<string, string>) : NativeImpls =
-        let environment =
-            // Tests may intentionally override the invariant-globalization default
-            // when they need full control of the guest environment.
-            (invariantGlobalizationEnv, environment)
-            ||> Map.fold (fun acc variable value -> acc |> Map.add variable value)
-
-        let tryGetEnvironmentVariable (variable : string) : string option = environment |> Map.tryFind variable
-
+    /// Deterministic `NativeImpls` for tests: invariant-globalization is already
+    /// seeded by `EmulatedKernel.defaultEnvironment`, so this mock only needs to
+    /// cover the *behavioural* surface (processor count, managed thread id,
+    /// FailFast). Guest env vars beyond the invariant default are supplied via
+    /// the `env` argument to `Program.run` / `Program.prepare`, not here.
+    let make () : NativeImpls =
         {
             System_Environment =
                 { System_EnvironmentMock.Empty with
@@ -48,7 +42,6 @@ module MockEnv =
                                 thread
                             |> Tuple.withRight WhatWeDid.Executed
                             |> ExecutionResult.stepped
-                    TryGetEnvironmentVariable = tryGetEnvironmentVariable
                     // Surface FailFast as the abort outcome instead of raising
                     // NotImplementedException from the generated mock; the test
                     // harness then reports the guest-supplied diagnostic message,
@@ -59,13 +52,16 @@ module MockEnv =
                 }
         }
 
-    let make () : NativeImpls = makeWithEnvironment Map.empty
-
 type EndToEndTestCase =
     {
         FileName : string
         ExpectedReturnCode : int
         NativeImpls : NativeImpls
+        /// Guest environment overlay passed to `Program.run`. Layered on top
+        /// of `EmulatedKernel.defaultEnvironment` so the
+        /// invariant-globalization default is always present even when this
+        /// map is empty.
+        Environment : Map<string, string>
         ExpectsUnhandledException : bool
         /// Optional assertion run against the final PawPrint state once the
         /// guest has exited. Used by impure tests that want to verify

--- a/WoofWare.PawPrint.Test/TestImpureCases.fs
+++ b/WoofWare.PawPrint.Test/TestImpureCases.fs
@@ -28,6 +28,7 @@ module TestImpureCases =
                 FileName = "WriteLine.cs"
                 ExpectedReturnCode = 1
                 NativeImpls = NativeImpls.PassThru ()
+                Environment = Map.empty
                 ExpectsUnhandledException = false
                 AssertTerminalState = None
             }
@@ -38,6 +39,7 @@ module TestImpureCases =
             {
                 FileName = "InstaQuit.cs"
                 ExpectedReturnCode = 1
+                Environment = Map.empty
                 ExpectsUnhandledException = false
                 AssertTerminalState = None
                 NativeImpls =
@@ -54,7 +56,6 @@ module TestImpureCases =
 
                                         (state, WhatWeDid.Executed) |> ExecutionResult.stepped
                                 GetCurrentManagedThreadId = env.GetCurrentManagedThreadId
-                                TryGetEnvironmentVariable = env.TryGetEnvironmentVariable
                                 _Exit =
                                     fun thread state ->
                                         let state = state |> IlMachineState.loadArgument thread 0
@@ -67,6 +68,7 @@ module TestImpureCases =
                 // must terminate with the worker's exit code, not just that worker thread.
                 FileName = "ExitFromWorker.cs"
                 ExpectedReturnCode = 7
+                Environment = Map.empty
                 ExpectsUnhandledException = false
                 AssertTerminalState = None
                 NativeImpls =
@@ -90,6 +92,7 @@ module TestImpureCases =
                 // as a wrong exit code.
                 FileName = "SystemNativeWriteSuccess.cs"
                 ExpectedReturnCode = 0
+                Environment = Map.empty
                 ExpectsUnhandledException = false
                 NativeImpls = NativeImpls.PassThru ()
                 AssertTerminalState =
@@ -124,7 +127,16 @@ module TestImpureCases =
 
         try
             let terminalState, terminatingThread =
-                match Program.run loggerFactory (Some case.FileName) peImage dotnetRuntimes case.NativeImpls [] with
+                match
+                    Program.run
+                        loggerFactory
+                        (Some case.FileName)
+                        peImage
+                        dotnetRuntimes
+                        case.NativeImpls
+                        case.Environment
+                        []
+                with
                 | RunOutcome.GuestUnhandledException (_, _, exn) ->
                     failwith $"Guest threw unhandled exception: %O{exn.ExceptionObject}"
                 | RunOutcome.FailFast (_, _, message) ->

--- a/WoofWare.PawPrint.Test/TestManifestResources.fs
+++ b/WoofWare.PawPrint.Test/TestManifestResources.fs
@@ -80,7 +80,7 @@ public static class Entry
 
         use peImage = new MemoryStream (image)
 
-        match Program.prepare loggerFactory (Some sourceName) peImage dotnetRuntimes implementations [] with
+        match Program.prepare loggerFactory (Some sourceName) peImage dotnetRuntimes implementations Map.empty [] with
         | Program.ProgramStartResult.Ready prepared -> prepared
         | Program.ProgramStartResult.CompletedBeforeMain outcome ->
             failwith $"expected program to be ready before Main, but got %O{outcome}"

--- a/WoofWare.PawPrint.Test/TestNativeEnum.fs
+++ b/WoofWare.PawPrint.Test/TestNativeEnum.fs
@@ -103,7 +103,16 @@ public static class Entry
 
         use peImage = new MemoryStream (image)
 
-        match Program.prepare loggerFactory (Some "NativeEnumTest.cs") peImage dotnetRuntimes (MockEnv.make ()) [] with
+        match
+            Program.prepare
+                loggerFactory
+                (Some "NativeEnumTest.cs")
+                peImage
+                dotnetRuntimes
+                (MockEnv.make ())
+                Map.empty
+                []
+        with
         | Program.ProgramStartResult.Ready prepared -> prepared
         | Program.ProgramStartResult.CompletedBeforeMain outcome ->
             failwith $"expected enum test program to be ready before Main, got %O{outcome}"

--- a/WoofWare.PawPrint.Test/TestProgramDebugger.fs
+++ b/WoofWare.PawPrint.Test/TestProgramDebugger.fs
@@ -121,7 +121,7 @@ class Program
 
             let normalOutcome =
                 use stream = new MemoryStream (image)
-                Program.run normalLoggerFactory (Some "DebuggerProperty.cs") stream dotnetRuntimes impls []
+                Program.run normalLoggerFactory (Some "DebuggerProperty.cs") stream dotnetRuntimes impls Map.empty []
 
             let _, debuggerLoggerFactory = LoggerFactory.makeTest ()
             use _debuggerLoggerFactoryResource = debuggerLoggerFactory
@@ -131,7 +131,14 @@ class Program
                 use stream = new MemoryStream (image)
 
                 match
-                    Program.prepare debuggerLoggerFactory (Some "DebuggerProperty.cs") stream dotnetRuntimes impls []
+                    Program.prepare
+                        debuggerLoggerFactory
+                        (Some "DebuggerProperty.cs")
+                        stream
+                        dotnetRuntimes
+                        impls
+                        Map.empty
+                        []
                 with
                 | Program.ProgramStartResult.Ready prepared ->
                     stepToCompletion debuggerLoggerFactory logger impls prepared

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -128,6 +128,7 @@ module TestPureCases =
         (sourceName : string)
         (source : string)
         (nativeImpls : NativeImpls)
+        (env : Map<string, string>)
         (assertResult : byte array -> RunOutcome -> unit)
         : unit
         =
@@ -145,7 +146,7 @@ module TestPureCases =
 
         try
             let pawPrintResult =
-                Program.run loggerFactory (Some sourceName) peImage dotnetRuntimes nativeImpls []
+                Program.run loggerFactory (Some sourceName) peImage dotnetRuntimes nativeImpls env []
 
             assertResult image pawPrintResult
         with _ ->
@@ -161,6 +162,7 @@ module TestPureCases =
             case.FileName
             source
             case.NativeImpls
+            case.Environment
             (fun image pawPrintResult ->
                 let realResult = RealRuntime.executeWithRealRuntime [||] image
 
@@ -247,6 +249,7 @@ class Program
             "RethrowStackTrace.cs"
             source
             (MockEnv.make ())
+            Map.empty
             (fun _image pawPrintResult ->
                 match pawPrintResult with
                 | RunOutcome.GuestUnhandledException (_, _, exn) ->
@@ -275,6 +278,7 @@ class Program
             "MockEnvironmentInvariantGlobalization.cs"
             source
             (MockEnv.make ())
+            Map.empty
             (fun _image pawPrintResult ->
                 match pawPrintResult with
                 | RunOutcome.NormalExit (terminalState, terminatingThread) ->
@@ -335,7 +339,8 @@ class Program
         runPawPrintSource
             "MockEnvironmentConfiguredVariables.cs"
             source
-            (MockEnv.makeWithEnvironment ([ "PAWPRINT_TEST_VARIABLE", "configured" ] |> Map.ofList))
+            (MockEnv.make ())
+            ([ "PAWPRINT_TEST_VARIABLE", "configured" ] |> Map.ofList)
             (fun _image pawPrintResult ->
                 match pawPrintResult with
                 | RunOutcome.NormalExit (terminalState, terminatingThread) ->
@@ -380,6 +385,7 @@ class Program
             "MockEnvironmentMissingVariableLastPInvokeError.cs"
             source
             (MockEnv.make ())
+            Map.empty
             (fun _image pawPrintResult ->
                 match pawPrintResult with
                 | RunOutcome.NormalExit (terminalState, terminatingThread) ->
@@ -422,6 +428,7 @@ class Program
             "EnvironmentFailFast.cs"
             source
             nativeImpls
+            Map.empty
             (fun _image pawPrintResult ->
                 match pawPrintResult with
                 | RunOutcome.FailFast (_, _, message) -> message |> shouldEqual (Some "boom")
@@ -437,6 +444,7 @@ class Program
             FileName = fileName
             ExpectedReturnCode = 0
             NativeImpls = MockEnv.make ()
+            Environment = Map.empty
             ExpectsUnhandledException = false
             AssertTerminalState = None
         }
@@ -451,6 +459,7 @@ class Program
             FileName = fileName
             ExpectedReturnCode = exitCode
             NativeImpls = MockEnv.make ()
+            Environment = Map.empty
             ExpectsUnhandledException = false
             AssertTerminalState = None
         }
@@ -462,6 +471,7 @@ class Program
             FileName = fileName
             ExpectedReturnCode = 0
             NativeImpls = mock
+            Environment = Map.empty
             ExpectsUnhandledException = false
             AssertTerminalState = None
         }
@@ -474,6 +484,7 @@ class Program
             FileName = fileName
             ExpectedReturnCode = 0 // not checked; both runtimes are expected to throw
             NativeImpls = MockEnv.make ()
+            Environment = Map.empty
             ExpectsUnhandledException = true
             AssertTerminalState = None
         }
@@ -499,6 +510,7 @@ class Program
             FileName = fileName
             ExpectedReturnCode = 0
             NativeImpls = MockEnv.make ()
+            Environment = Map.empty
             ExpectsUnhandledException = false
             AssertTerminalState = None
         }
@@ -523,6 +535,7 @@ class Program
             FileName = fileName
             ExpectedReturnCode = 0
             NativeImpls = mock
+            Environment = Map.empty
             ExpectsUnhandledException = false
             AssertTerminalState = None
         }

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -408,6 +408,48 @@ class Program
             )
 
     [<Test>]
+    let ``Caller-supplied env overlay wins over seeded default under case-insensitive collision`` () =
+        // The seeded `EmulatedKernel.defaultEnvironment` carries
+        // `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1`. A caller that passes a
+        // lower-case overlay for the same logical name must replace the seed
+        // (Windows env-block semantics), not coexist with it — otherwise the
+        // case-insensitive `GetEnvironmentVariableW` would walk the map and
+        // could return either the seed or the overlay depending on Map
+        // ordering, which is not deterministic from the caller's perspective.
+        let source =
+            """
+using System;
+
+class Program
+{
+    static int Main(string[] args)
+    {
+        return Environment.GetEnvironmentVariable("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT") == "0" ? 0 : 1;
+    }
+}
+"""
+
+        runPawPrintSource
+            "MockEnvironmentCaseInsensitiveOverlayWins.cs"
+            source
+            (MockEnv.make ())
+            ([ "dotnet_system_globalization_invariant", "0" ] |> Map.ofList)
+            (fun _image pawPrintResult ->
+                match pawPrintResult with
+                | RunOutcome.NormalExit (terminalState, terminatingThread) ->
+                    match terminalState.ThreadState.[terminatingThread].MethodState.EvaluationStack.Values with
+                    | EvalStackValue.Int32 exitCode :: _ -> exitCode |> shouldEqual 0
+                    | [] -> failwith "expected program to return an int, but it returned void"
+                    | ret :: _ -> failwith $"expected program to return an int, but it returned %O{ret}"
+                | RunOutcome.ProcessExit _ -> failwith "expected normal exit, got process exit"
+                | RunOutcome.FailFast (_, _, message) ->
+                    let m = message |> Option.defaultValue "<no message>"
+                    failwith $"expected normal exit, got Environment.FailFast: %s{m}"
+                | RunOutcome.GuestUnhandledException (_, _, exn) ->
+                    failwith $"guest threw unhandled exception: %O{exn.ExceptionObject}"
+            )
+
+    [<Test>]
     let ``Mock environment preserves missing variable last PInvoke error`` () =
         let source =
             """

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -357,13 +357,13 @@ class Program
             )
 
     [<Test>]
-    let ``Kernel32 GetEnvironmentVariableW lookup is case-insensitive`` () =
-        // `kernel32!GetEnvironmentVariableW` is case-insensitive on Windows
-        // (the PEB env block is keyed by case-folded names). PawPrint stores
-        // the guest env as a plain F# `Map<string,string>`, so the QCall shim
-        // must walk it with an ordinal-ignore-case comparison instead of
-        // `Map.tryFind`; this test would have caught the eager `Map.tryFind`
-        // implementation that regressed Windows semantics.
+    let ``GetEnvironmentVariableW lookup is case-sensitive`` () =
+        // CoreCLR's Unix PAL implements the `kernel32!GetEnvironmentVariableW`
+        // import with exact name comparison (see pal/src/misc/environ.cpp
+        // `FindEnvVarValue`), so the QCall shim must do exact-string lookup
+        // against the kernel env map even though the *Windows* kernel32 entry
+        // would be case-insensitive: PawPrint is baselined against the host
+        // runtime, which is the Unix PAL on the hosts this repo runs on.
         let source =
             """
 using System;
@@ -372,14 +372,19 @@ class Program
 {
     static int Main(string[] args)
     {
-        if (Environment.GetEnvironmentVariable("pawprint_mixed_case_key") != "found")
+        if (Environment.GetEnvironmentVariable("PaWpRiNt_MiXeD_CaSe_KeY") != "found")
         {
             return 1;
         }
 
-        if (Environment.GetEnvironmentVariable("PAWPRINT_MIXED_CASE_KEY") != "found")
+        if (Environment.GetEnvironmentVariable("pawprint_mixed_case_key") != null)
         {
             return 2;
+        }
+
+        if (Environment.GetEnvironmentVariable("PAWPRINT_MIXED_CASE_KEY") != null)
+        {
+            return 3;
         }
 
         return 0;
@@ -388,52 +393,10 @@ class Program
 """
 
         runPawPrintSource
-            "MockEnvironmentCaseInsensitiveLookup.cs"
+            "MockEnvironmentCaseSensitiveLookup.cs"
             source
             (MockEnv.make ())
             ([ "PaWpRiNt_MiXeD_CaSe_KeY", "found" ] |> Map.ofList)
-            (fun _image pawPrintResult ->
-                match pawPrintResult with
-                | RunOutcome.NormalExit (terminalState, terminatingThread) ->
-                    match terminalState.ThreadState.[terminatingThread].MethodState.EvaluationStack.Values with
-                    | EvalStackValue.Int32 exitCode :: _ -> exitCode |> shouldEqual 0
-                    | [] -> failwith "expected program to return an int, but it returned void"
-                    | ret :: _ -> failwith $"expected program to return an int, but it returned %O{ret}"
-                | RunOutcome.ProcessExit _ -> failwith "expected normal exit, got process exit"
-                | RunOutcome.FailFast (_, _, message) ->
-                    let m = message |> Option.defaultValue "<no message>"
-                    failwith $"expected normal exit, got Environment.FailFast: %s{m}"
-                | RunOutcome.GuestUnhandledException (_, _, exn) ->
-                    failwith $"guest threw unhandled exception: %O{exn.ExceptionObject}"
-            )
-
-    [<Test>]
-    let ``Caller-supplied env overlay wins over seeded default under case-insensitive collision`` () =
-        // The seeded `EmulatedKernel.defaultEnvironment` carries
-        // `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1`. A caller that passes a
-        // lower-case overlay for the same logical name must replace the seed
-        // (Windows env-block semantics), not coexist with it — otherwise the
-        // case-insensitive `GetEnvironmentVariableW` would walk the map and
-        // could return either the seed or the overlay depending on Map
-        // ordering, which is not deterministic from the caller's perspective.
-        let source =
-            """
-using System;
-
-class Program
-{
-    static int Main(string[] args)
-    {
-        return Environment.GetEnvironmentVariable("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT") == "0" ? 0 : 1;
-    }
-}
-"""
-
-        runPawPrintSource
-            "MockEnvironmentCaseInsensitiveOverlayWins.cs"
-            source
-            (MockEnv.make ())
-            ([ "dotnet_system_globalization_invariant", "0" ] |> Map.ofList)
             (fun _image pawPrintResult ->
                 match pawPrintResult with
                 | RunOutcome.NormalExit (terminalState, terminatingThread) ->

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -357,6 +357,57 @@ class Program
             )
 
     [<Test>]
+    let ``Kernel32 GetEnvironmentVariableW lookup is case-insensitive`` () =
+        // `kernel32!GetEnvironmentVariableW` is case-insensitive on Windows
+        // (the PEB env block is keyed by case-folded names). PawPrint stores
+        // the guest env as a plain F# `Map<string,string>`, so the QCall shim
+        // must walk it with an ordinal-ignore-case comparison instead of
+        // `Map.tryFind`; this test would have caught the eager `Map.tryFind`
+        // implementation that regressed Windows semantics.
+        let source =
+            """
+using System;
+
+class Program
+{
+    static int Main(string[] args)
+    {
+        if (Environment.GetEnvironmentVariable("pawprint_mixed_case_key") != "found")
+        {
+            return 1;
+        }
+
+        if (Environment.GetEnvironmentVariable("PAWPRINT_MIXED_CASE_KEY") != "found")
+        {
+            return 2;
+        }
+
+        return 0;
+    }
+}
+"""
+
+        runPawPrintSource
+            "MockEnvironmentCaseInsensitiveLookup.cs"
+            source
+            (MockEnv.make ())
+            ([ "PaWpRiNt_MiXeD_CaSe_KeY", "found" ] |> Map.ofList)
+            (fun _image pawPrintResult ->
+                match pawPrintResult with
+                | RunOutcome.NormalExit (terminalState, terminatingThread) ->
+                    match terminalState.ThreadState.[terminatingThread].MethodState.EvaluationStack.Values with
+                    | EvalStackValue.Int32 exitCode :: _ -> exitCode |> shouldEqual 0
+                    | [] -> failwith "expected program to return an int, but it returned void"
+                    | ret :: _ -> failwith $"expected program to return an int, but it returned %O{ret}"
+                | RunOutcome.ProcessExit _ -> failwith "expected normal exit, got process exit"
+                | RunOutcome.FailFast (_, _, message) ->
+                    let m = message |> Option.defaultValue "<no message>"
+                    failwith $"expected normal exit, got Environment.FailFast: %s{m}"
+                | RunOutcome.GuestUnhandledException (_, _, exn) ->
+                    failwith $"guest threw unhandled exception: %O{exn.ExceptionObject}"
+            )
+
+    [<Test>]
     let ``Mock environment preserves missing variable last PInvoke error`` () =
         let source =
             """

--- a/WoofWare.PawPrint/EmulatedKernel.fs
+++ b/WoofWare.PawPrint/EmulatedKernel.fs
@@ -254,6 +254,15 @@ type EmulatedKernel =
         /// matching real-CLR behaviour. Per-stream views are derived in
         /// `OutputLogEntry.bytesFor`.
         OutputLog : ImmutableArray<OutputLogEntry>
+        /// Simulated process environment variable table. Consulted by
+        /// `Environment.GetEnvironmentVariable` and the Win32
+        /// `GetEnvironmentVariableW` shim. Seeded with
+        /// `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` so guest BCL code that
+        /// reads it during startup gets the invariant-globalization mode
+        /// PawPrint requires; the CLI overlays the host process's env on top
+        /// of this default at startup, and tests can pass their own overlay
+        /// via `Program.run`.
+        Environment : Map<string, string>
     }
 
 /// Deterministic non-cryptographic PRNG that backs
@@ -317,6 +326,16 @@ module NonCryptoRandom =
 
 [<RequireQualifiedAccess>]
 module EmulatedKernel =
+    /// Default environment variables for a freshly-minted simulated process.
+    /// PawPrint only implements invariant-globalization today, so this seed
+    /// must always be applied: callers that supply a custom environment
+    /// overlay it on top of these defaults, which means the host (or a test)
+    /// can override `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT` if it really
+    /// needs to, while forgetting to set it keeps the runtime in the regime
+    /// it actually supports.
+    let defaultEnvironment : Map<string, string> =
+        Map.ofList [ "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "1" ]
+
     let initial : EmulatedKernel =
         {
             LastPInvokeError = 0
@@ -331,4 +350,19 @@ module EmulatedKernel =
             StepCounter = 0L
             NonCryptoRandomState = NonCryptoRandom.initialState
             OutputLog = ImmutableArray<OutputLogEntry>.Empty
+            Environment = defaultEnvironment
+        }
+
+    /// Overlay the supplied environment variables on top of the kernel's
+    /// existing `Environment` map. Used by `Program.run` / the CLI to layer
+    /// host or test-supplied env vars on top of `defaultEnvironment` without
+    /// losing the seeded invariant-globalization default for keys the
+    /// caller does not set.
+    let withEnvironment (env : Map<string, string>) (kernel : EmulatedKernel) : EmulatedKernel =
+        let merged =
+            (kernel.Environment, env)
+            ||> Map.fold (fun acc key value -> Map.add key value acc)
+
+        { kernel with
+            Environment = merged
         }

--- a/WoofWare.PawPrint/EmulatedKernel.fs
+++ b/WoofWare.PawPrint/EmulatedKernel.fs
@@ -357,11 +357,26 @@ module EmulatedKernel =
     /// existing `Environment` map. Used by `Program.run` / the CLI to layer
     /// host or test-supplied env vars on top of `defaultEnvironment` without
     /// losing the seeded invariant-globalization default for keys the
-    /// caller does not set.
+    /// caller does not set. Matches Windows env-block semantics: each
+    /// overlay key replaces any existing entry with the same name under
+    /// `OrdinalIgnoreCase`, preserving the overlay's casing for the
+    /// resulting key. Without this, an overlay like
+    /// `dotnet_system_globalization_invariant=0` would coexist with the
+    /// seeded uppercase entry, and the case-insensitive
+    /// `GetEnvironmentVariableW` lookup could still return the seeded
+    /// value.
     let withEnvironment (env : Map<string, string>) (kernel : EmulatedKernel) : EmulatedKernel =
         let merged =
             (kernel.Environment, env)
-            ||> Map.fold (fun acc key value -> Map.add key value acc)
+            ||> Map.fold (fun acc key value ->
+                let withoutCollisions =
+                    acc
+                    |> Map.filter (fun existing _ ->
+                        not (System.String.Equals (existing, key, System.StringComparison.OrdinalIgnoreCase))
+                    )
+
+                Map.add key value withoutCollisions
+            )
 
         { kernel with
             Environment = merged

--- a/WoofWare.PawPrint/EmulatedKernel.fs
+++ b/WoofWare.PawPrint/EmulatedKernel.fs
@@ -357,26 +357,16 @@ module EmulatedKernel =
     /// existing `Environment` map. Used by `Program.run` / the CLI to layer
     /// host or test-supplied env vars on top of `defaultEnvironment` without
     /// losing the seeded invariant-globalization default for keys the
-    /// caller does not set. Matches Windows env-block semantics: each
-    /// overlay key replaces any existing entry with the same name under
-    /// `OrdinalIgnoreCase`, preserving the overlay's casing for the
-    /// resulting key. Without this, an overlay like
-    /// `dotnet_system_globalization_invariant=0` would coexist with the
-    /// seeded uppercase entry, and the case-insensitive
-    /// `GetEnvironmentVariableW` lookup could still return the seeded
-    /// value.
+    /// caller does not set. Matches the Unix-PAL semantics of the env table
+    /// (case-sensitive name comparison): overlay keys replace existing
+    /// entries with the same exact name, and names that differ only in case
+    /// are treated as distinct variables — which is what CoreCLR's Unix PAL
+    /// does for `GetEnvironmentVariableW` on the macOS/Linux hosts this
+    /// project runs on.
     let withEnvironment (env : Map<string, string>) (kernel : EmulatedKernel) : EmulatedKernel =
         let merged =
             (kernel.Environment, env)
-            ||> Map.fold (fun acc key value ->
-                let withoutCollisions =
-                    acc
-                    |> Map.filter (fun existing _ ->
-                        not (System.String.Equals (existing, key, System.StringComparison.OrdinalIgnoreCase))
-                    )
-
-                Map.add key value withoutCollisions
-            )
+            ||> Map.fold (fun acc key value -> Map.add key value acc)
 
         { kernel with
             Environment = merged

--- a/WoofWare.PawPrint/ExternImplementations/System.Environment.fs
+++ b/WoofWare.PawPrint/ExternImplementations/System.Environment.fs
@@ -7,8 +7,6 @@ type ISystem_Environment =
     abstract GetProcessorCount : ThreadId -> IlMachineState -> ExecutionResult
     /// The expected side-effect is to push an Int32 to the stack.
     abstract GetCurrentManagedThreadId : ThreadId -> IlMachineState -> ExecutionResult
-    /// Lookup a guest environment variable. Returning None means the variable is absent.
-    abstract TryGetEnvironmentVariable : variable : string -> string option
     /// The expected side effect is to terminate execution.
     abstract _Exit : ThreadId -> IlMachineState -> ExecutionResult
 
@@ -37,11 +35,6 @@ module System_Environment =
                     state
                 |> Tuple.withRight WhatWeDid.Executed
                 |> ExecutionResult.stepped
-
-            member _.TryGetEnvironmentVariable variable =
-                // The production pass-through reflects the host process. Tests
-                // that need deterministic inputs should use MockEnv instead.
-                System.Environment.GetEnvironmentVariable variable |> Option.ofObj
 
             member _._Exit currentThread state =
                 // Push the exit code (arg 0) onto the eval stack so the scheduler can report

--- a/WoofWare.PawPrint/Native/NativeKernel32.fs
+++ b/WoofWare.PawPrint/Native/NativeKernel32.fs
@@ -1,6 +1,5 @@
 namespace WoofWare.PawPrint
 
-open WoofWare.PawPrint.ExternImplementations
 
 [<RequireQualifiedAccess>]
 module NativeKernel32 =
@@ -142,10 +141,8 @@ module NativeKernel32 =
             let name =
                 NativeCall.readNullTerminatedUtf16 operation ctx.BaseClassTypes state namePtr
 
-            let env = ISystem_Environment_Env.get ctx.Implementations
-
             let plan =
-                planGetEnvironmentVariableW bufferSize (env.TryGetEnvironmentVariable name)
+                planGetEnvironmentVariableW bufferSize (Map.tryFind name state.Kernel.Environment)
 
             let state =
                 match plan.ValueToWrite with

--- a/WoofWare.PawPrint/Native/NativeKernel32.fs
+++ b/WoofWare.PawPrint/Native/NativeKernel32.fs
@@ -141,20 +141,16 @@ module NativeKernel32 =
             let name =
                 NativeCall.readNullTerminatedUtf16 operation ctx.BaseClassTypes state namePtr
 
-            // Real `kernel32!GetEnvironmentVariableW` is case-insensitive (Windows env
-            // names are stored in the PEB block keyed by case-folded names). The seeded
-            // `EmulatedKernel.Environment` is a plain F# `Map<string,string>`, so we walk
-            // it with an ordinal-ignore-case comparison rather than `Map.tryFind`.
-            let envValue =
-                state.Kernel.Environment
-                |> Map.tryPick (fun key value ->
-                    if System.String.Equals (key, name, System.StringComparison.OrdinalIgnoreCase) then
-                        Some value
-                    else
-                        None
-                )
-
-            let plan = planGetEnvironmentVariableW bufferSize envValue
+            // The "kernel32!GetEnvironmentVariableW" QCall is a CoreCLR PAL entry on
+            // Unix hosts, where the PAL implementation matches env-var names exactly
+            // (see CoreCLR pal/src/misc/environ.cpp `FindEnvVarValue`). On Windows
+            // the real kernel32 entry would be case-insensitive, but PawPrint is
+            // baselined against the host runtime — which is the Unix PAL on the
+            // macOS/Linux hosts this project actually runs on — so an exact
+            // `Map.tryFind` is the semantics that keeps PawPrint in step with the
+            // real runtime.
+            let plan =
+                planGetEnvironmentVariableW bufferSize (Map.tryFind name state.Kernel.Environment)
 
             let state =
                 match plan.ValueToWrite with

--- a/WoofWare.PawPrint/Native/NativeKernel32.fs
+++ b/WoofWare.PawPrint/Native/NativeKernel32.fs
@@ -141,8 +141,20 @@ module NativeKernel32 =
             let name =
                 NativeCall.readNullTerminatedUtf16 operation ctx.BaseClassTypes state namePtr
 
-            let plan =
-                planGetEnvironmentVariableW bufferSize (Map.tryFind name state.Kernel.Environment)
+            // Real `kernel32!GetEnvironmentVariableW` is case-insensitive (Windows env
+            // names are stored in the PEB block keyed by case-folded names). The seeded
+            // `EmulatedKernel.Environment` is a plain F# `Map<string,string>`, so we walk
+            // it with an ordinal-ignore-case comparison rather than `Map.tryFind`.
+            let envValue =
+                state.Kernel.Environment
+                |> Map.tryPick (fun key value ->
+                    if System.String.Equals (key, name, System.StringComparison.OrdinalIgnoreCase) then
+                        Some value
+                    else
+                        None
+                )
+
+            let plan = planGetEnvironmentVariableW bufferSize envValue
 
             let state =
                 match plan.ValueToWrite with

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -224,12 +224,18 @@ module Program =
         pumpPrepared loggerFactory logger impls prepared
 
     /// Reads the guest assembly and performs the one-time setup needed before Main is ready to schedule.
+    ///
+    /// `env` is overlaid on top of `EmulatedKernel.defaultEnvironment`, so callers that pass
+    /// `Map.empty` still get the seeded `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` default.
+    /// Keys present in `env` win over the default — that's how the CLI lets the host process
+    /// override the seed if it really needs to.
     let prepare
         (loggerFactory : ILoggerFactory)
         (originalPath : string option)
         (fileStream : Stream)
         (dotnetRuntimeDirs : ImmutableArray<string>)
         impls
+        (env : Map<string, string>)
         (argv : string list)
         : ProgramStartResult
         =
@@ -247,7 +253,9 @@ module Program =
         if mainMethodFromMetadata.Signature.GenericParameterCount > 0 then
             failwith "Refusing to execute generic main method"
 
-        let state = IlMachineState.initial loggerFactory dotnetRuntimeDirs dumped
+        let state =
+            IlMachineState.initial loggerFactory dotnetRuntimeDirs dumped
+            |> fun s -> s.MapKernel (EmulatedKernel.withEnvironment env)
 
         // Find the core library by traversing the type hierarchy of the main method's declaring type
         // until we reach System.Object
@@ -517,11 +525,12 @@ module Program =
         (fileStream : Stream)
         (dotnetRuntimeDirs : ImmutableArray<string>)
         impls
+        (env : Map<string, string>)
         (argv : string list)
         : RunOutcome
         =
         let logger = loggerFactory.CreateLogger "Program"
 
-        match prepare loggerFactory originalPath fileStream dotnetRuntimeDirs impls argv with
+        match prepare loggerFactory originalPath fileStream dotnetRuntimeDirs impls env argv with
         | ProgramStartResult.CompletedBeforeMain outcome -> outcome
         | ProgramStartResult.Ready prepared -> pumpPrepared loggerFactory logger impls prepared


### PR DESCRIPTION
## Summary
- Carry guest env vars on `EmulatedKernel.Environment`, seeded with `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` so tests can't accidentally drop the invariant default when they swap `NativeImpls`.
- CLI snapshots the host process env on startup and overlays it on top of the seed (host wins for shared keys); tests pass their own overlay through the new `env` parameter on `Program.run` / `Program.prepare` / `DebuggerServer.run`.
- Delete `TryGetEnvironmentVariable` from `ISystem_Environment`: env-var lookup is now a data lookup against `state.Kernel.Environment` in the `kernel32!GetEnvironmentVariableW` QCall, not a behavior hook on the native-impls record.
- Keep the lookup case-sensitive to match CoreCLR's Unix PAL semantics (`pal/src/misc/environ.cpp:FindEnvVarValue`), which is the implementation of the `GetEnvironmentVariableW` import on the macOS/Linux hosts this project runs on. An end-to-end test asserts the case-sensitive behavior.

## Test plan
- [x] `nix develop -c dotnet build WoofWare.PawPrint.slnx` — 0 warnings, 0 errors
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 822/822 passing
- [x] `nix develop -c dotnet fantomas .` — no formatting changes required
- [x] `codex review --base main` — clean (no introduced correctness issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)