### PR TITLE
Implement Float × Float arms for ordered branch ops via cle/cge helpers

### DIFF
--- a/WoofWare.PawPrint.Test/TestEvalStack.fs
+++ b/WoofWare.PawPrint.Test/TestEvalStack.fs
@@ -489,3 +489,165 @@ module TestEvalStack =
 
         if EvalStackValueComparisons.cltUn lo alsoLo then
             failwith "clt.un should report equal native-memory offsets as not strictly ordered"
+
+    // Sentinel floats covering the regimes the ordered ble/bge arms must respect.
+    // ECMA-335 III.3.7 specifies "ordered" for ble/bge: NaN comparisons must report the
+    // branch as *not* taken, which corresponds to IEEE `<=` / `>=` returning false on NaN.
+    let private nan : float = System.Double.NaN
+    let private pInf : float = System.Double.PositiveInfinity
+    let private nInf : float = System.Double.NegativeInfinity
+    let private pZero : float = 0.0
+    let private nZero : float = -0.0
+    let private subnormal : float = System.Double.Epsilon
+
+    let private floatEsv (v : float) : EvalStackValue = EvalStackValue.Float v
+
+    [<Test>]
+    let ``cle on Float × Float matches IEEE <= (ordered semantics)`` () : unit =
+        EvalStackValueComparisons.cle (floatEsv 1.0) (floatEsv 2.0) |> shouldEqual true
+        EvalStackValueComparisons.cle (floatEsv 2.0) (floatEsv 1.0) |> shouldEqual false
+        EvalStackValueComparisons.cle (floatEsv 1.0) (floatEsv 1.0) |> shouldEqual true
+
+        // ±0 compare equal.
+        EvalStackValueComparisons.cle (floatEsv pZero) (floatEsv nZero)
+        |> shouldEqual true
+
+        EvalStackValueComparisons.cle (floatEsv nZero) (floatEsv pZero)
+        |> shouldEqual true
+
+        // ±Inf.
+        EvalStackValueComparisons.cle (floatEsv nInf) (floatEsv 0.0) |> shouldEqual true
+        EvalStackValueComparisons.cle (floatEsv 0.0) (floatEsv pInf) |> shouldEqual true
+
+        EvalStackValueComparisons.cle (floatEsv pInf) (floatEsv pInf)
+        |> shouldEqual true
+
+        EvalStackValueComparisons.cle (floatEsv pInf) (floatEsv 0.0)
+        |> shouldEqual false
+
+        // Subnormals are real, finite values; ordering is well-defined.
+        EvalStackValueComparisons.cle (floatEsv subnormal) (floatEsv 1.0)
+        |> shouldEqual true
+
+        EvalStackValueComparisons.cle (floatEsv 0.0) (floatEsv subnormal)
+        |> shouldEqual true
+
+        // Ordered: NaN compared to anything (including itself) must report false, so the
+        // branch is not taken.
+        EvalStackValueComparisons.cle (floatEsv nan) (floatEsv 1.0) |> shouldEqual false
+        EvalStackValueComparisons.cle (floatEsv 1.0) (floatEsv nan) |> shouldEqual false
+        EvalStackValueComparisons.cle (floatEsv nan) (floatEsv nan) |> shouldEqual false
+
+        EvalStackValueComparisons.cle (floatEsv nan) (floatEsv pInf)
+        |> shouldEqual false
+
+        EvalStackValueComparisons.cle (floatEsv nInf) (floatEsv nan)
+        |> shouldEqual false
+
+    [<Test>]
+    let ``cge on Float × Float matches IEEE >= (ordered semantics)`` () : unit =
+        EvalStackValueComparisons.cge (floatEsv 2.0) (floatEsv 1.0) |> shouldEqual true
+        EvalStackValueComparisons.cge (floatEsv 1.0) (floatEsv 2.0) |> shouldEqual false
+        EvalStackValueComparisons.cge (floatEsv 1.0) (floatEsv 1.0) |> shouldEqual true
+
+        EvalStackValueComparisons.cge (floatEsv pZero) (floatEsv nZero)
+        |> shouldEqual true
+
+        EvalStackValueComparisons.cge (floatEsv nZero) (floatEsv pZero)
+        |> shouldEqual true
+
+        EvalStackValueComparisons.cge (floatEsv pInf) (floatEsv 0.0) |> shouldEqual true
+        EvalStackValueComparisons.cge (floatEsv 0.0) (floatEsv nInf) |> shouldEqual true
+
+        EvalStackValueComparisons.cge (floatEsv nInf) (floatEsv nInf)
+        |> shouldEqual true
+
+        EvalStackValueComparisons.cge (floatEsv 0.0) (floatEsv pInf)
+        |> shouldEqual false
+
+        EvalStackValueComparisons.cge (floatEsv 1.0) (floatEsv subnormal)
+        |> shouldEqual true
+
+        EvalStackValueComparisons.cge (floatEsv subnormal) (floatEsv 0.0)
+        |> shouldEqual true
+
+        EvalStackValueComparisons.cge (floatEsv nan) (floatEsv 1.0) |> shouldEqual false
+        EvalStackValueComparisons.cge (floatEsv 1.0) (floatEsv nan) |> shouldEqual false
+        EvalStackValueComparisons.cge (floatEsv nan) (floatEsv nan) |> shouldEqual false
+
+        EvalStackValueComparisons.cge (floatEsv pInf) (floatEsv nan)
+        |> shouldEqual false
+
+        EvalStackValueComparisons.cge (floatEsv nan) (floatEsv nInf)
+        |> shouldEqual false
+
+    [<Test>]
+    let ``cle and cge on Int × Int agree with the obvious arithmetic`` () : unit =
+        let i32 (v : int32) = EvalStackValue.Int32 v
+
+        let i64 (v : int64) =
+            EvalStackValue.Int64 (Int64Source.Verbatim v)
+
+        EvalStackValueComparisons.cle (i32 1) (i32 2) |> shouldEqual true
+        EvalStackValueComparisons.cle (i32 2) (i32 2) |> shouldEqual true
+        EvalStackValueComparisons.cle (i32 3) (i32 2) |> shouldEqual false
+
+        EvalStackValueComparisons.cge (i32 2) (i32 1) |> shouldEqual true
+        EvalStackValueComparisons.cge (i32 2) (i32 2) |> shouldEqual true
+        EvalStackValueComparisons.cge (i32 1) (i32 2) |> shouldEqual false
+
+        EvalStackValueComparisons.cle (i64 1L) (i64 2L) |> shouldEqual true
+        EvalStackValueComparisons.cle (i64 -5L) (i64 -5L) |> shouldEqual true
+        EvalStackValueComparisons.cge (i64 -1L) (i64 -5L) |> shouldEqual true
+        EvalStackValueComparisons.cge (i64 -5L) (i64 -1L) |> shouldEqual false
+
+    [<Test>]
+    let ``cle and cge fail on Float × Int (cross-type guard inherited from cgt/clt)`` () : unit =
+        // ECMA-335 leaves cross-shape numeric comparisons unverifiable; we keep the
+        // classifier honest by failing loudly rather than coercing one side. cle defers
+        // non-Float×Float to `not cgt`, so the Float × Int case re-uses cgt's existing
+        // "invalid comparison" failwith.
+        let f = EvalStackValue.Float 1.0
+        let i = EvalStackValue.Int32 1
+        let n = EvalStackValue.NativeInt (NativeIntSource.Verbatim 1L)
+
+        let exFI =
+            Assert.Throws<System.Exception> (fun () -> EvalStackValueComparisons.cle f i |> ignore)
+
+        exFI.Message |> shouldContainText "invalid comparison"
+
+        let exIF =
+            Assert.Throws<System.Exception> (fun () -> EvalStackValueComparisons.cle i f |> ignore)
+
+        exIF.Message |> shouldContainText "invalid comparison"
+
+        let exFN =
+            Assert.Throws<System.Exception> (fun () -> EvalStackValueComparisons.cle f n |> ignore)
+
+        exFN.Message |> shouldContainText "invalid comparison"
+
+        let exNF =
+            Assert.Throws<System.Exception> (fun () -> EvalStackValueComparisons.cle n f |> ignore)
+
+        exNF.Message |> shouldContainText "invalid comparison"
+
+        // And symmetrically for cge (defers to `not clt`).
+        let gxFI =
+            Assert.Throws<System.Exception> (fun () -> EvalStackValueComparisons.cge f i |> ignore)
+
+        gxFI.Message |> shouldContainText "invalid comparison"
+
+        let gxIF =
+            Assert.Throws<System.Exception> (fun () -> EvalStackValueComparisons.cge i f |> ignore)
+
+        gxIF.Message |> shouldContainText "invalid comparison"
+
+        let gxFN =
+            Assert.Throws<System.Exception> (fun () -> EvalStackValueComparisons.cge f n |> ignore)
+
+        gxFN.Message |> shouldContainText "invalid comparison"
+
+        let gxNF =
+            Assert.Throws<System.Exception> (fun () -> EvalStackValueComparisons.cge n f |> ignore)
+
+        gxNF.Message |> shouldContainText "invalid comparison"

--- a/WoofWare.PawPrint.Test/TestUnaryConstIlOp.fs
+++ b/WoofWare.PawPrint.Test/TestUnaryConstIlOp.fs
@@ -231,3 +231,163 @@ module TestUnaryConstIlOp =
         if bltTaken = 0 || bltNotTaken = 0 || bgtTaken = 0 || bgtNotTaken = 0 then
             failwith
                 $"generator missed required regimes: bltTaken=%d{bltTaken}, bltNotTaken=%d{bltNotTaken}, bgtTaken=%d{bgtTaken}, bgtNotTaken=%d{bgtNotTaken}"
+
+    /// Push two float operands onto a fresh evaluation stack, queue `op` as the only instruction,
+    /// then dispatch it. Returns the post-dispatch PC and the residual eval stack so callers can
+    /// assert both branch direction (PC) and that the operands were consumed.
+    let private runFloatBranch (op : UnaryConstIlOp) (value1 : float) (value2 : float) : int32 * EvalStackValue list =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+
+        let state, method =
+            initialState loggerFactory |> methodWithUnaryConst loggerFactory op
+
+        let methodState =
+            match
+                MethodState.Empty
+                    state.ConcreteTypes
+                    baseClassTypes
+                    state._LoadedAssemblies
+                    corelib
+                    method
+                    ImmutableArray.Empty
+                    (ImmutableArray.Create (CliType.ObjectRef None))
+                    None
+            with
+            | Ok methodState -> methodState
+            | Error missing ->
+                failwith $"Unexpected missing assembly references creating float-branch test frame: %O{missing}"
+
+        let thread = ThreadId.ThreadId 0
+
+        let state =
+            { state with
+                ThreadState = Map.empty |> Map.add thread (ThreadState.New methodState)
+            }
+            |> IlMachineState.pushToEvalStack' (EvalStackValue.Float value1) thread
+            |> IlMachineState.pushToEvalStack' (EvalStackValue.Float value2) thread
+
+        let state, whatWeDid = UnaryConstIlOp.execute state thread op
+
+        whatWeDid |> shouldEqual WhatWeDid.Executed
+
+        let methodState = state.ThreadState.[thread].MethodState
+        methodState.IlOpIndex, methodState.EvaluationStack.Values
+
+    /// Expected PC after executing `op` (the only instruction in its method) given whether the
+    /// branch is taken.
+    let private expectedPcAfter (op : UnaryConstIlOp) (taken : bool) (offset : int32) : int32 =
+        let instructionSize = IlOp.NumberOfBytes (IlOp.UnaryConst op)
+        instructionSize + (if taken then offset else 0)
+
+    // Ordered float branches: ECMA-335 specifies that NaN comparisons report "branch not taken",
+    // matching .NET's default IEEE semantics for `<`/`<=`/`>`/`>=` (all return false for NaN).
+    // ±0 compare equal under IEEE; ±Inf orders sit at the extremes of the real-valued reals.
+    let private nanF : float = System.Double.NaN
+    let private pInfF : float = System.Double.PositiveInfinity
+    let private nInfF : float = System.Double.NegativeInfinity
+    let private subnormalF : float = System.Double.Epsilon
+
+    /// `(name, op, factory)` quartet: each branch op under test together with the helper that
+    /// reconstructs it for a given short-form offset. Long-form Ble/Bge are exercised in their
+    /// own test; the short-form (Blt_s/Ble_s/Bgt_s/Bge_s) versions are the ones that were
+    /// `failwith "todo"` for Float × Float before this change.
+    let private floatTakenCases (v1 : float) (v2 : float) : (string * bool) list =
+        [ "blt", v1 < v2 ; "ble", v1 <= v2 ; "bgt", v1 > v2 ; "bge", v1 >= v2 ]
+
+    [<Test>]
+    let ``Blt_s/Ble_s/Bgt_s/Bge_s on Float × Float follow IEEE ordered semantics`` () : unit =
+        let offset = 7
+
+        let assertCase (name : string) (op : UnaryConstIlOp) (expectedTaken : bool) (v1 : float) (v2 : float) : unit =
+            let pc, stack = runFloatBranch op v1 v2
+
+            stack |> shouldEqual []
+
+            let expectedPc = expectedPcAfter op expectedTaken offset
+
+            if pc <> expectedPc then
+                failwith
+                    $"%s{name} (%f{v1}, %f{v2}): expected pc=%d{expectedPc} (taken=%b{expectedTaken}), got pc=%d{pc}"
+
+        let cases : (float * float) list =
+            [
+                // Ordinary ordered finite reals.
+                1.0, 2.0
+                2.0, 1.0
+                1.0, 1.0
+                -3.5, -3.5
+                -3.5, 3.5
+                // ±0 equality.
+                0.0, -0.0
+                -0.0, 0.0
+                // ±Inf at the extremes.
+                pInfF, 1.0
+                1.0, pInfF
+                nInfF, 1.0
+                1.0, nInfF
+                pInfF, nInfF
+                nInfF, pInfF
+                pInfF, pInfF
+                nInfF, nInfF
+                // Subnormals are real, finite values; ordering is well-defined.
+                subnormalF, 1.0
+                1.0, subnormalF
+                0.0, subnormalF
+                // NaN: every ordered comparison must report "not taken" (false), in all
+                // directions and against any other regime (including itself).
+                nanF, 1.0
+                1.0, nanF
+                nanF, nanF
+                nanF, pInfF
+                nInfF, nanF
+                nanF, 0.0
+            ]
+
+        for v1, v2 in cases do
+            for name, taken in floatTakenCases v1 v2 do
+                let op =
+                    match name with
+                    | "blt" -> UnaryConstIlOp.Blt_s (int8 offset)
+                    | "ble" -> UnaryConstIlOp.Ble_s (int8 offset)
+                    | "bgt" -> UnaryConstIlOp.Bgt_s (int8 offset)
+                    | "bge" -> UnaryConstIlOp.Bge_s (int8 offset)
+                    | other -> failwith $"unexpected float-branch case: %s{other}"
+
+                assertCase name op taken v1 v2
+
+    [<Test>]
+    let ``Ble/Bge (long form) on Float × Float follow IEEE ordered semantics`` () : unit =
+        // The long-form ops were also previously `failwith "todo"` on Float; cover them here
+        // with a smaller but still NaN-inclusive battery. `Blt`/`Bgt` (long form) already
+        // delegated to `clt`/`cgt` before this change, but we exercise them too for symmetry.
+        let offset = 13
+
+        let assertCase (name : string) (op : UnaryConstIlOp) (expectedTaken : bool) (v1 : float) (v2 : float) : unit =
+            let pc, stack = runFloatBranch op v1 v2
+
+            stack |> shouldEqual []
+
+            let expectedPc = expectedPcAfter op expectedTaken offset
+
+            if pc <> expectedPc then
+                failwith
+                    $"%s{name} (%f{v1}, %f{v2}): expected pc=%d{expectedPc} (taken=%b{expectedTaken}), got pc=%d{pc}"
+
+        let cases : (float * float) list =
+            [
+                1.0, 2.0
+                2.0, 1.0
+                1.0, 1.0
+                0.0, -0.0
+                pInfF, nInfF
+                nanF, 1.0
+                1.0, nanF
+                nanF, nanF
+            ]
+
+        for v1, v2 in cases do
+            assertCase "blt" (UnaryConstIlOp.Blt offset) (v1 < v2) v1 v2
+            assertCase "ble" (UnaryConstIlOp.Ble offset) (v1 <= v2) v1 v2
+            assertCase "bgt" (UnaryConstIlOp.Bgt offset) (v1 > v2) v1 v2
+            assertCase "bge" (UnaryConstIlOp.Bge offset) (v1 >= v2) v1 v2

--- a/WoofWare.PawPrint/EvalStackValueComparisons.fs
+++ b/WoofWare.PawPrint/EvalStackValueComparisons.fs
@@ -100,6 +100,24 @@ module EvalStackValueComparisons =
         | EvalStackValue.UserDefinedValueType _, UserDefinedValueType _ ->
             failwith "TODO: Cgt UserDefinedValueType vs UserDefinedValueType comparison unimplemented"
 
+    /// Ordered "less than or equal". For floats this is IEEE `<=` (NaN ⇒ false), which is the
+    /// correct ECMA-335 ordered ble semantics. For other types we defer to `not (cgt v1 v2)` —
+    /// note that for floats this would be wrong (`not cgt` is the *unordered* ble, since
+    /// `cgt(NaN, _)` is false), so the Float × Float arm overrides explicitly. Cross-type
+    /// (Float vs Int / NativeInt) is inherited from `cgt`'s "invalid comparison" failwith.
+    let cle (var1 : EvalStackValue) (var2 : EvalStackValue) : bool =
+        match var1, var2 with
+        | EvalStackValue.Float var1, EvalStackValue.Float var2 -> var1 <= var2
+        | _ -> not (cgt var1 var2)
+
+    /// Ordered "greater than or equal". Mirrors `cle`: Float × Float uses IEEE `>=`
+    /// (NaN ⇒ false); other types defer to `not (clt v1 v2)`. Cross-type guards are
+    /// inherited from `clt`.
+    let cge (var1 : EvalStackValue) (var2 : EvalStackValue) : bool =
+        match var1, var2 with
+        | EvalStackValue.Float var1, EvalStackValue.Float var2 -> var1 >= var2
+        | _ -> not (clt var1 var2)
+
     let rec cgtUn (var1 : EvalStackValue) (var2 : EvalStackValue) : bool =
         let var1 = unwrapPlaceholderForBitComparison var1
         let var2 = unwrapPlaceholderForBitComparison var2

--- a/WoofWare.PawPrint/UnaryConstIlOp.fs
+++ b/WoofWare.PawPrint/UnaryConstIlOp.fs
@@ -213,26 +213,10 @@ module internal UnaryConstIlOp =
                    id
             |> Tuple.withRight WhatWeDid.Executed
         | Blt_s b ->
+            // Spec III.3.12: blt is identical to clt followed by brtrue.
             let value2, state = IlMachineState.popEvalStack currentThread state
             let value1, state = IlMachineState.popEvalStack currentThread state
-
-            let isLessThan =
-                match value1, value2 with
-                | EvalStackValue.Int32 v1, EvalStackValue.Int32 v2 -> v1 < v2
-                | EvalStackValue.Int32 i, EvalStackValue.NativeInt nativeIntSource -> failwith "todo"
-                | EvalStackValue.Int32 i, _ -> failwith $"invalid comparison, {i} with {value2}"
-                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.compareSigned v1 v2 < 0
-                | EvalStackValue.Int64 i, _ -> failwith $"invalid comparison, {i} with {value2}"
-                | EvalStackValue.NativeInt nativeIntSource, _ -> failwith "todo"
-                | EvalStackValue.Float v1, EvalStackValue.Float v2 -> failwith "todo"
-                | EvalStackValue.Float f, _ -> failwith $"invalid comparison, {f} with {value2}"
-                | EvalStackValue.ManagedPointer v1, EvalStackValue.ManagedPointer v2 -> failwith "todo"
-                | EvalStackValue.ManagedPointer v1, _ -> failwith $"invalid comparison, {v1} with {value2}"
-                | EvalStackValue.NullObjectRef, _
-                | _, EvalStackValue.NullObjectRef
-                | EvalStackValue.ObjectRef _, _ -> failwith "todo"
-                | EvalStackValue.UserDefinedValueType _, _ ->
-                    failwith "unexpectedly tried to compare user-defined value type"
+            let isLessThan = EvalStackValueComparisons.clt value1 value2
 
             state
             |> IlMachineState.advanceProgramCounter currentThread
@@ -244,24 +228,7 @@ module internal UnaryConstIlOp =
         | Ble_s b ->
             let value2, state = IlMachineState.popEvalStack currentThread state
             let value1, state = IlMachineState.popEvalStack currentThread state
-
-            let isLessEq =
-                match value1, value2 with
-                | EvalStackValue.Int32 v1, EvalStackValue.Int32 v2 -> v1 <= v2
-                | EvalStackValue.Int32 i, EvalStackValue.NativeInt nativeIntSource -> failwith "todo"
-                | EvalStackValue.Int32 i, _ -> failwith $"invalid comparison, {i} with {value2}"
-                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.compareSigned v1 v2 <= 0
-                | EvalStackValue.Int64 i, _ -> failwith $"invalid comparison, {i} with {value2}"
-                | EvalStackValue.NativeInt nativeIntSource, _ -> failwith "todo"
-                | EvalStackValue.Float v1, EvalStackValue.Float v2 -> failwith "todo"
-                | EvalStackValue.Float f, _ -> failwith $"invalid comparison, {f} with {value2}"
-                | EvalStackValue.ManagedPointer v1, EvalStackValue.ManagedPointer v2 -> failwith "todo"
-                | EvalStackValue.ManagedPointer v1, _ -> failwith $"invalid comparison, {v1} with {value2}"
-                | EvalStackValue.NullObjectRef, _
-                | _, EvalStackValue.NullObjectRef
-                | EvalStackValue.ObjectRef _, _ -> failwith "todo"
-                | EvalStackValue.UserDefinedValueType _, _ ->
-                    failwith "unexpectedly tried to compare user-defined value type"
+            let isLessEq = EvalStackValueComparisons.cle value1 value2
 
             state
             |> IlMachineState.advanceProgramCounter currentThread
@@ -271,26 +238,10 @@ module internal UnaryConstIlOp =
                    id
             |> Tuple.withRight WhatWeDid.Executed
         | Bgt_s b ->
+            // Spec III.3.8: bgt is identical to cgt followed by brtrue.
             let value2, state = IlMachineState.popEvalStack currentThread state
             let value1, state = IlMachineState.popEvalStack currentThread state
-
-            let isGreaterThan =
-                match value1, value2 with
-                | EvalStackValue.Int32 v1, EvalStackValue.Int32 v2 -> v1 > v2
-                | EvalStackValue.Int32 i, EvalStackValue.NativeInt nativeIntSource -> failwith "todo"
-                | EvalStackValue.Int32 i, _ -> failwith $"invalid comparison, {i} with {value2}"
-                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.compareSigned v1 v2 > 0
-                | EvalStackValue.Int64 i, _ -> failwith $"invalid comparison, {i} with {value2}"
-                | EvalStackValue.NativeInt nativeIntSource, _ -> failwith "todo"
-                | EvalStackValue.Float v1, EvalStackValue.Float v2 -> failwith "todo"
-                | EvalStackValue.Float f, _ -> failwith $"invalid comparison, {f} with {value2}"
-                | EvalStackValue.ManagedPointer v1, EvalStackValue.ManagedPointer v2 -> failwith "todo"
-                | EvalStackValue.ManagedPointer v1, _ -> failwith $"invalid comparison, {v1} with {value2}"
-                | EvalStackValue.NullObjectRef, _
-                | _, EvalStackValue.NullObjectRef
-                | EvalStackValue.ObjectRef _, _ -> failwith "todo"
-                | EvalStackValue.UserDefinedValueType _, _ ->
-                    failwith "unexpectedly tried to compare user-defined value type"
+            let isGreaterThan = EvalStackValueComparisons.cgt value1 value2
 
             state
             |> IlMachineState.advanceProgramCounter currentThread
@@ -302,24 +253,7 @@ module internal UnaryConstIlOp =
         | Bge_s b ->
             let value2, state = IlMachineState.popEvalStack currentThread state
             let value1, state = IlMachineState.popEvalStack currentThread state
-
-            let isGreaterEq =
-                match value1, value2 with
-                | EvalStackValue.Int32 v1, EvalStackValue.Int32 v2 -> v1 >= v2
-                | EvalStackValue.Int32 i, EvalStackValue.NativeInt nativeIntSource -> failwith "todo"
-                | EvalStackValue.Int32 i, _ -> failwith $"invalid comparison, {i} with {value2}"
-                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.compareSigned v1 v2 >= 0
-                | EvalStackValue.Int64 i, _ -> failwith $"invalid comparison, {i} with {value2}"
-                | EvalStackValue.NativeInt nativeIntSource, _ -> failwith "todo"
-                | EvalStackValue.Float v1, EvalStackValue.Float v2 -> failwith "todo"
-                | EvalStackValue.Float f, _ -> failwith $"invalid comparison, {f} with {value2}"
-                | EvalStackValue.ManagedPointer v1, EvalStackValue.ManagedPointer v2 -> failwith "todo"
-                | EvalStackValue.ManagedPointer v1, _ -> failwith $"invalid comparison, {v1} with {value2}"
-                | EvalStackValue.NullObjectRef, _
-                | _, EvalStackValue.NullObjectRef
-                | EvalStackValue.ObjectRef _, _ -> failwith "todo"
-                | EvalStackValue.UserDefinedValueType _, _ ->
-                    failwith "unexpectedly tried to compare user-defined value type"
+            let isGreaterEq = EvalStackValueComparisons.cge value1 value2
 
             state
             |> IlMachineState.advanceProgramCounter currentThread
@@ -357,24 +291,7 @@ module internal UnaryConstIlOp =
         | Ble i ->
             let value2, state = IlMachineState.popEvalStack currentThread state
             let value1, state = IlMachineState.popEvalStack currentThread state
-
-            let isLessEq =
-                match value1, value2 with
-                | EvalStackValue.Int32 v1, EvalStackValue.Int32 v2 -> v1 <= v2
-                | EvalStackValue.Int32 i, EvalStackValue.NativeInt nativeIntSource -> failwith "todo"
-                | EvalStackValue.Int32 i, _ -> failwith $"invalid comparison, {i} with {value2}"
-                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.compareSigned v1 v2 <= 0
-                | EvalStackValue.Int64 i, _ -> failwith $"invalid comparison, {i} with {value2}"
-                | EvalStackValue.NativeInt nativeIntSource, _ -> failwith "todo"
-                | EvalStackValue.Float v1, EvalStackValue.Float v2 -> failwith "todo"
-                | EvalStackValue.Float f, _ -> failwith $"invalid comparison, {f} with {value2}"
-                | EvalStackValue.ManagedPointer v1, EvalStackValue.ManagedPointer v2 -> failwith "todo"
-                | EvalStackValue.ManagedPointer v1, _ -> failwith $"invalid comparison, {v1} with {value2}"
-                | EvalStackValue.NullObjectRef, _
-                | _, EvalStackValue.NullObjectRef
-                | EvalStackValue.ObjectRef _, _ -> failwith "todo"
-                | EvalStackValue.UserDefinedValueType _, _ ->
-                    failwith "unexpectedly tried to compare user-defined value type"
+            let isLessEq = EvalStackValueComparisons.cle value1 value2
 
             state
             |> IlMachineState.advanceProgramCounter currentThread
@@ -399,24 +316,7 @@ module internal UnaryConstIlOp =
         | Bge i ->
             let value2, state = IlMachineState.popEvalStack currentThread state
             let value1, state = IlMachineState.popEvalStack currentThread state
-
-            let isGreaterEq =
-                match value1, value2 with
-                | EvalStackValue.Int32 v1, EvalStackValue.Int32 v2 -> v1 >= v2
-                | EvalStackValue.Int32 i, EvalStackValue.NativeInt nativeIntSource -> failwith "todo"
-                | EvalStackValue.Int32 i, _ -> failwith $"invalid comparison, {i} with {value2}"
-                | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 -> Int64Source.compareSigned v1 v2 >= 0
-                | EvalStackValue.Int64 i, _ -> failwith $"invalid comparison, {i} with {value2}"
-                | EvalStackValue.NativeInt nativeIntSource, _ -> failwith "todo"
-                | EvalStackValue.Float v1, EvalStackValue.Float v2 -> failwith "todo"
-                | EvalStackValue.Float f, _ -> failwith $"invalid comparison, {f} with {value2}"
-                | EvalStackValue.ManagedPointer v1, EvalStackValue.ManagedPointer v2 -> failwith "todo"
-                | EvalStackValue.ManagedPointer v1, _ -> failwith $"invalid comparison, {v1} with {value2}"
-                | EvalStackValue.NullObjectRef, _
-                | _, EvalStackValue.NullObjectRef
-                | EvalStackValue.ObjectRef _, _ -> failwith "todo"
-                | EvalStackValue.UserDefinedValueType _, _ ->
-                    failwith "unexpectedly tried to compare user-defined value type"
+            let isGreaterEq = EvalStackValueComparisons.cge value1 value2
 
             state
             |> IlMachineState.advanceProgramCounter currentThread


### PR DESCRIPTION
## Summary

- Adds `cle`/`cge` helpers to `EvalStackValueComparisons` mirroring the existing `clt`/`cgt` pair. Float × Float uses IEEE `<=` / `>=` directly so NaN ⇒ false (ECMA-335 III.3.7 ordered semantics for `ble`/`bge`); other type pairs defer to `not cgt` / `not clt`, inheriting their cross-type guards.
- Refactors `Blt_s`, `Ble_s`, `Bgt_s`, `Bge_s`, `Ble`, `Bge` in `UnaryConstIlOp.fs` to delegate to those helpers, removing six `failwith "todo"` arms and ~108 lines of duplicated cross-type matching. The previous Float × Float arms were missing entirely, so any program that branched on float comparisons hit a TODO.
- Adds tests covering Float × Float over NaN, ±0, ±Inf and subnormals at both helper and IL-op levels, plus tests asserting the inherited cross-type guards (`"invalid comparison"`).

The Float × Float arm is load-bearing: `not cgt(NaN, _) = true` would give *unordered* `ble` behaviour, so the helper must override the fallback and use IEEE directly to satisfy the ordered contract.

## Test plan

- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — full suite passes (1011 tests, 0 failures), including the new Float × Float branch tests and the existing `Floats.cs` end-to-end test.
- [x] `nix develop -c dotnet fantomas .` clean.
- [x] `codex review --base main` — no findings; verdict: *"The changes centralize signed branch comparisons and add ordered float handling for ble/bge without introducing observable regressions."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)