### PR TITLE
Implement semaphore WaitHandle slice for CoreCLR-on-Unix QCalls

### DIFF
--- a/WoofWare.PawPrint.App/DebuggerServer.fs
+++ b/WoofWare.PawPrint.App/DebuggerServer.fs
@@ -104,6 +104,11 @@ module DebuggerServer =
             writer.WriteString ("kind", "blockedOnSyncBlockWait")
             writer.WriteNumber ("lockObject", heapAddressValue lockObject)
             writer.WriteEndObject ()
+        | ThreadStatus.BlockedOnWaitHandle (WaitHandleId handle) ->
+            writer.WriteStartObject ()
+            writer.WriteString ("kind", "blockedOnWaitHandle")
+            writer.WriteNumber ("handle", handle)
+            writer.WriteEndObject ()
         | ThreadStatus.Terminated -> writer.WriteStringValue "terminated"
 
     let private writeFrameProperties

--- a/WoofWare.PawPrint.Test/TestWaitHandle.fs
+++ b/WoofWare.PawPrint.Test/TestWaitHandle.fs
@@ -1,0 +1,555 @@
+namespace WoofWare.PawPrint.Test
+
+open System.Collections.Immutable
+open FsCheck
+open FsCheck.FSharp
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+/// Property-based tests for the deterministic `WaitHandle` state machine
+/// that backs the `CreateSemaphoreExW` / `ReleaseSemaphore` / `CloseHandle`
+/// / `WaitHandle_WaitOneCore` QCalls. Mirrors `TestLowLevelMonitor.fs`:
+/// the state machine is exercised in isolation through a stub
+/// `IlMachineState`, since the wait-handle module only reads and writes
+/// `Status`, the `WaitHandles` registry, and `NextWaitHandleId`.
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestWaitHandle =
+
+    let private config : Config = Config.QuickThrowOnFailure.WithMaxTest 200
+
+    let private corelib : DumpedAssembly =
+        let corelibPath = typeof<obj>.Assembly.Location
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        Assembly.readFile loggerFactory corelibPath
+
+    let private baseState () : IlMachineState =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        IlMachineState.initial loggerFactory ImmutableArray.Empty corelib
+
+    /// Frame-less thread stub; wait-handle transitions only read/write
+    /// `Status`, so any code path that tried to dereference a frame would
+    /// crash on the sentinel `ActiveMethodState`, which is the correct
+    /// response if the wait-handle module ever started reaching for frames.
+    let private stubThreadState (status : ThreadStatus) : ThreadState =
+        {
+            MethodStates = Map.empty
+            NextFrameId = 0
+            ActiveMethodState = FrameId -1
+            Status = status
+        }
+
+    let private withThreads (threads : ThreadId list) (state : IlMachineState) : IlMachineState =
+        let threadMap =
+            threads
+            |> List.map (fun tid -> tid, stubThreadState ThreadStatus.Runnable)
+            |> Map.ofList
+
+        { state with
+            ThreadState = threadMap
+        }
+
+    let private statusOf (thread : ThreadId) (state : IlMachineState) : ThreadStatus = state.ThreadState.[thread].Status
+
+    let private semaphoreOf (id : WaitHandleId) (state : IlMachineState) : SemaphoreState =
+        match Map.find id state.Kernel.WaitHandles with
+        | WaitHandleState.Semaphore s -> s
+
+    let private acquired (outcome : WaitHandle.WaitOutcome) : IlMachineState =
+        match outcome with
+        | WaitHandle.WaitOutcome.Acquired state -> state
+        | WaitHandle.WaitOutcome.Blocked _ -> failwith "expected Acquired but got Blocked"
+
+    let private blocked (outcome : WaitHandle.WaitOutcome) : IlMachineState =
+        match outcome with
+        | WaitHandle.WaitOutcome.Blocked state -> state
+        | WaitHandle.WaitOutcome.Acquired _ -> failwith "expected Blocked but got Acquired"
+
+    let private t0 = ThreadId 0
+    let private t1 = ThreadId 1
+    let private t2 = ThreadId 2
+    let private t3 = ThreadId 3
+    let private t4 = ThreadId 4
+
+    // -------------------------------------------------------------------
+    // createSemaphore — round-trip and input validation
+    // -------------------------------------------------------------------
+
+    [<Test>]
+    let ``createSemaphore mints distinct ids`` () : unit =
+        let state = baseState ()
+        let id1, state = WaitHandle.createSemaphore 0 1 state
+        let id2, state = WaitHandle.createSemaphore 0 1 state
+        let id3, _ = WaitHandle.createSemaphore 0 1 state
+
+        id1 |> shouldNotEqual id2
+        id1 |> shouldNotEqual id3
+        id2 |> shouldNotEqual id3
+
+    [<Test>]
+    let ``minted wait-handle ids are never zero (BCL OOM guard never fires)`` () : unit =
+        let state = baseState ()
+        let id, _ = WaitHandle.createSemaphore 0 1 state
+        let (WaitHandleId i) = id
+        // The handle must be non-zero so the BCL's `if (handle ==
+        // IntPtr.Zero) throw new ...` check stays quiet for successful
+        // creates.
+        i |> shouldNotEqual 0
+
+    [<Test>]
+    let ``newly minted semaphore reflects the requested (count, maximum) with an empty queue`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createSemaphore 3 5 state
+
+        let s = semaphoreOf id state
+        s.Count |> shouldEqual 3
+        s.Maximum |> shouldEqual 5
+        s.WaitQueue |> shouldEqual []
+
+    [<Test>]
+    let ``createSemaphore rejects maximum < 1`` () : unit =
+        let state = baseState ()
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.createSemaphore 0 0 state |> ignore)
+
+        exn.Message |> shouldContainText "maximumCount"
+
+    [<Test>]
+    let ``createSemaphore rejects negative initial`` () : unit =
+        let state = baseState ()
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.createSemaphore -1 5 state |> ignore)
+
+        exn.Message |> shouldContainText "initialCount"
+
+    [<Test>]
+    let ``createSemaphore rejects initial > maximum`` () : unit =
+        let state = baseState ()
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.createSemaphore 6 5 state |> ignore)
+
+        exn.Message |> shouldContainText "exceeds maximumCount"
+
+    [<Test>]
+    let ``Property: createSemaphore round-trips the requested (initial, maximum)`` () : unit =
+        let property (NonNegativeInt initial) (PositiveInt maximum) : bool =
+            if initial > maximum then
+                true
+            else
+                let state = baseState ()
+                let id, state = WaitHandle.createSemaphore initial maximum state
+
+                let s = semaphoreOf id state
+                s.Count = initial && s.Maximum = maximum && s.WaitQueue = []
+
+        Check.One (config, property)
+
+    // -------------------------------------------------------------------
+    // waitOne — fast path / slow path
+    // -------------------------------------------------------------------
+
+    [<Test>]
+    let ``waitOne on a signalled semaphore decrements count and stays Runnable`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createSemaphore 2 5 state
+
+        let state = WaitHandle.waitOne t0 id state |> acquired
+
+        let s = semaphoreOf id state
+        s.Count |> shouldEqual 1
+        s.WaitQueue |> shouldEqual []
+        statusOf t0 state |> shouldEqual ThreadStatus.Runnable
+
+    [<Test>]
+    let ``waitOne on a zero-count semaphore parks the caller at the FIFO tail`` () : unit =
+        let state = baseState () |> withThreads [ t0 ; t1 ]
+        let id, state = WaitHandle.createSemaphore 0 5 state
+
+        let state = WaitHandle.waitOne t0 id state |> blocked
+        let state = WaitHandle.waitOne t1 id state |> blocked
+
+        let s = semaphoreOf id state
+        s.Count |> shouldEqual 0
+        s.WaitQueue |> shouldEqual [ t0 ; t1 ]
+        statusOf t0 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+
+    [<Test>]
+    let ``waitOne fast path drives count to zero in sequence`` () : unit =
+        let state = baseState () |> withThreads [ t0 ; t1 ; t2 ]
+        let id, state = WaitHandle.createSemaphore 2 5 state
+        let state = WaitHandle.waitOne t0 id state |> acquired
+        let state = WaitHandle.waitOne t1 id state |> acquired
+        // Count is now 0; t2 must block.
+        let state = WaitHandle.waitOne t2 id state |> blocked
+
+        let s = semaphoreOf id state
+        s.Count |> shouldEqual 0
+        s.WaitQueue |> shouldEqual [ t2 ]
+        statusOf t0 state |> shouldEqual ThreadStatus.Runnable
+        statusOf t1 state |> shouldEqual ThreadStatus.Runnable
+        statusOf t2 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+
+    // -------------------------------------------------------------------
+    // releaseSemaphore — direct handoff, overflow, FIFO
+    // -------------------------------------------------------------------
+
+    [<Test>]
+    let ``releaseSemaphore on an idle semaphore increments count and reports previous`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createSemaphore 1 5 state
+
+        let result, state = WaitHandle.releaseSemaphore id 2 state
+
+        result |> shouldEqual (Ok 1)
+        (semaphoreOf id state).Count |> shouldEqual 3
+
+    [<Test>]
+    let ``releaseSemaphore returns previous count of zero from a fresh semaphore`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createSemaphore 0 5 state
+
+        let result, state = WaitHandle.releaseSemaphore id 1 state
+
+        result |> shouldEqual (Ok 0)
+        (semaphoreOf id state).Count |> shouldEqual 1
+
+    [<Test>]
+    let ``releaseSemaphore wakes a single FIFO-head waiter via direct handoff`` () : unit =
+        let state = baseState () |> withThreads [ t0 ; t1 ]
+        let id, state = WaitHandle.createSemaphore 0 5 state
+        let state = WaitHandle.waitOne t0 id state |> blocked
+        let state = WaitHandle.waitOne t1 id state |> blocked
+
+        let result, state = WaitHandle.releaseSemaphore id 1 state
+
+        result |> shouldEqual (Ok 0)
+        let s = semaphoreOf id state
+        // Direct handoff: the freshly-added unit was consumed by t0;
+        // count stays at 0. t1 remains parked behind.
+        s.Count |> shouldEqual 0
+        s.WaitQueue |> shouldEqual [ t1 ]
+        statusOf t0 state |> shouldEqual ThreadStatus.Runnable
+        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+
+    [<Test>]
+    let ``releaseSemaphore N wakes min(N, K) FIFO-head waiters and leaves N-K units accumulated`` () : unit =
+        let state = baseState () |> withThreads [ t0 ; t1 ; t2 ; t3 ]
+
+        let id, state = WaitHandle.createSemaphore 0 10 state
+        let state = WaitHandle.waitOne t0 id state |> blocked
+        let state = WaitHandle.waitOne t1 id state |> blocked
+        let state = WaitHandle.waitOne t2 id state |> blocked
+        // Release 5 with 3 waiters: wakes all three; (5 - 3) = 2 units
+        // accumulate in Count.
+        let result, state = WaitHandle.releaseSemaphore id 5 state
+
+        result |> shouldEqual (Ok 0)
+        let s = semaphoreOf id state
+        s.Count |> shouldEqual 2
+        s.WaitQueue |> shouldEqual []
+        statusOf t0 state |> shouldEqual ThreadStatus.Runnable
+        statusOf t1 state |> shouldEqual ThreadStatus.Runnable
+        statusOf t2 state |> shouldEqual ThreadStatus.Runnable
+
+    [<Test>]
+    let ``releaseSemaphore N wakes only N of K waiters when K > N`` () : unit =
+        let state = baseState () |> withThreads [ t0 ; t1 ; t2 ; t3 ; t4 ]
+
+        let id, state = WaitHandle.createSemaphore 0 10 state
+        let state = WaitHandle.waitOne t0 id state |> blocked
+        let state = WaitHandle.waitOne t1 id state |> blocked
+        let state = WaitHandle.waitOne t2 id state |> blocked
+        let state = WaitHandle.waitOne t3 id state |> blocked
+        let state = WaitHandle.waitOne t4 id state |> blocked
+
+        let result, state = WaitHandle.releaseSemaphore id 2 state
+
+        result |> shouldEqual (Ok 0)
+        let s = semaphoreOf id state
+        // Direct handoff: both new units consumed by the FIFO-head pair;
+        // Count remains 0. t2..t4 stay parked in FIFO order.
+        s.Count |> shouldEqual 0
+        s.WaitQueue |> shouldEqual [ t2 ; t3 ; t4 ]
+        statusOf t0 state |> shouldEqual ThreadStatus.Runnable
+        statusOf t1 state |> shouldEqual ThreadStatus.Runnable
+        statusOf t2 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+        statusOf t3 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+        statusOf t4 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+
+    [<Test>]
+    let ``releaseSemaphore rejects overflow and leaves state unchanged`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createSemaphore 4 5 state
+        let before = semaphoreOf id state
+
+        let result, state' = WaitHandle.releaseSemaphore id 2 state
+
+        match result with
+        | Error (WaitHandle.ReleaseFailure.WouldExceedMaximum (attempted, maximum)) ->
+            attempted |> shouldEqual 6
+            maximum |> shouldEqual 5
+        | Ok _ -> failwith "expected overflow but got success"
+
+        // State must be untouched: a failed release is observably a no-op
+        // on the semaphore side, mirroring `ERROR_TOO_MANY_POSTS` /
+        // `SemaphoreFullException`.
+        semaphoreOf id state' |> shouldEqual before
+
+    [<Test>]
+    let ``releaseSemaphore rejects non-positive releaseCount`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createSemaphore 0 5 state
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.releaseSemaphore id 0 state |> ignore)
+
+        exn.Message |> shouldContainText "releaseCount"
+
+    [<Test>]
+    let ``Property: balanced release-then-waitOne pairs return semaphore to its initial count`` () : unit =
+        let property (PositiveInt n) : bool =
+            let n = min 16 n
+            let threads = [ 0 .. n - 1 ] |> List.map ThreadId
+            let state = baseState () |> withThreads threads
+            // Start signalled at n so every waitOne is fast-path; releases
+            // bring count back up to n.
+            let id, state = WaitHandle.createSemaphore n n state
+
+            let state =
+                threads
+                |> List.fold
+                    (fun s tid ->
+                        let s = WaitHandle.waitOne tid id s |> acquired
+                        let _, s = WaitHandle.releaseSemaphore id 1 s
+                        s
+                    )
+                    state
+
+            let s = semaphoreOf id state
+
+            s.Count = n
+            && s.WaitQueue = []
+            && threads |> List.forall (fun t -> statusOf t state = ThreadStatus.Runnable)
+
+        Check.One (config, property)
+
+    /// FIFO fairness oracle for releaseSemaphore. Block K threads on a
+    /// zero-count semaphore in registration order, then issue K single-unit
+    /// releases. Each release must wake the FIFO head of the wait queue
+    /// (not a later waiter), so the observed wake order equals the
+    /// registration order. Moving the wait queue to LIFO or arbitrary
+    /// ordering would break LowLevelLifoSemaphore fairness higher up.
+    [<Test>]
+    let ``Property: releaseSemaphore wakes parked waiters in FIFO registration order`` () : unit =
+        let property (PositiveInt k) : bool =
+            let k = min 16 k
+            let threads = [ 0 .. k - 1 ] |> List.map ThreadId
+            let state = baseState () |> withThreads threads
+            let id, state = WaitHandle.createSemaphore 0 k state
+
+            let state =
+                threads |> List.fold (fun s tid -> WaitHandle.waitOne tid id s |> blocked) state
+
+            // Snapshot the queue before any releases.
+            let expectedWakeOrder = (semaphoreOf id state).WaitQueue
+
+            let mutable state = state
+            let mutable observed = []
+
+            for _ in 1..k do
+                // Look at which thread is currently at the head before
+                // release; we'll verify it transitioned to Runnable below.
+                let head = List.head (semaphoreOf id state).WaitQueue
+                let result, s = WaitHandle.releaseSemaphore id 1 state
+                state <- s
+
+                match result with
+                | Ok _ -> ()
+                | Error _ -> failwith "unexpected overflow in a fresh K-zero semaphore"
+
+                if statusOf head state <> ThreadStatus.Runnable then
+                    failwith $"release did not wake the FIFO head %O{head}"
+
+                observed <- observed @ [ head ]
+
+            let s = semaphoreOf id state
+
+            observed = expectedWakeOrder
+            && s.Count = 0
+            && s.WaitQueue = []
+            && threads |> List.forall (fun t -> statusOf t state = ThreadStatus.Runnable)
+
+        Check.One (config, property)
+
+    // -------------------------------------------------------------------
+    // close — invariants
+    // -------------------------------------------------------------------
+
+    [<Test>]
+    let ``close removes a quiescent semaphore from the registry`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createSemaphore 0 1 state
+
+        let state = WaitHandle.close id state
+
+        Map.containsKey id state.Kernel.WaitHandles |> shouldEqual false
+
+    [<Test>]
+    let ``close on a signalled (non-zero count) semaphore is permitted`` () : unit =
+        // The Win32 contract only forbids closing with parked waiters;
+        // a semaphore that simply has spare capacity (no blocked threads)
+        // is fine to dispose. The BCL's `Dispose` does exactly this.
+        let state = baseState ()
+        let id, state = WaitHandle.createSemaphore 3 5 state
+
+        let state = WaitHandle.close id state
+
+        Map.containsKey id state.Kernel.WaitHandles |> shouldEqual false
+
+    [<Test>]
+    let ``close fails loud with parked waiters`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createSemaphore 0 5 state
+        let state = WaitHandle.waitOne t0 id state |> blocked
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.close id state |> ignore)
+
+        exn.Message |> shouldContainText "parked"
+
+    [<Test>]
+    let ``close on an unknown handle fails loud (use-after-free)`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createSemaphore 0 1 state
+        let state = WaitHandle.close id state
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.close id state |> ignore)
+
+        exn.Message |> shouldContainText "not registered"
+
+    [<Test>]
+    let ``waitOne on a closed handle fails loud (use-after-free)`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createSemaphore 1 5 state
+        let state = WaitHandle.close id state
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.waitOne t0 id state |> ignore)
+
+        exn.Message |> shouldContainText "not registered"
+
+    [<Test>]
+    let ``releaseSemaphore on a closed handle fails loud (use-after-free)`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createSemaphore 1 5 state
+        let state = WaitHandle.close id state
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.releaseSemaphore id 1 state |> ignore)
+
+        exn.Message |> shouldContainText "not registered"
+
+    // -------------------------------------------------------------------
+    // Count invariant oracle: an arbitrary script of Wait / Release on a
+    // single semaphore must keep `Count ∈ [0, Maximum]` and preserve the
+    // conservation law
+    //     Count - |WaitQueue| = initial + Σreleases - Σwaits
+    // where Σreleases counts only successful releases (overflows reject)
+    // and Σwaits counts every `waitOne` call applied to the semaphore (both
+    // fast-path acquires that decrement Count and slow-path parks that
+    // enqueue). The sign of `|WaitQueue|` is negative because a parked
+    // thread is "owed" a unit: a subsequent release will hand a freshly
+    // issued unit to it directly, never accumulating into Count.
+    // -------------------------------------------------------------------
+
+    [<RequireQualifiedAccess>]
+    type private Op =
+        | Wait of ThreadId
+        | Release of int
+
+    /// Apply one script step. Returns the updated state plus a pair of
+    /// (delta-from-waits, delta-from-releases) used by the oracle. A
+    /// release that overflows contributes 0 (its state is unchanged); a
+    /// wait by a thread that's already blocked is a guest bug and we just
+    /// skip the script step (the oracle works on what was actually applied).
+    let private applyOp
+        (id : WaitHandleId)
+        (op : Op)
+        (state : IlMachineState)
+        (waited : int)
+        (released : int)
+        : IlMachineState * int * int
+        =
+        match op with
+        | Op.Wait tid ->
+            // A thread that's already blocked cannot wait again; in
+            // PawPrint that would re-park it which is a guest bug. Skip.
+            match statusOf tid state with
+            | ThreadStatus.BlockedOnWaitHandle _ -> state, waited, released
+            | _ ->
+                let outcome = WaitHandle.waitOne tid id state
+
+                match outcome with
+                | WaitHandle.WaitOutcome.Acquired s -> s, waited + 1, released
+                | WaitHandle.WaitOutcome.Blocked s -> s, waited + 1, released
+        | Op.Release n ->
+            let result, state' = WaitHandle.releaseSemaphore id n state
+
+            match result with
+            | Ok _ -> state', waited, released + n
+            | Error _ -> state, waited, released
+
+    [<Test>]
+    let ``Property: count invariant + conservation hold across an arbitrary Wait/Release script`` () : unit =
+        // Generators kept small so the script stays scrutable but covers
+        // the interesting interleavings (fast-path acquires, parking, and
+        // releases that wake K of N waiters).
+        let property (NonNegativeInt initialRaw) (PositiveInt maximumRaw) (PositiveInt threadCountRaw) : bool =
+            let maximum = 1 + (maximumRaw % 10)
+            let initial = min initialRaw maximum
+            let threadCount = 1 + (threadCountRaw % 6)
+            let threads = [ 0 .. threadCount - 1 ] |> List.map ThreadId
+            let state = baseState () |> withThreads threads
+            let id, state = WaitHandle.createSemaphore initial maximum state
+
+            // Drive a fixed-length pseudo-random script using a
+            // deterministic seed so any failure shrinks reproducibly.
+            let scriptLen = 40
+            let mutable rng = System.Random (initial * 31 + maximum * 17 + threadCount)
+            let mutable state = state
+            let mutable totalWaited = 0
+            let mutable totalReleased = 0
+            let mutable invariantOk = true
+
+            for _ in 1..scriptLen do
+                let op =
+                    if rng.Next 2 = 0 then
+                        Op.Wait (List.item (rng.Next threadCount) threads)
+                    else
+                        Op.Release (1 + rng.Next maximum)
+
+                let s, w, r = applyOp id op state totalWaited totalReleased
+                state <- s
+                totalWaited <- w
+                totalReleased <- r
+
+                let sem = semaphoreOf id state
+
+                if sem.Count < 0 || sem.Count > sem.Maximum then
+                    invariantOk <- false
+
+            let sem = semaphoreOf id state
+            // Conservation: count - parked = initial + releases - waits.
+            // A parked thread is owed a unit, hence the negative sign.
+            let parked = List.length sem.WaitQueue
+            let conservation = sem.Count - parked = initial + totalReleased - totalWaited
+
+            invariantOk && conservation && sem.Maximum = maximum
+
+        Check.One (config, property)

--- a/WoofWare.PawPrint.Test/TestWaitHandle.fs
+++ b/WoofWare.PawPrint.Test/TestWaitHandle.fs
@@ -66,6 +66,16 @@ module TestWaitHandle =
         | WaitHandle.WaitOutcome.Blocked state -> state
         | WaitHandle.WaitOutcome.Acquired _ -> failwith "expected Blocked but got Acquired"
 
+    let private tryAcquired (outcome : WaitHandle.TryWaitOutcome) : IlMachineState =
+        match outcome with
+        | WaitHandle.TryWaitOutcome.Acquired state -> state
+        | WaitHandle.TryWaitOutcome.TimedOut _ -> failwith "expected Acquired but got TimedOut"
+
+    let private timedOut (outcome : WaitHandle.TryWaitOutcome) : IlMachineState =
+        match outcome with
+        | WaitHandle.TryWaitOutcome.TimedOut state -> state
+        | WaitHandle.TryWaitOutcome.Acquired _ -> failwith "expected TimedOut but got Acquired"
+
     let private t0 = ThreadId 0
     let private t1 = ThreadId 1
     let private t2 = ThreadId 2
@@ -193,6 +203,160 @@ module TestWaitHandle =
         statusOf t0 state |> shouldEqual ThreadStatus.Runnable
         statusOf t1 state |> shouldEqual ThreadStatus.Runnable
         statusOf t2 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+
+    // -------------------------------------------------------------------
+    // tryWaitOne — non-blocking probe used by zero-timeout WaitOne(0)
+    // -------------------------------------------------------------------
+
+    [<Test>]
+    let ``tryWaitOne on a signalled semaphore decrements count and reports Acquired`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createSemaphore 2 5 state
+
+        let state = WaitHandle.tryWaitOne id state |> tryAcquired
+
+        let s = semaphoreOf id state
+        s.Count |> shouldEqual 1
+        s.WaitQueue |> shouldEqual []
+
+    [<Test>]
+    let ``tryWaitOne on a zero-count semaphore reports TimedOut without parking`` () : unit =
+        // The deterministic non-blocking probe the BCL drives through a
+        // zero-timeout WaitOne(0). CoreCLR's semantics: the caller does
+        // not enter the wait queue and the handle is left untouched —
+        // we'd be observably violating the contract if we parked the
+        // thread for what should be an immediate-return path.
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createSemaphore 0 5 state
+
+        let state = WaitHandle.tryWaitOne id state |> timedOut
+
+        let s = semaphoreOf id state
+        s.Count |> shouldEqual 0
+        s.WaitQueue |> shouldEqual []
+        statusOf t0 state |> shouldEqual ThreadStatus.Runnable
+
+    // -------------------------------------------------------------------
+    // waitOnePrioritized — LIFO insertion at head of wait queue
+    // -------------------------------------------------------------------
+
+    [<Test>]
+    let ``waitOnePrioritized on a signalled semaphore decrements count and stays Runnable`` () : unit =
+        // Fast path is identical to waitOne: priority only matters when
+        // the wait actually blocks.
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createSemaphore 2 5 state
+
+        let state = WaitHandle.waitOnePrioritized t0 id state |> acquired
+
+        let s = semaphoreOf id state
+        s.Count |> shouldEqual 1
+        s.WaitQueue |> shouldEqual []
+        statusOf t0 state |> shouldEqual ThreadStatus.Runnable
+
+    [<Test>]
+    let ``waitOnePrioritized parks each caller at the HEAD of the wait queue`` () : unit =
+        // PAL_WaitForSingleObjectPrioritized contract: prioritized waiters
+        // are registered at the BEGINNING of the wait queue (LIFO release
+        // policy). Verifies the queue shape after three back-to-back
+        // prioritized waits.
+        let state = baseState () |> withThreads [ t0 ; t1 ; t2 ]
+        let id, state = WaitHandle.createSemaphore 0 5 state
+
+        let state = WaitHandle.waitOnePrioritized t0 id state |> blocked
+        let state = WaitHandle.waitOnePrioritized t1 id state |> blocked
+        let state = WaitHandle.waitOnePrioritized t2 id state |> blocked
+
+        let s = semaphoreOf id state
+        s.Count |> shouldEqual 0
+        // Latest-arrived prioritized waiter is at head; oldest is at tail.
+        s.WaitQueue |> shouldEqual [ t2 ; t1 ; t0 ]
+        statusOf t0 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+        statusOf t2 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+
+    [<Test>]
+    let ``releaseSemaphore wakes prioritized waiters in LIFO order`` () : unit =
+        // The LowLevelLifoSemaphore contract that PortableThreadPool
+        // relies on: a later-arrived prioritized waiter is woken before
+        // an earlier-arrived one.
+        let state = baseState () |> withThreads [ t0 ; t1 ; t2 ]
+        let id, state = WaitHandle.createSemaphore 0 5 state
+
+        let state = WaitHandle.waitOnePrioritized t0 id state |> blocked
+        let state = WaitHandle.waitOnePrioritized t1 id state |> blocked
+        let state = WaitHandle.waitOnePrioritized t2 id state |> blocked
+
+        let _, state = WaitHandle.releaseSemaphore id 1 state
+
+        statusOf t2 state |> shouldEqual ThreadStatus.Runnable
+        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+        statusOf t0 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+
+        let _, state = WaitHandle.releaseSemaphore id 1 state
+
+        statusOf t1 state |> shouldEqual ThreadStatus.Runnable
+        statusOf t0 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+
+        let _, state = WaitHandle.releaseSemaphore id 1 state
+
+        statusOf t0 state |> shouldEqual ThreadStatus.Runnable
+
+    [<Test>]
+    let ``prioritized waiter wakes before any earlier-arrived non-prioritized waiter`` () : unit =
+        // PAL contract: a prioritized waiter goes to the HEAD of the queue
+        // even when non-prioritized waiters are already enqueued behind it.
+        // Verifies the cross-class ordering (prioritized strictly precedes
+        // earlier-arrived non-prioritized in wake order).
+        let state = baseState () |> withThreads [ t0 ; t1 ; t2 ]
+        let id, state = WaitHandle.createSemaphore 0 5 state
+
+        let state = WaitHandle.waitOne t0 id state |> blocked
+        let state = WaitHandle.waitOne t1 id state |> blocked
+        let state = WaitHandle.waitOnePrioritized t2 id state |> blocked
+
+        let s = semaphoreOf id state
+        // t2 is at the head; t0 and t1 preserve their FIFO ordering behind.
+        s.WaitQueue |> shouldEqual [ t2 ; t0 ; t1 ]
+
+        let _, state = WaitHandle.releaseSemaphore id 1 state
+
+        statusOf t2 state |> shouldEqual ThreadStatus.Runnable
+        statusOf t0 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+
+    [<Test>]
+    let ``Property: releaseSemaphore wakes prioritized waiters in LIFO registration order`` () : unit =
+        let property (PositiveInt k) : bool =
+            let k = min 16 k
+            let threads = [ 0 .. k - 1 ] |> List.map ThreadId
+            let state = baseState () |> withThreads threads
+            let id, state = WaitHandle.createSemaphore 0 k state
+
+            let state =
+                threads
+                |> List.fold (fun s tid -> WaitHandle.waitOnePrioritized tid id s |> blocked) state
+
+            // LIFO over prioritized waiters: latest registration wakes first.
+            let expectedWakeOrder = List.rev threads
+
+            let mutable state = state
+            let mutable observed = []
+
+            for _ in 1..k do
+                let head = List.head (semaphoreOf id state).WaitQueue
+                let _, s = WaitHandle.releaseSemaphore id 1 state
+                state <- s
+                observed <- observed @ [ head ]
+
+            let s = semaphoreOf id state
+
+            observed = expectedWakeOrder
+            && s.Count = 0
+            && s.WaitQueue = []
+            && threads |> List.forall (fun t -> statusOf t state = ThreadStatus.Runnable)
+
+        Check.One (config, property)
 
     // -------------------------------------------------------------------
     // releaseSemaphore — direct handoff, overflow, FIFO

--- a/WoofWare.PawPrint.Test/TestWaitHandle.fs
+++ b/WoofWare.PawPrint.Test/TestWaitHandle.fs
@@ -291,13 +291,39 @@ module TestWaitHandle =
 
         match result with
         | Error (WaitHandle.ReleaseFailure.WouldExceedMaximum (attempted, maximum)) ->
-            attempted |> shouldEqual 6
+            attempted |> shouldEqual 6L
             maximum |> shouldEqual 5
         | Ok _ -> failwith "expected overflow but got success"
 
         // State must be untouched: a failed release is observably a no-op
         // on the semaphore side, mirroring `ERROR_TOO_MANY_POSTS` /
         // `SemaphoreFullException`.
+        semaphoreOf id state' |> shouldEqual before
+
+    [<Test>]
+    let ``releaseSemaphore rejects overflow without int32 wraparound near Int32.MaxValue`` () : unit =
+        // Regression for an int32 overflow in the maximum check: at
+        // `previousCount = Int32.MaxValue`, computing `previousCount +
+        // releaseCount` wraps to a negative value that's < Maximum, so
+        // the naive check would silently accept the release and store a
+        // negative `Count`. The actual check must compare without
+        // computing the sum.
+        let state = baseState ()
+
+        let id, state =
+            WaitHandle.createSemaphore System.Int32.MaxValue System.Int32.MaxValue state
+
+        let before = semaphoreOf id state
+
+        let result, state' = WaitHandle.releaseSemaphore id 1 state
+
+        match result with
+        | Error (WaitHandle.ReleaseFailure.WouldExceedMaximum (attempted, maximum)) ->
+            // The error must carry the true (non-wrapped) total.
+            attempted |> shouldEqual (int64 System.Int32.MaxValue + 1L)
+            maximum |> shouldEqual System.Int32.MaxValue
+        | Ok _ -> failwith "expected overflow but got success"
+
         semaphoreOf id state' |> shouldEqual before
 
     [<Test>]

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -66,6 +66,7 @@
     <Compile Include="TestDebuggerServer.fs" />
     <Compile Include="TestBclIntrinsicStaticFields.fs" />
     <Compile Include="TestLowLevelMonitor.fs" />
+    <Compile Include="TestWaitHandle.fs" />
     <Compile Include="TestSyncBlockMonitor.fs" />
     <Compile Include="TestPureCases.fs" />
     <Compile Include="TestImpureCases.fs" />

--- a/WoofWare.PawPrint/AbstractMachineDomain.fs
+++ b/WoofWare.PawPrint/AbstractMachineDomain.fs
@@ -62,3 +62,16 @@ type LowLevelMonitorId =
     override this.ToString () =
         match this with
         | LowLevelMonitorId.LowLevelMonitorId i -> $"<low-level monitor #%i{i}>"
+
+/// Opaque handle for a Win32-shaped wait handle (semaphore today; event/mutex
+/// in future PRs) minted by the `CreateSemaphoreExW` / `CreateEventExW` /
+/// `CreateMutexExW` QCalls. Round-trips through guest code as an `IntPtr` (see
+/// `NativeIntSource.WaitHandlePtr`), wrapped by the BCL in a `SafeWaitHandle`.
+/// Globally scoped within the `IlMachineState`; never reused after `CloseHandle`
+/// so that use-after-free is caught at the use site.
+type WaitHandleId =
+    | WaitHandleId of int
+
+    override this.ToString () =
+        match this with
+        | WaitHandleId.WaitHandleId i -> $"<wait handle #%i{i}>"

--- a/WoofWare.PawPrint/CliNumericType.fs
+++ b/WoofWare.PawPrint/CliNumericType.fs
@@ -337,6 +337,7 @@ type CliNumericType =
             | NativeIntSource.EventPipeProviderPtr _ -> failwith "refusing to express EventPipeProviderPtr as bytes"
             | NativeIntSource.EventPipeEventPtr _ -> failwith "refusing to express EventPipeEventPtr as bytes"
             | NativeIntSource.LowLevelMonitorPtr _ -> failwith "refusing to express LowLevelMonitorPtr as bytes"
+            | NativeIntSource.WaitHandlePtr _ -> failwith "refusing to express WaitHandlePtr as bytes"
             | NativeIntSource.AssemblyHandle _ -> failwith "refusing to express AssemblyHandle as bytes"
             | NativeIntSource.ModuleHandle _ -> failwith "refusing to express ModuleHandle as bytes"
             | NativeIntSource.MetadataImportHandle _ -> failwith "refusing to express MetadataImportHandle as bytes"

--- a/WoofWare.PawPrint/CliType.fs
+++ b/WoofWare.PawPrint/CliType.fs
@@ -68,6 +68,7 @@ module private ByteAddressabilityClassifier =
         | NativeIntSource.EventPipeProviderPtr _
         | NativeIntSource.EventPipeEventPtr _
         | NativeIntSource.LowLevelMonitorPtr _
+        | NativeIntSource.WaitHandlePtr _
         | NativeIntSource.SyntheticCrossArrayOffset _
         | NativeIntSource.OpaqueHashBits _ ->
             CliByteAddressability.Rejected (CliByteAddressabilityRejection.NativeIntSourceNotByteAddressable source)

--- a/WoofWare.PawPrint/EmulatedKernel.fs
+++ b/WoofWare.PawPrint/EmulatedKernel.fs
@@ -123,6 +123,38 @@ type SyncBlockSpuriousWakeupStrategy =
     /// changes.
     | Scripted of wakeups : (int64 * ManagedHeapAddress * ThreadId) list
 
+/// Deterministic model of a single Win32-shaped semaphore kernel object, as
+/// minted by `CreateSemaphoreExW`. CoreCLR backs this with a real Win32
+/// `CreateSemaphoreEx` on Windows and with a `SemaphoreSlim`-style construct
+/// on Unix (via the QCall-rebound `Libraries.Kernel32`). PawPrint reproduces
+/// the observable semantics through three pieces of state owned by the
+/// kernel's `WaitHandles` registry:
+///
+///   - `Count` is the current signalled count: `WaitOne` decrements it
+///     when positive, otherwise the caller is parked on `WaitQueue`.
+///   - `Maximum` is the ceiling supplied at create time;
+///     `ReleaseSemaphore` refuses (with `ERROR_TOO_MANY_POSTS`) when an
+///     increment would breach it.
+///   - `WaitQueue` is the FIFO list of threads parked in
+///     `BlockedOnWaitHandle`. The head is woken first by a subsequent
+///     `Release`; FIFO order is load-bearing for the higher-level
+///     `LowLevelLifoSemaphore` fairness contract.
+type SemaphoreState =
+    {
+        Count : int
+        Maximum : int
+        WaitQueue : ThreadId list
+    }
+
+/// Kind-tagged state for a single Win32-shaped wait-handle kernel object
+/// resident in `EmulatedKernel.WaitHandles`. Kind-agnostic operations
+/// (`WaitHandle_WaitOneCore`, `CloseHandle`) take one map lookup and then
+/// match on kind; new kinds (Event, Mutex) slot in as additional cases
+/// without disturbing the table or the wait/close handlers.
+[<RequireQualifiedAccess>]
+type WaitHandleState = | Semaphore of SemaphoreState
+// future: | Event of EventState | Mutex of MutexState
+
 /// One entry in `EmulatedKernel.OutputLog`: the role the guest targeted (a
 /// writable standard stream — stdout or stderr) and the byte payload of
 /// that single `SystemNative_Write` call. Chunks are not coalesced across
@@ -199,6 +231,19 @@ type EmulatedKernel =
         /// is never triggered for a successfully-minted monitor. IDs are
         /// never reused; freeing a monitor leaves a gap.
         NextLowLevelMonitorId : int
+        /// Registry of Win32-shaped wait-handle kernel objects (Semaphore /
+        /// Event / Mutex), minted by `CreateSemaphoreExW` and its peers. The
+        /// handle held by the guest (as an `IntPtr` produced by the QCall) is
+        /// the `WaitHandleId` key; the value is the deterministic kind-tagged
+        /// state. `CloseHandle` removes the entry so any retained handle
+        /// fails loudly at the next use rather than silently referencing a
+        /// recycled object.
+        WaitHandles : Map<WaitHandleId, WaitHandleState>
+        /// Monotonic ID source for `WaitHandlePtr`. Starts at 1 so the BCL's
+        /// "create failed" check (`if (handle == IntPtr.Zero) throw new ...`)
+        /// is never triggered for a successfully-minted handle. IDs are never
+        /// reused; closing a handle leaves a gap.
+        NextWaitHandleId : int
         /// Monotonic ID source for opaque EventPipe provider/event handles
         /// minted by the `EventPipeInternal_*` QCalls. PawPrint never opens a
         /// tracing session, so the IDs are not stored in any registry; they
@@ -344,6 +389,8 @@ module EmulatedKernel =
             FileDescriptors = FileDescriptorRegistry.initial
             LowLevelMonitors = Map.empty
             NextLowLevelMonitorId = 1
+            WaitHandles = Map.empty
+            NextWaitHandleId = 1
             NextEventPipeId = 1L
             SpuriousWakeup = SpuriousWakeupStrategy.Disabled
             SyncBlockSpuriousWakeup = SyncBlockSpuriousWakeupStrategy.Disabled

--- a/WoofWare.PawPrint/EvalStack.fs
+++ b/WoofWare.PawPrint/EvalStack.fs
@@ -59,6 +59,8 @@ module EvalStackValue =
             failwith $"%s{operation}: refusing to convert EventPipe event handle #%d{id} to an integer"
         | NativeIntSource.LowLevelMonitorPtr id ->
             failwith $"%s{operation}: refusing to convert low-level monitor handle %O{id} to an integer"
+        | NativeIntSource.WaitHandlePtr id ->
+            failwith $"%s{operation}: refusing to convert wait handle %O{id} to an integer"
         | NativeIntSource.AssemblyHandle assemblyName ->
             failwith $"%s{operation}: refusing to convert assembly handle %s{assemblyName} to an integer"
         | NativeIntSource.ModuleHandle moduleName ->
@@ -246,6 +248,8 @@ module EvalStackValue =
                 failwith $"Conv_U: refusing to convert EventPipe event handle #%d{id} to unsigned native int"
             | NativeIntSource.LowLevelMonitorPtr id ->
                 failwith $"Conv_U: refusing to convert low-level monitor handle %O{id} to unsigned native int"
+            | NativeIntSource.WaitHandlePtr id ->
+                failwith $"Conv_U: refusing to convert wait handle %O{id} to unsigned native int"
             | NativeIntSource.AssemblyHandle assemblyName ->
                 failwith $"Conv_U: refusing to convert assembly handle %s{assemblyName} to unsigned native int"
             | NativeIntSource.ModuleHandle moduleName ->
@@ -564,6 +568,7 @@ module EvalStackValue =
                         failwith $"refusing to coerce EventPipe event handle #%d{id} to int64"
                     | NativeIntSource.LowLevelMonitorPtr id ->
                         failwith $"refusing to coerce low-level monitor handle %O{id} to int64"
+                    | NativeIntSource.WaitHandlePtr id -> failwith $"refusing to coerce wait handle %O{id} to int64"
                     | NativeIntSource.AssemblyHandle f -> failwith $"TODO: {f}"
                     | NativeIntSource.ModuleHandle f -> failwith $"TODO: {f}"
                     | NativeIntSource.MetadataImportHandle f ->
@@ -673,6 +678,7 @@ module EvalStackValue =
                     failwith "refusing to interpret EventPipe event handle as an object ref"
                 | NativeIntSource.LowLevelMonitorPtr _ ->
                     failwith "refusing to interpret low-level monitor handle as an object ref"
+                | NativeIntSource.WaitHandlePtr _ -> failwith "refusing to interpret wait handle as an object ref"
                 | NativeIntSource.AssemblyHandle _ -> failwith "refusing to interpret assembly handle as an object ref"
                 | NativeIntSource.ModuleHandle _ -> failwith "refusing to interpret module handle as an object ref"
                 | NativeIntSource.MetadataImportHandle _ ->
@@ -732,6 +738,9 @@ module EvalStackValue =
                 | NativeIntSource.LowLevelMonitorPtr id ->
                     failwith
                         $"refusing to coerce low-level monitor handle %O{id} to runtime pointer: monitor handles are opaque, not addresses"
+                | NativeIntSource.WaitHandlePtr id ->
+                    failwith
+                        $"refusing to coerce wait handle %O{id} to runtime pointer: wait handles are opaque, not addresses"
                 | NativeIntSource.AssemblyHandle _ -> failwith "todo: AssemblyHandle into CliType.RuntimePointer"
                 | NativeIntSource.ModuleHandle _ -> failwith "todo: ModuleHandle into CliType.RuntimePointer"
                 | NativeIntSource.MetadataImportHandle _ ->

--- a/WoofWare.PawPrint/EvalStackValueComparisons.fs
+++ b/WoofWare.PawPrint/EvalStackValueComparisons.fs
@@ -434,6 +434,7 @@ module EvalStackValueComparisons =
             | NativeIntSource.EventPipeProviderPtr f1, NativeIntSource.EventPipeProviderPtr f2 -> f1 = f2
             | NativeIntSource.EventPipeEventPtr f1, NativeIntSource.EventPipeEventPtr f2 -> f1 = f2
             | NativeIntSource.LowLevelMonitorPtr f1, NativeIntSource.LowLevelMonitorPtr f2 -> f1 = f2
+            | NativeIntSource.WaitHandlePtr f1, NativeIntSource.WaitHandlePtr f2 -> f1 = f2
             | NativeIntSource.Verbatim f1, NativeIntSource.Verbatim f2 -> f1 = f2
             | NativeIntSource.SyntheticCrossArrayOffset _, NativeIntSource.SyntheticCrossArrayOffset _
             | NativeIntSource.Verbatim _, NativeIntSource.SyntheticCrossArrayOffset _
@@ -482,7 +483,9 @@ module EvalStackValueComparisons =
             | NativeIntSource.OpaqueHashBits _, NativeIntSource.EventPipeEventPtr _
             | NativeIntSource.EventPipeEventPtr _, NativeIntSource.OpaqueHashBits _
             | NativeIntSource.OpaqueHashBits _, NativeIntSource.LowLevelMonitorPtr _
-            | NativeIntSource.LowLevelMonitorPtr _, NativeIntSource.OpaqueHashBits _ ->
+            | NativeIntSource.LowLevelMonitorPtr _, NativeIntSource.OpaqueHashBits _
+            | NativeIntSource.OpaqueHashBits _, NativeIntSource.WaitHandlePtr _
+            | NativeIntSource.WaitHandlePtr _, NativeIntSource.OpaqueHashBits _ ->
                 failwith
                     $"TODO (CEQ): synthesised hash bits vs handle pointer requires materialising the handle's bits through PointerHashCounters; got {var1} vs {var2}"
             // CoreCLR's TypeHandle wraps either a MethodTable* (when !IsTypeDesc) or a tagged
@@ -553,7 +556,9 @@ module EvalStackValueComparisons =
             | NativeIntSource.EventPipeEventPtr _, _
             | _, NativeIntSource.EventPipeEventPtr _
             | NativeIntSource.LowLevelMonitorPtr _, _
-            | _, NativeIntSource.LowLevelMonitorPtr _ -> false
+            | _, NativeIntSource.LowLevelMonitorPtr _
+            | NativeIntSource.WaitHandlePtr _, _
+            | _, NativeIntSource.WaitHandlePtr _ -> false
             // OpaqueHashBits vs ManagedPointer: every other OpaqueHashBits
             // pairing is handled above (vs Verbatim/OpaqueHashBits, vs
             // SyntheticCrossArrayOffset, and vs the various handle kinds);

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -77,6 +77,10 @@ module NativeQCall =
             "ReleaseSemaphore", NativeWaitHandle.tryExecuteQCall "ReleaseSemaphore"
             "CloseHandle", NativeWaitHandle.tryExecuteQCall "CloseHandle"
             "WaitHandle_WaitOneCore", NativeWaitHandle.tryExecuteQCall "WaitHandle_WaitOneCore"
+            // `LowLevelLifoSemaphore.Unix.cs` independently imports the
+            // prioritized 2-arg waiter; routes to the same deterministic
+            // state machine as `WaitOneCore`.
+            "WaitHandle_WaitOnePrioritized", NativeWaitHandle.tryExecuteQCall "WaitHandle_WaitOnePrioritized"
         ]
         |> Map.ofList
 

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -67,6 +67,16 @@ module NativeQCall =
             // assembly we execute presents this PAL entry point through QCall
             // import metadata.
             "GetEnvironmentVariableW", NativeKernel32.tryExecuteQCall "GetEnvironmentVariableW"
+            // CoreCLR-on-Unix rebinds `Libraries.Kernel32` to `RuntimeHelpers.QCall`,
+            // so the Win32-shaped Semaphore P/Invokes plus `CloseHandle` reach
+            // the runtime as QCalls under their Win32 wide-string names.
+            // `WaitHandle_WaitOneCore` is a separate QCall declared on
+            // `WaitHandle` itself. All four are dispatched into the
+            // deterministic state machine in `WaitHandle.fs`.
+            "CreateSemaphoreExW", NativeWaitHandle.tryExecuteQCall "CreateSemaphoreExW"
+            "ReleaseSemaphore", NativeWaitHandle.tryExecuteQCall "ReleaseSemaphore"
+            "CloseHandle", NativeWaitHandle.tryExecuteQCall "CloseHandle"
+            "WaitHandle_WaitOneCore", NativeWaitHandle.tryExecuteQCall "WaitHandle_WaitOneCore"
         ]
         |> Map.ofList
 

--- a/WoofWare.PawPrint/Native/NativeWaitHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeWaitHandle.fs
@@ -1,0 +1,260 @@
+namespace WoofWare.PawPrint
+
+/// Native handler for the Win32-shaped wait-handle QCalls reachable from
+/// CoreCLR-on-Unix: `CreateSemaphoreExW`, `ReleaseSemaphore`,
+/// `CloseHandle`, and `WaitHandle_WaitOneCore`. On .NET 10 the BCL
+/// compiles `Semaphore.Windows.cs` regardless of host, with
+/// `Libraries.Kernel32` rebound to `RuntimeHelpers.QCall`, so every
+/// Kernel32 LibraryImport routes to the runtime as a QCall whose entry
+/// point uses the Win32 wide-string name. PawPrint catches each entry
+/// point here and forwards it to the deterministic state machine in
+/// `WaitHandle.fs`.
+///
+/// This first slice supports the semaphore variant only; events,
+/// mutexes, multi-handle waits, and finite timeouts are out of scope
+/// pending future PRs and a virtual clock.
+[<RequireQualifiedAccess>]
+module NativeWaitHandle =
+
+    /// `ERROR_TOO_MANY_POSTS = 0x12A`. The Win32 contract returned by
+    /// `ReleaseSemaphore` when the release would breach the configured
+    /// maximum. `Semaphore.ReleaseCore` checks the BOOL return and
+    /// throws `SemaphoreFullException` without inspecting the error
+    /// code, but the source-generator wrapper still propagates the last
+    /// error into `LastPInvokeError`, so we set it for fidelity with
+    /// any guest that reads `Marshal.GetLastPInvokeError` after the
+    /// throw.
+    let private errorTooManyPosts : int = 298
+
+    /// Mutate the kernel's `LastSystemError` slot. The
+    /// LibraryImport-generated stub for a `SetLastError = true` import
+    /// reads this immediately after the QCall returns and copies it
+    /// into `LastPInvokeError`, so writing here is sufficient to make
+    /// the error visible to `Marshal.GetLastPInvokeError`.
+    let private withLastSystemError (error : int) (state : IlMachineState) : IlMachineState =
+        state.MapKernel (fun kernel ->
+            { kernel with
+                LastSystemError = error
+            }
+        )
+
+    /// Decode the `IntPtr handle` argument that every wait-handle entry
+    /// point except `CreateSemaphoreExW` carries. The guest only ever
+    /// obtains this value from a Create QCall, so a foreign IntPtr
+    /// (e.g. a LowLevelMonitor handle, a GcHandle, a `Verbatim` scratch
+    /// value) is unambiguously a guest bug. Null is rejected too: the
+    /// managed wrappers null-check before reaching the P/Invoke in
+    /// every normal path.
+    let private waitHandleOfArgument (operation : string) (arg : CliType) : WaitHandleId =
+        match CliType.unwrapPrimitiveLikeDeep arg with
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.WaitHandlePtr id)) -> id
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim 0L))
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.ManagedPointer ManagedPointerSource.Null)) ->
+            failwith
+                $"%s{operation}: handle argument was IntPtr.Zero, but WaitHandle invariants require a non-null handle (the BCL wrapper would have thrown ObjectDisposedException or set SafeHandle.IsInvalid before reaching the runtime)."
+        | other -> failwith $"%s{operation}: expected WaitHandle handle, got %O{other}"
+
+    /// Decode an IntPtr argument that should be either `IntPtr.Zero`
+    /// (CoreLib passes 0 for `lpSecurityAttributes`) or fail loud.
+    let private requireNullIntPtr (operation : string) (argName : string) (arg : CliType) : unit =
+        match CliType.unwrapPrimitiveLikeDeep arg with
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim 0L))
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.ManagedPointer ManagedPointerSource.Null))
+        | CliType.RuntimePointer (CliRuntimePointer.Verbatim 0L)
+        | CliType.RuntimePointer (CliRuntimePointer.Managed ManagedPointerSource.Null) -> ()
+        | other ->
+            failwith
+                $"%s{operation}: expected %s{argName} to be IntPtr.Zero (CoreLib does not pass security attributes through this QCall), got %O{other}"
+
+    /// Decode an Int32 argument representing a Win32 BOOL flag. The
+    /// LibraryImport source generator marshals `[MarshalAs(UnmanagedType
+    /// .Bool)] bool` as 4-byte BOOL in the QCall signature; both 0
+    /// (FALSE) and any non-zero value (TRUE) are accepted.
+    let private boolOfBoolArgument (operation : string) (argName : string) (arg : CliType) : bool =
+        match CliType.unwrapPrimitiveLikeDeep arg with
+        | CliType.Numeric (CliNumericType.Int32 i) -> i <> 0
+        | other -> failwith $"%s{operation}: expected %s{argName} to be Int32 BOOL, got %O{other}"
+
+    /// Decode the UTF-16 `name` pointer for `CreateSemaphoreExW`. CoreLib
+    /// passes `null` for unnamed semaphores; named semaphores are out of
+    /// scope until the named-handle registry lands, so a non-null name
+    /// pointer fails loud.
+    let private requireNullName (operation : string) (arg : CliType) : unit =
+        match CliType.unwrapPrimitiveLikeDeep arg with
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim 0L))
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.ManagedPointer ManagedPointerSource.Null))
+        | CliType.RuntimePointer (CliRuntimePointer.Verbatim 0L)
+        | CliType.RuntimePointer (CliRuntimePointer.Managed ManagedPointerSource.Null) -> ()
+        | other ->
+            failwith
+                $"%s{operation}: named wait handles are not yet supported; expected a null name pointer, got %O{other}"
+
+    /// Decode an optional `int*` out-pointer that may be `IntPtr.Zero`.
+    /// `Some ptr` means we must write to `*ptr`; `None` means the
+    /// caller passed null and the write is skipped (matching the Win32
+    /// `lpPreviousCount` contract).
+    let private optionalIntPointer
+        (operation : string)
+        (argName : string)
+        (arg : CliType)
+        : ManagedPointerSource option
+        =
+        match CliType.unwrapPrimitiveLikeDeep arg with
+        | CliType.RuntimePointer (CliRuntimePointer.Managed ManagedPointerSource.Null)
+        | CliType.RuntimePointer (CliRuntimePointer.Verbatim 0L)
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim 0L))
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.ManagedPointer ManagedPointerSource.Null)) -> None
+        | CliType.RuntimePointer (CliRuntimePointer.Managed ptr) -> Some ptr
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.ManagedPointer ptr)) -> Some ptr
+        | other -> failwith $"%s{operation}: expected %s{argName} to be a managed int pointer or null, got %O{other}"
+
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
+        let state = ctx.State
+        let instruction = ctx.Instruction
+
+        match
+            entryPoint,
+            ctx.TargetAssembly.Name.Name,
+            ctx.TargetType.Name,
+            instruction.ExecutingMethod.Signature.ParameterTypes,
+            instruction.ExecutingMethod.Signature.ReturnType
+        with
+        | "CreateSemaphoreExW",
+          "System.Private.CoreLib",
+          "Kernel32",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32
+            ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt16)
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt32
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt32 ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr) ->
+            let operation = "CreateSemaphoreExW"
+            // CoreLib's `CreateSemaphoreCore` passes `lpSecurityAttributes = 0`,
+            // `flags = 0`, and `AccessRights` for `dwDesiredAccess`. We refuse a
+            // non-null security-attributes pointer (out of scope) but ignore
+            // `flags` / `dwDesiredAccess` — deviation from the documented
+            // defaults would still produce a working handle on real Win32,
+            // and modelling fidelity here would just paint over a guest bug
+            // that should surface elsewhere.
+            requireNullIntPtr operation "lpSecurityAttributes" instruction.Arguments.[0]
+
+            let initialCount = NativeCall.int32Argument operation instruction.Arguments.[1]
+
+            let maximumCount = NativeCall.int32Argument operation instruction.Arguments.[2]
+
+            requireNullName operation instruction.Arguments.[3]
+
+            let id, state = WaitHandle.createSemaphore initialCount maximumCount state
+
+            state
+            |> withLastSystemError 0
+            |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt (NativeIntSource.WaitHandlePtr id)) ctx.Thread
+            |> Tuple.withRight WhatWeDid.Executed
+            |> ExecutionResult.stepped
+            |> Some
+
+        | "ReleaseSemaphore",
+          "System.Private.CoreLib",
+          "Kernel32",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32
+            ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
+            let operation = "ReleaseSemaphore"
+            let id = waitHandleOfArgument operation instruction.Arguments.[0]
+
+            let releaseCount = NativeCall.int32Argument operation instruction.Arguments.[1]
+
+            let previousCountPtr =
+                optionalIntPointer operation "lpPreviousCount" instruction.Arguments.[2]
+
+            let outcome, state = WaitHandle.releaseSemaphore id releaseCount state
+
+            match outcome with
+            | Ok previousCount ->
+                let state =
+                    match previousCountPtr with
+                    | None -> state
+                    | Some ptr ->
+                        IlMachineState.writeManagedByrefWithBase
+                            ctx.BaseClassTypes
+                            state
+                            ptr
+                            (CliType.Numeric (CliNumericType.Int32 previousCount))
+
+                state
+                |> withLastSystemError 0
+                |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 1) ctx.Thread
+                |> Tuple.withRight WhatWeDid.Executed
+                |> ExecutionResult.stepped
+                |> Some
+
+            | Error (WaitHandle.ReleaseFailure.WouldExceedMaximum _) ->
+                state
+                |> withLastSystemError errorTooManyPosts
+                |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread
+                |> Tuple.withRight WhatWeDid.Executed
+                |> ExecutionResult.stepped
+                |> Some
+
+        | "CloseHandle",
+          "System.Private.CoreLib",
+          "Kernel32",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
+            let operation = "CloseHandle"
+            let id = waitHandleOfArgument operation instruction.Arguments.[0]
+            let state = WaitHandle.close id state
+
+            state
+            |> withLastSystemError 0
+            |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 1) ctx.Thread
+            |> Tuple.withRight WhatWeDid.Executed
+            |> ExecutionResult.stepped
+            |> Some
+
+        | "WaitHandle_WaitOneCore",
+          "System.Private.CoreLib",
+          "WaitHandle",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32 ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
+            let operation = "WaitHandle_WaitOneCore"
+            let id = waitHandleOfArgument operation instruction.Arguments.[0]
+
+            let timeout = NativeCall.int32Argument operation instruction.Arguments.[1]
+            // `useTrivialWaits` only affects async-context teardown ordering
+            // (whether `Wait` may run APC-style callbacks); PawPrint does not
+            // model that ordering, so we decode the argument for shape
+            // validation but otherwise ignore it.
+            let _useTrivialWaits =
+                boolOfBoolArgument operation "useTrivialWaits" instruction.Arguments.[2]
+
+            if timeout <> System.Threading.Timeout.Infinite then
+                // No virtual clock yet. Same envelope as `Monitor_Wait` /
+                // `SystemNative_LowLevelMonitor_TimedWait`: silently treating
+                // a finite timeout as Infinite would mask guest bugs that
+                // depend on timeout-based wakeups; treating it as immediate
+                // timeout would break the higher-level fairness contract.
+                failwith
+                    $"%s{operation}: finite timeout (%d{timeout} ms) is not yet implemented; PawPrint has no virtual clock. Guest code that depends on timed waits must be lifted onto a deterministic clock abstraction first."
+
+            // Both the fast path (count > 0) and the slow path (parked)
+            // return WAIT_OBJECT_0 = 0 to the guest. The IL site advances
+            // in both cases; the scheduler simply will not pick this thread
+            // again until a subsequent `releaseSemaphore` wakes it. This
+            // mirrors `SystemNative_LowLevelMonitor_Acquire`'s posture.
+            let state =
+                match WaitHandle.waitOne ctx.Thread id state with
+                | WaitHandle.WaitOutcome.Acquired state
+                | WaitHandle.WaitOutcome.Blocked state -> state
+
+            state
+            |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread
+            |> Tuple.withRight WhatWeDid.Executed
+            |> ExecutionResult.stepped
+            |> Some
+
+        | _ -> None

--- a/WoofWare.PawPrint/Native/NativeWaitHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeWaitHandle.fs
@@ -2,13 +2,16 @@ namespace WoofWare.PawPrint
 
 /// Native handler for the Win32-shaped wait-handle QCalls reachable from
 /// CoreCLR-on-Unix: `CreateSemaphoreExW`, `ReleaseSemaphore`,
-/// `CloseHandle`, and `WaitHandle_WaitOneCore`. On .NET 10 the BCL
-/// compiles `Semaphore.Windows.cs` regardless of host, with
-/// `Libraries.Kernel32` rebound to `RuntimeHelpers.QCall`, so every
-/// Kernel32 LibraryImport routes to the runtime as a QCall whose entry
-/// point uses the Win32 wide-string name. PawPrint catches each entry
-/// point here and forwards it to the deterministic state machine in
-/// `WaitHandle.fs`.
+/// `CloseHandle`, `WaitHandle_WaitOneCore`, and
+/// `WaitHandle_WaitOnePrioritized`. On .NET 10 the BCL compiles
+/// `Semaphore.Windows.cs` regardless of host, with `Libraries.Kernel32`
+/// rebound to `RuntimeHelpers.QCall`, so every Kernel32 LibraryImport
+/// routes to the runtime as a QCall whose entry point uses the Win32
+/// wide-string name. `LowLevelLifoSemaphore.Unix.cs` independently
+/// imports `WaitHandle_WaitOnePrioritized` (the PAL-prioritized waiter
+/// that `PortableThreadPool` workers park on). PawPrint catches each
+/// entry point here and forwards it to the deterministic state machine
+/// in `WaitHandle.fs`.
 ///
 /// This first slice supports the semaphore variant only; events,
 /// mutexes, multi-handle waits, and finite timeouts are out of scope
@@ -246,6 +249,47 @@ module NativeWaitHandle =
             // in both cases; the scheduler simply will not pick this thread
             // again until a subsequent `releaseSemaphore` wakes it. This
             // mirrors `SystemNative_LowLevelMonitor_Acquire`'s posture.
+            let state =
+                match WaitHandle.waitOne ctx.Thread id state with
+                | WaitHandle.WaitOutcome.Acquired state
+                | WaitHandle.WaitOutcome.Blocked state -> state
+
+            state
+            |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread
+            |> Tuple.withRight WhatWeDid.Executed
+            |> ExecutionResult.stepped
+            |> Some
+
+        | "WaitHandle_WaitOnePrioritized",
+          "System.Private.CoreLib",
+          "LowLevelLifoSemaphore",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32 ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
+            // `LowLevelLifoSemaphore.WaitCore` (PortableThreadPool's worker
+            // park primitive on Unix) imports this 2-arg variant of the
+            // waiter. The "Prioritized" tag tells the real PAL to use
+            // `PAL_WaitForSingleObjectPrioritized` — a host-side priority
+            // hint that does not change the wakeup semantics from the
+            // guest's point of view. PawPrint does not model thread
+            // priority, so the slow path uses the same FIFO `WaitQueue`
+            // as `WaitOneCore`; this preserves determinism while leaving
+            // a hook for a future priority-aware queue if a guest ever
+            // depends on it.
+            let operation = "WaitHandle_WaitOnePrioritized"
+            let id = waitHandleOfArgument operation instruction.Arguments.[0]
+
+            let timeout = NativeCall.int32Argument operation instruction.Arguments.[1]
+
+            if timeout <> System.Threading.Timeout.Infinite then
+                // Same envelope as `WaitOneCore`. The threadpool worker
+                // path always passes a finite timeout, so failing here
+                // is the deterministic surfacing of the missing virtual-
+                // clock primitive — masking it would let the threadpool
+                // run with no fairness/progress guarantees.
+                failwith
+                    $"%s{operation}: finite timeout (%d{timeout} ms) is not yet implemented; PawPrint has no virtual clock. Guest code that depends on timed waits must be lifted onto a deterministic clock abstraction first."
+
             let state =
                 match WaitHandle.waitOne ctx.Thread id state with
                 | WaitHandle.WaitOutcome.Acquired state

--- a/WoofWare.PawPrint/Native/NativeWaitHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeWaitHandle.fs
@@ -14,8 +14,10 @@ namespace WoofWare.PawPrint
 /// in `WaitHandle.fs`.
 ///
 /// This first slice supports the semaphore variant only; events,
-/// mutexes, multi-handle waits, and finite timeouts are out of scope
-/// pending future PRs and a virtual clock.
+/// mutexes, multi-handle waits, and non-zero finite timeouts are out
+/// of scope pending future PRs and a virtual clock. Zero-timeout waits
+/// (the deterministic non-blocking probe `WaitOne(0)` emits) are
+/// handled inline — no clock is needed.
 [<RequireQualifiedAccess>]
 module NativeWaitHandle =
 
@@ -28,6 +30,18 @@ module NativeWaitHandle =
     /// any guest that reads `Marshal.GetLastPInvokeError` after the
     /// throw.
     let private errorTooManyPosts : int = 298
+
+    /// `WAIT_OBJECT_0 = 0`. The Win32 return code for a successful wait
+    /// — the wait acquired its target object. Matches
+    /// `WaitHandle.WaitSuccess` in the BCL.
+    let private waitObjectZero : int = 0
+
+    /// `WAIT_TIMEOUT = 0x102 = 258`. The Win32 return code for a wait
+    /// that did not acquire its target before the timeout expired.
+    /// `WaitHandle.WaitOne(int)` checks the return against
+    /// `WaitHandle.WaitTimeout = 0x102` to decide whether to return
+    /// `true` / `false` to the guest.
+    let private waitTimeout : int = 0x102
 
     /// Mutate the kernel's `LastSystemError` slot. The
     /// LibraryImport-generated stub for a `SetLastError = true` import
@@ -91,6 +105,60 @@ module NativeWaitHandle =
         | other ->
             failwith
                 $"%s{operation}: named wait handles are not yet supported; expected a null name pointer, got %O{other}"
+
+    /// Drive the timeout dispatch shared by `WaitHandle_WaitOneCore`
+    /// and `WaitHandle_WaitOnePrioritized`: timeout = -1 (INFINITE)
+    /// blocks via `blockingWait`; timeout = 0 (the non-blocking probe
+    /// `WaitOne(0)` issues) takes the deterministic try-and-return path
+    /// via `tryWaitOne`; any other finite timeout currently fails loud
+    /// (no virtual clock — same blocker as
+    /// `SystemNative_LowLevelMonitor_TimedWait`). Returns the new
+    /// `IlMachineState` and the Int32 return value the guest sees.
+    ///
+    /// The two callers differ in `blockingWait`: `WaitOneCore` uses
+    /// `WaitHandle.waitOne` (FIFO tail insertion);
+    /// `WaitOnePrioritized` uses `WaitHandle.waitOnePrioritized`
+    /// (LIFO head insertion). Both share the zero-timeout `tryWaitOne`
+    /// because priority only matters when the wait actually parks.
+    let private dispatchWait
+        (operation : string)
+        (id : WaitHandleId)
+        (timeout : int)
+        (blockingWait : IlMachineState -> WaitHandle.WaitOutcome)
+        (state : IlMachineState)
+        : IlMachineState * int
+        =
+        if timeout = System.Threading.Timeout.Infinite then
+            // Both fast (count > 0) and slow (parked) blocking paths
+            // return WAIT_OBJECT_0 to the guest; the IL site advances
+            // in both cases, and the scheduler simply will not pick a
+            // parked thread again until a subsequent `releaseSemaphore`
+            // wakes it. This mirrors
+            // `SystemNative_LowLevelMonitor_Acquire`'s posture.
+            let state =
+                match blockingWait state with
+                | WaitHandle.WaitOutcome.Acquired state
+                | WaitHandle.WaitOutcome.Blocked state -> state
+
+            state, waitObjectZero
+        elif timeout = 0 then
+            // Zero-timeout: try the fast path, then return immediately.
+            // CoreCLR returns `WAIT_OBJECT_0` if the handle was signalled,
+            // else `WAIT_TIMEOUT`; the caller is never enqueued. Treating
+            // a zero-timeout as an unimplemented finite timeout would
+            // crash on a deterministic non-blocking probe (e.g. the
+            // `WaitOne(0)` poll pattern), which is the wrong envelope.
+            match WaitHandle.tryWaitOne id state with
+            | WaitHandle.TryWaitOutcome.Acquired state -> state, waitObjectZero
+            | WaitHandle.TryWaitOutcome.TimedOut state -> state, waitTimeout
+        else
+            // No virtual clock yet. Same envelope as `Monitor_Wait` /
+            // `SystemNative_LowLevelMonitor_TimedWait`: silently treating
+            // a finite timeout as Infinite would mask guest bugs that
+            // depend on timeout-based wakeups; treating it as immediate
+            // timeout would break the higher-level fairness contract.
+            failwith
+                $"%s{operation}: finite timeout (%d{timeout} ms) is not yet implemented; PawPrint has no virtual clock. Guest code that depends on timed waits must be lifted onto a deterministic clock abstraction first."
 
     /// Decode an optional `int*` out-pointer that may be `IntPtr.Zero`.
     /// `Some ptr` means we must write to `*ptr`; `None` means the
@@ -235,27 +303,11 @@ module NativeWaitHandle =
             let _useTrivialWaits =
                 boolOfBoolArgument operation "useTrivialWaits" instruction.Arguments.[2]
 
-            if timeout <> System.Threading.Timeout.Infinite then
-                // No virtual clock yet. Same envelope as `Monitor_Wait` /
-                // `SystemNative_LowLevelMonitor_TimedWait`: silently treating
-                // a finite timeout as Infinite would mask guest bugs that
-                // depend on timeout-based wakeups; treating it as immediate
-                // timeout would break the higher-level fairness contract.
-                failwith
-                    $"%s{operation}: finite timeout (%d{timeout} ms) is not yet implemented; PawPrint has no virtual clock. Guest code that depends on timed waits must be lifted onto a deterministic clock abstraction first."
-
-            // Both the fast path (count > 0) and the slow path (parked)
-            // return WAIT_OBJECT_0 = 0 to the guest. The IL site advances
-            // in both cases; the scheduler simply will not pick this thread
-            // again until a subsequent `releaseSemaphore` wakes it. This
-            // mirrors `SystemNative_LowLevelMonitor_Acquire`'s posture.
-            let state =
-                match WaitHandle.waitOne ctx.Thread id state with
-                | WaitHandle.WaitOutcome.Acquired state
-                | WaitHandle.WaitOutcome.Blocked state -> state
+            let state, ret =
+                dispatchWait operation id timeout (WaitHandle.waitOne ctx.Thread id) state
 
             state
-            |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread
+            |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 ret) ctx.Thread
             |> Tuple.withRight WhatWeDid.Executed
             |> ExecutionResult.stepped
             |> Some
@@ -268,35 +320,23 @@ module NativeWaitHandle =
           MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
             // `LowLevelLifoSemaphore.WaitCore` (PortableThreadPool's worker
             // park primitive on Unix) imports this 2-arg variant of the
-            // waiter. The "Prioritized" tag tells the real PAL to use
-            // `PAL_WaitForSingleObjectPrioritized` — a host-side priority
-            // hint that does not change the wakeup semantics from the
-            // guest's point of view. PawPrint does not model thread
-            // priority, so the slow path uses the same FIFO `WaitQueue`
-            // as `WaitOneCore`; this preserves determinism while leaving
-            // a hook for a future priority-aware queue if a guest ever
-            // depends on it.
+            // waiter. The "Prioritized" tag corresponds to
+            // `PAL_WaitForSingleObjectPrioritized`'s LIFO release policy:
+            // new waiters are registered at the head of the wait queue
+            // and a later `Release` wakes the most recent one first.
+            // This is load-bearing for `LowLevelLifoSemaphore` (and hence
+            // `PortableThreadPool`) — that's exactly why it has its own
+            // entry point separate from `WaitOneCore`.
             let operation = "WaitHandle_WaitOnePrioritized"
             let id = waitHandleOfArgument operation instruction.Arguments.[0]
 
             let timeout = NativeCall.int32Argument operation instruction.Arguments.[1]
 
-            if timeout <> System.Threading.Timeout.Infinite then
-                // Same envelope as `WaitOneCore`. The threadpool worker
-                // path always passes a finite timeout, so failing here
-                // is the deterministic surfacing of the missing virtual-
-                // clock primitive — masking it would let the threadpool
-                // run with no fairness/progress guarantees.
-                failwith
-                    $"%s{operation}: finite timeout (%d{timeout} ms) is not yet implemented; PawPrint has no virtual clock. Guest code that depends on timed waits must be lifted onto a deterministic clock abstraction first."
-
-            let state =
-                match WaitHandle.waitOne ctx.Thread id state with
-                | WaitHandle.WaitOutcome.Acquired state
-                | WaitHandle.WaitOutcome.Blocked state -> state
+            let state, ret =
+                dispatchWait operation id timeout (WaitHandle.waitOnePrioritized ctx.Thread id) state
 
             state
-            |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread
+            |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 ret) ctx.Thread
             |> Tuple.withRight WhatWeDid.Executed
             |> ExecutionResult.stepped
             |> Some

--- a/WoofWare.PawPrint/NativeIntSource.fs
+++ b/WoofWare.PawPrint/NativeIntSource.fs
@@ -119,6 +119,15 @@ type NativeIntSource =
     /// `Verbatim 0L` so the BCL's allocation-failure check (`if _nativeMonitor
     /// == IntPtr.Zero throw new OutOfMemoryException()`) does not fire.
     | LowLevelMonitorPtr of LowLevelMonitorId
+    /// Opaque handle returned by `CreateSemaphoreExW` (and, in future PRs,
+    /// `CreateEventExW` / `CreateMutexExW`). Round-trips through the guest as
+    /// an `IntPtr` wrapped in a `SafeWaitHandle`, and is fed back into
+    /// `WaitHandle_WaitOneCore`, `ReleaseSemaphore`, and `CloseHandle`. The
+    /// handle is distinguished by tag so a foreign `IntPtr` cannot be mistaken
+    /// for a PawPrint-minted wait handle; never compares equal to
+    /// `Verbatim 0L`, so the BCL's "create failed → throw" check does not fire
+    /// for a successfully-minted handle.
+    | WaitHandlePtr of WaitHandleId
     /// Returned by `Unsafe.ByteOffset` or managed-pointer subtraction for two byrefs into distinct byte-addressed
     /// storage containers.
     | SyntheticCrossArrayOffset of SyntheticCrossArrayOffset
@@ -153,6 +162,7 @@ type NativeIntSource =
         | NativeIntSource.EventPipeProviderPtr id -> $"<EventPipe provider #%i{id}>"
         | NativeIntSource.EventPipeEventPtr id -> $"<EventPipe event #%i{id}>"
         | NativeIntSource.LowLevelMonitorPtr id -> $"%O{id}"
+        | NativeIntSource.WaitHandlePtr id -> $"%O{id}"
         | NativeIntSource.SyntheticCrossArrayOffset _ -> "<synthetic cross-storage byte offset>"
         | NativeIntSource.OpaqueHashBits bits -> $"<opaque hash bits (native int) 0x%x{bits}>"
 
@@ -177,6 +187,7 @@ type NativeIntSource =
             | NativeIntSource.EventPipeProviderPtr left, NativeIntSource.EventPipeProviderPtr right -> left = right
             | NativeIntSource.EventPipeEventPtr left, NativeIntSource.EventPipeEventPtr right -> left = right
             | NativeIntSource.LowLevelMonitorPtr left, NativeIntSource.LowLevelMonitorPtr right -> left = right
+            | NativeIntSource.WaitHandlePtr left, NativeIntSource.WaitHandlePtr right -> left = right
             | NativeIntSource.SyntheticCrossArrayOffset left, NativeIntSource.SyntheticCrossArrayOffset right ->
                 left = right
             | NativeIntSource.OpaqueHashBits left, NativeIntSource.OpaqueHashBits right -> left = right
@@ -195,6 +206,7 @@ type NativeIntSource =
             | NativeIntSource.EventPipeProviderPtr _, _
             | NativeIntSource.EventPipeEventPtr _, _
             | NativeIntSource.LowLevelMonitorPtr _, _
+            | NativeIntSource.WaitHandlePtr _, _
             | NativeIntSource.SyntheticCrossArrayOffset _, _
             | NativeIntSource.OpaqueHashBits _, _ -> false
         | _ -> false
@@ -225,6 +237,7 @@ type NativeIntSource =
         | NativeIntSource.SyntheticCrossArrayOffset s -> HashCode.Combine (14, hash s)
         | NativeIntSource.OpaqueHashBits bits -> HashCode.Combine (15, bits)
         | NativeIntSource.LowLevelMonitorPtr id -> HashCode.Combine (16, id)
+        | NativeIntSource.WaitHandlePtr id -> HashCode.Combine (17, id)
 
 [<RequireQualifiedAccess>]
 module NativeIntSource =
@@ -251,6 +264,7 @@ module NativeIntSource =
         | NativeIntSource.EventPipeProviderPtr _
         | NativeIntSource.EventPipeEventPtr _
         | NativeIntSource.LowLevelMonitorPtr _
+        | NativeIntSource.WaitHandlePtr _
         | NativeIntSource.AssemblyHandle _
         | NativeIntSource.MetadataImportHandle _
         | NativeIntSource.ModuleHandle _ -> false
@@ -276,6 +290,7 @@ module NativeIntSource =
         | NativeIntSource.EventPipeProviderPtr _
         | NativeIntSource.EventPipeEventPtr _
         | NativeIntSource.LowLevelMonitorPtr _
+        | NativeIntSource.WaitHandlePtr _
         | NativeIntSource.AssemblyHandle _
         | NativeIntSource.MetadataImportHandle _
         | NativeIntSource.ModuleHandle _ -> true

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -159,7 +159,8 @@ module NullaryIlOp =
             | EvalStackValue.NativeInt (NativeIntSource.MetadataImportHandle _)
             | EvalStackValue.NativeInt (NativeIntSource.EventPipeProviderPtr _)
             | EvalStackValue.NativeInt (NativeIntSource.EventPipeEventPtr _)
-            | EvalStackValue.NativeInt (NativeIntSource.LowLevelMonitorPtr _) ->
+            | EvalStackValue.NativeInt (NativeIntSource.LowLevelMonitorPtr _)
+            | EvalStackValue.NativeInt (NativeIntSource.WaitHandlePtr _) ->
                 failwith $"Localloc: refusing to use pointer-like value %O{value} as a byte count"
             | EvalStackValue.NativeInt (NativeIntSource.OpaqueHashBits bits) ->
                 failwith $"Localloc: refusing to use synthesised pointer-hash bits 0x%x{bits} as a byte count"
@@ -311,6 +312,7 @@ module NullaryIlOp =
             | NativeIntSource.EventPipeEventPtr id -> failwith $"Neg: refusing to negate EventPipe event handle %d{id}"
             | NativeIntSource.LowLevelMonitorPtr id ->
                 failwith $"Neg: refusing to negate low-level monitor handle %O{id}"
+            | NativeIntSource.WaitHandlePtr id -> failwith $"Neg: refusing to negate wait handle %O{id}"
             | NativeIntSource.OpaqueHashBits bits ->
                 // Negating synthesised hash bits is a bit-mixing operation
                 // that stays in the synthesis domain; the result keeps the
@@ -517,6 +519,7 @@ module NullaryIlOp =
                 | NativeIntSource.EventPipeProviderPtr _
                 | NativeIntSource.EventPipeEventPtr _
                 | NativeIntSource.LowLevelMonitorPtr _
+                | NativeIntSource.WaitHandlePtr _
                 | NativeIntSource.ManagedPointer _ -> failwith "Refusing to treat a pointer as an array index"
                 | NativeIntSource.SyntheticCrossArrayOffset _ ->
                     failwith "Refusing to treat a synthetic cross-storage byte offset as an array index"
@@ -570,6 +573,7 @@ module NullaryIlOp =
                 | NativeIntSource.EventPipeProviderPtr _
                 | NativeIntSource.EventPipeEventPtr _
                 | NativeIntSource.LowLevelMonitorPtr _
+                | NativeIntSource.WaitHandlePtr _
                 | NativeIntSource.ManagedPointer _ -> failwith "Refusing to treat a pointer as an array index"
                 | NativeIntSource.SyntheticCrossArrayOffset _ ->
                     failwith "Refusing to treat a synthetic cross-storage byte offset as an array index"

--- a/WoofWare.PawPrint/PointerHashSynthesis.fs
+++ b/WoofWare.PawPrint/PointerHashSynthesis.fs
@@ -29,6 +29,7 @@ type CanonicalPointerKey =
     | EventPipeProvider of int64
     | EventPipeEvent of int64
     | LowLevelMonitor of LowLevelMonitorId
+    | WaitHandle of WaitHandleId
     | AssemblyHandle of string
     | ModuleHandle of string
     | MetadataImportHandle of string
@@ -92,6 +93,7 @@ module PointerHashSynthesis =
         | NativeIntSource.EventPipeProviderPtr id -> CanonicalPointerKey.EventPipeProvider id
         | NativeIntSource.EventPipeEventPtr id -> CanonicalPointerKey.EventPipeEvent id
         | NativeIntSource.LowLevelMonitorPtr id -> CanonicalPointerKey.LowLevelMonitor id
+        | NativeIntSource.WaitHandlePtr id -> CanonicalPointerKey.WaitHandle id
         | NativeIntSource.AssemblyHandle name -> CanonicalPointerKey.AssemblyHandle name
         | NativeIntSource.ModuleHandle name -> CanonicalPointerKey.ModuleHandle name
         | NativeIntSource.MetadataImportHandle name -> CanonicalPointerKey.MetadataImportHandle name
@@ -133,6 +135,7 @@ module PointerHashSynthesis =
         | CanonicalPointerKey.EventPipeProvider _
         | CanonicalPointerKey.EventPipeEvent _
         | CanonicalPointerKey.LowLevelMonitor _
+        | CanonicalPointerKey.WaitHandle _
         | CanonicalPointerKey.AssemblyHandle _
         | CanonicalPointerKey.ModuleHandle _
         | CanonicalPointerKey.MetadataImportHandle _ -> 0UL

--- a/WoofWare.PawPrint/ThreadState.fs
+++ b/WoofWare.PawPrint/ThreadState.fs
@@ -45,6 +45,16 @@ type ThreadStatus =
     /// re-owning the lock. Parallel with `BlockedOnMonitorWait` but for managed
     /// SyncBlocks rather than `LowLevelMonitor`.
     | BlockedOnSyncBlockWait of lockObject : ManagedHeapAddress
+    /// This thread called `WaitHandle.WaitOne` (via the `WaitHandle_WaitOneCore`
+    /// QCall) on a wait handle whose count was zero / unsignalled, and is
+    /// parked at the handle's FIFO `WaitQueue`. A subsequent state change that
+    /// produces a wake (semaphore `Release`, event `Set`, mutex unlock) flips
+    /// the head of the queue back to `Runnable`; the IL `WaitOne` call site
+    /// has already advanced past itself, so when the scheduler picks the woken
+    /// thread it resumes with `WAIT_OBJECT_0` already on the evaluation stack.
+    /// Single-handle blocking only; multi-handle wait will need a separate
+    /// variant carrying a list plus a wait-all/wait-any flag.
+    | BlockedOnWaitHandle of handle : WaitHandleId
     /// This thread has executed its final `ret`; it will never run again. Its state is kept
     /// only so other threads can observe termination (e.g. to satisfy Join).
     | Terminated

--- a/WoofWare.PawPrint/WaitHandle.fs
+++ b/WoofWare.PawPrint/WaitHandle.fs
@@ -1,0 +1,247 @@
+namespace WoofWare.PawPrint
+
+/// Deterministic state machine for the Win32-shaped wait-handle kernel
+/// objects exposed to managed code through `CreateSemaphoreExW`,
+/// `ReleaseSemaphore`, `CloseHandle`, and `WaitHandle_WaitOneCore`. On
+/// .NET 10 CoreCLR-on-Unix the BCL compiles `Semaphore.Windows.cs`
+/// regardless of host, with `Libraries.Kernel32` rebound to
+/// `RuntimeHelpers.QCall`; every Kernel32 LibraryImport therefore routes
+/// to the runtime as a QCall whose entry point uses the Win32 wide-string
+/// name. PawPrint reproduces the observable semantics through
+/// `WaitHandleState` (registry value, kind-tagged) and one new
+/// `ThreadStatus` case (`BlockedOnWaitHandle`).
+///
+/// This first slice supports the semaphore variant only. The DU's job is
+/// to keep "kind dispatch in WaitOne/Close" exhaustive so the compiler
+/// catches a missing branch when `Event` or `Mutex` lands.
+///
+/// The module is pure: every transition is `IlMachineState ->
+/// IlMachineState` (or returns an outcome carrying the next state) and
+/// never reads from a real clock, the host's semaphore implementation, or
+/// any nondeterministic source. Ordering decisions over `WaitQueue` are
+/// FIFO, mirroring the `LowLevelMonitor` AcquireQueue contract that
+/// higher-level guest primitives (`LowLevelLifoSemaphore`,
+/// `PortableThreadPool`) depend on.
+///
+/// Timeouts: finite timeouts on `WaitHandle_WaitOneCore` are not
+/// implemented today, for the same reason `LowLevelMonitor.TimedWait`
+/// is not — PawPrint has no virtual clock. Calls with a finite timeout
+/// fail loud in the native handler.
+[<RequireQualifiedAccess>]
+module WaitHandle =
+
+    /// Why `releaseSemaphore` rejected a request.
+    [<RequireQualifiedAccess>]
+    type ReleaseFailure =
+        /// Adding `releaseCount` to the current count would breach the
+        /// semaphore's maximum. The Win32 contract sets
+        /// `ERROR_TOO_MANY_POSTS` and returns FALSE; the BCL turns that
+        /// into a `SemaphoreFullException`.
+        | WouldExceedMaximum of attemptedTotal : int * maximum : int
+
+    /// Outcome of a `waitOne` call. The native handler treats both
+    /// constructors identically — advance IL and return `WAIT_OBJECT_0` —
+    /// because the IL `WaitOne` call site has already moved past itself
+    /// by the time the scheduler picks the woken thread. The split
+    /// exists so callers (notably future multi-handle waits) can
+    /// distinguish "took ownership on the fast path" from "parked".
+    [<RequireQualifiedAccess>]
+    type WaitOutcome =
+        | Acquired of IlMachineState
+        | Blocked of IlMachineState
+
+    /// Look up the handle for `id`, or fail loud. A retained IntPtr that
+    /// outlives `close` lands here so use-after-free shows up at the use
+    /// site rather than as a confusing null-handle bug elsewhere.
+    let private lookup (id : WaitHandleId) (state : IlMachineState) : WaitHandleState =
+        match Map.tryFind id state.Kernel.WaitHandles with
+        | Some handle -> handle
+        | None ->
+            failwith
+                $"WaitHandle %O{id} is not registered; either it was never created or it has already been closed (use-after-free on a stale handle)."
+
+    let private writeHandle (id : WaitHandleId) (handle : WaitHandleState) (state : IlMachineState) : IlMachineState =
+        state.MapKernel (fun kernel ->
+            { kernel with
+                WaitHandles = kernel.WaitHandles |> Map.add id handle
+            }
+        )
+
+    let private expectSemaphore (operation : string) (id : WaitHandleId) (handle : WaitHandleState) : SemaphoreState =
+        match handle with
+        | WaitHandleState.Semaphore s -> s
+
+    /// Allocate a fresh semaphore kernel object. Returns the new handle
+    /// alongside the updated state. The handle is non-zero (counters
+    /// start at 1) so the BCL's "create failed → throw" check does not
+    /// fire.
+    ///
+    /// Fails loud on invalid `(initialCount, maximumCount)` rather than
+    /// the Win32-style `ERROR_INVALID_PARAMETER` route: the BCL's
+    /// `Semaphore..ctor` validates these arguments before the P/Invoke,
+    /// so reaching the runtime with a bad pair indicates a guest that
+    /// bypassed the wrapper (i.e. a bug).
+    let createSemaphore
+        (initialCount : int)
+        (maximumCount : int)
+        (state : IlMachineState)
+        : WaitHandleId * IlMachineState
+        =
+        if maximumCount < 1 then
+            failwith
+                $"WaitHandle.createSemaphore: maximumCount = %d{maximumCount} is not strictly positive; the BCL Semaphore ctor would have thrown ArgumentOutOfRangeException before reaching the runtime."
+
+        if initialCount < 0 then
+            failwith
+                $"WaitHandle.createSemaphore: initialCount = %d{initialCount} is negative; the BCL Semaphore ctor would have thrown ArgumentOutOfRangeException before reaching the runtime."
+
+        if initialCount > maximumCount then
+            failwith
+                $"WaitHandle.createSemaphore: initialCount = %d{initialCount} exceeds maximumCount = %d{maximumCount}; the BCL Semaphore ctor would have thrown ArgumentException before reaching the runtime."
+
+        let id = WaitHandleId state.Kernel.NextWaitHandleId
+
+        let semaphore : SemaphoreState =
+            {
+                Count = initialCount
+                Maximum = maximumCount
+                WaitQueue = []
+            }
+
+        let state =
+            state.MapKernel (fun kernel ->
+                { kernel with
+                    WaitHandles = kernel.WaitHandles |> Map.add id (WaitHandleState.Semaphore semaphore)
+                    NextWaitHandleId = kernel.NextWaitHandleId + 1
+                }
+            )
+
+        id, state
+
+    /// Try to take one unit from the semaphore on behalf of `thread`.
+    ///
+    /// Returns `Acquired` if the fast path applied: count was > 0 and we
+    /// decremented it. The IL `WaitOne` site advances and the thread
+    /// stays Runnable.
+    ///
+    /// Returns `Blocked` if count was 0: the thread is parked at the
+    /// FIFO tail of `WaitQueue` and its status flips to
+    /// `BlockedOnWaitHandle`. The IL site still advances (the native
+    /// handler returns `Stepped/Executed` in both cases); when the
+    /// thread is later woken by `releaseSemaphore`, its count slot has
+    /// already been consumed by the wake step, so resuming past the
+    /// `WaitOne` call is correct without re-decrementing.
+    let waitOne (thread : ThreadId) (id : WaitHandleId) (state : IlMachineState) : WaitOutcome =
+        let handle = lookup id state
+        let semaphore = expectSemaphore "WaitHandle.waitOne" id handle
+
+        if semaphore.Count > 0 then
+            // Fast path: consume one unit and stay Runnable. The new
+            // count is in `[0, Maximum - 1]`, preserving the invariant.
+            let semaphore =
+                { semaphore with
+                    Count = semaphore.Count - 1
+                }
+
+            state
+            |> writeHandle id (WaitHandleState.Semaphore semaphore)
+            |> WaitOutcome.Acquired
+        else
+            // Slow path: park at the tail of the FIFO wait queue.
+            // The unit will be consumed inline by `releaseSemaphore`
+            // when it wakes us, so we leave Count at 0.
+            let semaphore =
+                { semaphore with
+                    WaitQueue = semaphore.WaitQueue @ [ thread ]
+                }
+
+            state
+            |> writeHandle id (WaitHandleState.Semaphore semaphore)
+            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnWaitHandle id)
+            |> WaitOutcome.Blocked
+
+    /// Increment the semaphore by `releaseCount`, waking up to that many
+    /// FIFO-head waiters. Returns the previous count on success (matching
+    /// the Win32 `lpPreviousCount` out-parameter contract) and the
+    /// updated state. On overflow returns `ReleaseFailure
+    /// .WouldExceedMaximum` and the state is unchanged — the native
+    /// handler then sets `LastPInvokeError = ERROR_TOO_MANY_POSTS` and
+    /// returns FALSE.
+    ///
+    /// The wake step transfers ownership of the freshly-added units
+    /// directly: each woken waiter consumes one unit before we add it
+    /// to `Count`, so a release of N that wakes K waiters (K ≤ N) leaves
+    /// only `(N - K)` units accumulated in `Count`. This mirrors the
+    /// CoreCLR direct-handoff posture used by `Monitor.Exit` and
+    /// `LowLevelMonitor.release` — the woken thread resumes past its
+    /// `WaitOne` call site already holding a unit, so its IL flow is
+    /// sound without re-running the decrement.
+    let releaseSemaphore
+        (id : WaitHandleId)
+        (releaseCount : int)
+        (state : IlMachineState)
+        : Result<int, ReleaseFailure> * IlMachineState
+        =
+        if releaseCount < 1 then
+            failwith
+                $"WaitHandle.releaseSemaphore: releaseCount = %d{releaseCount} is not strictly positive; the BCL Semaphore.Release validates this before the P/Invoke."
+
+        let handle = lookup id state
+        let semaphore = expectSemaphore "WaitHandle.releaseSemaphore" id handle
+
+        let previousCount = semaphore.Count
+        let attemptedTotal = previousCount + releaseCount
+
+        if attemptedTotal > semaphore.Maximum then
+            Error (ReleaseFailure.WouldExceedMaximum (attemptedTotal, semaphore.Maximum)), state
+        else
+            // Direct-handoff: each wake consumes one of the new units.
+            // FIFO over WaitQueue is load-bearing for the
+            // LowLevelLifoSemaphore fairness contract higher up the
+            // stack — switching to LIFO or arbitrary order is not a
+            // refactor.
+            let toWake = min releaseCount (List.length semaphore.WaitQueue)
+            let wakers, remainingQueue = List.splitAt toWake semaphore.WaitQueue
+
+            let semaphore =
+                { semaphore with
+                    Count = attemptedTotal - toWake
+                    WaitQueue = remainingQueue
+                }
+
+            let state =
+                state
+                |> writeHandle id (WaitHandleState.Semaphore semaphore)
+                |> (fun s ->
+                    wakers
+                    |> List.fold (fun acc tid -> Scheduler.setThreadStatus tid ThreadStatus.Runnable acc) s
+                )
+
+            Ok previousCount, state
+
+    /// Tear down a wait handle. The Win32 contract is that `CloseHandle`
+    /// runs after the handle is fully quiescent — no thread is currently
+    /// waiting on it. We enforce that contract loudly: closing a handle
+    /// with a non-empty wait queue is a guest bug that would otherwise
+    /// present as the waiters being permanently parked on a recycled
+    /// object.
+    ///
+    /// IDs are never reused; the entry is removed from the table, so a
+    /// retained `IntPtr` to the closed handle fails loudly at the next
+    /// use.
+    let close (id : WaitHandleId) (state : IlMachineState) : IlMachineState =
+        let handle = lookup id state
+
+        match handle with
+        | WaitHandleState.Semaphore semaphore ->
+            match semaphore.WaitQueue with
+            | [] -> ()
+            | waiters ->
+                failwith
+                    $"WaitHandle %O{id}: refusing to Close a semaphore with %d{List.length waiters} thread(s) parked in BlockedOnWaitHandle (%A{waiters}); the guest must Release before Disposing."
+
+        state.MapKernel (fun kernel ->
+            { kernel with
+                WaitHandles = kernel.WaitHandles |> Map.remove id
+            }
+        )

--- a/WoofWare.PawPrint/WaitHandle.fs
+++ b/WoofWare.PawPrint/WaitHandle.fs
@@ -36,8 +36,11 @@ module WaitHandle =
         /// Adding `releaseCount` to the current count would breach the
         /// semaphore's maximum. The Win32 contract sets
         /// `ERROR_TOO_MANY_POSTS` and returns FALSE; the BCL turns that
-        /// into a `SemaphoreFullException`.
-        | WouldExceedMaximum of attemptedTotal : int * maximum : int
+        /// into a `SemaphoreFullException`. `attemptedTotal` is reported
+        /// as `int64` so that the value stays meaningful when an `int32`
+        /// add of two near-`Int32.MaxValue` ints would overflow — the
+        /// check itself is done without computing the sum.
+        | WouldExceedMaximum of attemptedTotal : int64 * maximum : int
 
     /// Outcome of a `waitOne` call. The native handler treats both
     /// constructors identically — advance IL and return `WAIT_OBJECT_0` —
@@ -190,9 +193,17 @@ module WaitHandle =
         let semaphore = expectSemaphore "WaitHandle.releaseSemaphore" id handle
 
         let previousCount = semaphore.Count
-        let attemptedTotal = previousCount + releaseCount
-
-        if attemptedTotal > semaphore.Maximum then
+        // Order the comparison so the int32 add can never overflow:
+        // `previousCount ≤ Maximum` is an invariant, so `Maximum -
+        // previousCount` is non-negative, and `releaseCount ≥ 1` is
+        // asserted above. A guest that creates a semaphore at near
+        // `Int32.MaxValue` and posts a release would otherwise wrap to a
+        // negative `attemptedTotal`, sneak past the maximum check, and
+        // store a negative `Count`.
+        if releaseCount > semaphore.Maximum - previousCount then
+            // Compute `attemptedTotal` in int64 so the error stays
+            // meaningful even in the overflow regime.
+            let attemptedTotal = int64 previousCount + int64 releaseCount
             Error (ReleaseFailure.WouldExceedMaximum (attemptedTotal, semaphore.Maximum)), state
         else
             // Direct-handoff: each wake consumes one of the new units.
@@ -202,10 +213,13 @@ module WaitHandle =
             // refactor.
             let toWake = min releaseCount (List.length semaphore.WaitQueue)
             let wakers, remainingQueue = List.splitAt toWake semaphore.WaitQueue
+            // Now safe: the guard above ensures `previousCount +
+            // releaseCount ≤ Maximum`, so the int32 add cannot overflow.
+            let newCount = previousCount + releaseCount - toWake
 
             let semaphore =
                 { semaphore with
-                    Count = attemptedTotal - toWake
+                    Count = newCount
                     WaitQueue = remainingQueue
                 }
 

--- a/WoofWare.PawPrint/WaitHandle.fs
+++ b/WoofWare.PawPrint/WaitHandle.fs
@@ -23,10 +23,14 @@ namespace WoofWare.PawPrint
 /// higher-level guest primitives (`LowLevelLifoSemaphore`,
 /// `PortableThreadPool`) depend on.
 ///
-/// Timeouts: finite timeouts on `WaitHandle_WaitOneCore` are not
-/// implemented today, for the same reason `LowLevelMonitor.TimedWait`
-/// is not — PawPrint has no virtual clock. Calls with a finite timeout
-/// fail loud in the native handler.
+/// Timeouts: non-zero finite timeouts on `WaitHandle_WaitOneCore` /
+/// `WaitHandle_WaitOnePrioritized` are not implemented today, for the
+/// same reason `LowLevelMonitor.TimedWait` is not — PawPrint has no
+/// virtual clock. Calls with a non-zero finite timeout fail loud in
+/// the native handler. The zero-timeout case is fully deterministic
+/// (`tryWaitOne`): it does not park, never touches the queue, and
+/// returns `WAIT_OBJECT_0` or `WAIT_TIMEOUT` depending on whether the
+/// fast path applied.
 [<RequireQualifiedAccess>]
 module WaitHandle =
 
@@ -52,6 +56,17 @@ module WaitHandle =
     type WaitOutcome =
         | Acquired of IlMachineState
         | Blocked of IlMachineState
+
+    /// Outcome of a non-blocking `tryWaitOne` probe (zero-timeout wait).
+    /// `Acquired` means the fast path applied — count was decremented.
+    /// `TimedOut` means count was 0; the state is unchanged (no enqueue,
+    /// no thread-status flip — that's the entire point of distinguishing
+    /// this from `waitOne`). The native handler maps these to
+    /// `WAIT_OBJECT_0` (0) and `WAIT_TIMEOUT` (0x102) respectively.
+    [<RequireQualifiedAccess>]
+    type TryWaitOutcome =
+        | Acquired of IlMachineState
+        | TimedOut of IlMachineState
 
     /// Look up the handle for `id`, or fail loud. A retained IntPtr that
     /// outlives `close` lands here so use-after-free shows up at the use
@@ -163,6 +178,71 @@ module WaitHandle =
             |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnWaitHandle id)
             |> WaitOutcome.Blocked
 
+    /// Non-blocking probe used to model the zero-timeout `WaitOne(0)`
+    /// path. CoreCLR's contract for a zero millisecond timeout: try the
+    /// fast path; if it cannot succeed, return `WAIT_TIMEOUT` without
+    /// ever entering the wait queue. Distinct from `waitOne` because the
+    /// caller is *not* parked — leaving the thread Runnable is the entire
+    /// observable difference from a guest's point of view, and silently
+    /// parking would deadlock guests that rely on `WaitOne(0)` as a poll.
+    let tryWaitOne (id : WaitHandleId) (state : IlMachineState) : TryWaitOutcome =
+        let handle = lookup id state
+        let semaphore = expectSemaphore "WaitHandle.tryWaitOne" id handle
+
+        if semaphore.Count > 0 then
+            let semaphore =
+                { semaphore with
+                    Count = semaphore.Count - 1
+                }
+
+            state
+            |> writeHandle id (WaitHandleState.Semaphore semaphore)
+            |> TryWaitOutcome.Acquired
+        else
+            // State must be returned verbatim: no enqueue, no status flip.
+            TryWaitOutcome.TimedOut state
+
+    /// Prioritized variant of `waitOne` matching the
+    /// `PAL_WaitForSingleObjectPrioritized` contract: when the wait
+    /// blocks, the thread is registered at the **head** of `WaitQueue`
+    /// (not the tail). A subsequent `releaseSemaphore` therefore wakes
+    /// the most recently registered prioritized waiter first, giving
+    /// LIFO release semantics among prioritized waiters — and strict
+    /// precedence over any earlier-arrived non-prioritized waiters.
+    /// `LowLevelLifoSemaphore` (the PortableThreadPool worker park
+    /// primitive on Unix) imports this entry point precisely because its
+    /// fairness contract is LIFO over the kernel semaphore's FIFO base.
+    ///
+    /// The fast path is identical to `waitOne`: priority only matters
+    /// when the call has to block.
+    let waitOnePrioritized (thread : ThreadId) (id : WaitHandleId) (state : IlMachineState) : WaitOutcome =
+        let handle = lookup id state
+        let semaphore = expectSemaphore "WaitHandle.waitOnePrioritized" id handle
+
+        if semaphore.Count > 0 then
+            let semaphore =
+                { semaphore with
+                    Count = semaphore.Count - 1
+                }
+
+            state
+            |> writeHandle id (WaitHandleState.Semaphore semaphore)
+            |> WaitOutcome.Acquired
+        else
+            // Prioritized slow path: prepend to the head of the queue.
+            // The wake step in `releaseSemaphore` pops from the head, so
+            // a later release will hand its freshly-issued unit to this
+            // thread before any earlier-enqueued waiter.
+            let semaphore =
+                { semaphore with
+                    WaitQueue = thread :: semaphore.WaitQueue
+                }
+
+            state
+            |> writeHandle id (WaitHandleState.Semaphore semaphore)
+            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnWaitHandle id)
+            |> WaitOutcome.Blocked
+
     /// Increment the semaphore by `releaseCount`, waking up to that many
     /// FIFO-head waiters. Returns the previous count on success (matching
     /// the Win32 `lpPreviousCount` out-parameter contract) and the
@@ -207,10 +287,14 @@ module WaitHandle =
             Error (ReleaseFailure.WouldExceedMaximum (attemptedTotal, semaphore.Maximum)), state
         else
             // Direct-handoff: each wake consumes one of the new units.
-            // FIFO over WaitQueue is load-bearing for the
-            // LowLevelLifoSemaphore fairness contract higher up the
-            // stack — switching to LIFO or arbitrary order is not a
-            // refactor.
+            // The wake step always pops from the head of `WaitQueue`;
+            // ordering discipline lives at insertion time (`waitOne`
+            // appends to the tail for FIFO; `waitOnePrioritized`
+            // prepends to the head for LIFO over prioritized waiters,
+            // matching `PAL_WaitForSingleObjectPrioritized`). The
+            // LowLevelLifoSemaphore fairness contract that
+            // PortableThreadPool depends on is delivered through that
+            // insertion-side asymmetry, not by changing this wake step.
             let toWake = min releaseCount (List.length semaphore.WaitQueue)
             let wakers, remainingQueue = List.splitAt toWake semaphore.WaitQueue
             // Now safe: the guard above ensures `previousCount +

--- a/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
+++ b/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
@@ -79,6 +79,7 @@
     <Compile Include="ExternImplementations\NativeImpls.fs" />
     <Compile Include="Scheduler.fs" />
     <Compile Include="LowLevelMonitor.fs" />
+    <Compile Include="WaitHandle.fs" />
     <Compile Include="SyncBlockMonitor.fs" />
     <Compile Include="ExternImplementations\System.Threading.Monitor.fs" />
     <Compile Include="Native\NativeCall.fs" />
@@ -98,6 +99,7 @@
     <Compile Include="Native\NativeArray.fs" />
     <Compile Include="Native\NativeEnum.fs" />
     <Compile Include="Native\NativeKernel32.fs" />
+    <Compile Include="Native\NativeWaitHandle.fs" />
     <Compile Include="Native\NativeRuntimeAssembly.fs" />
     <Compile Include="Native\NativeMetadataUpdater.fs" />
     <Compile Include="Native\NativeThreading.fs" />


### PR DESCRIPTION
## Summary

Adds the first slice of the wait-handle kernel-object scaffolding: a deterministic semaphore primitive end-to-end. On .NET 10 CoreCLR-on-Unix, `Libraries.Kernel32` is rebound to `RuntimeHelpers.QCall`, so `Semaphore.Windows.cs` compiles unchanged and every `CreateSemaphoreExW` / `ReleaseSemaphore` / `CloseHandle` / `WaitHandle_WaitOneCore` LibraryImport reaches the runtime as a QCall under its Win32 wide-string name. This PR catches those entry points (plus `WaitHandle_WaitOnePrioritized`, used by `LowLevelLifoSemaphore`) and forwards them into a pure state machine in `WaitHandle.fs`.

- Unified `WaitHandleState` DU over `SemaphoreState` (Event/Mutex slot in without disturbing the table or the close/wait handlers).
- FIFO queue at insertion for `waitOne`; LIFO insertion at head for `waitOnePrioritized`, matching `PAL_WaitForSingleObjectPrioritized`'s LIFO release policy (load-bearing for `LowLevelLifoSemaphore` and hence `PortableThreadPool`).
- Zero-timeout waits (`WaitOne(0)`) handled deterministically via `tryWaitOne` — succeed immediately if signalled, return `WAIT_TIMEOUT` otherwise, never enqueue. Non-zero finite timeouts still fail loud (no virtual clock yet — same blocker as `LowLevelMonitor.TimedWait`).
- Direct-handoff release: each wake consumes one of the newly issued units before they accumulate, mirroring the CoreCLR posture.
- Fails loud on stale or wrong-kind handles, closing with parked waiters, named handles, or non-null security attributes — these all indicate guest bugs that would otherwise present as confusing downstream symptoms.

34 new property/example tests (FsCheck 200 cases per property) covering: round-trip, fast/slow waits, FIFO and LIFO wake orderings, cross-class ordering (prioritized strictly precedes earlier-arrived non-prioritized), overflow rejection (including a regression for Int32 wraparound near `Int32.MaxValue`), use-after-close, close-with-waiters, count invariant + conservation across an arbitrary Wait/Release script.

## Test plan

- [x] `nix develop -c dotnet build WoofWare.PawPrint.slnx` — clean
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --filter "Name~WaitHandle"` — 34/34 pass
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — full suite 1039/1039 pass
- [x] `nix develop -c dotnet fantomas .` — formatted
- [x] `codex review --base main` — no findings (after two rounds of fixes for prioritized-wait LIFO, Int32 overflow, and zero-timeout handling, all included)

## Out of scope (explicit follow-ups)

- Events (`CreateEventExW` / `SetEvent` / `ResetEvent`) — slot into the DU.
- Mutexes (`CreateMutexExW` / `ReleaseMutex`) — owner + recursion + queue.
- Multi-handle wait (`WaitHandle_WaitMultipleIgnoringSyncContext` / `WaitHandle_SignalAndWait`) — new `BlockedOnAnyWaitHandle` / `BlockedOnAllWaitHandles` thread statuses.
- Named handles (`OpenSemaphoreW`) — needs a named-handle registry.
- Non-zero finite timeouts — blocked on the same missing virtual-clock primitive as `LowLevelMonitor.TimedWait`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)