### PR TITLE
Wrap ctor and cctor exceptions from Activator.CreateInstance<T>() in TargetInvocationException

### DIFF
--- a/WoofWare.PawPrint.Domain/TypeInfo.fs
+++ b/WoofWare.PawPrint.Domain/TypeInfo.fs
@@ -230,6 +230,10 @@ type BaseClassTypes<'corelib> =
         OutOfMemoryException : TypeInfo<GenericParamFromMetadata, TypeDefn>
         ArgumentException : TypeInfo<GenericParamFromMetadata, TypeDefn>
         ArgumentNullException : TypeInfo<GenericParamFromMetadata, TypeDefn>
+        /// `System.Reflection.TargetInvocationException`. Used to wrap the inner exception
+        /// when a reflection-style invocation (e.g. `Activator.CreateInstance<T>()`) propagates
+        /// an exception thrown by user code through the runtime's invocation seam.
+        TargetInvocationException : TypeInfo<GenericParamFromMetadata, TypeDefn>
         /// `System.DateTime`. Host-known because CoreCLR's `MarshalInfo` short-circuits a
         /// DateTime field to `MARSHAL_TYPE_DATE` (8 bytes) before the AutoLayout rejection
         /// triggers; reproducing that requires identifying DateTime nominally at marshal time.

--- a/WoofWare.PawPrint.Test/TestExceptionHResults.fs
+++ b/WoofWare.PawPrint.Test/TestExceptionHResults.fs
@@ -13,10 +13,14 @@ module TestExceptionHResults =
     let private getActualHResult (typeName : string) : int =
         let ty = Type.GetType (typeName, throwOnError = true)
 
-        // TypeInitializationException has no default constructor; it requires (string, Exception).
+        // A few exception types lack a public parameterless ctor.
         let exn =
             if typeName = "System.TypeInitializationException" then
+                // ctor signature: TypeInitializationException(string, Exception)
                 Activator.CreateInstance (ty, [| box "Foo" ; box (null : Exception) |]) :?> Exception
+            elif typeName = "System.Reflection.TargetInvocationException" then
+                // ctor signature: TargetInvocationException(Exception)
+                Activator.CreateInstance (ty, [| box (null : Exception) |]) :?> Exception
             else
                 Activator.CreateInstance ty :?> Exception
 

--- a/WoofWare.PawPrint.Test/TestFaultHandlers.fs
+++ b/WoofWare.PawPrint.Test/TestFaultHandlers.fs
@@ -138,6 +138,7 @@ module TestFaultHandlers =
                 WasConstructingObj = None
                 CallSiteIlOpIndex = threadState.MethodState.IlOpIndex
                 DispatchAsExceptionOnReturn = false
+                WrapExceptionInTargetInvocation = false
             }
 
         let calleeFrame =

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -30,7 +30,6 @@ module TestPureCases =
             "Threads.cs" // blocked by pointer arithmetic over a generated Data field after Interlocked.CompareExchange
             "IsAssignableToBasic.cs" // MethodTable field projection for MethodTable::PerInstInfo
             "RuntimeTypeHandleGetInstantiationOpenGeneric.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringMethodForGenericParameter
-            "ActivatorCreateInstanceThrowingCtor.cs" // Expected: 0; was: 3
             "IndirectMemoryOperations.cs" // raise IndexOutOfRangeException: array index 8 >= length 3 on array
         ]
         |> Set.ofList

--- a/WoofWare.PawPrint.Test/sourcesPure/ActivatorCreateInstanceCachedCctorFailure.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/ActivatorCreateInstanceCachedCctorFailure.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Reflection;
+
+public class Program
+{
+    class BoomCctor
+    {
+        static BoomCctor()
+        {
+            throw new InvalidOperationException("cctor boom");
+        }
+
+        public BoomCctor() { }
+    }
+
+    public static int Main(string[] args)
+    {
+        // First touch: triggers the failing cctor. We swallow the wrap so the runtime
+        // caches the TypeInitializationException for subsequent accesses.
+        try
+        {
+            var _ = Activator.CreateInstance<BoomCctor>();
+            return 1;
+        }
+        catch (TargetInvocationException)
+        {
+            // Expected.
+        }
+        catch (Exception)
+        {
+            return 2;
+        }
+
+        // Second touch: the cctor is NOT re-run. CoreCLR still rewraps the cached
+        // TypeInitializationException in a fresh TargetInvocationException because the
+        // wrap fires inside CreateInstanceOfT independently of the cache state.
+        try
+        {
+            var _ = Activator.CreateInstance<BoomCctor>();
+            return 3;
+        }
+        catch (TargetInvocationException tie)
+        {
+            if (tie.InnerException is TypeInitializationException typeInit)
+            {
+                if (typeInit.InnerException is InvalidOperationException)
+                {
+                    return 0;
+                }
+                return 4;
+            }
+            return 5;
+        }
+        catch (TypeInitializationException)
+        {
+            return 6;
+        }
+        catch (Exception)
+        {
+            return 7;
+        }
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/ActivatorCreateInstanceCtorCatchesOwnException.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/ActivatorCreateInstanceCtorCatchesOwnException.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Reflection;
+
+public class Program
+{
+    class CtorWithLocalCatch
+    {
+        public int Tag;
+
+        public CtorWithLocalCatch()
+        {
+            try
+            {
+                throw new InvalidOperationException("local");
+            }
+            catch (InvalidOperationException)
+            {
+                Tag = 17;
+            }
+        }
+    }
+
+    public static int Main(string[] args)
+    {
+        try
+        {
+            var x = Activator.CreateInstance<CtorWithLocalCatch>();
+            // A try/catch *inside* the ctor that handles the exception should not trigger
+            // CreateInstanceOfT's TargetInvocationException wrap — control returns normally
+            // and the object should be observable.
+            return x.Tag == 17 ? 0 : 1;
+        }
+        catch (TargetInvocationException)
+        {
+            return 2;
+        }
+        catch (InvalidOperationException)
+        {
+            return 3;
+        }
+        catch (Exception)
+        {
+            return 4;
+        }
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/ActivatorCreateInstanceThrowingCctor.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/ActivatorCreateInstanceThrowingCctor.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Reflection;
+
+public class Program
+{
+    class BoomCctor
+    {
+        static BoomCctor()
+        {
+            throw new InvalidOperationException("cctor boom");
+        }
+
+        public BoomCctor() { }
+    }
+
+    public static int Main(string[] args)
+    {
+        // CoreCLR wraps any exception escaping the T..ctor or T..cctor path inside
+        // RuntimeType.CreateInstanceOfT in a TargetInvocationException. The cctor case
+        // produces TargetInvocationException whose InnerException is the
+        // TypeInitializationException (which itself wraps the original InvalidOperationException).
+        try
+        {
+            var x = Activator.CreateInstance<BoomCctor>();
+            return 1;
+        }
+        catch (TargetInvocationException tie)
+        {
+            if (tie.InnerException is TypeInitializationException typeInit)
+            {
+                if (typeInit.InnerException is InvalidOperationException)
+                {
+                    return 0;
+                }
+                return 2;
+            }
+            return 3;
+        }
+        catch (TypeInitializationException)
+        {
+            // If we see a raw TypeInitializationException here, the wrap didn't happen.
+            return 4;
+        }
+        catch (Exception)
+        {
+            return 5;
+        }
+    }
+}

--- a/WoofWare.PawPrint/AbstractMachine.fs
+++ b/WoofWare.PawPrint/AbstractMachine.fs
@@ -166,6 +166,7 @@ module AbstractMachine =
                     currentThreadState
                     originalCallSitePC
                     false
+                    false // wrapExceptionInTargetInvocation
                     state
 
             ExecutionResult.stepped (state, WhatWeDid.Executed)

--- a/WoofWare.PawPrint/Corelib.fs
+++ b/WoofWare.PawPrint/Corelib.fs
@@ -115,6 +115,9 @@ module Corelib =
         let argumentNullException = findCorelibType corelib "System" "ArgumentNullException"
         let dateTime = findCorelibType corelib "System" "DateTime"
 
+        let targetInvocationException =
+            findCorelibType corelib "System.Reflection" "TargetInvocationException"
+
         {
             Corelib = corelib
             String = stringType
@@ -166,6 +169,7 @@ module Corelib =
             ArgumentException = argumentException
             ArgumentNullException = argumentNullException
             DateTime = dateTime
+            TargetInvocationException = targetInvocationException
         }
 
     let concretizeAll

--- a/WoofWare.PawPrint/ExceptionDispatching.fs
+++ b/WoofWare.PawPrint/ExceptionDispatching.fs
@@ -553,6 +553,42 @@ module ExceptionDispatching =
 
                 state, wrappedCliException, tieType
 
+        // If this frame was the ctor target of `Activator.CreateInstance<T>()` (or any other
+        // CreateInstanceOfT-style invocation that opts in via `WrapExceptionInTargetInvocation`),
+        // wrap the in-flight exception in a fresh `TargetInvocationException` whose
+        // `_innerException` field points at the original. This mirrors CoreCLR's
+        // `try { ctor } catch (Exception e) { throw new TargetInvocationException(e); }` wrap
+        // around `cache.CallRefConstructor` in `RuntimeType.CreateInstanceOfT` without
+        // synthesising an extra trampoline frame: the wrap only fires on unwind across this
+        // frame's boundary, so a try/catch *inside* the ctor that handles the exception is
+        // unaffected.
+        let state, cliException, exceptionType =
+            if not returnState.WrapExceptionInTargetInvocation then
+                state, cliException, exceptionType
+            else
+                let state =
+                    IlMachineState.setExceptionStackTraceString
+                        loggerFactory
+                        corelib
+                        cliException.ExceptionObject
+                        cliException.StackTrace
+                        state
+
+                let tieAddr, tieType, state =
+                    IlMachineState.synthesizeTargetInvocationException
+                        loggerFactory
+                        corelib
+                        cliException.ExceptionObject
+                        state
+
+                let wrappedCliException =
+                    {
+                        ExceptionObject = tieAddr
+                        StackTrace = []
+                    }
+
+                state, wrappedCliException, tieType
+
         // Pop to caller frame
         let callerFrame = ThreadState.getFrame returnState.JumpTo threadState
 

--- a/WoofWare.PawPrint/Exceptions.fs
+++ b/WoofWare.PawPrint/Exceptions.fs
@@ -79,6 +79,7 @@ module internal ExceptionHResults =
             "System.MissingMethodException", int 0x80131513u // COR_E_MISSINGMETHOD
             "System.ArgumentException", int 0x80070057u // COR_E_ARGUMENT
             "System.ArgumentNullException", 0x80004003 // E_POINTER (ArgumentNullException maps to E_POINTER in the CLR)
+            "System.Reflection.TargetInvocationException", int 0x80131604u // COR_E_TARGETINVOCATION
         ]
 
     /// The fallback HResult for exception types not in the table.

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -898,10 +898,10 @@ module IlMachineRuntimeMetadata =
 
     /// Synthesize a TargetInvocationException wrapping the given inner exception object.
     /// Allocates the exception on the heap with zero-initialized fields (constructor is NOT run).
-    /// Sets the _innerException and _HResult fields on the base Exception so that
-    /// `catch (TargetInvocationException ex) { ... ex.InnerException ... }` sees the original
-    /// exception, matching what `new TargetInvocationException(inner)` would have done in CoreCLR.
-    /// Returns the heap address, the ConcreteTypeHandle, and the updated state.
+    /// Sets the _innerException, _message and _HResult fields on the base Exception to match what
+    /// `new TargetInvocationException(inner)` would have done in CoreCLR (whose base ctor sets
+    /// `_message` to the SR.Arg_TargetInvocationException string). Returns the heap address, the
+    /// ConcreteTypeHandle, and the updated state.
     /// See https://github.com/dotnet/runtime/blob/HEAD/src/libraries/System.Private.CoreLib/src/System/Reflection/TargetInvocationException.cs
     let synthesizeTargetInvocationException
         (loggerFactory : ILoggerFactory)
@@ -939,6 +939,19 @@ module IlMachineRuntimeMetadata =
 
         let addr, state = IlMachineThreadState.allocateManagedObject tieHandle fields state
 
+        // CoreCLR's TargetInvocationException(Exception) ctor calls
+        //     base(SR.Arg_TargetInvocationException, inner)
+        // which sets `_message` to the canonical string below. Bypassing the ctor would leave
+        // `_message` null and divert `Message` / `ToString()` to the
+        // "Exception of type '...' was thrown." fallback in Exception.Message, so allocate and
+        // store the message explicitly.
+        let messageAddr, state =
+            allocateManagedString
+                loggerFactory
+                baseClassTypes
+                "Exception has been thrown by the target of an invocation."
+                state
+
         let heapObj = ManagedHeap.get addr state.ManagedHeap
 
         let exceptionHandle =
@@ -948,6 +961,10 @@ module IlMachineRuntimeMetadata =
             FieldIdentity.requiredOwnInstanceField baseClassTypes.Exception "_innerException"
             |> FieldIdentity.fieldId exceptionHandle
 
+        let messageField =
+            FieldIdentity.requiredOwnInstanceField baseClassTypes.Exception "_message"
+            |> FieldIdentity.fieldId exceptionHandle
+
         let hresultField =
             FieldIdentity.requiredOwnInstanceField baseClassTypes.Exception "_HResult"
             |> FieldIdentity.fieldId exceptionHandle
@@ -955,6 +972,7 @@ module IlMachineRuntimeMetadata =
         let heapObj =
             heapObj
             |> AllocatedNonArrayObject.SetFieldById innerExceptionField (CliType.ObjectRef (Some innerExceptionAddr))
+            |> AllocatedNonArrayObject.SetFieldById messageField (CliType.ObjectRef (Some messageAddr))
             |> AllocatedNonArrayObject.SetFieldById
                 hresultField
                 (CliType.Numeric (

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -896,6 +896,78 @@ module IlMachineRuntimeMetadata =
 
         addr, tieHandle, state
 
+    /// Synthesize a TargetInvocationException wrapping the given inner exception object.
+    /// Allocates the exception on the heap with zero-initialized fields (constructor is NOT run).
+    /// Sets the _innerException and _HResult fields on the base Exception so that
+    /// `catch (TargetInvocationException ex) { ... ex.InnerException ... }` sees the original
+    /// exception, matching what `new TargetInvocationException(inner)` would have done in CoreCLR.
+    /// Returns the heap address, the ConcreteTypeHandle, and the updated state.
+    /// See https://github.com/dotnet/runtime/blob/HEAD/src/libraries/System.Private.CoreLib/src/System/Reflection/TargetInvocationException.cs
+    let synthesizeTargetInvocationException
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (innerExceptionAddr : ManagedHeapAddress)
+        (state : IlMachineState)
+        : ManagedHeapAddress * ConcreteTypeHandle * IlMachineState
+        =
+        let tieTypeInfo = baseClassTypes.TargetInvocationException
+
+        let stk =
+            DumpedAssembly.signatureTypeKind baseClassTypes state._LoadedAssemblies tieTypeInfo
+
+        let state, tieHandle =
+            IlMachineTypeResolution.concretizeType
+                loggerFactory
+                baseClassTypes
+                state
+                tieTypeInfo.Assembly
+                ImmutableArray.Empty
+                ImmutableArray.Empty
+                (TypeDefn.FromDefinition (tieTypeInfo.Identity, stk))
+
+        let state, allFields =
+            collectAllInstanceFields loggerFactory baseClassTypes state tieHandle
+
+        let fields =
+            CliValueType.OfFields
+                baseClassTypes
+                state.ConcreteTypes
+                tieHandle
+                tieTypeInfo.Layout
+                (CharSetMetadata.ofTypeAttributes tieTypeInfo.TypeAttributes)
+                allFields
+
+        let addr, state = IlMachineThreadState.allocateManagedObject tieHandle fields state
+
+        let heapObj = ManagedHeap.get addr state.ManagedHeap
+
+        let exceptionHandle =
+            AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes baseClassTypes.Exception
+
+        let innerExceptionField =
+            FieldIdentity.requiredOwnInstanceField baseClassTypes.Exception "_innerException"
+            |> FieldIdentity.fieldId exceptionHandle
+
+        let hresultField =
+            FieldIdentity.requiredOwnInstanceField baseClassTypes.Exception "_HResult"
+            |> FieldIdentity.fieldId exceptionHandle
+
+        let heapObj =
+            heapObj
+            |> AllocatedNonArrayObject.SetFieldById innerExceptionField (CliType.ObjectRef (Some innerExceptionAddr))
+            |> AllocatedNonArrayObject.SetFieldById
+                hresultField
+                (CliType.Numeric (
+                    CliNumericType.Int32 (ExceptionHResults.lookup "System.Reflection.TargetInvocationException")
+                ))
+
+        let state =
+            { state with
+                ManagedHeap = ManagedHeap.set addr heapObj state.ManagedHeap
+            }
+
+        addr, tieHandle, state
+
     /// Resolve a MetadataToken (TypeDefinition, TypeReference, or TypeSpecification) to a TypeDefn,
     /// together with the assembly the type was resolved in.
     let resolveTypeMetadataToken

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -191,6 +191,9 @@ module IlMachineState =
     let synthesizeTypeInitializationException =
         IlMachineRuntimeMetadata.synthesizeTypeInitializationException
 
+    let synthesizeTargetInvocationException =
+        IlMachineRuntimeMetadata.synthesizeTargetInvocationException
+
     let resolveTypeMetadataToken = IlMachineRuntimeMetadata.resolveTypeMetadataToken
 
     let tryGetConcreteTypeInfo = IlMachineRuntimeMetadata.tryGetConcreteTypeInfo

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -63,6 +63,9 @@ module IlMachineState =
     let withReplacedConstructedObject =
         IlMachineThreadState.withReplacedConstructedObject
 
+    let markActiveFrameWrapInTargetInvocation =
+        IlMachineThreadState.markActiveFrameWrapInTargetInvocation
+
     let pushToEvalStack' = IlMachineThreadState.pushToEvalStack'
 
     let pushToEvalStack = IlMachineThreadState.pushToEvalStack

--- a/WoofWare.PawPrint/IlMachineStateExecution.fs
+++ b/WoofWare.PawPrint/IlMachineStateExecution.fs
@@ -717,6 +717,7 @@ module IlMachineStateExecution =
         (threadState : ThreadState)
         (callSiteIlOpIndexOverride : int option)
         (dispatchAsExceptionOnReturn : bool)
+        (wrapExceptionInTargetInvocation : bool)
         (state : IlMachineState)
         : IlMachineState
         =
@@ -769,13 +770,15 @@ module IlMachineStateExecution =
         // allocate the object and run its parameterless ctor by recursing through `callMethod`.
         // See https://github.com/dotnet/runtime/blob/HEAD/src/coreclr/System.Private.CoreLib/src/System/Activator.RuntimeType.cs#L138
         //
-        // Known unimplemented behaviour:
+        // Exception wrapping:
         //  - CoreCLR's `CreateInstanceOfT` wraps any exception thrown by the recursed ctor in a
-        //    `TargetInvocationException`. We don't intercept the exception today; user code that
-        //    catches `TargetInvocationException` around `Activator.CreateInstance<T>()` will see the
-        //    raw guest exception instead. Tracked by `ActivatorCreateInstanceThrowingCtor.cs` in the
-        //    `unimplemented` set. Fix needs a marker on the ctor frame so the exception dispatcher
-        //    rethrows wrapped, plus a host-side `TargetInvocationException` constructor.
+        //    `TargetInvocationException`. We can't observe that in a separate Activator frame
+        //    because we inline the intrinsic, so the recursive `callMethod` for the ctor sets
+        //    `WrapExceptionInTargetInvocation = true` on the ctor frame's `ReturnState`. When
+        //    `ExceptionDispatching.unwindToCallerAndSearch` pops the ctor frame, it synthesises
+        //    a fresh `TargetInvocationException` with the original exception as `_innerException`
+        //    and continues the search with the wrapped exception. A try/catch *inside* the ctor
+        //    that handles the exception is unaffected, matching CoreCLR.
         //
         // Intentional divergence (see docs/divergences.md):
         //  - For `BeforeFieldInit` reference types, CoreCLR defers the type initializer past the
@@ -952,6 +955,7 @@ module IlMachineStateExecution =
                         threadState
                         None
                         false
+                        true // wrapExceptionInTargetInvocation: mirror CreateInstanceOfT
                         state
                     |> Some
                 | WhatWeDid.SuspendedForClassInit ->
@@ -1146,6 +1150,7 @@ module IlMachineStateExecution =
                         WasConstructingObj = wasConstructing
                         CallSiteIlOpIndex = callSiteIlOpIndexOverride |> Option.defaultValue afterPop.IlOpIndex
                         DispatchAsExceptionOnReturn = dispatchAsExceptionOnReturn
+                        WrapExceptionInTargetInvocation = wrapExceptionInTargetInvocation
                     }
 
             match
@@ -1349,6 +1354,7 @@ module IlMachineStateExecution =
                     currentThreadState
                     None
                     false
+                    false // wrapExceptionInTargetInvocation
                     state
                 |> FirstLoadThis
             | None ->
@@ -1483,5 +1489,6 @@ module IlMachineStateExecution =
             threadState
             None
             true // dispatchAsExceptionOnReturn
+            false // wrapExceptionInTargetInvocation
             state,
         WhatWeDid.Executed

--- a/WoofWare.PawPrint/IlMachineStateExecution.fs
+++ b/WoofWare.PawPrint/IlMachineStateExecution.fs
@@ -906,6 +906,49 @@ module IlMachineStateExecution =
                             $"Activator.CreateInstance<T>(): concrete type handle %O{tHandle} not found in AllConcreteTypes"
                     )
 
+                // CoreCLR's `CreateInstanceOfT` catches *every* exception escaping the
+                // cache.CallRefConstructor path — including a `TypeInitializationException`
+                // raised by T's `.cctor` — and rethrows it wrapped in `TargetInvocationException`.
+                // We mirror that on three sub-paths:
+                //
+                //   (a) T's cctor was previously cached as Failed. We synthesise a fresh
+                //       `TargetInvocationException` whose `_innerException` is the cached TIE
+                //       and dispatch it ourselves. Per CoreCLR the cctor is NOT re-run, but a
+                //       fresh wrap is produced each time (verified against .NET 10).
+                //   (b) T's cctor is about to run for the first time. We let `ensureTypeInitialised`
+                //       push the cctor frame, then flip its `WrapExceptionInTargetInvocation`
+                //       flag so that if the cctor unwinds with a TIE (after the existing
+                //       `WasInitialisingType` wrap), the dispatcher additionally wraps it in
+                //       `TargetInvocationException` on the way out of the cctor frame.
+                //   (c) T's cctor has already run successfully; we just call the instance ctor
+                //       with the wrap flag set on the ctor's frame.
+                match TypeInitTable.tryGet tHandle state.TypeInitTable with
+                | Some (TypeInitState.Failed (cachedTieAddr, _cachedTieType)) ->
+                    let state =
+                        IlMachineState.setExceptionStackTraceString loggerFactory baseClassTypes cachedTieAddr [] state
+
+                    let tieAddr, tieType, state =
+                        IlMachineState.synthesizeTargetInvocationException
+                            loggerFactory
+                            baseClassTypes
+                            cachedTieAddr
+                            state
+
+                    match
+                        ExceptionDispatching.throwExceptionObject
+                            loggerFactory
+                            baseClassTypes
+                            state
+                            thread
+                            tieAddr
+                            tieType
+                    with
+                    | ExceptionDispatchResult.HandlerFound state -> Some state
+                    | ExceptionDispatchResult.ExceptionUnhandled _ ->
+                        failwith
+                            "Unhandled TargetInvocationException wrapping a cached TypeInitializationException during Activator.CreateInstance<T>(); should have been caught by a handler"
+                | _ ->
+
                 let state, init =
                     ensureTypeInitialised loggerFactory baseClassTypes thread tHandle state
 
@@ -968,6 +1011,12 @@ module IlMachineStateExecution =
                     //
                     // Caller-PC advancement happens later in `callMethod` (line ~961); by short-
                     // circuiting here we never reach it, so the caller's PC stays put. Good.
+                    //
+                    // The cctor frame is now the active frame on this thread. Mark it so that if
+                    // the cctor throws, the resulting TIE is rewrapped in TargetInvocationException
+                    // when the cctor frame unwinds — see comment block (a)/(b)/(c) above.
+                    let state = IlMachineState.markActiveFrameWrapInTargetInvocation thread state
+
                     Some state
                 | WhatWeDid.BlockedOnClassInit _ ->
                     failwith
@@ -976,9 +1025,10 @@ module IlMachineStateExecution =
                     failwith
                         "logic error: ensureTypeInitialised inside Activator.CreateInstance<T>() cannot suspend for an arbitrary managed call"
                 | WhatWeDid.ThrowingTypeInitializationException ->
-                    // Exception dispatch is in flight; the in-flight exception handler will take
-                    // over from the caller, not us.
-                    Some state
+                    // Unreachable: the only way `ensureTypeInitialised` returns this is via the
+                    // `TypeInitState.Failed` cached-cctor path, which we pre-handle above.
+                    failwith
+                        "logic error: ensureTypeInitialised should not reach the cached-failure path inside Activator.CreateInstance<T>() (handled separately above)"
             else
                 None
 

--- a/WoofWare.PawPrint/IlMachineThreadState.fs
+++ b/WoofWare.PawPrint/IlMachineThreadState.fs
@@ -77,6 +77,37 @@ module IlMachineThreadState =
             ThreadState = state.ThreadState |> Map.add thread threadState
         }
 
+    /// Set `WrapExceptionInTargetInvocation = true` on the active frame's `ReturnState`.
+    /// Used by `Activator.CreateInstance<T>()` after `ensureTypeInitialised` has just
+    /// pushed `T`'s `.cctor` frame: marking it ensures that if the .cctor throws (producing
+    /// a `TypeInitializationException` via the existing `WasInitialisingType` wrap), the
+    /// dispatcher *also* wraps the resulting TIE in a fresh `TargetInvocationException`
+    /// when the cctor frame unwinds, matching CoreCLR's `CreateInstanceOfT` semantics for
+    /// the cctor-failure path. Fails loudly if invoked on a frame with no `ReturnState`.
+    let markActiveFrameWrapInTargetInvocation (thread : ThreadId) (state : IlMachineState) : IlMachineState =
+        let threadState = state.ThreadState.[thread]
+        let activeFrameId = threadState.ActiveMethodState
+
+        let updateFrame (frame : MethodState) : MethodState =
+            match frame.ReturnState with
+            | None ->
+                failwith
+                    $"markActiveFrameWrapInTargetInvocation: active frame %s{frame.ExecutingMethod.Name} has no ReturnState; cannot install wrap marker"
+            | Some returnState ->
+                { frame with
+                    ReturnState =
+                        Some
+                            { returnState with
+                                WrapExceptionInTargetInvocation = true
+                            }
+                }
+
+        let threadState = ThreadState.mapFrame activeFrameId updateFrame threadState
+
+        { state with
+            ThreadState = state.ThreadState |> Map.add thread threadState
+        }
+
     let pushToEvalStack' (o : EvalStackValue) (thread : ThreadId) (state : IlMachineState) =
         let activeThreadState = state.ThreadState.[thread]
 

--- a/WoofWare.PawPrint/MethodState.fs
+++ b/WoofWare.PawPrint/MethodState.fs
@@ -602,6 +602,14 @@ type MethodReturnState =
         /// managed exception on return instead of being pushed onto the caller's eval stack.
         /// Used by raiseRuntimeException to run exception ctors via the dispatch loop.
         DispatchAsExceptionOnReturn : bool
+        /// When true, an exception escaping this frame is wrapped in a fresh
+        /// `System.Reflection.TargetInvocationException` whose `_innerException` points at the
+        /// original exception object. Used by the `Activator.CreateInstance<T>()` intrinsic to
+        /// reproduce CoreCLR's `RuntimeType.CreateInstanceOfT` `try { ctor } catch (Exception e)
+        /// { throw new TargetInvocationException(e); }` wrap without synthesising a trampoline
+        /// frame. The wrap fires only on unwind across this frame's boundary, so a `try`/`catch`
+        /// *inside* the ctor that handles the exception is unaffected.
+        WrapExceptionInTargetInvocation : bool
     }
 
 and MethodState =

--- a/WoofWare.PawPrint/Native/NativeCustomAttribute.fs
+++ b/WoofWare.PawPrint/Native/NativeCustomAttribute.fs
@@ -451,6 +451,7 @@ module NativeCustomAttribute =
                         threadState
                         None
                         false
+                        false // wrapExceptionInTargetInvocation
                         state
 
                 ExecutionResult.stepped (state, WhatWeDid.SuspendedForManagedCall) |> Some

--- a/WoofWare.PawPrint/Native/NativeRuntimeType.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeType.fs
@@ -2528,6 +2528,7 @@ module NativeRuntimeType =
                         threadState
                         None
                         false
+                        false // wrapExceptionInTargetInvocation
                         state
 
                 ExecutionResult.stepped (state, WhatWeDid.SuspendedForManagedCall) |> Some

--- a/WoofWare.PawPrint/UnaryMetadataCallOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataCallOps.fs
@@ -233,6 +233,7 @@ module internal UnaryMetadataCallOps =
                 threadState
                 None
                 false
+                false // wrapExceptionInTargetInvocation
                 state,
             WhatWeDid.Executed
         | FirstLoadThis state -> reinstallConstrained state, WhatWeDid.SuspendedForClassInit
@@ -613,6 +614,7 @@ module internal UnaryMetadataCallOps =
             threadState
             None
             false
+            false // wrapExceptionInTargetInvocation
             state,
         WhatWeDid.Executed
 

--- a/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
@@ -308,6 +308,7 @@ module internal UnaryMetadataObjectOps =
             threadState
             None
             false
+            false // wrapExceptionInTargetInvocation
             state,
         WhatWeDid.Executed
 


### PR DESCRIPTION
## Summary

- Mirrors CoreCLR's `RuntimeType.CreateInstanceOfT` semantics: any exception escaping the inlined `Activator.CreateInstance<T>()` intrinsic is wrapped in a fresh `System.Reflection.TargetInvocationException` whose `_innerException` points at the original.
- Covers three paths: an instance `.ctor` that throws (handled by a new `WrapExceptionInTargetInvocation` flag on `MethodReturnState` consulted during unwind), a `.cctor` that throws on first access (cctor frame is marked at suspend time so the existing `WasInitialisingType` TIE wrap is followed by the TIE→`TargetInvocationException` wrap), and a previously-cached `.cctor` failure (synthesizes a fresh `TargetInvocationException` around the cached TIE per CoreCLR's behaviour, verified against .NET 10).
- A `try`/`catch` *inside* the `.ctor` that handles its own exception is unaffected — the wrap only fires on unwind across the marked frame boundary.
- Synthesized `TargetInvocationException` now sets `_message` to the canonical "Exception has been thrown by the target of an invocation." so `ex.Message` / `ex.ToString()` match CoreCLR.

## Test plan
- [x] `dotnet test` — full suite green (1046/1046).
- [x] New pure tests: `ActivatorCreateInstanceCtorCatchesOwnException.cs`, `ActivatorCreateInstanceThrowingCctor.cs`, `ActivatorCreateInstanceCachedCctorFailure.cs`.
- [x] Previously-unimplemented `ActivatorCreateInstanceThrowingCtor.cs` is removed from the `unimplemented` set and now passes.
- [x] `codex review --base main` — clean ("no actionable correctness issues").

🤖 Generated with [Claude Code](https://claude.com/claude-code)