### PR TITLE
Lower CustomAttribFixedArg to CliType

### DIFF
--- a/WoofWare.PawPrint.Test/TestCustomAttribValueLowering.fs
+++ b/WoofWare.PawPrint.Test/TestCustomAttribValueLowering.fs
@@ -135,23 +135,44 @@ module TestCustomAttribValueLowering =
         | other -> failwithf "expected ObjectRef (Some _), got %A" other
 
     [<Test>]
-    let ``toCliType: String (Some "") allocates an empty string`` () : unit =
+    let ``toCliType: String (Some "") routes through canonical empty string`` () : unit =
+        // CoreCLR's StringObject::NewString(0) returns GetEmptyString(); we mirror that
+        // so attribute consumers comparing against `string.Empty` / `ldstr ""` get the
+        // expected reference identity. See CustomAttribValueLowering.toCliType docs.
         let loggerFactory, state = freshState ()
 
         let result, stateAfter =
             CustomAttribValueLowering.toCliType loggerFactory bct (CustomAttribFixedArg.String (Some "")) state
 
+        let canonicalAddr, _ =
+            IlMachineState.internCanonicalEmptyString loggerFactory bct stateAfter
+
         match result with
         | CliType.ObjectRef (Some addr) ->
             ManagedHeap.getStringContents addr stateAfter.ManagedHeap
             |> shouldEqual (Some "")
+
+            addr |> shouldEqual canonicalAddr
         | other -> failwithf "expected ObjectRef (Some _), got %A" other
 
     [<Test>]
-    let ``toCliType: String (Some _) allocates distinct objects on repeated calls`` () : unit =
-        // CustomAttribValueLowering is at the QCall boundary; nothing here interns,
-        // and the CLR also produces a fresh instance each time `GetDataFromBlob`
-        // unmarshals a SerString.
+    let ``toCliType: String (Some "") is identity-stable across repeated calls`` () : unit =
+        let loggerFactory, state = freshState ()
+
+        let r1, state =
+            CustomAttribValueLowering.toCliType loggerFactory bct (CustomAttribFixedArg.String (Some "")) state
+
+        let r2, _ =
+            CustomAttribValueLowering.toCliType loggerFactory bct (CustomAttribFixedArg.String (Some "")) state
+
+        match r1, r2 with
+        | CliType.ObjectRef (Some a1), CliType.ObjectRef (Some a2) -> a1 |> shouldEqual a2
+        | _ -> failwithf "expected two ObjectRef (Some _), got %A and %A" r1 r2
+
+    [<Test>]
+    let ``toCliType: String (Some non-empty) allocates distinct objects on repeated calls`` () : unit =
+        // Non-empty SerString values are not interned by CoreCLR's GetDataFromBlob;
+        // each call to StringObject::NewString(psz, cBytes) produces a fresh instance.
         let loggerFactory, state = freshState ()
 
         let r1, state =

--- a/WoofWare.PawPrint.Test/TestCustomAttribValueLowering.fs
+++ b/WoofWare.PawPrint.Test/TestCustomAttribValueLowering.fs
@@ -1,0 +1,218 @@
+namespace WoofWare.PawPrint.Test
+
+open System.Collections.Generic
+open System.Collections.Immutable
+open FsCheck
+open FsCheck.FSharp
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestCustomAttribValueLowering =
+
+    // The factory is intentionally undisposed: the returned DumpedAssembly.Logger closes
+    // over its sinks, and disposing while the assembly is still live would silently drop
+    // events.
+    let private corelib : DumpedAssembly =
+        let corelibPath = typeof<obj>.Assembly.Location
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        Assembly.readFile loggerFactory corelibPath
+
+    let private bct : BaseClassTypes<DumpedAssembly> = Corelib.getBaseTypes corelib
+
+    let private loaded : ImmutableDictionary<string, DumpedAssembly> =
+        ImmutableDictionary.CreateRange [ KeyValuePair (corelib.Name.FullName, corelib) ]
+
+    let private concreteTypes : AllConcreteTypes =
+        Corelib.concretizeAll loaded bct AllConcreteTypes.Empty
+
+    let private freshState () : Microsoft.Extensions.Logging.ILoggerFactory * IlMachineState =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+
+        let state =
+            { IlMachineState.initial loggerFactory ImmutableArray.Empty corelib with
+                ConcreteTypes = concreteTypes
+            }
+
+        loggerFactory, state
+
+    [<Test>]
+    let ``primitive: Bool false`` () : unit =
+        CustomAttribValueLowering.tryToPureCliType (CustomAttribFixedArg.Bool false)
+        |> shouldEqual (Ok (CliType.Bool 0uy))
+
+    [<Test>]
+    let ``primitive: Bool true`` () : unit =
+        CustomAttribValueLowering.tryToPureCliType (CustomAttribFixedArg.Bool true)
+        |> shouldEqual (Ok (CliType.Bool 1uy))
+
+    [<Test>]
+    let ``primitive: Char ASCII`` () : unit =
+        // ASCII 'A' is U+0041, so high byte = 0x00, low byte = 0x41.
+        CustomAttribValueLowering.tryToPureCliType (CustomAttribFixedArg.Char 'A')
+        |> shouldEqual (Ok (CliType.Char (0x00uy, 0x41uy)))
+
+    [<Test>]
+    let ``primitive: Char above BMP byte`` () : unit =
+        // U+4E2D ('中') has high byte 0x4E, low byte 0x2D.
+        CustomAttribValueLowering.tryToPureCliType (CustomAttribFixedArg.Char '中')
+        |> shouldEqual (Ok (CliType.Char (0x4Euy, 0x2Duy)))
+
+    [<Test>]
+    let ``primitive: I1 wraps -1 correctly`` () : unit =
+        CustomAttribValueLowering.tryToPureCliType (CustomAttribFixedArg.I1 -1y)
+        |> shouldEqual (Ok (CliType.Numeric (CliNumericType.Int8 -1y)))
+
+    [<Test>]
+    let ``primitive: U1 max`` () : unit =
+        CustomAttribValueLowering.tryToPureCliType (CustomAttribFixedArg.U1 255uy)
+        |> shouldEqual (Ok (CliType.Numeric (CliNumericType.UInt8 255uy)))
+
+    [<Test>]
+    let ``primitive: I4 round-trips negative`` () : unit =
+        CustomAttribValueLowering.tryToPureCliType (CustomAttribFixedArg.I4 -2147483648)
+        |> shouldEqual (Ok (CliType.Numeric (CliNumericType.Int32 -2147483648)))
+
+    [<Test>]
+    let ``primitive: U4 max stored as Int32 -1 (two's complement wraparound)`` () : unit =
+        CustomAttribValueLowering.tryToPureCliType (CustomAttribFixedArg.U4 4294967295u)
+        |> shouldEqual (Ok (CliType.Numeric (CliNumericType.Int32 -1)))
+
+    [<Test>]
+    let ``primitive: I8 round-trips`` () : unit =
+        CustomAttribValueLowering.tryToPureCliType (CustomAttribFixedArg.I8 -9223372036854775808L)
+        |> shouldEqual (Ok (CliType.Numeric (CliNumericType.Int64 (Int64Source.Verbatim -9223372036854775808L))))
+
+    [<Test>]
+    let ``primitive: U8 max stored as Int64 -1`` () : unit =
+        CustomAttribValueLowering.tryToPureCliType (CustomAttribFixedArg.U8 18446744073709551615UL)
+        |> shouldEqual (Ok (CliType.Numeric (CliNumericType.Int64 (Int64Source.Verbatim -1L))))
+
+    [<Test>]
+    let ``primitive: R4 round-trips`` () : unit =
+        CustomAttribValueLowering.tryToPureCliType (CustomAttribFixedArg.R4 3.14159f)
+        |> shouldEqual (Ok (CliType.Numeric (CliNumericType.Float32 3.14159f)))
+
+    [<Test>]
+    let ``primitive: R8 round-trips`` () : unit =
+        CustomAttribValueLowering.tryToPureCliType (CustomAttribFixedArg.R8 2.718281828459045)
+        |> shouldEqual (Ok (CliType.Numeric (CliNumericType.Float64 2.718281828459045)))
+
+    [<Test>]
+    let ``String None lowers to null object ref`` () : unit =
+        CustomAttribValueLowering.tryToPureCliType (CustomAttribFixedArg.String None)
+        |> shouldEqual (Ok (CliType.ObjectRef None))
+
+    [<Test>]
+    let ``tryToPureCliType rejects String (Some _)`` () : unit =
+        match CustomAttribValueLowering.tryToPureCliType (CustomAttribFixedArg.String (Some "hello")) with
+        | Error msg -> msg |> shouldContainText "allocation"
+        | Ok r -> failwithf "expected Error, got Ok %A" r
+
+    [<Test>]
+    let ``toCliType: String None routes through pure path`` () : unit =
+        let loggerFactory, state = freshState ()
+
+        let result, stateAfter =
+            CustomAttribValueLowering.toCliType loggerFactory bct (CustomAttribFixedArg.String None) state
+
+        result |> shouldEqual (CliType.ObjectRef None)
+        System.Object.ReferenceEquals (stateAfter, state) |> shouldEqual true
+
+    [<Test>]
+    let ``toCliType: String (Some _) allocates a managed string with the right contents`` () : unit =
+        let loggerFactory, state = freshState ()
+
+        let result, stateAfter =
+            CustomAttribValueLowering.toCliType loggerFactory bct (CustomAttribFixedArg.String (Some "hello")) state
+
+        match result with
+        | CliType.ObjectRef (Some addr) ->
+            ManagedHeap.getStringContents addr stateAfter.ManagedHeap
+            |> shouldEqual (Some "hello")
+        | other -> failwithf "expected ObjectRef (Some _), got %A" other
+
+    [<Test>]
+    let ``toCliType: String (Some "") allocates an empty string`` () : unit =
+        let loggerFactory, state = freshState ()
+
+        let result, stateAfter =
+            CustomAttribValueLowering.toCliType loggerFactory bct (CustomAttribFixedArg.String (Some "")) state
+
+        match result with
+        | CliType.ObjectRef (Some addr) ->
+            ManagedHeap.getStringContents addr stateAfter.ManagedHeap
+            |> shouldEqual (Some "")
+        | other -> failwithf "expected ObjectRef (Some _), got %A" other
+
+    [<Test>]
+    let ``toCliType: String (Some _) allocates distinct objects on repeated calls`` () : unit =
+        // CustomAttribValueLowering is at the QCall boundary; nothing here interns,
+        // and the CLR also produces a fresh instance each time `GetDataFromBlob`
+        // unmarshals a SerString.
+        let loggerFactory, state = freshState ()
+
+        let r1, state =
+            CustomAttribValueLowering.toCliType loggerFactory bct (CustomAttribFixedArg.String (Some "dup")) state
+
+        let r2, _ =
+            CustomAttribValueLowering.toCliType loggerFactory bct (CustomAttribFixedArg.String (Some "dup")) state
+
+        match r1, r2 with
+        | CliType.ObjectRef (Some a1), CliType.ObjectRef (Some a2) -> a1 |> shouldNotEqual a2
+        | _ -> failwithf "expected two ObjectRef (Some _), got %A and %A" r1 r2
+
+    // --- property-based primitive round-trip --------------------------------
+
+    let private propertyConfig : Config = Config.QuickThrowOnFailure.WithMaxTest 200
+
+    let private genPrimitiveArg : Gen<CustomAttribFixedArg> =
+        Gen.oneof
+            [
+                ArbMap.defaults |> ArbMap.generate<bool> |> Gen.map CustomAttribFixedArg.Bool
+                ArbMap.defaults |> ArbMap.generate<char> |> Gen.map CustomAttribFixedArg.Char
+                ArbMap.defaults |> ArbMap.generate<sbyte> |> Gen.map CustomAttribFixedArg.I1
+                ArbMap.defaults |> ArbMap.generate<byte> |> Gen.map CustomAttribFixedArg.U1
+                ArbMap.defaults |> ArbMap.generate<int16> |> Gen.map CustomAttribFixedArg.I2
+                ArbMap.defaults |> ArbMap.generate<uint16> |> Gen.map CustomAttribFixedArg.U2
+                ArbMap.defaults |> ArbMap.generate<int32> |> Gen.map CustomAttribFixedArg.I4
+                ArbMap.defaults |> ArbMap.generate<uint32> |> Gen.map CustomAttribFixedArg.U4
+                ArbMap.defaults |> ArbMap.generate<int64> |> Gen.map CustomAttribFixedArg.I8
+                ArbMap.defaults |> ArbMap.generate<uint64> |> Gen.map CustomAttribFixedArg.U8
+                ArbMap.defaults
+                |> ArbMap.generate<NormalFloat>
+                |> Gen.map (fun (NormalFloat f) -> CustomAttribFixedArg.R4 (float32 f))
+                ArbMap.defaults
+                |> ArbMap.generate<NormalFloat>
+                |> Gen.map (fun (NormalFloat f) -> CustomAttribFixedArg.R8 f)
+                Gen.constant (CustomAttribFixedArg.String None)
+            ]
+
+    /// SizeOf agrees with the canonical mapping in `CliType.zeroOfPrimitive`,
+    /// so the lowering preserves the expected slot width.
+    let private expectedSize (arg : CustomAttribFixedArg) : int =
+        match arg with
+        | CustomAttribFixedArg.Bool _ -> 1
+        | CustomAttribFixedArg.Char _ -> 2
+        | CustomAttribFixedArg.I1 _
+        | CustomAttribFixedArg.U1 _ -> 1
+        | CustomAttribFixedArg.I2 _
+        | CustomAttribFixedArg.U2 _ -> 2
+        | CustomAttribFixedArg.I4 _
+        | CustomAttribFixedArg.U4 _ -> 4
+        | CustomAttribFixedArg.I8 _
+        | CustomAttribFixedArg.U8 _ -> 8
+        | CustomAttribFixedArg.R4 _ -> 4
+        | CustomAttribFixedArg.R8 _ -> 8
+        | CustomAttribFixedArg.String _ -> 8
+
+    [<Test>]
+    let ``tryToPureCliType: every non-allocating arg yields the expected slot size`` () : unit =
+        let property (arg : CustomAttribFixedArg) : bool =
+            match CustomAttribValueLowering.tryToPureCliType arg with
+            | Ok cli -> (CliType.SizeOf cli).Size = expectedSize arg
+            | Error _ -> false
+
+        Check.One (propertyConfig, Prop.forAll (Arb.fromGen genPrimitiveArg) property)

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="Roslyn.fs" />
     <Compile Include="TestAssemblyReadCache.fs" />
     <Compile Include="TestCustomAttributeBlob.fs" />
+    <Compile Include="TestCustomAttribValueLowering.fs" />
     <Compile Include="TestFriendAssemblies.fs" />
     <Compile Include="TestAccessCheck.fs" />
     <Compile Include="RealRuntime.fs" />

--- a/WoofWare.PawPrint/CustomAttribValueLowering.fs
+++ b/WoofWare.PawPrint/CustomAttribValueLowering.fs
@@ -1,0 +1,74 @@
+namespace WoofWare.PawPrint
+
+open Microsoft.Extensions.Logging
+
+/// <summary>
+/// Lower a decoded <c>CustomAttribFixedArg</c> to the <c>CliType</c> value the
+/// attribute ctor expects on its parameter slot.
+/// </summary>
+/// <remarks>
+/// Mirrors the per-arg cases that CoreCLR's <c>CustomAttribute_CreateCustomAttributeInstance</c>
+/// (<c>customattribute.cpp:900</c>) produces via <c>GetDataFromBlob</c> + <c>Box</c> just
+/// before invoking the ctor. The current set is limited to the cases the Phase A
+/// blob reader emits: primitives and <c>SerString</c>. <c>TYPE</c>, <c>ENUM</c>,
+/// <c>SZARRAY</c>, and <c>TAGGED_OBJECT</c> will be added when the QCall handler
+/// needs them.
+/// </remarks>
+[<RequireQualifiedAccess>]
+module CustomAttribValueLowering =
+
+    /// <summary>
+    /// Convert a fixed arg that does not need heap allocation. Returns
+    /// <c>Error</c> for variants whose lowering must allocate
+    /// (currently only <c>String (Some _)</c>); callers should use
+    /// <c>toCliType</c> in that case.
+    /// </summary>
+    /// <remarks>
+    /// CLI eval-stack rules treat <c>uint32</c>/<c>uint64</c> identically to their
+    /// signed counterparts (the spec stores them with two's-complement wraparound;
+    /// see the <c>UInt32</c>/<c>UInt64</c> branches of <c>CliType.zeroOfPrimitive</c>),
+    /// so the unsigned variants here route through <c>Int32</c>/<c>Int64</c>.
+    /// </remarks>
+    let tryToPureCliType (arg : CustomAttribFixedArg) : Result<CliType, string> =
+        match arg with
+        | CustomAttribFixedArg.Bool b -> CliType.Bool (if b then 1uy else 0uy) |> Ok
+        | CustomAttribFixedArg.Char c ->
+            let v = uint16 c
+            CliType.Char (byte (v >>> 8), byte (v &&& 0xFFus)) |> Ok
+        | CustomAttribFixedArg.I1 v -> CliType.Numeric (CliNumericType.Int8 v) |> Ok
+        | CustomAttribFixedArg.U1 v -> CliType.Numeric (CliNumericType.UInt8 v) |> Ok
+        | CustomAttribFixedArg.I2 v -> CliType.Numeric (CliNumericType.Int16 v) |> Ok
+        | CustomAttribFixedArg.U2 v -> CliType.Numeric (CliNumericType.UInt16 v) |> Ok
+        | CustomAttribFixedArg.I4 v -> CliType.Numeric (CliNumericType.Int32 v) |> Ok
+        | CustomAttribFixedArg.U4 v -> CliType.Numeric (CliNumericType.Int32 (int32 v)) |> Ok
+        | CustomAttribFixedArg.I8 v -> CliType.Numeric (CliNumericType.Int64 (Int64Source.Verbatim v)) |> Ok
+        | CustomAttribFixedArg.U8 v -> CliType.Numeric (CliNumericType.Int64 (Int64Source.Verbatim (int64 v))) |> Ok
+        | CustomAttribFixedArg.R4 v -> CliType.Numeric (CliNumericType.Float32 v) |> Ok
+        | CustomAttribFixedArg.R8 v -> CliType.Numeric (CliNumericType.Float64 v) |> Ok
+        | CustomAttribFixedArg.String None -> CliType.ObjectRef None |> Ok
+        | CustomAttribFixedArg.String (Some _) ->
+            Error "CustomAttribFixedArg.String (Some _) requires allocation; use CustomAttribValueLowering.toCliType"
+
+    /// <summary>
+    /// Lower a fixed arg to a <c>CliType</c>, allocating a managed string on the
+    /// heap when the arg is a non-null <c>SerString</c>. For every other variant
+    /// the state is returned unchanged.
+    /// </summary>
+    let toCliType
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (arg : CustomAttribFixedArg)
+        (state : IlMachineState)
+        : CliType * IlMachineState
+        =
+        match arg with
+        | CustomAttribFixedArg.String (Some s) ->
+            let addr, state =
+                IlMachineState.allocateManagedString loggerFactory baseClassTypes s state
+
+            CliType.ObjectRef (Some addr), state
+        | _ ->
+            match tryToPureCliType arg with
+            | Ok t -> t, state
+            | Error msg ->
+                failwithf "CustomAttribValueLowering.toCliType: bug — non-allocating arg %A produced Error %s" arg msg

--- a/WoofWare.PawPrint/CustomAttribValueLowering.fs
+++ b/WoofWare.PawPrint/CustomAttribValueLowering.fs
@@ -54,6 +54,14 @@ module CustomAttribValueLowering =
     /// heap when the arg is a non-null <c>SerString</c>. For every other variant
     /// the state is returned unchanged.
     /// </summary>
+    /// <remarks>
+    /// The empty <c>SerString</c> routes through the canonical interned empty
+    /// string, mirroring CoreCLR's <c>GetDataFromBlob</c> for
+    /// <c>SERIALIZATION_TYPE_STRING</c>: <c>StringObject::NewString(0)</c>
+    /// (and the <c>(LPCUTF8, cBytes)</c> overload's <c>cBytes == 0</c> branch)
+    /// both return <c>GetEmptyString()</c>. Non-empty <c>SerString</c> values
+    /// allocate a fresh heap object on every call.
+    /// </remarks>
     let toCliType
         (loggerFactory : ILoggerFactory)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
@@ -62,6 +70,11 @@ module CustomAttribValueLowering =
         : CliType * IlMachineState
         =
         match arg with
+        | CustomAttribFixedArg.String (Some "") ->
+            let addr, state =
+                IlMachineState.internCanonicalEmptyString loggerFactory baseClassTypes state
+
+            CliType.ObjectRef (Some addr), state
         | CustomAttribFixedArg.String (Some s) ->
             let addr, state =
                 IlMachineState.allocateManagedString loggerFactory baseClassTypes s state

--- a/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
+++ b/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
@@ -44,6 +44,7 @@
     <Compile Include="IlMachineManagedByref.fs" />
     <Compile Include="IlMachineRuntimeMetadata.fs" />
     <Compile Include="IlMachineState.fs" />
+    <Compile Include="CustomAttribValueLowering.fs" />
     <Compile Include="MethodTableProjection.fs" />
     <Compile Include="RawArrayDataProjection.fs" />
     <Compile Include="RuntimeFieldProjection.fs" />


### PR DESCRIPTION
## Summary

Phase B of the `CustomAttribute_CreateCustomAttributeInstance` QCall plan (`docs/plans/2026-05-15-customattribute-createinstance-qcall.md`): lower a decoded `CustomAttribFixedArg` to the `CliType` the ctor parameter slot expects.

- New `CustomAttribValueLowering` module with two entry points:
  - `tryToPureCliType` — pure conversion; returns `Error` for `String (Some _)` (the only allocating case).
  - `toCliType` — full conversion threading `IlMachineState` for the heap allocations.
- Mirrors CoreCLR's `customattribute.cpp:CustomAttribute_CreateCustomAttributeInstance` per-arg behaviour:
  - Unsigned ints/longs route through their signed twins (two's-complement wraparound), matching the `UInt32`/`UInt64` branches of `CliType.zeroOfPrimitive`.
  - Empty `SerString` interns the canonical empty string (`StringObject::NewString(0)` returns `GetEmptyString()`), so attribute consumers comparing against `string.Empty` / `ldstr ""` see the same reference.
  - Non-empty `SerString` allocates a fresh heap object on every call (CoreCLR's `GetDataFromBlob` does not intern these).
- 20 NUnit tests covering each primitive, `Char` byte ordering, signed/unsigned wraparound at the extremes, all three `String` cases, identity stability of the canonical empty string, and a property test asserting the lowered slot size matches the canonical mapping.

## Test plan

- [x] `nix develop -c dotnet build WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — clean.
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --filter "Name~CustomAttribValueLowering"` — all 20 tests pass.
- [x] `codex review --base main` — empty-SerString interning feedback addressed in `13e56b3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)