### PR TITLE
Implement multi-dim array Address intrinsic

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/MultiDimensionalArrayAddress.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/MultiDimensionalArrayAddress.cs
@@ -1,0 +1,52 @@
+using System;
+
+public class TestMultiDimensionalArrayAddress
+{
+    private static void IncrementByRef(ref int x) => x++;
+
+    private static int ReadByRef(ref int x) => x;
+
+    public static int TestAddress()
+    {
+        int[,] arr = new int[2, 3];
+
+        // Initialise via Set so the layout is well-defined before we take addresses.
+        for (int i = 0; i < 2; i++)
+            for (int j = 0; j < 3; j++)
+                arr[i, j] = i * 10 + j;
+
+        // `ref arr[1, 2]` forces the C# compiler to emit `call instance int32&
+        // int32[0...,0...]::Address(int32, int32)`. Mutating via the byref must be
+        // visible through subsequent Get on the same indices.
+        IncrementByRef(ref arr[1, 2]);
+        if (arr[1, 2] != 13) return 1;
+
+        // Address must round-trip every (i, j) — wrong row-major flattening would
+        // surface here as a value mismatch on an interior cell.
+        for (int i = 0; i < 2; i++)
+        {
+            for (int j = 0; j < 3; j++)
+            {
+                int viaByref = ReadByRef(ref arr[i, j]);
+                int expected = i * 10 + j + (i == 1 && j == 2 ? 1 : 0);
+                if (viaByref != expected) return 100 + i * 10 + j;
+            }
+        }
+
+        // Write through Address, read through Get to confirm the byref aliases
+        // the canonical backing store rather than producing a stale copy.
+        ref int slot = ref arr[0, 1];
+        slot = 999;
+        if (arr[0, 1] != 999) return 2;
+
+        return 0;
+    }
+
+    public static int Main(string[] argv)
+    {
+        int result = TestAddress();
+        if (result != 0) return 8500 + result;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/UnaryMetadataCallOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataCallOps.fs
@@ -235,11 +235,154 @@ module internal UnaryMetadataCallOps =
 
         state, WhatWeDid.Executed
 
+    /// Implements `call instance T& T[<rank>]::Address(int32, ..., int32)` — the
+    /// runtime-synthesized element-address operation for a multi-dimensional array of
+    /// element type `elementType`. Pops `rank` Int32 indices (top-of-stack is the
+    /// rightmost) and the array reference, then pushes a managed byref to the slot at
+    /// the row-major flat offset.
+    ///
+    /// ECMA-335 III.4.10: without the `readonly.` prefix, the metadata-derived element
+    /// type must exactly equal the array's stored element type (no assignment-compat
+    /// fallback); otherwise `ArrayTypeMismatchException`. With `readonly.`, the result
+    /// is a controlled-mutability byref and the check is suppressed — matching the
+    /// szarray `ldelema` precedent in `UnaryMetadataArrayOps.executeLdelema`.
+    let private executeMultiDimArrayAddress
+        (ctx : UnaryMetadataIlOpContext)
+        (state : IlMachineState)
+        (elementType : TypeDefn)
+        (rank : int)
+        (signature : MemberSignature)
+        : IlMachineState * WhatWeDid
+        =
+        let loggerFactory = ctx.LoggerFactory
+        let baseClassTypes = ctx.BaseClassTypes
+        let activeAssy = ctx.ActiveAssembly
+        let currentMethod = ctx.CurrentMethod
+        let thread = ctx.Thread
+
+        if rank < 2 then
+            failwith
+                $"TODO: multi-dim array Address on rank-%d{rank} ELEMENT_TYPE_ARRAY; rank-1 should morph to SZARRAY per CoreCLR semantics"
+
+        let methodSig =
+            match signature with
+            | MemberSignature.Method m -> m
+            | MemberSignature.Field _ ->
+                failwith
+                    $"BUG: multi-dim array Address for rank %d{rank} had a field signature; expected method signature"
+
+        if methodSig.ParameterTypes.Length <> rank then
+            failwith
+                $"TODO: multi-dim array Address for rank %d{rank} had %d{methodSig.ParameterTypes.Length} parameters; only the zero-lower-bound form (%d{rank} Int32 indices) is implemented"
+
+        // ECMA-335 III.2.2: capture-and-clear the `readonly.` prefix. The prefix's scope
+        // is exactly this instruction, so we always clear it; we capture into `wasReadonly`
+        // so the element-type check below can branch on it.
+        let activeFrameId = state.ThreadState.[thread].ActiveMethodState
+        let wasReadonly = state.ThreadState.[thread].MethodState.PendingPrefix.Readonly
+
+        let state =
+            if wasReadonly then
+                state
+                |> IlMachineState.mapFrame
+                    thread
+                    activeFrameId
+                    (fun frame ->
+                        { frame with
+                            PendingPrefix =
+                                { frame.PendingPrefix with
+                                    Readonly = false
+                                }
+                        }
+                    )
+            else
+                state
+
+        let indices, arrAddrOpt, state =
+            popMultiDimIndicesAndArray baseClassTypes thread rank state
+
+        match arrAddrOpt with
+        | None ->
+            // Don't advance PC: exception dispatch needs the faulting instruction's offset.
+            IlMachineStateExecution.raiseRuntimeException
+                loggerFactory
+                baseClassTypes
+                baseClassTypes.NullReferenceException
+                thread
+                state
+        | Some arrAddr ->
+
+        let arrObj =
+            match state.ManagedHeap.Arrays.TryGetValue arrAddr with
+            | true, v -> v
+            | false, _ -> failwith $"multi-dim array Address: array allocation not found at %O{arrAddr}"
+
+        if arrObj.Lengths.Length <> rank then
+            failwith
+                $"multi-dim array Address: rank %d{rank} from metadata does not match the allocated array's rank %d{arrObj.Lengths.Length} at %O{arrAddr}"
+
+        if indicesOutOfRange arrObj.Lengths indices then
+            IlMachineStateExecution.raiseRuntimeException
+                loggerFactory
+                baseClassTypes
+                baseClassTypes.IndexOutOfRangeException
+                thread
+                state
+        else
+
+        let flat = rowMajorOffset arrObj.Lengths indices
+
+        let buildResult (state : IlMachineState) : IlMachineState * WhatWeDid =
+            let result =
+                ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arrAddr, flat), [])
+                |> EvalStackValue.ManagedPointer
+
+            let state =
+                IlMachineState.pushToEvalStack' result thread state
+                |> IlMachineState.advanceProgramCounter thread
+
+            state, WhatWeDid.Executed
+
+        if wasReadonly then
+            // The readonly. prefix produces a controlled-mutability byref and suppresses
+            // the array-element-type check.
+            buildResult state
+        else
+
+        let typeGenerics = currentMethod.DeclaringType.Generics
+        let methodGenerics = currentMethod.Generics
+
+        let state, _zeroOfType, tokenElementHandle =
+            IlMachineState.cliTypeZeroOf
+                loggerFactory
+                baseClassTypes
+                activeAssy
+                elementType
+                typeGenerics
+                methodGenerics
+                state
+
+        let arrayElementHandle =
+            match arrObj.ConcreteType with
+            | ConcreteTypeHandle.Array (h, _) -> h
+            | other ->
+                failwith $"BUG: multi-dim array Address: array at %O{arrAddr} has non-Array ConcreteType %O{other}"
+
+        if tokenElementHandle <> arrayElementHandle then
+            IlMachineStateExecution.raiseRuntimeException
+                loggerFactory
+                baseClassTypes
+                baseClassTypes.ArrayTypeMismatchException
+                thread
+                state
+        else
+            buildResult state
+
     /// Detect `call` targeting a runtime-synthesized member on a multi-dim array
     /// (ECMA-335 II.14.2): a MemberReference whose parent TypeSpec is `TypeDefn.Array`.
     /// `newobj` for the synthesized ctor is handled in `executeNewobj`; this entry
-    /// point covers the `Set`/`Get` members invoked via plain `call`. Returns `None`
-    /// for ordinary method calls so they take the normal resolution path.
+    /// point covers the `Set`/`Get`/`Address` members invoked via plain `call`. Returns
+    /// `None` for ordinary method calls so they take the normal resolution path.
     let private tryGetMultiDimArrayCall
         (activeAssy : DumpedAssembly)
         (metadataToken : MetadataToken)
@@ -281,9 +424,7 @@ module internal UnaryMetadataCallOps =
             match name with
             | "Set" -> executeMultiDimArraySet ctx state elt rank sig0
             | "Get" -> executeMultiDimArrayGet ctx state rank sig0
-            | "Address" ->
-                failwith
-                    $"TODO: multi-dim array Address(int32, ..., int32) intrinsic not yet implemented (rank %d{rank})"
+            | "Address" -> executeMultiDimArrayAddress ctx state elt rank sig0
             | other ->
                 failwith
                     $"unexpected synthesized member %s{other} on multi-dim array (rank %d{rank}); expected Get/Set/Address/.ctor"


### PR DESCRIPTION
## Summary

`ref arr[i, j]` for `T[,]` lowers to a call to the runtime-synthesised `T& T[,]::Address(int32, int32)` (ECMA-335 II.14.2); follow-up to #556 which only wired up `Get`/`Set`. The Address dispatch in `UnaryMetadataCallOps.executeCall` previously dispatched to a `failwith` TODO; this change adds an inline implementation mirroring the szarray `ldelema` precedent in `UnaryMetadataArrayOps.executeLdelema`.

- Null receiver raises managed `NullReferenceException` via `raiseRuntimeException` (PC not advanced so exception dispatch sees the faulting offset).
- Out-of-range indices raise `IndexOutOfRangeException` via the same per-dimension bounds check used by Get/Set (a flat-offset check alone is insufficient).
- `readonly.` prefix (ECMA-335 III.2.2) is captured-and-cleared identically to the ldelema handler; on the prefixed path the result is a controlled-mutability byref and the element-type check is suppressed.
- Without `readonly.`, exact-handle match between the metadata-derived element type (`TypeDefn.Array (elt, rank)` of the parent TypeSpec, concretised via `cliTypeZeroOf`) and the array's stored element handle (`ConcreteTypeHandle.Array (h, _)`) is required; mismatch raises `ArrayTypeMismatchException`. This matches CoreCLR's `INTOP_LDELEMA_REF` semantics — exact equality, not assignment-compatibility — and is also why C# emits `readonly.` for `in` parameter and `ref readonly` contexts.
- Successful Address pushes `ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arrAddr, flat), [])`, identical in representation to the szarray byref produced by `ldelema`, so downstream byref operations need no special-casing.

## Test plan

- [x] New sourcesPure test `MultiDimensionalArrayAddress.cs` exercises the unprefixed path via `ref arr[i, j]` argument passing and `ref int x = ref arr[i, j]; x = ...` aliasing; asserts writes through the byref are visible via subsequent Get and that the row-major flat offset is correct on every interior cell
- [x] `nix develop -c dotnet test ... --filter "Name~MultiDimensionalArrayAddress"` passes
- [x] Full suite green (1049/1049)
- [x] `nix develop -c dotnet fantomas .`
- [x] `codex review --base main` reports no actionable issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)