### PR TITLE
Drop dead address-keyed method-stub registry

### DIFF
--- a/WoofWare.PawPrint/MethodHandleRegistry.fs
+++ b/WoofWare.PawPrint/MethodHandleRegistry.fs
@@ -24,7 +24,11 @@ type MethodHandleRegistry =
             /// iterator on `RuntimeTypeHandle`) that hold a bare `RuntimeMethodHandleInternal`
             /// id and need to recover the underlying `MethodHandle`.
             IdToMethodHandle : Map<int64, MethodHandle>
-            MethodHandleToMethod : Map<ManagedHeapAddress, MethodHandle>
+            /// Dedup cache for `getOrAllocate`: when an F# caller asks for the stub address
+            /// of a method we've previously allocated through this same path, return that
+            /// existing address rather than minting a fresh stub. Note that this dedup is
+            /// scoped to F#-side allocations — stubs the BCL constructs in managed code (via
+            /// `new RuntimeMethodInfoStub(...)`) bypass this registry entirely.
             MethodToHandle : Map<MethodHandle, ManagedHeapAddress>
             NextHandle : int64
         }
@@ -33,7 +37,6 @@ type MethodHandleRegistry =
 module MethodHandleRegistry =
     let empty () =
         {
-            MethodHandleToMethod = Map.empty
             MethodToHandle = Map.empty
             MethodHandleToId = Map.empty
             IdToMethodHandle = Map.empty
@@ -366,12 +369,7 @@ module MethodHandleRegistry =
 
         let reg =
             { reg with
-                MethodHandleToMethod = reg.MethodHandleToMethod |> Map.add alloc handle
                 MethodToHandle = reg.MethodToHandle |> Map.add handle alloc
             }
 
         runtimeMethodHandle alloc, reg, state
-
-    /// Given the ManagedHeapAddress of a RuntimeMethodInfoStub, resolve it to the MethodHandle.
-    let resolveMethodFromAddress (addr : ManagedHeapAddress) (reg : MethodHandleRegistry) : MethodHandle option =
-        Map.tryFind addr reg.MethodHandleToMethod

--- a/WoofWare.PawPrint/Native/NativeCustomAttribute.fs
+++ b/WoofWare.PawPrint/Native/NativeCustomAttribute.fs
@@ -240,14 +240,11 @@ module NativeCustomAttribute =
                     failwith
                         $"TODO: %s{operation}: value-typed attribute %s{attrTypeInfo.Namespace}.%s{attrTypeInfo.Name} would need unboxing for `this` slot; CoreCLR's value-type branch is unreachable from the BCL filter and is not yet modelled here"
 
-                // Resolve the ctor metadata via the method-handle registry. We can't rely on the
-                // stub's heap address being in `MethodHandleToMethod`: only stubs allocated by
-                // `IlMachineState.getOrAllocateMethod` are registered that way. The real BCL path
-                // (`ModuleHandle.ResolveMethodHandle(...).GetMethodInfo()`) constructs the stub in
-                // managed code, so its address is unknown to the registry. The stub's `m_value`
-                // field (a `RuntimeMethodHandleInternal`) does, however, carry a registry id that
-                // the producing QCall minted — that's the canonical path, and it works for both
-                // origins.
+                // Resolve the ctor metadata via the method-handle registry. The stub's `m_value`
+                // field (a `RuntimeMethodHandleInternal`) carries a registry id minted by whichever
+                // QCall produced the handle, and that's the canonical identity available regardless
+                // of whether the stub was allocated F#-side (via `IlMachineState.getOrAllocateMethod`)
+                // or by the BCL itself (via `ModuleHandle.ResolveMethodHandle(...).GetMethodInfo()`).
                 let ctorStubObj = ManagedHeap.get ctorStubAddr state.ManagedHeap
 
                 let stubValueField =


### PR DESCRIPTION
## Summary
- Removes the `MethodHandleToMethod` map (`ManagedHeapAddress → MethodHandle`) and its only reader, `resolveMethodFromAddress`, from `MethodHandleRegistry`. The PR #551 review confirmed the address keying was unreliable: stubs the BCL constructs in managed code (via `new RuntimeMethodInfoStub(...)` from `ModuleHandle.ResolveMethodHandle(...).GetMethodInfo()`) bypass `getOrAllocate`, so their addresses were never registered. The canonical identity now lives on the stub itself in `m_value.m_handle` (a `RuntimeMethodHandleInternal` carrying a registry id), and that path works for both F#-side and BCL-side allocations.
- Updates the comment in `NativeCustomAttribute.fs` that mentioned the now-removed map.

## Test plan
- [x] `dotnet build` clean
- [x] `dotnet test` — all 1008 tests pass
- [x] `dotnet fantomas .` no changes
- [x] `codex review --base main` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)