### PR TITLE
Implement CustomAttribute_CreateCustomAttributeInstance QCall

### DIFF
--- a/WoofWare.PawPrint.Test/TestNativeCustomAttribute.fs
+++ b/WoofWare.PawPrint.Test/TestNativeCustomAttribute.fs
@@ -1,0 +1,571 @@
+namespace WoofWare.PawPrint.Test
+
+open System.Collections.Immutable
+open System.IO
+open System.Reflection.Metadata
+open FsUnitTyped
+open Microsoft.Extensions.Logging
+open NUnit.Framework
+open WoofWare.PawPrint
+open WoofWare.PawPrint.ExternImplementations
+
+[<TestFixture>]
+module TestNativeCustomAttribute =
+
+    let private attributeSource =
+        """
+public sealed class MyAttribute : System.Attribute
+{
+    public MyAttribute(int x, string s) { }
+}
+"""
+
+    type private Fixture =
+        {
+            LoggerFactory : ILoggerFactory
+            BaseClassTypes : BaseClassTypes<DumpedAssembly>
+            Corelib : DumpedAssembly
+            GuestAssembly : DumpedAssembly
+            CustomAttributeType : TypeInfo<GenericParamFromMetadata, TypeDefn>
+            QCallMethod : MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>
+            AttributeType : TypeInfo<GenericParamFromMetadata, TypeDefn>
+            AttributeTypeHandle : ConcreteTypeHandle
+            AttributeRuntimeTypeAddr : ManagedHeapAddress
+            CtorStubAddr : ManagedHeapAddress
+            State : IlMachineState
+        }
+
+    let private requiredTopLevelType
+        (assembly : DumpedAssembly)
+        (namespaceName : string)
+        (typeName : string)
+        : TypeInfo<GenericParamFromMetadata, TypeDefn>
+        =
+        assembly.TryGetTopLevelTypeDef namespaceName typeName
+        |> Option.defaultWith (fun () ->
+            failwith $"type %s{namespaceName}.%s{typeName} not found in %s{assembly.Name.Name}"
+        )
+
+    let private concretizeTypeInfo
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (typeInfo : TypeInfo<GenericParamFromMetadata, TypeDefn>)
+        : IlMachineState * ConcreteTypeHandle
+        =
+        let typeDefn =
+            DumpedAssembly.typeInfoToTypeDefn' baseClassTypes state._LoadedAssemblies typeInfo
+
+        IlMachineState.concretizeType
+            loggerFactory
+            baseClassTypes
+            state
+            typeInfo.Assembly
+            ImmutableArray.Empty
+            ImmutableArray.Empty
+            typeDefn
+
+    /// Constructs an `ObjectHandleOnStack` value that wraps a `void*` pointing at the
+    /// given managed pointer source. Mirrors the inline `new ObjectHandleOnStack(ref x)`
+    /// pattern that the C# wrapper IL produces before calling the PInvoke stub.
+    let private objectHandleOnStackValue
+        (fixture : Fixture)
+        (target : ManagedPointerSource)
+        (state : IlMachineState)
+        : CliType * IlMachineState
+        =
+        let objectHandleOnStackType =
+            requiredTopLevelType fixture.Corelib "System.Runtime.CompilerServices" "ObjectHandleOnStack"
+
+        let state, objectHandleOnStackHandle =
+            concretizeTypeInfo fixture.LoggerFactory fixture.BaseClassTypes state objectHandleOnStackType
+
+        let zero, state =
+            IlMachineState.cliTypeZeroOfHandle state fixture.BaseClassTypes objectHandleOnStackHandle
+
+        let value =
+            match zero with
+            | CliType.ValueType vt ->
+                let ptrField =
+                    IlMachineState.requiredOwnInstanceFieldId state objectHandleOnStackHandle "_ptr"
+
+                CliValueType.WithFieldSetById ptrField (CliType.RuntimePointer (CliRuntimePointer.Managed target)) vt
+                |> CliType.ValueType
+            | other -> failwith $"ObjectHandleOnStack zero value was not a value type: %O{other}"
+
+        value, state
+
+    /// Constructs a `QCallModule` value with the `_module` field set to the guest assembly's
+    /// `ModuleHandle` tag and `_ptr` left at its zero value. Mirrors the CoreCLR layout
+    /// `struct QCallModule { void* _ptr; IntPtr _module; }`.
+    let private qCallModuleValue (fixture : Fixture) (state : IlMachineState) : CliType * IlMachineState =
+        let qCallModuleType =
+            requiredTopLevelType fixture.Corelib "System.Runtime.CompilerServices" "QCallModule"
+
+        let state, qCallModuleHandle =
+            concretizeTypeInfo fixture.LoggerFactory fixture.BaseClassTypes state qCallModuleType
+
+        let zero, state =
+            IlMachineState.cliTypeZeroOfHandle state fixture.BaseClassTypes qCallModuleHandle
+
+        let value =
+            match zero with
+            | CliType.ValueType vt ->
+                let moduleField =
+                    IlMachineState.requiredOwnInstanceFieldId state qCallModuleHandle "_module"
+
+                CliValueType.WithFieldSetById
+                    moduleField
+                    (CliType.Numeric (
+                        CliNumericType.NativeInt (NativeIntSource.ModuleHandle fixture.GuestAssembly.Name.FullName)
+                    ))
+                    vt
+                |> CliType.ValueType
+            | other -> failwith $"QCallModule zero value was not a value type: %O{other}"
+
+        value, state
+
+    /// Allocates a single-element object[] holding `value` and returns a managed pointer
+    /// source targeting cell 0. Suitable for backing an `ObjectHandleOnStack._ptr`.
+    let private allocateObjectRefSlot
+        (fixture : Fixture)
+        (value : CliType)
+        (state : IlMachineState)
+        : ManagedHeapAddress * ManagedPointerSource * IlMachineState
+        =
+        let objectHandle =
+            AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes fixture.BaseClassTypes.Object
+
+        let arrayAddr, state =
+            IlMachineState.allocateArray (ConcreteTypeHandle.OneDimArrayZero objectHandle) (fun () -> value) 1 state
+
+        arrayAddr, ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arrayAddr, 0), []), state
+
+    /// Build the CustomAttrib blob for `MyAttribute(42, "hello")` plus a zero named-arg count.
+    /// Layout (14 bytes total) follows ECMA-335 II.23.3:
+    ///   prolog              0x01 0x00                            (2 bytes)
+    ///   I4 value 42         0x2A 0x00 0x00 0x00                  (4 bytes)
+    ///   SerString "hello"   0x05 0x68 0x65 0x6C 0x6C 0x6F        (6 bytes)
+    ///   named-arg count     0x00 0x00                            (2 bytes)
+    let private blobBytes : byte array =
+        [|
+            0x01uy
+            0x00uy
+            0x2Auy
+            0x00uy
+            0x00uy
+            0x00uy
+            0x05uy
+            0x68uy
+            0x65uy
+            0x6Cuy
+            0x6Cuy
+            0x6Fuy
+            0x00uy
+            0x00uy
+        |]
+
+    /// Allocates the byte[14] blob, plus a one-cell IntPtr[] holding the current cursor
+    /// (a byref into the blob's cell 0). Returns the blob array address and the IntPtr[]
+    /// address so the test can later read back the updated cursor cell.
+    let private allocateBlobArrays
+        (fixture : Fixture)
+        (state : IlMachineState)
+        : ManagedHeapAddress * ManagedHeapAddress * IlMachineState
+        =
+        let byteHandle =
+            AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes fixture.BaseClassTypes.Byte
+
+        let blobArr, state =
+            IlMachineState.allocateArray
+                (ConcreteTypeHandle.OneDimArrayZero byteHandle)
+                (fun () -> CliType.Numeric (CliNumericType.UInt8 0uy))
+                blobBytes.Length
+                state
+
+        let state =
+            (state, [ 0 .. blobBytes.Length - 1 ])
+            ||> List.fold (fun state i ->
+                IlMachineState.setArrayValue blobArr (CliType.Numeric (CliNumericType.UInt8 blobBytes.[i])) i state
+            )
+
+        let intPtrHandle =
+            AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes fixture.BaseClassTypes.IntPtr
+
+        let intPtrArr, state =
+            IlMachineState.allocateArray
+                (ConcreteTypeHandle.OneDimArrayZero intPtrHandle)
+                (fun () -> CliType.RuntimePointer (CliRuntimePointer.Verbatim 0L))
+                1
+                state
+
+        let cursorStart =
+            CliType.RuntimePointer (
+                CliRuntimePointer.Managed (ManagedPointerSource.Byref (ByrefRoot.ArrayElement (blobArr, 0), []))
+            )
+
+        let state = IlMachineState.setArrayValue intPtrArr cursorStart 0 state
+
+        blobArr, intPtrArr, state
+
+    /// Allocates a single-cell Int32[] zero-initialised. The QCall writes `pcNamedArgs`
+    /// into cell 0.
+    let private allocateInt32OutSlot
+        (fixture : Fixture)
+        (state : IlMachineState)
+        : ManagedHeapAddress * IlMachineState
+        =
+        let int32Handle =
+            AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes fixture.BaseClassTypes.Int32
+
+        IlMachineState.allocateArray
+            (ConcreteTypeHandle.OneDimArrayZero int32Handle)
+            (fun () -> CliType.Numeric (CliNumericType.Int32 0))
+            1
+            state
+
+    /// Locates the static partial PInvoke stub for `CustomAttribute_CreateCustomAttributeInstance`
+    /// on the corelib's `System.Reflection.CustomAttribute` type. The wrapper method has IL;
+    /// the QCall target is the same-named static stub whose `NativeImport` points at
+    /// `QCall::CustomAttribute_CreateCustomAttributeInstance`.
+    let private findQCallStub
+        (customAttributeType : TypeInfo<GenericParamFromMetadata, TypeDefn>)
+        : MethodInfo<GenericParamFromMetadata, GenericParamFromMetadata, TypeDefn>
+        =
+        customAttributeType.Methods
+        |> List.filter (fun method ->
+            match method.NativeImport with
+            | Some import ->
+                import.ModuleName = "QCall"
+                && import.EntryPointName = "CustomAttribute_CreateCustomAttributeInstance"
+            | None -> false
+        )
+        |> function
+            | [ method ] -> method
+            | [] ->
+                failwith
+                    "QCall entry point CustomAttribute_CreateCustomAttributeInstance not found on System.Reflection.CustomAttribute"
+            | methods ->
+                failwith
+                    $"QCall entry point CustomAttribute_CreateCustomAttributeInstance was ambiguous on System.Reflection.CustomAttribute: %d{methods.Length} matches"
+
+    /// Compile MyAttribute, load corelib, find and concretize the QCall method and the
+    /// attribute type, allocate the RuntimeType and RuntimeMethodInfoStub for the attribute
+    /// + its ctor. Mirrors the state the BCL would have prepared by the time it reaches the
+    /// CreateCustomAttributeInstance QCall.
+    let private makeFixture () : Fixture =
+        let image =
+            Roslyn.compileAssembly
+                "CustomAttributeQCallTestAssembly"
+                Microsoft.CodeAnalysis.OutputKind.DynamicallyLinkedLibrary
+                []
+                [ attributeSource ]
+
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        let corelibPath = typeof<obj>.Assembly.Location
+
+        let corelib =
+            global.WoofWare.PawPrint.AssemblyApi.readFile loggerFactory corelibPath
+
+        let baseClassTypes = Corelib.getBaseTypes corelib
+
+        use assemblyStream = new MemoryStream (image)
+
+        let guestAssembly =
+            global.WoofWare.PawPrint.AssemblyApi.read loggerFactory None assemblyStream
+
+        let state : IlMachineState =
+            let initialState =
+                IlMachineState.initial loggerFactory ImmutableArray.Empty guestAssembly
+
+            let state = initialState.WithLoadedAssembly corelib.Name corelib
+
+            { state with
+                ConcreteTypes = Corelib.concretizeAll state._LoadedAssemblies baseClassTypes state.ConcreteTypes
+            }
+
+        let customAttributeType =
+            requiredTopLevelType corelib "System.Reflection" "CustomAttribute"
+
+        let rawQCallStub = findQCallStub customAttributeType
+
+        // Concretize the QCall method; this also concretizes its parameter types so the
+        // active-pattern match (QCallModule / ObjectHandleOnStack / pointer-to-Int32 etc.)
+        // in the handler succeeds at dispatch time.
+        let state, qCallMethod, _ =
+            ExecutionConcretization.concretizeMethodWithTypeGenerics
+                loggerFactory
+                baseClassTypes
+                ImmutableArray.Empty
+                rawQCallStub
+                None
+                corelib.Name
+                ImmutableArray.Empty
+                state
+
+        let attributeType = requiredTopLevelType guestAssembly "" "MyAttribute"
+
+        let state, attributeTypeHandle =
+            concretizeTypeInfo loggerFactory baseClassTypes state attributeType
+
+        let attributeRuntimeTypeAddr, state =
+            IlMachineState.getOrAllocateType
+                loggerFactory
+                baseClassTypes
+                (RuntimeTypeHandleTarget.Closed attributeTypeHandle)
+                state
+
+        // Locate the attribute ctor (we wrote exactly one, taking int + string).
+        let rawCtor = attributeType.Methods |> List.find (fun m -> m.Name = ".ctor")
+
+        let state, concretizedCtor, _ =
+            ExecutionConcretization.concretizeMethodWithAllGenerics
+                loggerFactory
+                baseClassTypes
+                ImmutableArray.Empty
+                rawCtor
+                ImmutableArray.Empty
+                state
+
+        let ctorMethodHandle, state =
+            IlMachineState.getOrAllocateMethod loggerFactory baseClassTypes concretizedCtor state
+
+        let ctorStubAddr =
+            match ctorMethodHandle with
+            | CliType.ValueType vt ->
+                match CliValueType.DereferenceField "m_value" vt with
+                | CliType.ObjectRef (Some addr) -> addr
+                | other -> failwith $"Expected RuntimeMethodHandle.m_value to be an object ref, got %O{other}"
+            | other -> failwith $"Expected RuntimeMethodHandle value type, got %O{other}"
+
+        {
+            LoggerFactory = loggerFactory
+            BaseClassTypes = baseClassTypes
+            Corelib = corelib
+            GuestAssembly = guestAssembly
+            CustomAttributeType = customAttributeType
+            QCallMethod = qCallMethod
+            AttributeType = attributeType
+            AttributeTypeHandle = attributeTypeHandle
+            AttributeRuntimeTypeAddr = attributeRuntimeTypeAddr
+            CtorStubAddr = ctorStubAddr
+            State = state
+        }
+
+    /// Build the seven-argument frame the QCall expects, install it on a fresh thread,
+    /// and return the slot addresses the test will inspect after invocation.
+    let private prepareInvocation
+        (fixture : Fixture)
+        : {|
+              BlobArr : ManagedHeapAddress
+              IntPtrArr : ManagedHeapAddress
+              NamedArgsArr : ManagedHeapAddress
+              InstanceArr : ManagedHeapAddress
+              Thread : ThreadId
+              State : IlMachineState
+          |}
+        =
+        let state = fixture.State
+
+        let qCallModule, state = qCallModuleValue fixture state
+
+        // pCaType points at a slot holding the RuntimeType for MyAttribute.
+        let _typeArr, typeSlot, state =
+            allocateObjectRefSlot fixture (CliType.ObjectRef (Some fixture.AttributeRuntimeTypeAddr)) state
+
+        let pCaType, state = objectHandleOnStackValue fixture typeSlot state
+
+        // pCtor points at a slot holding the RuntimeMethodInfoStub for the ctor.
+        let _ctorArr, ctorSlot, state =
+            allocateObjectRefSlot fixture (CliType.ObjectRef (Some fixture.CtorStubAddr)) state
+
+        let pCtor, state = objectHandleOnStackValue fixture ctorSlot state
+
+        let blobArr, intPtrArr, state = allocateBlobArrays fixture state
+
+        let ppBlob =
+            CliType.RuntimePointer (
+                CliRuntimePointer.Managed (ManagedPointerSource.Byref (ByrefRoot.ArrayElement (intPtrArr, 0), []))
+            )
+
+        let pEndBlob =
+            CliType.RuntimePointer (
+                CliRuntimePointer.Managed (
+                    ManagedPointerSource.Byref (ByrefRoot.ArrayElement (blobArr, blobBytes.Length), [])
+                )
+            )
+
+        let namedArgsArr, state = allocateInt32OutSlot fixture state
+
+        let pcNamedArgs =
+            CliType.RuntimePointer (
+                CliRuntimePointer.Managed (ManagedPointerSource.Byref (ByrefRoot.ArrayElement (namedArgsArr, 0), []))
+            )
+
+        // The `instance` ObjectHandleOnStack receives the allocated attribute. Start it null.
+        let instanceArr, instanceSlot, state =
+            allocateObjectRefSlot fixture (CliType.ObjectRef None) state
+
+        let pInstance, state = objectHandleOnStackValue fixture instanceSlot state
+
+        let methodArgs =
+            ImmutableArray.CreateRange [ qCallModule ; pCaType ; pCtor ; ppBlob ; pEndBlob ; pcNamedArgs ; pInstance ]
+
+        let methodState =
+            match
+                MethodState.Empty
+                    state.ConcreteTypes
+                    fixture.BaseClassTypes
+                    state._LoadedAssemblies
+                    fixture.Corelib
+                    fixture.QCallMethod
+                    ImmutableArray.Empty
+                    methodArgs
+                    None
+            with
+            | Ok methodState -> methodState
+            | Error missing -> failwith $"Unexpected missing assembly references creating QCall frame: %O{missing}"
+
+        let thread = ThreadId 0
+
+        let state =
+            { state with
+                ThreadState = Map.empty |> Map.add thread (ThreadState.New methodState)
+            }
+
+        {|
+            BlobArr = blobArr
+            IntPtrArr = intPtrArr
+            NamedArgsArr = namedArgsArr
+            InstanceArr = instanceArr
+            Thread = thread
+            State = state
+        |}
+
+    let private invokeHandler (fixture : Fixture) (thread : ThreadId) (state : IlMachineState) : ExecutionResult =
+        let ctx : NativeCallContext =
+            {
+                LoggerFactory = fixture.LoggerFactory
+                Implementations = MockEnv.make ()
+                BaseClassTypes = fixture.BaseClassTypes
+                Thread = thread
+                State = state
+                Instruction = state.ThreadState.[thread].MethodState
+                TargetAssembly = fixture.Corelib
+                TargetType = fixture.CustomAttributeType
+            }
+
+        match NativeCustomAttribute.tryExecuteQCall "CustomAttribute_CreateCustomAttributeInstance" ctx with
+        | Some result -> result
+        | None -> failwith "NativeCustomAttribute handler did not match"
+
+    [<Test>]
+    let ``Phase 1 suspends with ctor frame and advances blob cursor / pcNamedArgs`` () : unit =
+        let fixture = makeFixture ()
+        let prep = prepareInvocation fixture
+
+        let result = invokeHandler fixture prep.Thread prep.State
+
+        let state =
+            match result with
+            | ExecutionResult.Stepped (state, WhatWeDid.SuspendedForManagedCall, _) -> state
+            | other -> failwithf "Phase 1 expected SuspendedForManagedCall, got %A" other
+
+        // The blob cursor cell now points one-past-end of the blob: fixed-args consumed
+        // 12 bytes, then the named-arg count uint16 added 2 more.
+        match IlMachineState.getArrayValue prep.IntPtrArr 0 state with
+        | CliType.RuntimePointer (CliRuntimePointer.Managed (ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr,
+                                                                                                                 idx),
+                                                                                         []))) ->
+            arr |> shouldEqual prep.BlobArr
+            idx |> shouldEqual blobBytes.Length
+        | other -> failwithf "Expected ppBlob cell to hold an advanced ArrayElement byref, got %A" other
+
+        // pcNamedArgs out-cell holds the parsed named-arg count (zero in our blob).
+        match IlMachineState.getArrayValue prep.NamedArgsArr 0 state with
+        | CliType.Numeric (CliNumericType.Int32 n) -> n |> shouldEqual 0
+        | other -> failwithf "Expected pcNamedArgs cell to hold an Int32, got %A" other
+
+        // The instance slot must still be null at this point: phase 2 writes it on re-entry.
+        match IlMachineState.getArrayValue prep.InstanceArr 0 state with
+        | CliType.ObjectRef None -> ()
+        | other -> failwithf "Expected instance slot to remain null after phase 1, got %A" other
+
+        // The QCall frame's eval stack carries the allocated-instance marker; the ctor
+        // frame is now the active one with `this` + 2 args.
+        let threadState = state.ThreadState.[prep.Thread]
+
+        let qCallFrameId =
+            threadState.MethodStates
+            |> Map.toList
+            |> List.find (fun (_, ms) ->
+                ms.ExecutingMethod.DeclaringType.Identity = fixture.CustomAttributeType.Identity
+                && ms.ExecutingMethod.Name = fixture.QCallMethod.Name
+            )
+            |> fst
+
+        let qCallFrame = threadState.MethodStates.[qCallFrameId]
+
+        let markerAddr =
+            match qCallFrame.EvaluationStack.Values with
+            | [ EvalStackValue.ObjectRef addr ] -> addr
+            | other -> failwithf "Expected QCall frame eval stack to be [ObjectRef marker], got %A" other
+
+        // The marker references an allocated MyAttribute heap object.
+        let allocated = ManagedHeap.get markerAddr state.ManagedHeap
+        allocated.ConcreteType |> shouldEqual fixture.AttributeTypeHandle
+
+        // The active frame is the ctor; check its arguments match the blob payload.
+        let activeFrame = threadState.MethodState
+        activeFrame.ExecutingMethod.Name |> shouldEqual ".ctor"
+
+        activeFrame.ExecutingMethod.DeclaringType.Identity
+        |> shouldEqual fixture.AttributeType.Identity
+
+        activeFrame.Arguments.Length |> shouldEqual 3
+
+        match activeFrame.Arguments.[0] with
+        | CliType.ObjectRef (Some a) -> a |> shouldEqual markerAddr
+        | other -> failwithf "Expected ctor arg 0 to be `this` = marker, got %A" other
+
+        match activeFrame.Arguments.[1] with
+        | CliType.Numeric (CliNumericType.Int32 n) -> n |> shouldEqual 42
+        | other -> failwithf "Expected ctor arg 1 to be Int32 42, got %A" other
+
+        match activeFrame.Arguments.[2] with
+        | CliType.ObjectRef (Some stringAddr) ->
+            ManagedHeap.getStringContents stringAddr state.ManagedHeap
+            |> shouldEqual (Some "hello")
+        | other -> failwithf "Expected ctor arg 2 to be a managed string \"hello\", got %A" other
+
+    [<Test>]
+    let ``Phase 2 pops the marker and writes the instance ObjectHandleOnStack`` () : unit =
+        let fixture = makeFixture ()
+        let prep = prepareInvocation fixture
+
+        // Synthesise a post-suspend state: we don't need to actually run the ctor; the
+        // contract is "QCall frame has a single ObjectRef marker on its eval stack, and the
+        // handler is re-entered with that marker visible". Build that directly by pushing
+        // the marker onto the only frame's eval stack — its address can be any
+        // ManagedHeapAddress, and using the AttributeRuntimeTypeAddr happens to also be a
+        // real allocated heap object, which makes failure diagnostics readable.
+        let markerAddr = fixture.AttributeRuntimeTypeAddr
+
+        let state =
+            IlMachineState.pushToEvalStack' (EvalStackValue.ObjectRef markerAddr) prep.Thread prep.State
+
+        let result = invokeHandler fixture prep.Thread state
+
+        let state =
+            match result with
+            | ExecutionResult.Stepped (state, WhatWeDid.Executed, _) -> state
+            | other -> failwithf "Phase 2 expected Executed, got %A" other
+
+        // The instance ObjectHandleOnStack slot now points at the marker.
+        match IlMachineState.getArrayValue prep.InstanceArr 0 state with
+        | CliType.ObjectRef (Some addr) -> addr |> shouldEqual markerAddr
+        | other -> failwithf "Expected instance slot to hold the marker addr, got %A" other
+
+        // And the eval stack has been emptied.
+        let threadState = state.ThreadState.[prep.Thread]
+        threadState.MethodState.EvaluationStack.Values |> shouldEqual []

--- a/WoofWare.PawPrint.Test/TestNativeCustomAttribute.fs
+++ b/WoofWare.PawPrint.Test/TestNativeCustomAttribute.fs
@@ -20,6 +20,21 @@ public sealed class MyAttribute : System.Attribute
 }
 """
 
+    /// Variant attribute whose declaring type has a non-trivial static initialiser, so that
+    /// the QCall's `ensureTypeInitialised` call returns `SuspendedForClassInit` on first
+    /// entry. Pins down the contract that the cursor / named-arg out-slots are *not* written
+    /// when class init suspends — otherwise the re-entered QCall would re-parse from the
+    /// wrong offset.
+    let private cctorAttributeSource =
+        """
+public sealed class CctorAttribute : System.Attribute
+{
+    private static readonly int Sentinel = ComputeSentinel();
+    public CctorAttribute(int x, string s) { }
+    private static int ComputeSentinel() => 7;
+}
+"""
+
     type private Fixture =
         {
             LoggerFactory : ILoggerFactory
@@ -249,11 +264,11 @@ public sealed class MyAttribute : System.Attribute
                 failwith
                     $"QCall entry point CustomAttribute_CreateCustomAttributeInstance was ambiguous on System.Reflection.CustomAttribute: %d{methods.Length} matches"
 
-    /// Compile MyAttribute, load corelib, find and concretize the QCall method and the
-    /// attribute type, allocate the RuntimeType and RuntimeMethodInfoStub for the attribute
-    /// + its ctor. Mirrors the state the BCL would have prepared by the time it reaches the
-    /// CreateCustomAttributeInstance QCall.
-    let private makeFixture () : Fixture =
+    /// Compile the given attribute source, load corelib, find and concretize the QCall method
+    /// and the named attribute type, allocate the RuntimeType and RuntimeMethodInfoStub for
+    /// the attribute + its ctor. Mirrors the state the BCL would have prepared by the time it
+    /// reaches the CreateCustomAttributeInstance QCall.
+    let private makeFixtureWith (attributeSource : string) (attributeTypeName : string) : Fixture =
         let image =
             Roslyn.compileAssembly
                 "CustomAttributeQCallTestAssembly"
@@ -303,7 +318,7 @@ public sealed class MyAttribute : System.Attribute
                 ImmutableArray.Empty
                 state
 
-        let attributeType = requiredTopLevelType guestAssembly "" "MyAttribute"
+        let attributeType = requiredTopLevelType guestAssembly "" attributeTypeName
 
         let state, attributeTypeHandle =
             concretizeTypeInfo loggerFactory baseClassTypes state attributeType
@@ -351,6 +366,9 @@ public sealed class MyAttribute : System.Attribute
             CtorStubAddr = ctorStubAddr
             State = state
         }
+
+    let private makeFixture () : Fixture =
+        makeFixtureWith attributeSource "MyAttribute"
 
     /// Build the seven-argument frame the QCall expects, install it on a fresh thread,
     /// and return the slot addresses the test will inspect after invocation.
@@ -569,3 +587,40 @@ public sealed class MyAttribute : System.Attribute
         // And the eval stack has been emptied.
         let threadState = state.ThreadState.[prep.Thread]
         threadState.MethodState.EvaluationStack.Values |> shouldEqual []
+
+    [<Test>]
+    let ``Class-init suspension leaves blob cursor and pcNamedArgs untouched`` () : unit =
+        // CctorAttribute has a static field initialiser, so the attribute type's cctor must
+        // run before the QCall can allocate the instance. The handler must therefore return
+        // `SuspendedForClassInit` *without* having written the blob cursor or named-arg count
+        // out-cells — when the cctor finishes and the QCall is re-entered, the BCL re-parses
+        // the blob from `*ppBlob`, and a prematurely-advanced cursor would feed it bytes that
+        // belong past the end of the blob.
+        let fixture = makeFixtureWith cctorAttributeSource "CctorAttribute"
+        let prep = prepareInvocation fixture
+
+        let result = invokeHandler fixture prep.Thread prep.State
+
+        let state =
+            match result with
+            | ExecutionResult.Stepped (state, WhatWeDid.SuspendedForClassInit, _) -> state
+            | other -> failwithf "Class-init suspension test expected SuspendedForClassInit, got %A" other
+
+        // The blob cursor cell must still be the starting byref into cell 0 of the blob.
+        match IlMachineState.getArrayValue prep.IntPtrArr 0 state with
+        | CliType.RuntimePointer (CliRuntimePointer.Managed (ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr,
+                                                                                                                 idx),
+                                                                                         []))) ->
+            arr |> shouldEqual prep.BlobArr
+            idx |> shouldEqual 0
+        | other -> failwithf "Expected ppBlob cell to still point at blob[0] after suspension, got %A" other
+
+        // pcNamedArgs must still hold its zero-initialised default.
+        match IlMachineState.getArrayValue prep.NamedArgsArr 0 state with
+        | CliType.Numeric (CliNumericType.Int32 n) -> n |> shouldEqual 0
+        | other -> failwithf "Expected pcNamedArgs cell to still hold its initial zero, got %A" other
+
+        // The instance slot is still null too — phase 2 hasn't run.
+        match IlMachineState.getArrayValue prep.InstanceArr 0 state with
+        | CliType.ObjectRef None -> ()
+        | other -> failwithf "Expected instance slot to remain null after suspension, got %A" other

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -45,6 +45,7 @@
     <Compile Include="TestFieldHandleRegistry.fs" />
     <Compile Include="TestNativeMetadataImport.fs" />
     <Compile Include="TestNativeSignature.fs" />
+    <Compile Include="TestNativeCustomAttribute.fs" />
     <Compile Include="TestManifestResources.fs" />
     <Compile Include="TestNativeEnum.fs" />
     <Compile Include="TestMethodHandleRegistry.fs" />

--- a/WoofWare.PawPrint/Native/NativeCustomAttribute.fs
+++ b/WoofWare.PawPrint/Native/NativeCustomAttribute.fs
@@ -1,0 +1,437 @@
+namespace WoofWare.PawPrint
+
+open System.Collections.Immutable
+
+[<RequireQualifiedAccess>]
+module NativeCustomAttribute =
+    /// Decode an `ObjectHandleOnStack` argument whose target slot holds an object reference,
+    /// and return that referenced address. Mirrors CoreCLR's `pHandle.Get()` on a `pCaType`-
+    /// or `pCtor`-shaped argument: the QCall caller hands us a byref to a managed slot, and
+    /// the slot's current value is the heap object we want to operate on.
+    let private dereferenceObjectHandle
+        (operation : string)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (argName : string)
+        (arg : CliType)
+        : ManagedHeapAddress
+        =
+        let ptr = NativeCall.objectHandleOnStackTarget operation state argName arg
+
+        match IlMachineState.readManagedByref baseClassTypes state ptr with
+        | CliType.ObjectRef (Some addr) -> addr
+        | CliType.ObjectRef None ->
+            failwith $"%s{operation}: ObjectHandleOnStack(%s{argName}) pointed at a null reference"
+        | other -> failwith $"%s{operation}: expected ObjectRef behind ObjectHandleOnStack(%s{argName}), got %O{other}"
+
+    /// Materialise the byte slice `[startIdx, endIdx)` of `arr` into an
+    /// `ImmutableArray<byte>`. Each cell must already be a UInt8 (the byte[] shape produced
+    /// by callers that allocate a fresh blob buffer); a different cell shape indicates the
+    /// caller wired a non-byte-array into a byte pointer slot and is a contract violation.
+    let private materialiseBytes
+        (operation : string)
+        (state : IlMachineState)
+        (arr : ManagedHeapAddress)
+        (startIdx : int)
+        (endIdx : int)
+        : ImmutableArray<byte>
+        =
+        if endIdx < startIdx then
+            failwith $"%s{operation}: blob end index %d{endIdx} is before start index %d{startIdx} (same array %O{arr})"
+
+        let builder = ImmutableArray.CreateBuilder<byte> (endIdx - startIdx)
+
+        for i in startIdx .. endIdx - 1 do
+            match ManagedHeap.getArrayValue arr i state.ManagedHeap with
+            | CliType.Numeric (CliNumericType.UInt8 b) -> builder.Add b
+            | other ->
+                failwith $"%s{operation}: expected UInt8 cell at byte offset %d{i} of array %O{arr}, got %O{other}"
+
+        builder.MoveToImmutable ()
+
+    /// Extract `(arrayAddr, byteIndex)` from a blob byte pointer. PawPrint currently models
+    /// the `byte*` cursor as a managed byref into a `byte[]` cell; ECMA-style raw native
+    /// pointers haven't yet been threaded through the BCL's `CustomAttributeRecord` path,
+    /// so we require both `ppBlob` and `pEndBlob` to be plain `ArrayElement` byrefs (no
+    /// projections) into the same byte array. Generalising to other shapes is upstream
+    /// work tracked alongside the metadata-blob reader.
+    let private blobPointerBounds
+        (operation : string)
+        (label : string)
+        (ptr : ManagedPointerSource)
+        : ManagedHeapAddress * int
+        =
+        match ptr with
+        | ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, idx), []) -> arr, idx
+        | ManagedPointerSource.Null ->
+            failwith
+                $"TODO: %s{operation} %s{label} pointer is null; CoreCLR allows a null *ppBlob to skip the entire blob parse but PawPrint hasn't modelled that path yet"
+        | other ->
+            failwith
+                $"TODO: %s{operation} %s{label} pointer must be a plain ArrayElement byref (no projections); other shapes (e.g. raw native pointers, byte-view projections) are not yet supported, got %O{other}"
+
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
+        let state = ctx.State
+        let instruction = ctx.Instruction
+
+        // Note: we deliberately omit `instruction.ExecutingMethod.Name` from the match.
+        // For `CustomAttribute_CreateCustomAttributeInstance` the actual PInvoke stub
+        // carries a Roslyn-generated mangled name (`<CreateCustomAttributeInstance>g____PInvoke|30_0`),
+        // whereas other QCalls (e.g. `RuntimeMethodHandle::IsCAVisibleFromDecoratedType`)
+        // are unwrapped P/Invoke methods with the natural name. The entry-point name and
+        // the parameter/return signature together already disambiguate this QCall.
+        match
+            entryPoint,
+            ctx.TargetAssembly.Name.Name,
+            ctx.TargetType.Namespace,
+            ctx.TargetType.Name,
+            instruction.ExecutingMethod.Signature.ParameterTypes,
+            instruction.ExecutingMethod.Signature.ReturnType
+        with
+        | "CustomAttribute_CreateCustomAttributeInstance",
+          "System.Private.CoreLib",
+          "System.Reflection",
+          "CustomAttribute",
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "QCallModule",
+                                              moduleGenerics)
+            ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "ObjectHandleOnStack",
+                                              typeHandleGenerics)
+            ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "ObjectHandleOnStack",
+                                              ctorHandleGenerics)
+            ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr)
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr
+            ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32)
+            ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "ObjectHandleOnStack",
+                                              instanceHandleGenerics) ],
+          MethodReturnType.Void when
+            moduleGenerics.IsEmpty
+            && typeHandleGenerics.IsEmpty
+            && ctorHandleGenerics.IsEmpty
+            && instanceHandleGenerics.IsEmpty
+            ->
+            let operation = "CustomAttribute.CreateCustomAttributeInstance"
+
+            if instruction.Arguments.Length <> 7 then
+                failwith $"%s{operation}: expected seven native arguments, got %d{instruction.Arguments.Length}"
+
+            // The handler runs in two phases, sharing the marker discipline used by
+            // `RuntimeTypeHandle_CreateInstanceForAnotherGenericParameter` (NativeRuntimeType.fs:
+            // around line 2347): phase 1 allocates the attribute instance, writes the cursor /
+            // named-arg-count out-slots, pushes the allocated address as a re-entry marker, then
+            // hands control to the ctor; phase 2 sees the marker on re-entry and copies it into
+            // the `instance` ObjectHandleOnStack. We defer the `result.Set` write to phase 2
+            // rather than match CoreCLR's pre-ctor placement: in CoreCLR the caller GC-protects
+            // through `pInstance`, but PawPrint's caller (RuntimeCustomAttributeData) treats a
+            // ctor-thrown exception as fatal anyway, so the observable difference is nil.
+            let resultHandle =
+                NativeCall.objectHandleOnStackTarget operation state "instance" instruction.Arguments.[6]
+
+            match instruction.EvaluationStack.Values with
+            | [ marker ] ->
+                let addr =
+                    match marker with
+                    | EvalStackValue.ObjectRef a -> a
+                    | other ->
+                        failwith
+                            $"%s{operation}: expected re-entry marker (object ref to allocated attribute instance) on eval stack, got %O{other}"
+
+                let _, state = IlMachineState.popEvalStack ctx.Thread state
+
+                let state =
+                    IlMachineState.writeManagedByrefWithBase
+                        ctx.BaseClassTypes
+                        state
+                        resultHandle
+                        (CliType.ObjectRef (Some addr))
+
+                (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            | [] ->
+                // QCallModule is not consulted on the success path; CoreCLR threads it through
+                // `GetDataFromBlob` for SERIALIZATION_TYPE_TYPE / TAGGED_OBJECT, which the
+                // Phase A blob reader does not yet emit. Decode and ignore for now so that
+                // refactoring the wiring later doesn't require reshuffling argument positions.
+                let _moduleAssemblyFullName =
+                    NativeCall.qCallModuleToAssemblyFullName
+                        operation
+                        state
+                        (instruction.Arguments.[0] |> EvalStackValue.ofCliType)
+
+                let attrTypeAddr =
+                    dereferenceObjectHandle operation ctx.BaseClassTypes state "pCaType" instruction.Arguments.[1]
+
+                let ctorStubAddr =
+                    dereferenceObjectHandle operation ctx.BaseClassTypes state "pCtor" instruction.Arguments.[2]
+
+                // `ref IntPtr ppBlob` is a managed byref to an IntPtr cell. The byref itself
+                // lets us write the new cursor back via `*ppBlob = updated`; the *current*
+                // cursor is the IntPtr value stored in that cell, so we have to read through
+                // the byref once more before decoding the underlying managed pointer. Don't
+                // collapse this into a single `managedPointerOfPointerArgument` call — that
+                // would treat the outer byref as if it were the IntPtr itself.
+                let blobCursorSlot =
+                    NativeCall.managedPointerOfPointerArgument operation "ppBlob" instruction.Arguments.[3]
+
+                let blobCursorIntPtr =
+                    IlMachineState.readManagedByref ctx.BaseClassTypes state blobCursorSlot
+
+                let blobCursorPtr =
+                    NativeCall.managedPointerOfPointerArgument operation "*ppBlob" blobCursorIntPtr
+
+                // `pEndBlob` is `IntPtr` by value, so it already *is* the cursor.
+                let blobEndPtr =
+                    NativeCall.managedPointerOfPointerArgument operation "pEndBlob" instruction.Arguments.[4]
+
+                let namedArgsSlot =
+                    NativeCall.managedPointerOfPointerArgument operation "pcNamedArgs" instruction.Arguments.[5]
+
+                // ECMA-335 attribute ctors are reference-typed by construction (custom-attribute
+                // classes derive from `System.Attribute`, a reference type). CoreCLR's QCall path
+                // explicitly handles value-typed ctor declaring types by unboxing the allocated
+                // instance for `args[0]`; that path is unreachable from the BCL filter
+                // (`FilterCustomAttributeRecord` only surfaces attribute types), and PawPrint's
+                // `concretizeMethodWithAllGenerics` produces a ConcreteTypeHandle which the
+                // caller would have to unbox before passing in. Until a real value-type
+                // attribute case appears, refuse it explicitly here rather than silently
+                // allocating a boxed instance.
+                let typeHandleTarget =
+                    NativeCall.runtimeTypeHandleTargetOfRuntimeTypeRef
+                        operation
+                        state
+                        (EvalStackValue.ObjectRef attrTypeAddr)
+
+                let instantiatedHandle =
+                    match typeHandleTarget with
+                    | RuntimeTypeHandleTarget.Closed handle -> handle
+                    | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
+                        failwith
+                            $"TODO: %s{operation}: attribute type is an open generic type definition (%s{identity.AssemblyFullName} / %O{identity.TypeDefinition.Get}); attribute decoration is restricted to closed types"
+                    | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
+                        failwith
+                            $"%s{operation}: attribute type was a generic parameter #%i{position} of %O{declaringType.TypeDefinition.Get}; the BCL filter should never surface this"
+                    | RuntimeTypeHandleTarget.MethodGenericParameter (declaringType, declaringMethod, position) ->
+                        failwith
+                            $"%s{operation}: attribute type was a method generic parameter #%i{position} of method %O{declaringMethod.Get} on %O{declaringType.TypeDefinition.Get}; the BCL filter should never surface this"
+
+                let concreteType =
+                    AllConcreteTypes.lookup instantiatedHandle state.ConcreteTypes
+                    |> Option.defaultWith (fun () ->
+                        failwith
+                            $"%s{operation}: attribute type handle %O{instantiatedHandle} was not registered in ConcreteTypes"
+                    )
+
+                let attrAssembly =
+                    state.LoadedAssembly concreteType.Assembly
+                    |> Option.defaultWith (fun () ->
+                        failwith
+                            $"%s{operation}: attribute type's assembly %s{concreteType.Assembly.FullName} is not loaded"
+                    )
+
+                let attrTypeInfo = attrAssembly.TypeDefs.[concreteType.Definition.Get]
+
+                if DumpedAssembly.isValueType ctx.BaseClassTypes state._LoadedAssemblies attrTypeInfo then
+                    failwith
+                        $"TODO: %s{operation}: value-typed attribute %s{attrTypeInfo.Namespace}.%s{attrTypeInfo.Name} would need unboxing for `this` slot; CoreCLR's value-type branch is unreachable from the BCL filter and is not yet modelled here"
+
+                // Resolve the ctor metadata via the method-handle registry. The BCL handed us a
+                // RuntimeMethodInfoStub address; the registry maps it back to the canonical
+                // `MethodHandle` we minted when this ctor was first reflected, which carries
+                // the declaring type's concrete generics and the method's own generic args.
+                let methodHandle =
+                    MethodHandleRegistry.resolveMethodFromAddress ctorStubAddr state.MethodHandles
+                    |> Option.defaultWith (fun () ->
+                        failwith
+                            $"%s{operation}: RuntimeMethodInfoStub at %O{ctorStubAddr} did not resolve to a registered MethodHandle"
+                    )
+
+                let ctorAssemblyName = methodHandle.GetAssemblyFullName ()
+
+                let ctorAssembly =
+                    state.LoadedAssembly' ctorAssemblyName
+                    |> Option.defaultWith (fun () ->
+                        failwith $"%s{operation}: ctor's declaring assembly %s{ctorAssemblyName} is not loaded"
+                    )
+
+                let methodDefHandle = methodHandle.GetMethodDefinitionHandle().Get
+
+                let ctorMetadata =
+                    let mutable found = Unchecked.defaultof<_>
+
+                    if not (ctorAssembly.Methods.TryGetValue (methodDefHandle, &found)) then
+                        failwith
+                            $"%s{operation}: ctor MethodDef %O{methodDefHandle} not found in assembly %s{ctorAssemblyName}"
+
+                    found
+
+                // ECMA-335 II.23.3 attribute ctors must be instance methods; CoreCLR likewise
+                // rejects vararg ctors before this QCall (FilterCustomAttributeRecord). A
+                // mismatch indicates a corrupted BCL filter rather than user error, so we surface
+                // the precise condition.
+                if ctorMetadata.IsStatic then
+                    failwith
+                        $"%s{operation}: ctor %s{attrTypeInfo.Namespace}.%s{attrTypeInfo.Name}::.ctor is static; attribute ctors must be instance methods"
+
+                let blobStartArr, blobStartIdx =
+                    blobPointerBounds operation "*ppBlob (start)" blobCursorPtr
+
+                let blobEndArr, blobEndIdx = blobPointerBounds operation "pEndBlob" blobEndPtr
+
+                if blobStartArr <> blobEndArr then
+                    failwith
+                        $"%s{operation}: ppBlob (array %O{blobStartArr}) and pEndBlob (array %O{blobEndArr}) point into different arrays; the bounds must straddle a single contiguous byte buffer"
+
+                let blobBytes =
+                    materialiseBytes operation state blobStartArr blobStartIdx blobEndIdx
+
+                let fixedArgs, fixedArgsConsumed =
+                    match CustomAttribute.readFixedArgs ctorMetadata.Signature.ParameterTypes blobBytes with
+                    | Ok (args, next) -> args, next
+                    | Error msg -> failwith $"%s{operation}: failed to parse fixed args from CustomAttrib blob: %s{msg}"
+
+                // ECMA-335 II.23.3: the named-arg count is a uint16 that follows the fixed args.
+                // If the blob is exhausted at this point the BCL convention is "zero named args";
+                // CoreCLR's `pBlob != pEndBlob` check guards the read. Mirror that here.
+                let remainingBytes = blobBytes.Length - fixedArgsConsumed
+
+                let namedArgCount, cursorAfterNamedArgs =
+                    if remainingBytes = 0 then
+                        0, fixedArgsConsumed
+                    elif remainingBytes < 2 then
+                        failwith
+                            $"%s{operation}: CustomAttrib blob has %d{remainingBytes} byte(s) after fixed args, but the named-arg count requires 2 bytes"
+                    else
+                        let lo = blobBytes.[fixedArgsConsumed]
+                        let hi = blobBytes.[fixedArgsConsumed + 1]
+                        let n = int (uint16 lo ||| (uint16 hi <<< 8))
+                        n, fixedArgsConsumed + 2
+
+                if namedArgCount = 0 && cursorAfterNamedArgs <> blobBytes.Length then
+                    failwith
+                        $"%s{operation}: CustomAttrib blob declares zero named args but %d{blobBytes.Length - cursorAfterNamedArgs} byte(s) remain at offset %d{cursorAfterNamedArgs} (total %d{blobBytes.Length})"
+
+                let updatedCursor =
+                    ManagedPointerSource.Byref (
+                        ByrefRoot.ArrayElement (blobStartArr, blobStartIdx + cursorAfterNamedArgs),
+                        []
+                    )
+
+                let state =
+                    IlMachineState.writeManagedByrefWithBase
+                        ctx.BaseClassTypes
+                        state
+                        blobCursorSlot
+                        (CliType.RuntimePointer (CliRuntimePointer.Managed updatedCursor))
+
+                let state =
+                    IlMachineState.writeManagedByrefWithBase
+                        ctx.BaseClassTypes
+                        state
+                        namedArgsSlot
+                        (CliType.Numeric (CliNumericType.Int32 namedArgCount))
+
+                let state, typeInit =
+                    IlMachineStateExecution.ensureTypeInitialised
+                        ctx.LoggerFactory
+                        ctx.BaseClassTypes
+                        ctx.Thread
+                        instantiatedHandle
+                        state
+
+                match typeInit with
+                | WhatWeDid.SuspendedForClassInit ->
+                    ExecutionResult.stepped (state, WhatWeDid.SuspendedForClassInit) |> Some
+                | WhatWeDid.BlockedOnClassInit blockedBy ->
+                    ExecutionResult.stepped (state, WhatWeDid.BlockedOnClassInit blockedBy) |> Some
+                | WhatWeDid.ThrowingTypeInitializationException ->
+                    ExecutionResult.stepped (state, WhatWeDid.ThrowingTypeInitializationException)
+                    |> Some
+                | WhatWeDid.SuspendedForManagedCall ->
+                    failwith "logic error: ensureTypeInitialised cannot suspend for an arbitrary managed call"
+                | WhatWeDid.Executed ->
+
+                let state, allFields =
+                    IlMachineState.collectAllInstanceFields
+                        ctx.LoggerFactory
+                        ctx.BaseClassTypes
+                        state
+                        instantiatedHandle
+
+                let instanceFields =
+                    CliValueType.OfFields
+                        ctx.BaseClassTypes
+                        state.ConcreteTypes
+                        instantiatedHandle
+                        attrTypeInfo.Layout
+                        (CharSetMetadata.ofTypeAttributes attrTypeInfo.TypeAttributes)
+                        allFields
+
+                let instanceAddr, state =
+                    IlMachineState.allocateManagedObject instantiatedHandle instanceFields state
+
+                let state, concretizedCtor, _declaringTypeHandle =
+                    ExecutionConcretization.concretizeMethodWithAllGenerics
+                        ctx.LoggerFactory
+                        ctx.BaseClassTypes
+                        concreteType.Generics
+                        ctorMetadata
+                        (methodHandle.GetMethodGenerics () |> ImmutableArray.CreateRange)
+                        state
+
+                if concretizedCtor.Parameters.Length <> List.length fixedArgs then
+                    failwith
+                        $"%s{operation}: ctor expects %d{concretizedCtor.Parameters.Length} fixed argument(s) but the blob produced %d{List.length fixedArgs}"
+
+                // Push the re-entry marker first so it survives the ctor call below: `callMethod`
+                // pops `this` plus the ctor args, leaving exactly one ObjectRef beneath the new
+                // frame's locals. The phase-2 branch above pops that marker to recover the
+                // allocated instance address.
+                let state =
+                    IlMachineState.pushToEvalStack (CliType.ObjectRef (Some instanceAddr)) ctx.Thread state
+
+                let state =
+                    IlMachineState.pushToEvalStack (CliType.ObjectRef (Some instanceAddr)) ctx.Thread state
+
+                let state =
+                    (state, fixedArgs)
+                    ||> List.fold (fun state arg ->
+                        let cliValue, state =
+                            CustomAttribValueLowering.toCliType ctx.LoggerFactory ctx.BaseClassTypes arg state
+
+                        IlMachineState.pushToEvalStack cliValue ctx.Thread state
+                    )
+
+                let threadState = state.ThreadState.[ctx.Thread]
+
+                // wasConstructing = None: we drive the ctor as a regular instance call, since
+                // the constructed instance is already on the eval stack as the re-entry marker.
+                // dispatchAsExceptionOnReturn = false / advanceProgramCounterOfCaller = false:
+                // the native QCall frame has no IL to advance.
+                let state =
+                    IlMachineStateExecution.callMethod
+                        ctx.LoggerFactory
+                        ctx.BaseClassTypes
+                        None
+                        None
+                        false
+                        false
+                        false
+                        concretizedCtor.Generics
+                        concretizedCtor
+                        ctx.Thread
+                        threadState
+                        None
+                        false
+                        state
+
+                ExecutionResult.stepped (state, WhatWeDid.SuspendedForManagedCall) |> Some
+            | other ->
+                failwith
+                    $"%s{operation}: expected at most one re-entry marker on the eval stack, got %d{other.Length} value(s): %A{other}"
+        | _ -> None

--- a/WoofWare.PawPrint/Native/NativeCustomAttribute.fs
+++ b/WoofWare.PawPrint/Native/NativeCustomAttribute.fs
@@ -240,15 +240,34 @@ module NativeCustomAttribute =
                     failwith
                         $"TODO: %s{operation}: value-typed attribute %s{attrTypeInfo.Namespace}.%s{attrTypeInfo.Name} would need unboxing for `this` slot; CoreCLR's value-type branch is unreachable from the BCL filter and is not yet modelled here"
 
-                // Resolve the ctor metadata via the method-handle registry. The BCL handed us a
-                // RuntimeMethodInfoStub address; the registry maps it back to the canonical
-                // `MethodHandle` we minted when this ctor was first reflected, which carries
-                // the declaring type's concrete generics and the method's own generic args.
-                let methodHandle =
-                    MethodHandleRegistry.resolveMethodFromAddress ctorStubAddr state.MethodHandles
+                // Resolve the ctor metadata via the method-handle registry. We can't rely on the
+                // stub's heap address being in `MethodHandleToMethod`: only stubs allocated by
+                // `IlMachineState.getOrAllocateMethod` are registered that way. The real BCL path
+                // (`ModuleHandle.ResolveMethodHandle(...).GetMethodInfo()`) constructs the stub in
+                // managed code, so its address is unknown to the registry. The stub's `m_value`
+                // field (a `RuntimeMethodHandleInternal`) does, however, carry a registry id that
+                // the producing QCall minted — that's the canonical path, and it works for both
+                // origins.
+                let ctorStubObj = ManagedHeap.get ctorStubAddr state.ManagedHeap
+
+                let stubValueField =
+                    IlMachineState.requiredOwnInstanceFieldId state ctorStubObj.ConcreteType "m_value"
+
+                let stubMValue =
+                    AllocatedNonArrayObject.DereferenceFieldById stubValueField ctorStubObj
+
+                let methodRegistryId =
+                    NativeCall.methodHandleIdOfRuntimeMethodHandleInternal operation stubMValue
                     |> Option.defaultWith (fun () ->
                         failwith
-                            $"%s{operation}: RuntimeMethodInfoStub at %O{ctorStubAddr} did not resolve to a registered MethodHandle"
+                            $"%s{operation}: RuntimeMethodInfoStub at %O{ctorStubAddr} carried a null RuntimeMethodHandleInternal"
+                    )
+
+                let methodHandle =
+                    MethodHandleRegistry.resolveMethodFromId methodRegistryId state.MethodHandles
+                    |> Option.defaultWith (fun () ->
+                        failwith
+                            $"%s{operation}: RuntimeMethodHandleInternal id %d{methodRegistryId} (from stub at %O{ctorStubAddr}) did not resolve to a registered MethodHandle"
                     )
 
                 let ctorAssemblyName = methodHandle.GetAssemblyFullName ()
@@ -316,26 +335,13 @@ module NativeCustomAttribute =
                     failwith
                         $"%s{operation}: CustomAttrib blob declares zero named args but %d{blobBytes.Length - cursorAfterNamedArgs} byte(s) remain at offset %d{cursorAfterNamedArgs} (total %d{blobBytes.Length})"
 
-                let updatedCursor =
-                    ManagedPointerSource.Byref (
-                        ByrefRoot.ArrayElement (blobStartArr, blobStartIdx + cursorAfterNamedArgs),
-                        []
-                    )
-
-                let state =
-                    IlMachineState.writeManagedByrefWithBase
-                        ctx.BaseClassTypes
-                        state
-                        blobCursorSlot
-                        (CliType.RuntimePointer (CliRuntimePointer.Managed updatedCursor))
-
-                let state =
-                    IlMachineState.writeManagedByrefWithBase
-                        ctx.BaseClassTypes
-                        state
-                        namedArgsSlot
-                        (CliType.Numeric (CliNumericType.Int32 namedArgCount))
-
+                // Run type initialisation *before* writing back the blob cursor and named-arg
+                // count. If `ensureTypeInitialised` suspends for a static ctor (or a chain of
+                // them), the QCall frame is re-entered with an empty eval stack and the handler
+                // has to re-parse the blob from `*ppBlob`. Advancing the cursor first would mean
+                // the re-entered handler reads zero bytes (or the wrong bytes), so the writes
+                // must wait until we've committed to allocating the instance and calling the
+                // ctor.
                 let state, typeInit =
                     IlMachineStateExecution.ensureTypeInitialised
                         ctx.LoggerFactory
@@ -355,6 +361,26 @@ module NativeCustomAttribute =
                 | WhatWeDid.SuspendedForManagedCall ->
                     failwith "logic error: ensureTypeInitialised cannot suspend for an arbitrary managed call"
                 | WhatWeDid.Executed ->
+
+                let updatedCursor =
+                    ManagedPointerSource.Byref (
+                        ByrefRoot.ArrayElement (blobStartArr, blobStartIdx + cursorAfterNamedArgs),
+                        []
+                    )
+
+                let state =
+                    IlMachineState.writeManagedByrefWithBase
+                        ctx.BaseClassTypes
+                        state
+                        blobCursorSlot
+                        (CliType.RuntimePointer (CliRuntimePointer.Managed updatedCursor))
+
+                let state =
+                    IlMachineState.writeManagedByrefWithBase
+                        ctx.BaseClassTypes
+                        state
+                        namedArgsSlot
+                        (CliType.Numeric (CliNumericType.Int32 namedArgCount))
 
                 let state, allFields =
                     IlMachineState.collectAllInstanceFields

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -63,6 +63,8 @@ module NativeQCall =
             "AssemblyNative_GetTypeCore", NativeRuntimeAssembly.tryExecuteQCall "AssemblyNative_GetTypeCore"
             "AssemblyNative_IsApplyUpdateSupported",
             NativeMetadataUpdater.tryExecuteQCall "AssemblyNative_IsApplyUpdateSupported"
+            "CustomAttribute_CreateCustomAttributeInstance",
+            NativeCustomAttribute.tryExecuteQCall "CustomAttribute_CreateCustomAttributeInstance"
             // The CoreLib source is a Kernel32 LibraryImport, but the runtime
             // assembly we execute presents this PAL entry point through QCall
             // import metadata.

--- a/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
+++ b/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
@@ -103,6 +103,7 @@
     <Compile Include="Native\NativeThreading.fs" />
     <Compile Include="Native\NativeDebugger.fs" />
     <Compile Include="Native\NativeEventPipe.fs" />
+    <Compile Include="Native\NativeCustomAttribute.fs" />
     <Compile Include="Native\NativeQCall.fs" />
     <Compile Include="Native\NativeType.fs" />
     <Compile Include="Native\NativeString.fs" />


### PR DESCRIPTION
## Summary
- Registers the `CustomAttribute_CreateCustomAttributeInstance` QCall handler in `NativeQCall.fs`, completing the reflection-time custom-attribute construction path. Phase 1 reads the `CustomAttrib` blob via the existing fixed-args reader (PR #548 / #549), allocates the attribute instance, writes the updated blob cursor and named-arg count to the BCL's out-pointers, then invokes the attribute ctor; phase 2 (re-entry after the ctor) writes the allocated instance into the caller-supplied `ObjectHandleOnStack`.
- The handler matches on parameter/return signature and QCall entry-point name. The method's own name is deliberately not part of the match because the actual PInvoke stub carries a Roslyn-generated mangled name (`<CreateCustomAttributeInstance>g____PInvoke|30_0`) on this entry point, unlike most other QCalls.
- Resolves the ctor stub through `m_value.m_handle` (the `RuntimeMethodHandleInternal` registry id) rather than the stub's heap address — the real BCL path (`ModuleHandle.ResolveMethodHandle(...).GetMethodInfo()`) constructs stubs in managed code, so their addresses aren't in `MethodHandleToMethod`, but the registry id is always set.
- Defers the cursor / `pcNamedArgs` writes until `ensureTypeInitialised` resolves to `Executed`, so a class-init suspension on the attribute type doesn't leave the cursor advanced when the QCall re-enters and re-parses the blob.

## Test plan
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --filter "Name~NativeCustomAttribute"` — 3 new tests cover phase 1 (suspends with ctor frame, advances cursor, parses fixed args), phase 2 (pops marker, writes instance slot), and class-init suspension (cursor + pcNamedArgs + instance slot left untouched on `SuspendedForClassInit`).
- [x] Full suite: 1007 passed, 0 failed.
- [x] `codex review --base main` — no findings on second pass; first pass surfaced two real bugs (P1 ctor resolution path, P2 cursor write ordering) which are addressed in commit 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)