### PR TITLE
Add minimal read/write race source and standalone harness

### DIFF
--- a/WoofWare.PawPrint.Test/TestRaces.fs
+++ b/WoofWare.PawPrint.Test/TestRaces.fs
@@ -1,0 +1,50 @@
+namespace WoofWare.Pawprint.Test
+
+open System.Collections.Immutable
+open System.IO
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.DotnetRuntimeLocator
+open WoofWare.PawPrint
+open WoofWare.PawPrint.ExternImplementations
+open WoofWare.PawPrint.Test
+
+[<TestFixture>]
+module TestRaces =
+    let private assy = typeof<RunResult>.Assembly
+
+    let private runSource (sourceName : string) : RunOutcome =
+        let source = Assembly.getEmbeddedResourceAsString sourceName assy
+        let image = Roslyn.compile [ source ]
+
+        let _messages, loggerFactory =
+            LoggerFactory.makeTestWithProperties [ "source_file", sourceName ]
+
+        use _loggerFactoryResource = loggerFactory
+
+        let dotnetRuntimes =
+            DotnetRuntime.SelectForDll assy.Location |> ImmutableArray.CreateRange
+
+        use peImage = new MemoryStream (image)
+
+        Program.run loggerFactory (Some sourceName) peImage dotnetRuntimes (MockEnv.make ()) Map.empty []
+
+    // The guest reads a shared `int` between starting a worker (which writes 1)
+    // and joining it. Both 0 (read precedes worker's write) and 1 (read follows
+    // worker's write) are legal outcomes; any other value would indicate a bug.
+    // Once schedule fuzzing exists this should be strengthened to assert that
+    // *both* outcomes are observable across schedules.
+    [<Test>]
+    let ``ReadWriteRace exits with a legal outcome`` () : unit =
+        match runSource "ReadWriteRace.cs" with
+        | RunOutcome.NormalExit (terminalState, terminatingThread)
+        | RunOutcome.ProcessExit (terminalState, terminatingThread) ->
+            match terminalState.ThreadState.[terminatingThread].MethodState.EvaluationStack.Values with
+            | EvalStackValue.Int32 exitCode :: _ -> [ 0 ; 1 ] |> List.contains exitCode |> shouldEqual true
+            | [] -> failwith "expected program to return a value, but it returned void"
+            | ret :: _ -> failwith $"expected program to return an int, but it returned %O{ret}"
+        | RunOutcome.FailFast (_, _, message) ->
+            let m = message |> Option.defaultValue "<no message>"
+            failwith $"PawPrint guest called Environment.FailFast: %s{m}"
+        | RunOutcome.GuestUnhandledException (_, _, exn) ->
+            failwith $"guest threw unhandled exception: %O{exn.ExceptionObject}"

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -71,10 +71,12 @@
     <Compile Include="TestSyncBlockMonitor.fs" />
     <Compile Include="TestPureCases.fs" />
     <Compile Include="TestImpureCases.fs" />
+    <Compile Include="TestRaces.fs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="sourcesPure\*.cs" />
     <EmbeddedResource Include="sourcesImpure\*.cs" />
+    <EmbeddedResource Include="sources\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WoofWare.PawPrint.Test/sources/ReadWriteRace.cs
+++ b/WoofWare.PawPrint.Test/sources/ReadWriteRace.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+
+namespace HelloWorldApp
+{
+    class Program
+    {
+        static int x;
+
+        static void Worker()
+        {
+            x = 1;
+        }
+
+        static int Main(string[] args)
+        {
+            Thread t = new Thread(Worker);
+            t.Start();
+            int observed = x;
+            t.Join();
+            return observed;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- New `WoofWare.PawPrint.Test/sources/ReadWriteRace.cs`: minimal data race — worker thread writes `x = 1`; main thread reads `x` between `Thread.Start()` and `Thread.Join()` and returns the observed value. Legal outcomes are `{0, 1}` depending on interleaving.
- New `sources/` directory wired into the test project as an `EmbeddedResource`, but kept outside the `sourcesPure` / `sourcesImpure` globs that feed the auto-discovered comparison harness — that harness can't characterise a multi-outcome program with a single-run match against the real runtime.
- New `WoofWare.PawPrint.Test/TestRaces.fs`: standalone NUnit fixture that compiles the source, runs it once through PawPrint with `MockEnv.make ()`, and asserts the exit code is in `{0, 1}`. A comment notes the assertion should be strengthened to "both outcomes observable across schedules" once schedule fuzzing exists.

## Test plan
- [x] `nix develop -c dotnet build WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — succeeds with no warnings
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --no-build --filter "Name~ReadWriteRace"` — passes
- [x] `codex review --base main` — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)