### PR TITLE
Add CustomAttrib fixed-args blob reader

### DIFF
--- a/WoofWare.PawPrint.Domain/CustomAttribute.fs
+++ b/WoofWare.PawPrint.Domain/CustomAttribute.fs
@@ -4,6 +4,35 @@ open System.Collections.Immutable
 open System.Reflection.Metadata
 
 /// <summary>
+/// One decoded fixed argument from a <c>CustomAttrib</c> blob (ECMA-335 II.23.3).
+/// Each variant corresponds to a <c>CorSerializationType</c> the metadata blob can carry.
+/// </summary>
+/// <remarks>
+/// Not all <c>CorSerializationType</c> values are represented yet:
+/// <c>TYPE</c> (0x50), <c>TAGGED_OBJECT</c> (0x51), <c>ENUM</c> (0x55), and
+/// <c>SZARRAY</c> (0x1d) will be added when the QCall handler needs them.
+/// The current set covers attributes whose ctors take only primitives and strings,
+/// which is the dominant shape on the ResourceManager-init code path.
+/// </remarks>
+[<RequireQualifiedAccess>]
+type CustomAttribFixedArg =
+    | Bool of bool
+    | Char of char
+    | I1 of sbyte
+    | U1 of byte
+    | I2 of int16
+    | U2 of uint16
+    | I4 of int32
+    | U4 of uint32
+    | I8 of int64
+    | U8 of uint64
+    | R4 of float32
+    | R8 of double
+    /// <c>None</c> for the SerString null sentinel (a single <c>0xFF</c> byte);
+    /// <c>Some ""</c> for the empty string; <c>Some s</c> for a non-empty UTF-8 string.
+    | String of string option
+
+/// <summary>
 /// Represents a custom attribute applied to a type, method, field, or other metadata entity.
 /// This is a strongly-typed representation of CustomAttribute from System.Reflection.Metadata.
 /// </summary>
@@ -130,3 +159,279 @@ module CustomAttribute =
                             blob.CopyTo (bodyStart, bytes, 0, length)
                             let s = System.Text.Encoding.UTF8.GetString bytes
                             Ok (Some s)
+
+    /// <summary>
+    /// Read a <c>PackedLen</c> (ECMA-335 II.23.2) starting at the given offset.
+    /// Returns the decoded length and the offset of the first byte after the
+    /// PackedLen header.
+    /// </summary>
+    let internal readPackedLen (blob : ImmutableArray<byte>) (offset : int) : Result<int * int, string> =
+        let len = blob.Length
+
+        if offset >= len then
+            Error (sprintf "CustomAttrib blob: PackedLen begins at offset %d but blob has only %d bytes" offset len)
+        else
+            let first = blob.[offset]
+
+            if first &&& 0x80uy = 0uy then
+                Ok (int first, offset + 1)
+            elif first &&& 0xC0uy = 0x80uy then
+                if offset + 2 > len then
+                    Error "CustomAttrib blob: truncated 2-byte PackedLen"
+                else
+                    let length = ((int first &&& 0x3F) <<< 8) ||| int blob.[offset + 1]
+                    Ok (length, offset + 2)
+            elif first &&& 0xE0uy = 0xC0uy then
+                if offset + 4 > len then
+                    Error "CustomAttrib blob: truncated 4-byte PackedLen"
+                else
+                    let length =
+                        ((int first &&& 0x1F) <<< 24)
+                        ||| (int blob.[offset + 1] <<< 16)
+                        ||| (int blob.[offset + 2] <<< 8)
+                        ||| int blob.[offset + 3]
+
+                    Ok (length, offset + 4)
+            else
+                Error (sprintf "CustomAttrib blob: invalid PackedLen leading byte 0x%02X" first)
+
+    /// <summary>
+    /// Read a <c>SerString</c> (ECMA-335 II.23.3) starting at the given offset.
+    /// Returns <c>None</c> for the null sentinel (a single <c>0xFF</c> byte) and
+    /// <c>Some s</c> for an empty or non-empty UTF-8 string, paired with the
+    /// offset of the first byte after the SerString.
+    /// </summary>
+    let internal readSerString (blob : ImmutableArray<byte>) (offset : int) : Result<string option * int, string> =
+        let len = blob.Length
+
+        if offset >= len then
+            Error (sprintf "CustomAttrib blob: SerString begins at offset %d but blob has only %d bytes" offset len)
+        elif blob.[offset] = 0xFFuy then
+            Ok (None, offset + 1)
+        else
+            match readPackedLen blob offset with
+            | Error e -> Error e
+            | Ok (length, bodyStart) ->
+                if bodyStart + length > len then
+                    Error (
+                        sprintf
+                            "CustomAttrib blob: SerString body truncated (declared %d bytes, %d available)"
+                            length
+                            (len - bodyStart)
+                    )
+                else
+                    let bytes = Array.zeroCreate<byte> length
+                    blob.CopyTo (bodyStart, bytes, 0, length)
+                    let s = System.Text.Encoding.UTF8.GetString bytes
+                    Ok (Some s, bodyStart + length)
+
+    /// <summary>
+    /// Decode the fixed-args section of a <c>CustomAttrib</c> blob (ECMA-335 II.23.3).
+    /// The blob must start with the two-byte prolog <c>0x0001</c>, followed by one
+    /// fixed-arg value for each entry in <paramref name="paramTypes"/> (in declared order),
+    /// encoded per ECMA-335 II.23.3 / <c>CorSerializationType</c>.
+    /// </summary>
+    /// <param name="paramTypes">The constructor's parameter types in declaration order.</param>
+    /// <param name="blob">The raw <c>CustomAttrib</c> blob.</param>
+    /// <returns>
+    /// On success: the decoded fixed-arg values in declaration order, and the offset of the
+    /// first byte after the fixed-args section (i.e. where the <c>NumNamed</c> count, if any,
+    /// begins). On failure: a diagnostic message.
+    /// </returns>
+    /// <remarks>
+    /// Mirrors the per-arg loop in CoreCLR's <c>CustomAttribute_CreateCustomAttributeInstance</c>
+    /// (<c>customattribute.cpp:900</c>), which dispatches via <c>GetDataFromBlob</c>.
+    /// </remarks>
+    let readFixedArgs
+        (paramTypes : TypeDefn list)
+        (blob : ImmutableArray<byte>)
+        : Result<CustomAttribFixedArg list * int, string>
+        =
+        let len = blob.Length
+
+        if len < 2 then
+            Error "CustomAttrib blob is shorter than the 2-byte prolog"
+        else
+
+        let prolog = uint16 blob.[0] ||| (uint16 blob.[1] <<< 8)
+
+        if prolog <> 0x0001us then
+            Error (sprintf "CustomAttrib blob has unexpected prolog 0x%04X (expected 0x0001)" prolog)
+        else
+
+        let readPrimitive
+            (size : int)
+            (offset : int)
+            (build : ImmutableArray<byte> -> int -> CustomAttribFixedArg)
+            : Result<CustomAttribFixedArg * int, string>
+            =
+            if offset + size > len then
+                Error (
+                    sprintf
+                        "CustomAttrib blob: primitive of size %d at offset %d would overrun blob length %d"
+                        size
+                        offset
+                        len
+                )
+            else
+                Ok (build blob offset, offset + size)
+
+        let readOne (paramType : TypeDefn) (offset : int) : Result<CustomAttribFixedArg * int, string> =
+            match paramType with
+            | TypeDefn.PrimitiveType pt ->
+                match pt with
+                | PrimitiveType.Boolean -> readPrimitive 1 offset (fun b o -> CustomAttribFixedArg.Bool (b.[o] <> 0uy))
+                | PrimitiveType.Char ->
+                    readPrimitive
+                        2
+                        offset
+                        (fun b o ->
+                            let v = uint16 b.[o] ||| (uint16 b.[o + 1] <<< 8)
+                            CustomAttribFixedArg.Char (char v)
+                        )
+                | PrimitiveType.SByte -> readPrimitive 1 offset (fun b o -> CustomAttribFixedArg.I1 (sbyte b.[o]))
+                | PrimitiveType.Byte -> readPrimitive 1 offset (fun b o -> CustomAttribFixedArg.U1 b.[o])
+                | PrimitiveType.Int16 ->
+                    readPrimitive
+                        2
+                        offset
+                        (fun b o ->
+                            let v = uint16 b.[o] ||| (uint16 b.[o + 1] <<< 8)
+                            CustomAttribFixedArg.I2 (int16 v)
+                        )
+                | PrimitiveType.UInt16 ->
+                    readPrimitive
+                        2
+                        offset
+                        (fun b o ->
+                            let v = uint16 b.[o] ||| (uint16 b.[o + 1] <<< 8)
+                            CustomAttribFixedArg.U2 v
+                        )
+                | PrimitiveType.Int32 ->
+                    readPrimitive
+                        4
+                        offset
+                        (fun b o ->
+                            let v =
+                                uint32 b.[o]
+                                ||| (uint32 b.[o + 1] <<< 8)
+                                ||| (uint32 b.[o + 2] <<< 16)
+                                ||| (uint32 b.[o + 3] <<< 24)
+
+                            CustomAttribFixedArg.I4 (int32 v)
+                        )
+                | PrimitiveType.UInt32 ->
+                    readPrimitive
+                        4
+                        offset
+                        (fun b o ->
+                            let v =
+                                uint32 b.[o]
+                                ||| (uint32 b.[o + 1] <<< 8)
+                                ||| (uint32 b.[o + 2] <<< 16)
+                                ||| (uint32 b.[o + 3] <<< 24)
+
+                            CustomAttribFixedArg.U4 v
+                        )
+                | PrimitiveType.Int64 ->
+                    readPrimitive
+                        8
+                        offset
+                        (fun b o ->
+                            let lo =
+                                uint32 b.[o]
+                                ||| (uint32 b.[o + 1] <<< 8)
+                                ||| (uint32 b.[o + 2] <<< 16)
+                                ||| (uint32 b.[o + 3] <<< 24)
+
+                            let hi =
+                                uint32 b.[o + 4]
+                                ||| (uint32 b.[o + 5] <<< 8)
+                                ||| (uint32 b.[o + 6] <<< 16)
+                                ||| (uint32 b.[o + 7] <<< 24)
+
+                            CustomAttribFixedArg.I8 (int64 (uint64 lo ||| (uint64 hi <<< 32)))
+                        )
+                | PrimitiveType.UInt64 ->
+                    readPrimitive
+                        8
+                        offset
+                        (fun b o ->
+                            let lo =
+                                uint32 b.[o]
+                                ||| (uint32 b.[o + 1] <<< 8)
+                                ||| (uint32 b.[o + 2] <<< 16)
+                                ||| (uint32 b.[o + 3] <<< 24)
+
+                            let hi =
+                                uint32 b.[o + 4]
+                                ||| (uint32 b.[o + 5] <<< 8)
+                                ||| (uint32 b.[o + 6] <<< 16)
+                                ||| (uint32 b.[o + 7] <<< 24)
+
+                            CustomAttribFixedArg.U8 (uint64 lo ||| (uint64 hi <<< 32))
+                        )
+                | PrimitiveType.Single ->
+                    readPrimitive
+                        4
+                        offset
+                        (fun b o ->
+                            let bits =
+                                uint32 b.[o]
+                                ||| (uint32 b.[o + 1] <<< 8)
+                                ||| (uint32 b.[o + 2] <<< 16)
+                                ||| (uint32 b.[o + 3] <<< 24)
+
+                            CustomAttribFixedArg.R4 (System.BitConverter.Int32BitsToSingle (int32 bits))
+                        )
+                | PrimitiveType.Double ->
+                    readPrimitive
+                        8
+                        offset
+                        (fun b o ->
+                            let lo =
+                                uint32 b.[o]
+                                ||| (uint32 b.[o + 1] <<< 8)
+                                ||| (uint32 b.[o + 2] <<< 16)
+                                ||| (uint32 b.[o + 3] <<< 24)
+
+                            let hi =
+                                uint32 b.[o + 4]
+                                ||| (uint32 b.[o + 5] <<< 8)
+                                ||| (uint32 b.[o + 6] <<< 16)
+                                ||| (uint32 b.[o + 7] <<< 24)
+
+                            let bits = uint64 lo ||| (uint64 hi <<< 32)
+                            CustomAttribFixedArg.R8 (System.BitConverter.Int64BitsToDouble (int64 bits))
+                        )
+                | PrimitiveType.String ->
+                    match readSerString blob offset with
+                    | Error e -> Error e
+                    | Ok (s, next) -> Ok (CustomAttribFixedArg.String s, next)
+                | other ->
+                    Error (
+                        sprintf
+                            "CustomAttrib blob: TODO: primitive type %O is not yet supported as a CustomAttrib fixed-arg"
+                            other
+                    )
+            | other ->
+                Error (
+                    sprintf
+                        "CustomAttrib blob: TODO: non-primitive parameter type %O is not yet supported as a CustomAttrib fixed-arg (need TYPE/ENUM/SZARRAY/TAGGED_OBJECT decoders)"
+                        other
+                )
+
+        let rec loop
+            (remaining : TypeDefn list)
+            (offset : int)
+            (acc : CustomAttribFixedArg list)
+            : Result<CustomAttribFixedArg list * int, string>
+            =
+            match remaining with
+            | [] -> Ok (List.rev acc, offset)
+            | head :: tail ->
+                match readOne head offset with
+                | Error e -> Error e
+                | Ok (value, next) -> loop tail next (value :: acc)
+
+        loop paramTypes 2 []

--- a/WoofWare.PawPrint.Domain/WoofWare.PawPrint.Domain.fsproj
+++ b/WoofWare.PawPrint.Domain/WoofWare.PawPrint.Domain.fsproj
@@ -12,7 +12,6 @@
         <Compile Include="Tokens.fs" />
         <Compile Include="TypeRef.fs" />
         <Compile Include="IlOp.fs" />
-        <Compile Include="CustomAttribute.fs" />
         <Compile Include="AssemblyReference.fs" />
         <Compile Include="EventDefn.fs" />
         <Compile Include="ComparableTypeDefinitionHandle.fs" />
@@ -22,6 +21,7 @@
         <Compile Include="ComparableGenericParameterHandle.fs" />
         <Compile Include="TypeIdentity.fs" />
         <Compile Include="TypeDefn.fs" />
+        <Compile Include="CustomAttribute.fs" />
         <Compile Include="GenericParameter.fs" />
         <Compile Include="ConcreteType.fs" />
         <Compile Include="FieldInfo.fs" />

--- a/WoofWare.PawPrint.Test/TestCustomAttributeBlob.fs
+++ b/WoofWare.PawPrint.Test/TestCustomAttributeBlob.fs
@@ -157,3 +157,195 @@ module TestCustomAttributeBlob =
             | _ -> false
 
         Check.One (propertyConfig, property)
+
+    // ----- readFixedArgs ----------------------------------------------------
+
+    /// Encode a single CustomAttribFixedArg per ECMA-335 II.23.3.
+    let private encodeFixedArg (arg : CustomAttribFixedArg) : byte array =
+        match arg with
+        | CustomAttribFixedArg.Bool b -> [| (if b then 1uy else 0uy) |]
+        | CustomAttribFixedArg.Char c ->
+            let v = uint16 c
+            [| byte (v &&& 0xFFus) ; byte ((v >>> 8) &&& 0xFFus) |]
+        | CustomAttribFixedArg.I1 v -> [| byte v |]
+        | CustomAttribFixedArg.U1 v -> [| v |]
+        | CustomAttribFixedArg.I2 v ->
+            let u = uint16 v
+            [| byte (u &&& 0xFFus) ; byte ((u >>> 8) &&& 0xFFus) |]
+        | CustomAttribFixedArg.U2 v -> [| byte (v &&& 0xFFus) ; byte ((v >>> 8) &&& 0xFFus) |]
+        | CustomAttribFixedArg.I4 v -> System.BitConverter.GetBytes (v)
+        | CustomAttribFixedArg.U4 v -> System.BitConverter.GetBytes (v)
+        | CustomAttribFixedArg.I8 v -> System.BitConverter.GetBytes (v)
+        | CustomAttribFixedArg.U8 v -> System.BitConverter.GetBytes (v)
+        | CustomAttribFixedArg.R4 v -> System.BitConverter.GetBytes (v)
+        | CustomAttribFixedArg.R8 v -> System.BitConverter.GetBytes (v)
+        | CustomAttribFixedArg.String None -> [| 0xFFuy |]
+        | CustomAttribFixedArg.String (Some s) ->
+            let utf8 = Encoding.UTF8.GetBytes (s : string)
+            Array.append (encodePackedLen utf8.Length) utf8
+
+    let private typeOfArg (arg : CustomAttribFixedArg) : TypeDefn =
+        match arg with
+        | CustomAttribFixedArg.Bool _ -> TypeDefn.PrimitiveType PrimitiveType.Boolean
+        | CustomAttribFixedArg.Char _ -> TypeDefn.PrimitiveType PrimitiveType.Char
+        | CustomAttribFixedArg.I1 _ -> TypeDefn.PrimitiveType PrimitiveType.SByte
+        | CustomAttribFixedArg.U1 _ -> TypeDefn.PrimitiveType PrimitiveType.Byte
+        | CustomAttribFixedArg.I2 _ -> TypeDefn.PrimitiveType PrimitiveType.Int16
+        | CustomAttribFixedArg.U2 _ -> TypeDefn.PrimitiveType PrimitiveType.UInt16
+        | CustomAttribFixedArg.I4 _ -> TypeDefn.PrimitiveType PrimitiveType.Int32
+        | CustomAttribFixedArg.U4 _ -> TypeDefn.PrimitiveType PrimitiveType.UInt32
+        | CustomAttribFixedArg.I8 _ -> TypeDefn.PrimitiveType PrimitiveType.Int64
+        | CustomAttribFixedArg.U8 _ -> TypeDefn.PrimitiveType PrimitiveType.UInt64
+        | CustomAttribFixedArg.R4 _ -> TypeDefn.PrimitiveType PrimitiveType.Single
+        | CustomAttribFixedArg.R8 _ -> TypeDefn.PrimitiveType PrimitiveType.Double
+        | CustomAttribFixedArg.String _ -> TypeDefn.PrimitiveType PrimitiveType.String
+
+    /// Build a CustomAttrib blob with the given fixed args and optional trailing bytes
+    /// (intended to represent the NumNamed count + named-args section).
+    let private buildFixedArgsBlob (args : CustomAttribFixedArg list) (trailing : byte array) : ImmutableArray<byte> =
+        let prolog = [| 0x01uy ; 0x00uy |]
+        let body = args |> List.collect (encodeFixedArg >> Array.toList) |> List.toArray
+        Array.concat [ prolog ; body ; trailing ] |> ImmutableArray.Create<byte>
+
+    [<Test>]
+    let ``readFixedArgs decodes empty list`` () : unit =
+        let blob = buildFixedArgsBlob [] [||]
+
+        match CustomAttribute.readFixedArgs [] blob with
+        | Ok (args, offset) ->
+            args |> shouldEqual []
+            offset |> shouldEqual 2
+        | Error e -> failwithf "expected Ok, got Error %s" e
+
+    [<Test>]
+    let ``readFixedArgs decodes single bool true`` () : unit =
+        let args = [ CustomAttribFixedArg.Bool true ]
+        let blob = buildFixedArgsBlob args [||]
+
+        match CustomAttribute.readFixedArgs (args |> List.map typeOfArg) blob with
+        | Ok (decoded, offset) ->
+            decoded |> shouldEqual args
+            offset |> shouldEqual 3
+        | Error e -> failwithf "expected Ok, got Error %s" e
+
+    [<Test>]
+    let ``readFixedArgs reports offset of trailing bytes`` () : unit =
+        let args =
+            [ CustomAttribFixedArg.I4 0x11223344 ; CustomAttribFixedArg.String (Some "ok") ]
+
+        let trailing = [| 0x05uy ; 0x06uy ; 0x07uy |]
+        let blob = buildFixedArgsBlob args trailing
+
+        match CustomAttribute.readFixedArgs (args |> List.map typeOfArg) blob with
+        | Ok (decoded, offset) ->
+            decoded |> shouldEqual args
+            // 2 (prolog) + 4 (int32) + 1 (PackedLen for "ok") + 2 ("ok")
+            offset |> shouldEqual 9
+            // Trailing bytes were not consumed.
+            blob.[offset] |> shouldEqual 0x05uy
+        | Error e -> failwithf "expected Ok, got Error %s" e
+
+    [<Test>]
+    let ``readFixedArgs decodes each primitive`` () : unit =
+        let cases : CustomAttribFixedArg list =
+            [
+                CustomAttribFixedArg.Bool false
+                CustomAttribFixedArg.Bool true
+                CustomAttribFixedArg.Char 'A'
+                CustomAttribFixedArg.Char '中'
+                CustomAttribFixedArg.I1 -1y
+                CustomAttribFixedArg.I1 127y
+                CustomAttribFixedArg.U1 255uy
+                CustomAttribFixedArg.I2 -12345s
+                CustomAttribFixedArg.U2 65535us
+                CustomAttribFixedArg.I4 -2147483648
+                CustomAttribFixedArg.U4 4294967295u
+                CustomAttribFixedArg.I8 -9223372036854775808L
+                CustomAttribFixedArg.U8 18446744073709551615UL
+                CustomAttribFixedArg.R4 3.14159f
+                CustomAttribFixedArg.R8 2.718281828459045
+                CustomAttribFixedArg.String None
+                CustomAttribFixedArg.String (Some "")
+                CustomAttribFixedArg.String (Some "hello")
+            ]
+
+        for arg in cases do
+            let blob = buildFixedArgsBlob [ arg ] [||]
+
+            match CustomAttribute.readFixedArgs [ typeOfArg arg ] blob with
+            | Ok ([ decoded ], _) -> decoded |> shouldEqual arg
+            | Ok (decoded, _) -> failwithf "expected single arg for %A, got %A" arg decoded
+            | Error e -> failwithf "expected Ok for %A, got Error %s" arg e
+
+    [<Test>]
+    let ``readFixedArgs rejects bad prolog`` () : unit =
+        let blob = ImmutableArray.Create<byte> ([| 0x00uy ; 0x00uy ; 0x01uy |])
+
+        match CustomAttribute.readFixedArgs [ TypeDefn.PrimitiveType PrimitiveType.Boolean ] blob with
+        | Error msg -> msg |> shouldContainText "prolog"
+        | Ok r -> failwithf "expected Error, got Ok %A" r
+
+    [<Test>]
+    let ``readFixedArgs rejects truncated primitive`` () : unit =
+        // Prolog + 3 bytes; an Int32 needs 4 body bytes.
+        let blob =
+            ImmutableArray.Create<byte> ([| 0x01uy ; 0x00uy ; 0xAAuy ; 0xBBuy ; 0xCCuy |])
+
+        match CustomAttribute.readFixedArgs [ TypeDefn.PrimitiveType PrimitiveType.Int32 ] blob with
+        | Error _ -> ()
+        | Ok r -> failwithf "expected Error, got Ok %A" r
+
+    [<Test>]
+    let ``readFixedArgs rejects unsupported primitive`` () : unit =
+        let blob = ImmutableArray.Create<byte> ([| 0x01uy ; 0x00uy |])
+
+        match CustomAttribute.readFixedArgs [ TypeDefn.PrimitiveType PrimitiveType.Object ] blob with
+        | Error msg -> msg |> shouldContainText "TODO"
+        | Ok r -> failwithf "expected Error, got Ok %A" r
+
+    let private genFixedArg : Gen<CustomAttribFixedArg> =
+        let serString : Gen<string option> =
+            Gen.frequency
+                [
+                    1, Gen.constant None
+                    1, Gen.constant (Some "")
+                    8,
+                    ArbMap.defaults
+                    |> ArbMap.generate<NonNull<string>>
+                    |> Gen.map (fun (NonNull s) -> Some s)
+                ]
+
+        Gen.oneof
+            [
+                ArbMap.defaults |> ArbMap.generate<bool> |> Gen.map CustomAttribFixedArg.Bool
+                ArbMap.defaults |> ArbMap.generate<char> |> Gen.map CustomAttribFixedArg.Char
+                ArbMap.defaults |> ArbMap.generate<sbyte> |> Gen.map CustomAttribFixedArg.I1
+                ArbMap.defaults |> ArbMap.generate<byte> |> Gen.map CustomAttribFixedArg.U1
+                ArbMap.defaults |> ArbMap.generate<int16> |> Gen.map CustomAttribFixedArg.I2
+                ArbMap.defaults |> ArbMap.generate<uint16> |> Gen.map CustomAttribFixedArg.U2
+                ArbMap.defaults |> ArbMap.generate<int32> |> Gen.map CustomAttribFixedArg.I4
+                ArbMap.defaults |> ArbMap.generate<uint32> |> Gen.map CustomAttribFixedArg.U4
+                ArbMap.defaults |> ArbMap.generate<int64> |> Gen.map CustomAttribFixedArg.I8
+                ArbMap.defaults |> ArbMap.generate<uint64> |> Gen.map CustomAttribFixedArg.U8
+                ArbMap.defaults
+                |> ArbMap.generate<NormalFloat>
+                |> Gen.map (fun (NormalFloat f) -> CustomAttribFixedArg.R4 (float32 f))
+                ArbMap.defaults
+                |> ArbMap.generate<NormalFloat>
+                |> Gen.map (fun (NormalFloat f) -> CustomAttribFixedArg.R8 f)
+                serString |> Gen.map CustomAttribFixedArg.String
+            ]
+
+    [<Test>]
+    let ``readFixedArgs round-trips arbitrary primitive arg lists`` () : unit =
+        let property (args : CustomAttribFixedArg list) : bool =
+            let blob = buildFixedArgsBlob args [||]
+            let types = args |> List.map typeOfArg
+
+            match CustomAttribute.readFixedArgs types blob with
+            | Ok (decoded, offset) -> decoded = args && offset = blob.Length
+            | Error _ -> false
+
+        let argsGen : Gen<CustomAttribFixedArg list> = Gen.listOf genFixedArg
+        let argsArb : Arbitrary<CustomAttribFixedArg list> = Arb.fromGen argsGen
+        Check.One (propertyConfig, Prop.forAll argsArb property)

--- a/docs/plans/2026-05-15-customattribute-createinstance-qcall.md
+++ b/docs/plans/2026-05-15-customattribute-createinstance-qcall.md
@@ -1,0 +1,173 @@
+# Plan: `CustomAttribute_CreateCustomAttributeInstance` QCall
+
+## Context
+
+`NullDereferenceTest.cs` (and `MakeGenericType{Struct,Class,New}Constraint.cs`, `ArithmeticOperations.cs`, and several others tagged in `TestPureCases.unimplemented`) is currently blocked by the unimplemented QCall
+
+```
+System.Reflection.CustomAttribute::CreateCustomAttributeInstance
+```
+
+(see `RuntimeCustomAttributeData.cs:1861` in the dotnet-runtime checkout; entry point string is `CustomAttribute_CreateCustomAttributeInstance`).
+
+The path that lands here for `NullDereferenceTest`:
+
+1. The test triggers a runtime-synthesised `NullReferenceException` (`ldfld` on null, `throw null`, `callvirt` on null, …).
+2. `IlMachineStateExecution.raiseRuntimeException` (`IlMachineStateExecution.fs:1414`) allocates the exception via `ExceptionDispatching.allocateRuntimeException` and **calls the parameterless `.ctor`** — this is faithful to CLR's `EEException::CreateThrowable` (clrex.cpp:972, `CallDefaultConstructor(throwable)` at line 996).
+3. `NullReferenceException()` calls `base(SR.Arg_NullReferenceException)` which initialises the CoreLib `ResourceManager`.
+4. ResourceManager init triggers `RuntimeCustomAttributeData.AddCustomAttributes`, which iterates each custom-attribute record on the relevant metadata token and, for any ctor with parameters, calls `CreateCustomAttributeInstance` via the QCall.
+5. The QCall has no handler in `NativeQCall.fs`, so dispatch falls through to `NativeCall.failUnimplemented` and the test aborts.
+
+`AssemblyNative_GetResource` (referenced in several other `unimplemented` comments) is **already implemented** at `Native/NativeRuntimeAssembly.fs:135`; the stale comments on those tests will resolve to the same `CustomAttribute_CreateCustomAttributeInstance` blocker once retested.
+
+## Why this is the right primitive to implement (not a workaround)
+
+We earlier considered short-circuiting `raiseRuntimeException` to skip the parameterless ctor and write `_message` directly (mirroring `IlMachineRuntimeMetadata.synthesizeTypeInitializationException`). CLR source shows this is semantically wrong:
+
+- **Opcode-synthesised exceptions** (`ldfld`/`stfld`/`callvirt` on null, overflow, etc.) ultimately route through `EEException::CreateThrowable` which **calls the default ctor** (`clrex.cpp:996`). Subclass-specific `.ctor` side effects (e.g., `NullReferenceException()` reading `SR.Arg_NullReferenceException` for the message) are observable.
+- **`throw null`** routes through `IL_Throw` → `DispatchManagedException(kNullReferenceException)` / `COMPlusThrow(kNullReferenceException)` (`jithelpers.cpp:799,834`), which lands at the same `EEException::CreateThrowable` path — also calls the default ctor.
+
+So bypassing the ctor would be a CLR-divergent shortcut, not a faithful primitive. `AGENTS.md` is explicit: "implement the primitive boundary itself rather than mocking or replacing a higher-level managed method that happens to call it."
+
+### Aside: `synthesizeTypeInitializationException` is itself incorrect
+
+While tracing the above, we confirmed that `IlMachineRuntimeMetadata.synthesizeTypeInitializationException` (`IlMachineRuntimeMetadata.fs:823`) is **not a faithful mirror of CLR**, despite the comment claiming so. CLR's `CreateTypeInitializationExceptionObject` (`src/coreclr/vm/excep.cpp:518`) allocates the TIE and then **calls `TypeInitializationException(string, Exception)`** (the `STR_EX_CTOR` MethodDesc) via `MethodDescCallSite.Call(args)` at `excep.cpp:593`. Our implementation skips the ctor and sets `_innerException`, `_typeName`, `_HResult` directly.
+
+This is observable: the real ctor chains through `Exception(string, Exception)` which sets `_message`, `_innerException`, and `HResult` via the base-class ctors, and `TypeInitializationException` sets its own `_typeName`. Our shortcut sets the same final field values for the simple case but skips any side effects of the ctor chain (e.g., today none observable, but the same SR/ResourceManager init that gates the present plan would fire if a guest were to construct a TIE via reflection or catch one whose message is inspected through the normal getter path).
+
+This should be fixed in the same direction as the present plan, but is **out of scope for this PR** — it is its own follow-up once `CustomAttribute_CreateCustomAttributeInstance` is in. Filed here so it is not forgotten:
+
+> **Follow-up:** Replace `synthesizeTypeInitializationException`'s direct field writes with a real ctor call to `TypeInitializationException(string, Exception)` (mirror CLR's `CreateTypeInitializationExceptionObject`). The current implementation is a hack; the comment claiming CLR-fidelity is inaccurate.
+
+## Approach
+
+Implement the QCall in a new handler module `Native/NativeCustomAttribute.fs`, register it in `NativeQCall.fs`. Modelled on `Native/NativeRuntimeAssembly.fs`/`Native/NativeRuntimeType.fs` (pattern match on QCall name + signature, decode args via `NativeCall` helpers, mutate state, return `ExecutionResult.stepped`).
+
+### Inputs (per `customattribute.cpp:900-1020` and `RuntimeCustomAttributeData.cs:1861`)
+
+| Param | C# type | Native shape | Meaning |
+| --- | --- | --- | --- |
+| `pModule` | `QCallModule` | pointer to module ref | The decorated module owning the metadata token. Needed to resolve `TYPE`/`STRING` blob references. |
+| `type` (in) | `ObjectHandleOnStack` (`RuntimeType`) | pointer to `RuntimeType` object | Attribute type to instantiate. |
+| `pCtor` (in) | `ObjectHandleOnStack` (`IRuntimeMethodInfo`) | pointer to `RuntimeMethodInfo` | Attribute ctor MD reflection wrapper. |
+| `ppBlob` (in/out) | `ref IntPtr` | pointer to pointer | Cursor into the attribute blob; advanced past the fixed-args section. |
+| `pEndBlob` (in) | `IntPtr` | end pointer | Hard limit for blob reads. |
+| `pcNamedArgs` (out) | `out int` | pointer to int | On success, the named-arg count read from the blob; the caller loops `cNamedArgs` times after the QCall returns. |
+| `instance` (out) | `ObjectHandleOnStack` | pointer to object slot | The freshly-allocated, ctor-invoked attribute instance. |
+
+### What the QCall does
+
+1. Recover the ctor `MethodDesc` and attribute type from the two `ObjectHandleOnStack` args.
+2. Allocate a zero-initialised instance of the attribute type (no-arg allocation; the ctor will run on this `this`).
+3. Walk the fixed-arg section of the blob using the ctor's signature; for each fixed arg call `GetDataFromBlob` (one of `BOOLEAN/CHAR/I1..I8/U1..U8/R4/R8/STRING/TYPE/ENUM/TAGGED_OBJECT/SZARRAY`).
+4. Push `this` + decoded args onto the eval stack of a new ctor frame, mark the frame so the return path produces the instance rather than a regular call result, and step into the ctor.
+5. After the ctor returns, read the named-arg count (a `uint16` immediately after the fixed args), update `*ppBlob` to point at the first named-arg entry, write `instance` and `cNamedArgs` to their out slots.
+
+### Implementation pieces required
+
+#### A. Domain-side blob reader for `CustomAttrib` fixed args
+
+`WoofWare.PawPrint.Domain/CustomAttribute.fs` already has `tryReadLeadingSerString` (for the `NeutralResourcesLanguageAttribute` shortcut elsewhere). It needs a generalised reader:
+
+```fsharp
+type CustomAttribFixedArg =
+    | Bool of bool
+    | Char of char
+    | I1 of sbyte | U1 of byte
+    | I2 of int16 | U2 of uint16
+    | I4 of int32 | U4 of uint32
+    | I8 of int64 | U8 of uint64
+    | R4 of float32 | R8 of double
+    | String of string option  // None for SerString null sentinel 0xFF
+    | Type of string option    // SerString of assembly-qualified type name; None for null
+    | Enum of underlyingType : CustomAttribFixedArg * declaredType : string
+    | TaggedObject of CustomAttribFixedArg
+    | SzArray of CustomAttribFixedArg list  // length read from blob; null = -1 elements
+```
+
+with a function
+
+```fsharp
+val readFixedArgs :
+    ctorParamTypes : TypeDefn list ->
+    blob : ImmutableArray<byte> ->
+    startOffset : int ->
+    Result<CustomAttribFixedArg list * int (* offset advanced past fixed args *), string>
+```
+
+mirroring CoreCLR's `GetDataFromBlob` (`customattribute.cpp` near line 200) and ECMA-335 II.23.3.
+
+This belongs in `Domain` (not `Native`) because the parsing is pure metadata work. Keep it total: errors return `Result.Error`, never raise. The QCall handler will translate `Error` into the appropriate managed `CustomAttributeFormatException` (CoreCLR throws `kCustomAttributeFormatException`).
+
+#### B. Eval-stack values for fixed args
+
+Convert each `CustomAttribFixedArg` to a `CliType` matching the ctor parameter slot:
+
+- Primitives map directly to `CliType.Numeric` / `CliType.Bool` / `CliType.Char`.
+- `String s` → `Some s` becomes an allocated managed string via `allocateManagedString`; `None` is `CliType.ObjectRef None`.
+- `Type t` → resolve type name to a `RuntimeType` (manually, the same way `RuntimeTypeHandle_ConstructName` etc. round-trip) and box. We probably need to share the resolution code with `Type.GetType` intrinsics.
+- `Enum (underlying, declared)` → the boxed value of the underlying primitive in the declared enum type; allocate a boxed enum.
+- `TaggedObject` → recursively decode the tagged value, box appropriately.
+- `SzArray` → allocate an array of the right element type and write decoded entries.
+
+Most attributes in the SR/ResourceManager init path have only primitive + `String` + `Type` fixed args, so the boxing/enum/array paths are not on the critical path but should be implemented for correctness — the project preference is "general correct solutions."
+
+#### C. Ctor invocation through the dispatch loop
+
+The QCall is synchronous in CLR (`ctorCallSite.CallWithValueTypes(args)`), but in PawPrint we can't synchronously run a managed ctor inside a single dispatch step. Two options here:
+
+1. **Step-by-step**: push a new method frame for the ctor with the decoded args, return `WhatWeDid.Executed` immediately, and rely on the post-return path to write the `ObjectHandleOnStack` slot. This requires a new `MethodCallReturnDisposition` case (or extending `WhatWeDid`) that says "when this frame returns, write its `this` to `<address>` rather than pushing to caller's eval stack." This is the same shape as `dispatchAsExceptionOnReturn` already used in `raiseRuntimeException` for ctor-on-exception.
+2. **In-line**: synthesise a small chain of pseudo-IL steps. Avoid — fragile.
+
+Pick option 1. We already have precedent: `raiseRuntimeException` (`IlMachineStateExecution.fs:1486`) passes `dispatchAsExceptionOnReturn = true` to `callMethod` so the ctor's `Ret` triggers exception dispatch instead of pushing the result. Add an analogous boolean `writeThisToObjectHandleOnStack : ManagedPointerSource option` (or a small DU for return-disposition) that tells `returnStackFrame` to write the constructed `this` to the supplied native pointer slot.
+
+#### D. Named-arg blob position
+
+After the ctor frame returns, we still need to:
+
+- Read the `uint16` named-arg count from the blob (the position immediately after the fixed args).
+- Write `*ppBlob` = current blob cursor.
+- Write `*pcNamedArgs` = the count.
+
+These writes need to happen *after* the ctor completes. The natural place is the same return-disposition handler from (C): when the synthesised ctor frame returns, also perform these out-pointer writes.
+
+This argues for the return disposition being a record:
+
+```fsharp
+type CustomAttributeCtorReturn =
+    {
+        InstanceSlot : ManagedPointerSource  // ObjectHandleOnStack target for `instance`
+        BlobCursorOut : ManagedPointerSource // ref IntPtr ppBlob
+        NamedArgCountOut : ManagedPointerSource // out int pcNamedArgs
+        BlobCursorAfterFixedArgs : int
+        BlobEnd : int
+    }
+```
+
+stored on the frame; consumed at `Ret`.
+
+#### E. Registration
+
+Add `"CustomAttribute_CreateCustomAttributeInstance"` to the `NativeQCall.handlers` map, pointing at `NativeCustomAttribute.tryExecuteQCall`.
+
+### What this PR does *not* include
+
+- `CustomAttribute_CreatePropertyOrFieldData` QCall — also a `[LibraryImport(... CustomAttribute_CreatePropertyOrFieldData ...)]` in `RuntimeCustomAttributeData.cs`, called once per named arg after `CreateCustomAttributeInstance` returns. Some attributes in the resource-init path may have zero named args, in which case it isn't needed; if any do (e.g., `NeutralResourcesLanguageAttribute.Location` is a property), we'll hit it as the next blocker. **Address in a follow-up PR if it actually fires** — out of scope here so the present PR stays reviewable.
+- Fixing `synthesizeTypeInitializationException` to actually call the ctor (see Aside above). Separate follow-up.
+- Any work on `SR.InternalGetResourceString`'s recursion-detection / `Environment.FailFast` path. If our resource-blob parsing path works end-to-end after (A)–(E), the fallback never fires; if it does fire, that's a separate investigation.
+
+### Likely next blockers after this PR lands
+
+Once `CustomAttribute_CreateCustomAttributeInstance` works, `NullDereferenceTest` will resume execution further into ResourceManager init. The candidates are, in rough order of likelihood:
+
+1. `CustomAttribute_CreatePropertyOrFieldData` (if any attribute on the path has named args).
+2. Resource-blob parsing failures in `RuntimeResourceSet`/`ResourceReader` (all managed; should work, but possibly trips on an unimplemented IL opcode or InternalCall).
+3. The `Arg_NullReferenceException`-lookup infinite-recursion `Environment.FailFast` (`SR.cs:71`) — would indicate our resource parsing returned `null` from `GetString`.
+
+Per `AGENTS.md`, each becomes its own incremental PR. The `unimplemented` entry for `NullDereferenceTest.cs` stays in `TestPureCases.fs` with an updated comment after each step.
+
+## Validation
+
+- Property/unit test for the new domain-side blob reader in `WoofWare.PawPrint.Test`: generate random ctor signatures + corresponding well-formed blobs, assert round-trip; assert that truncated / malformed blobs produce `Result.Error`.
+- A focused test that constructs a small attribute with a primitive + string fixed arg via the QCall path, checks the resulting instance's fields.
+- After landing, retest `NullDereferenceTest.cs` (and the other entries tagged with the same blocker in `unimplemented`) and update their comments with the new next-blocker.


### PR DESCRIPTION
## Summary
- First slice of the `CustomAttribute_CreateCustomAttributeInstance` QCall plan (`docs/plans/2026-05-15-customattribute-createinstance-qcall.md`). The plan also notes that the existing `synthesizeTypeInitializationException` shortcut is incorrect and will be revisited once the ctor-invocation path is in place.
- Introduces `CustomAttribFixedArg` (primitives + `SerString`; `TYPE`/`ENUM`/`SZARRAY`/`TAGGED_OBJECT` deferred) and `readFixedArgs`/`readPackedLen`/`readSerString` in `CustomAttribute.fs`, decoding the ECMA-335 II.23.3 prolog and per-arg payload while reporting the offset of the trailing `NumNamed` section for the upcoming named-args pass.
- Moves `CustomAttribute.fs` to compile after `TypeDefn.fs` so the reader can reference `TypeDefn`/`PrimitiveType` directly; nothing in between depends on the `CustomAttribute` record.

## Test plan
- [x] `nix develop -c dotnet build WoofWare.PawPrint.slnx` (clean)
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --no-build --filter "FullyQualifiedName~TestCustomAttributeBlob"` (22/22 pass, including a 200-case FsCheck round-trip over arbitrary primitive arg lists)
- [x] `nix develop -c dotnet fantomas .`
- [x] `codex review --base main` (no actionable findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)