### PR TITLE
Add mutex slice to WaitHandle infrastructure

### DIFF
--- a/WoofWare.PawPrint.Test/TestWaitHandle.fs
+++ b/WoofWare.PawPrint.Test/TestWaitHandle.fs
@@ -55,26 +55,48 @@ module TestWaitHandle =
     let private semaphoreOf (id : WaitHandleId) (state : IlMachineState) : SemaphoreState =
         match Map.find id state.Kernel.WaitHandles with
         | WaitHandleState.Semaphore s -> s
+        | WaitHandleState.Mutex _ -> failwith "expected a Semaphore handle but got a Mutex"
+
+    let private mutexOf (id : WaitHandleId) (state : IlMachineState) : MutexState =
+        match Map.find id state.Kernel.WaitHandles with
+        | WaitHandleState.Mutex m -> m
+        | WaitHandleState.Semaphore _ -> failwith "expected a Mutex handle but got a Semaphore"
 
     let private acquired (outcome : WaitHandle.WaitOutcome) : IlMachineState =
         match outcome with
         | WaitHandle.WaitOutcome.Acquired state -> state
+        | WaitHandle.WaitOutcome.AcquiredAbandoned _ -> failwith "expected Acquired but got AcquiredAbandoned"
         | WaitHandle.WaitOutcome.Blocked _ -> failwith "expected Acquired but got Blocked"
+
+    let private acquiredAbandoned (outcome : WaitHandle.WaitOutcome) : IlMachineState =
+        match outcome with
+        | WaitHandle.WaitOutcome.AcquiredAbandoned state -> state
+        | WaitHandle.WaitOutcome.Acquired _ -> failwith "expected AcquiredAbandoned but got Acquired"
+        | WaitHandle.WaitOutcome.Blocked _ -> failwith "expected AcquiredAbandoned but got Blocked"
 
     let private blocked (outcome : WaitHandle.WaitOutcome) : IlMachineState =
         match outcome with
         | WaitHandle.WaitOutcome.Blocked state -> state
         | WaitHandle.WaitOutcome.Acquired _ -> failwith "expected Blocked but got Acquired"
+        | WaitHandle.WaitOutcome.AcquiredAbandoned _ -> failwith "expected Blocked but got AcquiredAbandoned"
 
     let private tryAcquired (outcome : WaitHandle.TryWaitOutcome) : IlMachineState =
         match outcome with
         | WaitHandle.TryWaitOutcome.Acquired state -> state
+        | WaitHandle.TryWaitOutcome.AcquiredAbandoned _ -> failwith "expected Acquired but got AcquiredAbandoned"
         | WaitHandle.TryWaitOutcome.TimedOut _ -> failwith "expected Acquired but got TimedOut"
+
+    let private tryAcquiredAbandoned (outcome : WaitHandle.TryWaitOutcome) : IlMachineState =
+        match outcome with
+        | WaitHandle.TryWaitOutcome.AcquiredAbandoned state -> state
+        | WaitHandle.TryWaitOutcome.Acquired _ -> failwith "expected AcquiredAbandoned but got Acquired"
+        | WaitHandle.TryWaitOutcome.TimedOut _ -> failwith "expected AcquiredAbandoned but got TimedOut"
 
     let private timedOut (outcome : WaitHandle.TryWaitOutcome) : IlMachineState =
         match outcome with
         | WaitHandle.TryWaitOutcome.TimedOut state -> state
         | WaitHandle.TryWaitOutcome.Acquired _ -> failwith "expected TimedOut but got Acquired"
+        | WaitHandle.TryWaitOutcome.AcquiredAbandoned _ -> failwith "expected TimedOut but got AcquiredAbandoned"
 
     let private t0 = ThreadId 0
     let private t1 = ThreadId 1
@@ -210,10 +232,10 @@ module TestWaitHandle =
 
     [<Test>]
     let ``tryWaitOne on a signalled semaphore decrements count and reports Acquired`` () : unit =
-        let state = baseState ()
+        let state = baseState () |> withThreads [ t0 ]
         let id, state = WaitHandle.createSemaphore 2 5 state
 
-        let state = WaitHandle.tryWaitOne id state |> tryAcquired
+        let state = WaitHandle.tryWaitOne t0 id state |> tryAcquired
 
         let s = semaphoreOf id state
         s.Count |> shouldEqual 1
@@ -229,7 +251,7 @@ module TestWaitHandle =
         let state = baseState () |> withThreads [ t0 ]
         let id, state = WaitHandle.createSemaphore 0 5 state
 
-        let state = WaitHandle.tryWaitOne id state |> timedOut
+        let state = WaitHandle.tryWaitOne t0 id state |> timedOut
 
         let s = semaphoreOf id state
         s.Count |> shouldEqual 0
@@ -688,6 +710,10 @@ module TestWaitHandle =
                 match outcome with
                 | WaitHandle.WaitOutcome.Acquired s -> s, waited + 1, released
                 | WaitHandle.WaitOutcome.Blocked s -> s, waited + 1, released
+                | WaitHandle.WaitOutcome.AcquiredAbandoned _ ->
+                    // The semaphore variant never produces AcquiredAbandoned;
+                    // that's mutex-only. Surface as a script-invariant break.
+                    failwith "Semaphore waitOne unexpectedly produced AcquiredAbandoned"
         | Op.Release n ->
             let result, state' = WaitHandle.releaseSemaphore id n state
 
@@ -743,3 +769,379 @@ module TestWaitHandle =
             invariantOk && conservation && sem.Maximum = maximum
 
         Check.One (config, property)
+
+    // -------------------------------------------------------------------
+    // Mutex — create, re-entrancy, FIFO direct handoff, abandoned flag
+    // -------------------------------------------------------------------
+
+    [<Test>]
+    let ``createMutex without initialOwner starts free, not abandoned, with empty queue`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createMutex false t0 state
+
+        let m = mutexOf id state
+        m.Ownership |> shouldEqual (MutexOwnership.Free false)
+        m.WaitQueue |> shouldEqual []
+
+    [<Test>]
+    let ``createMutex with initialOwner installs the creator with recursion count 1`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createMutex true t0 state
+
+        let m = mutexOf id state
+        m.Ownership |> shouldEqual (MutexOwnership.Held (t0, 1))
+        m.WaitQueue |> shouldEqual []
+
+    [<Test>]
+    let ``minted mutex ids are never zero (BCL OOM guard never fires)`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, _ = WaitHandle.createMutex false t0 state
+        let (WaitHandleId i) = id
+        i |> shouldNotEqual 0
+
+    [<Test>]
+    let ``mutex ids interleave with semaphore ids on a shared counter`` () : unit =
+        // Single monotonic ID source; minting mutex / semaphore handles
+        // alternately produces distinct ids in registration order.
+        let state = baseState () |> withThreads [ t0 ]
+        let mutexId1, state = WaitHandle.createMutex false t0 state
+        let semId1, state = WaitHandle.createSemaphore 0 1 state
+        let mutexId2, state = WaitHandle.createMutex false t0 state
+        let semId2, _ = WaitHandle.createSemaphore 0 1 state
+
+        mutexId1 |> shouldNotEqual semId1
+        semId1 |> shouldNotEqual mutexId2
+        mutexId2 |> shouldNotEqual semId2
+        mutexId1 |> shouldNotEqual mutexId2
+
+    [<Test>]
+    let ``waitOne on a free mutex takes ownership with recursion count 1`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createMutex false t0 state
+
+        let state = WaitHandle.waitOne t0 id state |> acquired
+
+        let m = mutexOf id state
+        m.Ownership |> shouldEqual (MutexOwnership.Held (t0, 1))
+        m.WaitQueue |> shouldEqual []
+        statusOf t0 state |> shouldEqual ThreadStatus.Runnable
+
+    [<Test>]
+    let ``waitOne by owner is re-entrant and bumps recursion count`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createMutex false t0 state
+
+        let state = WaitHandle.waitOne t0 id state |> acquired
+        let state = WaitHandle.waitOne t0 id state |> acquired
+        let state = WaitHandle.waitOne t0 id state |> acquired
+
+        let m = mutexOf id state
+        m.Ownership |> shouldEqual (MutexOwnership.Held (t0, 3))
+        m.WaitQueue |> shouldEqual []
+
+    [<Test>]
+    let ``waitOne by a non-owner parks at the FIFO tail`` () : unit =
+        let state = baseState () |> withThreads [ t0 ; t1 ; t2 ]
+        let id, state = WaitHandle.createMutex true t0 state
+
+        let state = WaitHandle.waitOne t1 id state |> blocked
+        let state = WaitHandle.waitOne t2 id state |> blocked
+
+        let m = mutexOf id state
+        m.Ownership |> shouldEqual (MutexOwnership.Held (t0, 1))
+        m.WaitQueue |> shouldEqual [ t1 ; t2 ]
+        statusOf t0 state |> shouldEqual ThreadStatus.Runnable
+        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+        statusOf t2 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+
+    [<Test>]
+    let ``releaseMutex by owner without waiters marks the mutex free`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createMutex true t0 state
+
+        let result, state = WaitHandle.releaseMutex t0 id state
+
+        result |> shouldEqual (Ok ())
+        let m = mutexOf id state
+        m.Ownership |> shouldEqual (MutexOwnership.Free false)
+        m.WaitQueue |> shouldEqual []
+
+    [<Test>]
+    let ``releaseMutex unwinds recursion before releasing`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createMutex true t0 state
+        let state = WaitHandle.waitOne t0 id state |> acquired
+        let state = WaitHandle.waitOne t0 id state |> acquired
+
+        let _, state = WaitHandle.releaseMutex t0 id state
+        (mutexOf id state).Ownership |> shouldEqual (MutexOwnership.Held (t0, 2))
+
+        let _, state = WaitHandle.releaseMutex t0 id state
+        (mutexOf id state).Ownership |> shouldEqual (MutexOwnership.Held (t0, 1))
+
+        let _, state = WaitHandle.releaseMutex t0 id state
+        (mutexOf id state).Ownership |> shouldEqual (MutexOwnership.Free false)
+
+    [<Test>]
+    let ``releaseMutex with waiters hands ownership directly to the FIFO head`` () : unit =
+        let state = baseState () |> withThreads [ t0 ; t1 ; t2 ]
+        let id, state = WaitHandle.createMutex true t0 state
+        let state = WaitHandle.waitOne t1 id state |> blocked
+        let state = WaitHandle.waitOne t2 id state |> blocked
+
+        let result, state = WaitHandle.releaseMutex t0 id state
+
+        result |> shouldEqual (Ok ())
+        let m = mutexOf id state
+        // Direct handoff: t1 wakes already owning the mutex with
+        // recursion count 1; t2 stays parked behind.
+        m.Ownership |> shouldEqual (MutexOwnership.Held (t1, 1))
+        m.WaitQueue |> shouldEqual [ t2 ]
+        statusOf t0 state |> shouldEqual ThreadStatus.Runnable
+        statusOf t1 state |> shouldEqual ThreadStatus.Runnable
+        statusOf t2 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+
+    [<Test>]
+    let ``releaseMutex by a non-owner returns NotOwner and leaves state unchanged`` () : unit =
+        let state = baseState () |> withThreads [ t0 ; t1 ]
+        let id, state = WaitHandle.createMutex true t0 state
+        let before = mutexOf id state
+
+        let result, state' = WaitHandle.releaseMutex t1 id state
+
+        result |> shouldEqual (Error WaitHandle.ReleaseMutexFailure.NotOwner)
+        mutexOf id state' |> shouldEqual before
+
+    [<Test>]
+    let ``releaseMutex on a free mutex returns NotOwner and leaves state unchanged`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createMutex false t0 state
+        let before = mutexOf id state
+
+        let result, state' = WaitHandle.releaseMutex t0 id state
+
+        result |> shouldEqual (Error WaitHandle.ReleaseMutexFailure.NotOwner)
+        mutexOf id state' |> shouldEqual before
+
+    [<Test>]
+    let ``Property: matched waitOne/releaseMutex pairs by owner leave mutex Free false`` () : unit =
+        let property (PositiveInt depthRaw) : bool =
+            let depth = 1 + (depthRaw % 16)
+            let state = baseState () |> withThreads [ t0 ]
+            // Start free; the first WaitOne takes ownership; further
+            // WaitOnes bump the recursion count; matched releases unwind.
+            let id, state = WaitHandle.createMutex false t0 state
+
+            let state =
+                [ 1..depth ]
+                |> List.fold (fun s _ -> WaitHandle.waitOne t0 id s |> acquired) state
+
+            (mutexOf id state).Ownership = MutexOwnership.Held (t0, depth)
+            && let state =
+                [ 1..depth ]
+                |> List.fold
+                    (fun s _ ->
+                        let _, s = WaitHandle.releaseMutex t0 id s
+                        s
+                    )
+                    state in
+
+               (mutexOf id state).Ownership = MutexOwnership.Free false
+               && (mutexOf id state).WaitQueue = []
+
+        Check.One (config, property)
+
+    // -------------------------------------------------------------------
+    // tryWaitOne on mutex — kind-aware non-blocking probe
+    // -------------------------------------------------------------------
+
+    [<Test>]
+    let ``tryWaitOne on a free mutex acquires it`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createMutex false t0 state
+
+        let state = WaitHandle.tryWaitOne t0 id state |> tryAcquired
+
+        (mutexOf id state).Ownership |> shouldEqual (MutexOwnership.Held (t0, 1))
+
+    [<Test>]
+    let ``tryWaitOne by owner of a held mutex bumps recursion count`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createMutex true t0 state
+
+        let state = WaitHandle.tryWaitOne t0 id state |> tryAcquired
+
+        (mutexOf id state).Ownership |> shouldEqual (MutexOwnership.Held (t0, 2))
+
+    [<Test>]
+    let ``tryWaitOne on a mutex held by another thread reports TimedOut without parking`` () : unit =
+        let state = baseState () |> withThreads [ t0 ; t1 ]
+        let id, state = WaitHandle.createMutex true t0 state
+
+        let state = WaitHandle.tryWaitOne t1 id state |> timedOut
+
+        // No enqueue, no status flip — the entire point of the zero-
+        // timeout probe.
+        let m = mutexOf id state
+        m.Ownership |> shouldEqual (MutexOwnership.Held (t0, 1))
+        m.WaitQueue |> shouldEqual []
+        statusOf t1 state |> shouldEqual ThreadStatus.Runnable
+
+    // -------------------------------------------------------------------
+    // Abandoned flag — synthesised via direct state manipulation
+    // -------------------------------------------------------------------
+    // Full abandoned propagation (driving the flag via owner-thread
+    // termination) is structural and deferred — Scheduler.onThreadTerminated
+    // currently fails loud on owned mutexes. The state-machine behaviour
+    // on a Free(wasAbandoned=true) mutex is still required to be correct
+    // for when that gap closes; we test it here by synthesising the state
+    // directly. -------------------------------------------------------------------
+
+    let private installAbandonedMutex (id : WaitHandleId) (state : IlMachineState) : IlMachineState =
+        state.MapKernel (fun kernel ->
+            let mutex =
+                {
+                    Ownership = MutexOwnership.Free true
+                    WaitQueue = []
+                }
+
+            { kernel with
+                WaitHandles = Map.add id (WaitHandleState.Mutex mutex) kernel.WaitHandles
+            }
+        )
+
+    [<Test>]
+    let ``waitOne on an abandoned-flagged free mutex produces AcquiredAbandoned and clears the flag`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createMutex false t0 state
+        let state = installAbandonedMutex id state
+
+        let state = WaitHandle.waitOne t0 id state |> acquiredAbandoned
+
+        let m = mutexOf id state
+        m.Ownership |> shouldEqual (MutexOwnership.Held (t0, 1))
+
+    [<Test>]
+    let ``tryWaitOne on an abandoned-flagged free mutex produces AcquiredAbandoned and clears the flag`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createMutex false t0 state
+        let state = installAbandonedMutex id state
+
+        let state = WaitHandle.tryWaitOne t0 id state |> tryAcquiredAbandoned
+
+        let m = mutexOf id state
+        m.Ownership |> shouldEqual (MutexOwnership.Held (t0, 1))
+
+    [<Test>]
+    let ``releaseMutex on a mutex acquired-abandoned leaves the flag cleared`` () : unit =
+        // Once the abandoned flag is consumed by the acquiring WaitOne,
+        // a subsequent release produces a plain Free(false), not a
+        // Free(true) — the flag is sticky to a single wake, not to the
+        // mutex permanently.
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createMutex false t0 state
+        let state = installAbandonedMutex id state
+        let state = WaitHandle.waitOne t0 id state |> acquiredAbandoned
+
+        let _, state = WaitHandle.releaseMutex t0 id state
+
+        (mutexOf id state).Ownership |> shouldEqual (MutexOwnership.Free false)
+
+    // -------------------------------------------------------------------
+    // close — mutex variants
+    // -------------------------------------------------------------------
+
+    [<Test>]
+    let ``close removes a quiescent free mutex from the registry`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createMutex false t0 state
+
+        let state = WaitHandle.close id state
+
+        Map.containsKey id state.Kernel.WaitHandles |> shouldEqual false
+
+    [<Test>]
+    let ``close fails loud on a still-held mutex`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createMutex true t0 state
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.close id state |> ignore)
+
+        exn.Message |> shouldContainText "still held"
+
+    [<Test>]
+    let ``close fails loud on a mutex with parked waiters`` () : unit =
+        let state = baseState () |> withThreads [ t0 ; t1 ]
+        let id, state = WaitHandle.createMutex true t0 state
+        let state = WaitHandle.waitOne t1 id state |> blocked
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.close id state |> ignore)
+
+        exn.Message |> shouldContainText "parked"
+
+    // -------------------------------------------------------------------
+    // Cross-kind failures — wrong-kind handle to a kind-specific operation
+    // -------------------------------------------------------------------
+
+    [<Test>]
+    let ``releaseSemaphore on a mutex id fails loud`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createMutex false t0 state
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.releaseSemaphore id 1 state |> ignore)
+
+        exn.Message |> shouldContainText "Mutex"
+
+    [<Test>]
+    let ``waitOnePrioritized on a mutex id fails loud`` () : unit =
+        // The LowLevelLifoSemaphore park primitive is only ever called
+        // against semaphores; routing a mutex into the prioritized
+        // entry point is a guest bug.
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createMutex false t0 state
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.waitOnePrioritized t0 id state |> ignore)
+
+        exn.Message |> shouldContainText "Mutex"
+
+    [<Test>]
+    let ``releaseMutex on a semaphore id fails loud`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createSemaphore 1 5 state
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.releaseMutex t0 id state |> ignore)
+
+        exn.Message |> shouldContainText "Semaphore"
+
+    // -------------------------------------------------------------------
+    // Use-after-free
+    // -------------------------------------------------------------------
+
+    [<Test>]
+    let ``waitOne on a closed mutex fails loud (use-after-free)`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createMutex false t0 state
+        let state = WaitHandle.close id state
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.waitOne t0 id state |> ignore)
+
+        exn.Message |> shouldContainText "not registered"
+
+    [<Test>]
+    let ``releaseMutex on a closed mutex fails loud (use-after-free)`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createMutex true t0 state
+        // Release before close so the close itself succeeds.
+        let _, state = WaitHandle.releaseMutex t0 id state
+        let state = WaitHandle.close id state
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.releaseMutex t0 id state |> ignore)
+
+        exn.Message |> shouldContainText "not registered"

--- a/WoofWare.PawPrint/EmulatedKernel.fs
+++ b/WoofWare.PawPrint/EmulatedKernel.fs
@@ -146,14 +146,62 @@ type SemaphoreState =
         WaitQueue : ThreadId list
     }
 
+/// Ownership state of a single Win32-shaped mutex. Modelled as a DU
+/// rather than an `Owner option + RecursionCount + IsAbandoned` triple
+/// so that illegal states (held but with no owner; recursion count 0
+/// while held; held *and* abandoned) are unrepresentable.
+///
+/// `Free wasAbandoned = true` is the post-abandonment Win32 contract: the
+/// previous owner died while still holding the mutex, the kernel marks
+/// the mutex free with a sticky "abandoned" flag, and the very next
+/// `WaitOne` succeeds but returns `WAIT_ABANDONED` (which the BCL turns
+/// into `AbandonedMutexException`). The flag is cleared by the
+/// acquiring `WaitOne`.
+[<RequireQualifiedAccess>]
+type MutexOwnership =
+    /// No thread currently owns the mutex. `wasAbandoned = true` means
+    /// the previous owner terminated without calling `ReleaseMutex`;
+    /// the next acquirer observes that fact (via `WAIT_ABANDONED`) and
+    /// the flag clears as part of the acquire step.
+    | Free of wasAbandoned : bool
+    /// Held by `owner` with `recursionCount` outstanding `WaitOne`
+    /// calls. `recursionCount` is always `≥ 1`; the released-the-last-
+    /// nesting transition moves to `Free false` (or to a fresh `Held`
+    /// state for the woken queue head, via direct handoff).
+    | Held of owner : ThreadId * recursionCount : int
+
+/// Deterministic model of a single Win32-shaped mutex kernel object, as
+/// minted by `PAL_CreateMutexW`. Carries ownership (per `MutexOwnership`)
+/// plus the FIFO wait queue of threads parked in `BlockedOnWaitHandle`
+/// because the mutex was held by another thread when they called
+/// `WaitOne`. The wait queue lives outside the ownership DU because it
+/// is orthogonal to who currently owns the mutex — a free mutex can
+/// have a non-empty queue (transient, between direct-handoff release
+/// and the woken thread being picked by the scheduler) although our
+/// release path immediately re-installs the woken thread as the new
+/// owner so this is in practice always empty when `Free`.
+///
+/// Mutexes are re-entrant on `owner`: a second `WaitOne` from the
+/// owning thread succeeds on the fast path and bumps `recursionCount`.
+/// Matching `ReleaseMutex` calls walk the count back down; the
+/// outermost release either marks the mutex free or performs direct
+/// handoff to the FIFO head of the queue.
+type MutexState =
+    {
+        Ownership : MutexOwnership
+        WaitQueue : ThreadId list
+    }
+
 /// Kind-tagged state for a single Win32-shaped wait-handle kernel object
 /// resident in `EmulatedKernel.WaitHandles`. Kind-agnostic operations
 /// (`WaitHandle_WaitOneCore`, `CloseHandle`) take one map lookup and then
-/// match on kind; new kinds (Event, Mutex) slot in as additional cases
-/// without disturbing the table or the wait/close handlers.
+/// match on kind; new kinds (Event) slot in as additional cases without
+/// disturbing the table or the wait/close handlers.
 [<RequireQualifiedAccess>]
-type WaitHandleState = | Semaphore of SemaphoreState
-// future: | Event of EventState | Mutex of MutexState
+type WaitHandleState =
+    | Semaphore of SemaphoreState
+    | Mutex of MutexState
+// future: | Event of EventState
 
 /// One entry in `EmulatedKernel.OutputLog`: the role the guest targeted (a
 /// writable standard stream — stdout or stderr) and the byte payload of

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -83,6 +83,15 @@ module NativeQCall =
             // prioritized 2-arg waiter; routes to the same deterministic
             // state machine as `WaitOneCore`.
             "WaitHandle_WaitOnePrioritized", NativeWaitHandle.tryExecuteQCall "WaitHandle_WaitOnePrioritized"
+            // `Mutex.CoreCLR.Unix.cs` imports `PAL_CreateMutexW` directly
+            // (separate from the semaphore's `CreateSemaphoreExW`);
+            // `ReleaseMutex` is the Win32 wide-string name that
+            // `Interop.Mutex.cs` uses, routed to QCall on Unix via the
+            // `Libraries.Kernel32 = RuntimeHelpers.QCall` rebinding.
+            // Both dispatch into the deterministic mutex state machine
+            // in `WaitHandle.fs`.
+            "PAL_CreateMutexW", NativeWaitHandle.tryExecuteQCall "PAL_CreateMutexW"
+            "ReleaseMutex", NativeWaitHandle.tryExecuteQCall "ReleaseMutex"
         ]
         |> Map.ofList
 

--- a/WoofWare.PawPrint/Native/NativeWaitHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeWaitHandle.fs
@@ -145,6 +145,44 @@ module NativeWaitHandle =
             failwith
                 $"%s{operation}: named wait handles are not yet supported; expected a null name pointer, got %O{other}"
 
+    /// Decode the UTF-16 `name` pointer for `PAL_CreateMutexW`. Unlike
+    /// `Semaphore.Windows.cs`, which throws `PlatformNotSupportedException`
+    /// before ever passing a non-null name to the PAL, `Mutex.CoreCLR
+    /// .Unix.cs` treats `string.IsNullOrEmpty(name)` as unnamed at the
+    /// options layer but still flows the original `name` string through
+    /// the LibraryImport marshaller. An empty string therefore arrives
+    /// at this QCall as a non-null UTF-16 pointer to a single NUL char;
+    /// CoreLib still considers the call unnamed. Accept null or empty
+    /// UTF-16 here, and fail loud for any non-empty name — named
+    /// mutexes are out of scope until the named-handle registry lands.
+    let private requireUnnamedMutex
+        (operation : string)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (arg : CliType)
+        : unit
+        =
+        match CliType.unwrapPrimitiveLikeDeep arg with
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim 0L))
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.ManagedPointer ManagedPointerSource.Null))
+        | CliType.RuntimePointer (CliRuntimePointer.Verbatim 0L)
+        | CliType.RuntimePointer (CliRuntimePointer.Managed ManagedPointerSource.Null) -> ()
+        | CliType.RuntimePointer (CliRuntimePointer.Managed ptr) ->
+            let name = NativeCall.readNullTerminatedUtf16 operation baseClassTypes state ptr
+
+            if name <> "" then
+                failwith
+                    $"%s{operation}: named mutexes are not yet supported; expected an unnamed handle (null or empty name) but got '%s{name}'"
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.ManagedPointer ptr)) ->
+            let name = NativeCall.readNullTerminatedUtf16 operation baseClassTypes state ptr
+
+            if name <> "" then
+                failwith
+                    $"%s{operation}: named mutexes are not yet supported; expected an unnamed handle (null or empty name) but got '%s{name}'"
+        | other ->
+            failwith
+                $"%s{operation}: named mutexes are not yet supported; expected a null or empty UTF-16 name pointer, got %O{other}"
+
     /// Decode an unused `byte*` argument (e.g. `PAL_CreateMutexW`'s
     /// `systemCallErrors` out-buffer). The buffer is only written on the
     /// PAL failure paths we don't take; on success the BCL ignores its
@@ -432,7 +470,7 @@ module NativeWaitHandle =
             let initialOwner =
                 boolOfBoolArgument operation "initialOwner" instruction.Arguments.[0]
 
-            requireNullName operation instruction.Arguments.[1]
+            requireUnnamedMutex operation ctx.BaseClassTypes state instruction.Arguments.[1]
             // `currentUserOnly` flags whether the named-handle backing
             // store should be filtered to the current user. We don't
             // support named handles, so its value is moot — decode for

--- a/WoofWare.PawPrint/Native/NativeWaitHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeWaitHandle.fs
@@ -2,22 +2,24 @@ namespace WoofWare.PawPrint
 
 /// Native handler for the Win32-shaped wait-handle QCalls reachable from
 /// CoreCLR-on-Unix: `CreateSemaphoreExW`, `ReleaseSemaphore`,
-/// `CloseHandle`, `WaitHandle_WaitOneCore`, and
-/// `WaitHandle_WaitOnePrioritized`. On .NET 10 the BCL compiles
-/// `Semaphore.Windows.cs` regardless of host, with `Libraries.Kernel32`
-/// rebound to `RuntimeHelpers.QCall`, so every Kernel32 LibraryImport
-/// routes to the runtime as a QCall whose entry point uses the Win32
-/// wide-string name. `LowLevelLifoSemaphore.Unix.cs` independently
-/// imports `WaitHandle_WaitOnePrioritized` (the PAL-prioritized waiter
-/// that `PortableThreadPool` workers park on). PawPrint catches each
-/// entry point here and forwards it to the deterministic state machine
-/// in `WaitHandle.fs`.
+/// `CloseHandle`, `WaitHandle_WaitOneCore`,
+/// `WaitHandle_WaitOnePrioritized`, `PAL_CreateMutexW`, and
+/// `ReleaseMutex`. On .NET 10 the BCL compiles `Semaphore.Windows.cs`
+/// and `Mutex.CoreCLR.Unix.cs` regardless of host, with
+/// `Libraries.Kernel32` rebound to `RuntimeHelpers.QCall`, so every
+/// Kernel32 LibraryImport routes to the runtime as a QCall whose entry
+/// point uses the Win32 wide-string name. `LowLevelLifoSemaphore.Unix
+/// .cs` independently imports `WaitHandle_WaitOnePrioritized` (the
+/// PAL-prioritized waiter that `PortableThreadPool` workers park on);
+/// `Mutex.CoreCLR.Unix.cs` imports `PAL_CreateMutexW` directly. PawPrint
+/// catches each entry point here and forwards it to the deterministic
+/// state machine in `WaitHandle.fs`.
 ///
-/// This first slice supports the semaphore variant only; events,
-/// mutexes, multi-handle waits, and non-zero finite timeouts are out
-/// of scope pending future PRs and a virtual clock. Zero-timeout waits
-/// (the deterministic non-blocking probe `WaitOne(0)` emits) are
-/// handled inline — no clock is needed.
+/// Semaphore and mutex variants are supported today; events,
+/// multi-handle waits, named handles (`PAL_OpenMutexW`), and non-zero
+/// finite timeouts are out of scope pending future PRs and a virtual
+/// clock. Zero-timeout waits (the deterministic non-blocking probe
+/// `WaitOne(0)` emits) are handled inline — no clock is needed.
 [<RequireQualifiedAccess>]
 module NativeWaitHandle =
 
@@ -31,10 +33,28 @@ module NativeWaitHandle =
     /// throw.
     let private errorTooManyPosts : int = 298
 
+    /// `ERROR_NOT_OWNER = 0x120 = 288`. The Win32 contract returned by
+    /// `ReleaseMutex` when the calling thread does not own the mutex
+    /// (either the mutex is free, or another thread holds it). The
+    /// BCL's `Mutex.ReleaseMutex` checks the BOOL return and throws
+    /// `ApplicationException` (today: `SynchronizationLockException`)
+    /// without inspecting the error code, but the source-generator
+    /// wrapper still propagates the last error into
+    /// `LastPInvokeError`, so we set it for fidelity with any guest
+    /// that reads `Marshal.GetLastPInvokeError` after the throw.
+    let private errorNotOwner : int = 288
+
     /// `WAIT_OBJECT_0 = 0`. The Win32 return code for a successful wait
     /// — the wait acquired its target object. Matches
     /// `WaitHandle.WaitSuccess` in the BCL.
     let private waitObjectZero : int = 0
+
+    /// `WAIT_ABANDONED = 0x80 = 128`. The Win32 return code for a wait
+    /// that acquired its target mutex, but the previous owner had
+    /// terminated without calling `ReleaseMutex`. The BCL's
+    /// `Mutex.WaitOneNoCheck` translates this into
+    /// `AbandonedMutexException`.
+    let private waitAbandoned : int = 0x80
 
     /// `WAIT_TIMEOUT = 0x102 = 258`. The Win32 return code for a wait
     /// that did not acquire its target before the timeout expired.
@@ -56,7 +76,7 @@ module NativeWaitHandle =
         )
 
     /// Decode the `IntPtr handle` argument that every wait-handle entry
-    /// point except `CreateSemaphoreExW` carries. The guest only ever
+    /// point except the Create QCalls carries. The guest only ever
     /// obtains this value from a Create QCall, so a foreign IntPtr
     /// (e.g. a LowLevelMonitor handle, a GcHandle, a `Verbatim` scratch
     /// value) is unambiguously a guest bug. Null is rejected too: the
@@ -70,6 +90,25 @@ module NativeWaitHandle =
             failwith
                 $"%s{operation}: handle argument was IntPtr.Zero, but WaitHandle invariants require a non-null handle (the BCL wrapper would have thrown ObjectDisposedException or set SafeHandle.IsInvalid before reaching the runtime)."
         | other -> failwith $"%s{operation}: expected WaitHandle handle, got %O{other}"
+
+    /// Decode the `IntPtr handle` argument and additionally require
+    /// that it refer to a Semaphore (rather than a Mutex or any future
+    /// kind). Used by `WaitHandle_WaitOnePrioritized`: the
+    /// PAL-prioritized waiter is the LowLevelLifoSemaphore park
+    /// primitive and is only ever called against semaphore handles;
+    /// passing a mutex handle would be a guest bug. Fail loud rather
+    /// than fall through to a kind-generic probe.
+    let private semaphoreHandleOfArgument (operation : string) (arg : CliType) (state : IlMachineState) : WaitHandleId =
+        let id = waitHandleOfArgument operation arg
+
+        match Map.tryFind id state.Kernel.WaitHandles with
+        | Some (WaitHandleState.Semaphore _) -> id
+        | Some (WaitHandleState.Mutex _) ->
+            failwith
+                $"%s{operation}: WaitHandle %O{id} is a Mutex, but this entry point is only legal against a Semaphore (the BCL's LowLevelLifoSemaphore is the sole caller). This is a guest bug."
+        | None ->
+            failwith
+                $"%s{operation}: WaitHandle %O{id} is not registered (use-after-free on a closed handle, or never created)."
 
     /// Decode an IntPtr argument that should be either `IntPtr.Zero`
     /// (CoreLib passes 0 for `lpSecurityAttributes`) or fail loud.
@@ -106,50 +145,64 @@ module NativeWaitHandle =
             failwith
                 $"%s{operation}: named wait handles are not yet supported; expected a null name pointer, got %O{other}"
 
+    /// Decode an unused `byte*` argument (e.g. `PAL_CreateMutexW`'s
+    /// `systemCallErrors` out-buffer). The buffer is only written on the
+    /// PAL failure paths we don't take; on success the BCL ignores its
+    /// contents. We accept any managed/native pointer (the CoreLib
+    /// caller is a `stackalloc byte[256]` whose representation depends
+    /// on the frame's local layout) without inspecting them.
+    let private ignoreBytePointer (operation : string) (argName : string) (arg : CliType) : unit =
+        match CliType.unwrapPrimitiveLikeDeep arg with
+        | CliType.Numeric (CliNumericType.NativeInt _)
+        | CliType.RuntimePointer _ -> ()
+        | other -> failwith $"%s{operation}: expected %s{argName} to be a pointer-shaped argument, got %O{other}"
+
     /// Drive the timeout dispatch shared by `WaitHandle_WaitOneCore`
     /// and `WaitHandle_WaitOnePrioritized`: timeout = -1 (INFINITE)
     /// blocks via `blockingWait`; timeout = 0 (the non-blocking probe
     /// `WaitOne(0)` issues) takes the deterministic try-and-return path
-    /// via `tryWaitOne`; any other finite timeout currently fails loud
+    /// via `tryWait`; any other finite timeout currently fails loud
     /// (no virtual clock — same blocker as
     /// `SystemNative_LowLevelMonitor_TimedWait`). Returns the new
     /// `IlMachineState` and the Int32 return value the guest sees.
     ///
-    /// The two callers differ in `blockingWait`: `WaitOneCore` uses
-    /// `WaitHandle.waitOne` (FIFO tail insertion);
-    /// `WaitOnePrioritized` uses `WaitHandle.waitOnePrioritized`
-    /// (LIFO head insertion). Both share the zero-timeout `tryWaitOne`
-    /// because priority only matters when the wait actually parks.
+    /// `blockingWait` and `tryWait` are passed in separately rather
+    /// than derived from a shared kind-generic primitive so that the
+    /// prioritized handler can route to semaphore-only variants and a
+    /// mutex handle reaching the prioritized entry point fails loud at
+    /// the decoder level rather than accidentally succeeding via a
+    /// kind-generic probe.
     let private dispatchWait
         (operation : string)
-        (id : WaitHandleId)
         (timeout : int)
         (blockingWait : IlMachineState -> WaitHandle.WaitOutcome)
+        (tryWait : IlMachineState -> WaitHandle.TryWaitOutcome)
         (state : IlMachineState)
         : IlMachineState * int
         =
         if timeout = System.Threading.Timeout.Infinite then
-            // Both fast (count > 0) and slow (parked) blocking paths
-            // return WAIT_OBJECT_0 to the guest; the IL site advances
-            // in both cases, and the scheduler simply will not pick a
-            // parked thread again until a subsequent `releaseSemaphore`
-            // wakes it. This mirrors
-            // `SystemNative_LowLevelMonitor_Acquire`'s posture.
-            let state =
-                match blockingWait state with
-                | WaitHandle.WaitOutcome.Acquired state
-                | WaitHandle.WaitOutcome.Blocked state -> state
-
-            state, waitObjectZero
+            // Both fast (count > 0 / mutex free / re-entrant) and slow
+            // (parked) blocking paths advance the IL site; the
+            // scheduler will not pick a parked thread again until a
+            // subsequent wake. `Acquired` returns `WAIT_OBJECT_0`;
+            // `AcquiredAbandoned` returns `WAIT_ABANDONED`; `Blocked`
+            // pushes `WAIT_OBJECT_0` at park time (see the
+            // abandoned-mutex-propagation note in `WaitHandle.fs`).
+            match blockingWait state with
+            | WaitHandle.WaitOutcome.Acquired state -> state, waitObjectZero
+            | WaitHandle.WaitOutcome.AcquiredAbandoned state -> state, waitAbandoned
+            | WaitHandle.WaitOutcome.Blocked state -> state, waitObjectZero
         elif timeout = 0 then
             // Zero-timeout: try the fast path, then return immediately.
-            // CoreCLR returns `WAIT_OBJECT_0` if the handle was signalled,
-            // else `WAIT_TIMEOUT`; the caller is never enqueued. Treating
-            // a zero-timeout as an unimplemented finite timeout would
-            // crash on a deterministic non-blocking probe (e.g. the
-            // `WaitOne(0)` poll pattern), which is the wrong envelope.
-            match WaitHandle.tryWaitOne id state with
+            // CoreCLR returns `WAIT_OBJECT_0` / `WAIT_ABANDONED` if the
+            // handle was signalled, else `WAIT_TIMEOUT`; the caller is
+            // never enqueued. Treating a zero-timeout as an
+            // unimplemented finite timeout would crash on a
+            // deterministic non-blocking probe (e.g. the `WaitOne(0)`
+            // poll pattern), which is the wrong envelope.
+            match tryWait state with
             | WaitHandle.TryWaitOutcome.Acquired state -> state, waitObjectZero
+            | WaitHandle.TryWaitOutcome.AcquiredAbandoned state -> state, waitAbandoned
             | WaitHandle.TryWaitOutcome.TimedOut state -> state, waitTimeout
         else
             // No virtual clock yet. Same envelope as `Monitor_Wait` /
@@ -304,7 +357,12 @@ module NativeWaitHandle =
                 boolOfBoolArgument operation "useTrivialWaits" instruction.Arguments.[2]
 
             let state, ret =
-                dispatchWait operation id timeout (WaitHandle.waitOne ctx.Thread id) state
+                dispatchWait
+                    operation
+                    timeout
+                    (WaitHandle.waitOne ctx.Thread id)
+                    (WaitHandle.tryWaitOne ctx.Thread id)
+                    state
 
             state
             |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 ret) ctx.Thread
@@ -328,17 +386,104 @@ module NativeWaitHandle =
             // `PortableThreadPool`) — that's exactly why it has its own
             // entry point separate from `WaitOneCore`.
             let operation = "WaitHandle_WaitOnePrioritized"
-            let id = waitHandleOfArgument operation instruction.Arguments.[0]
+            // Enforce the semaphore-only contract at the decoder layer so
+            // a mutex handle reaching this entry point is a clean guest-
+            // bug failure rather than an accidental success via the
+            // kind-generic primitive.
+            let id = semaphoreHandleOfArgument operation instruction.Arguments.[0] state
 
             let timeout = NativeCall.int32Argument operation instruction.Arguments.[1]
 
             let state, ret =
-                dispatchWait operation id timeout (WaitHandle.waitOnePrioritized ctx.Thread id) state
+                dispatchWait
+                    operation
+                    timeout
+                    (WaitHandle.waitOnePrioritized ctx.Thread id)
+                    (WaitHandle.tryWaitOneSemaphore id)
+                    state
 
             state
             |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 ret) ctx.Thread
             |> Tuple.withRight WhatWeDid.Executed
             |> ExecutionResult.stepped
             |> Some
+
+        | "PAL_CreateMutexW",
+          "System.Private.CoreLib",
+          "Mutex",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32
+            ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt16)
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32
+            ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.Byte)
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt32 ],
+          MethodReturnType.Returns _ ->
+            // `Mutex.CoreCLR.Unix.cs` declares this as a `partial
+            // SafeWaitHandle` return; the LibraryImport source generator
+            // marshals the SafeWaitHandle as an `IntPtr` over the wire,
+            // but the QCall return type recorded in the method's
+            // signature is the SafeWaitHandle reference type (the
+            // marshalling is applied by the generated stub on either
+            // side of the call). We don't constrain the return type
+            // here beyond "the method has a return" because the
+            // declared return is a reference type in IL terms, not the
+            // primitive `IntPtr` the semaphore Create QCall uses.
+            let operation = "PAL_CreateMutexW"
+
+            let initialOwner =
+                boolOfBoolArgument operation "initialOwner" instruction.Arguments.[0]
+
+            requireNullName operation instruction.Arguments.[1]
+            // `currentUserOnly` flags whether the named-handle backing
+            // store should be filtered to the current user. We don't
+            // support named handles, so its value is moot — decode for
+            // shape validation but ignore.
+            let _currentUserOnly =
+                boolOfBoolArgument operation "currentUserOnly" instruction.Arguments.[2]
+
+            ignoreBytePointer operation "systemCallErrors" instruction.Arguments.[3]
+            // `systemCallErrorsBufferSize` is only consulted on the
+            // failure paths we don't take. CoreLib hardcodes 256; we
+            // accept whatever's there.
+            let _bufSize = NativeCall.int32Argument operation instruction.Arguments.[4]
+
+            let id, state = WaitHandle.createMutex initialOwner ctx.Thread state
+
+            state
+            |> withLastSystemError 0
+            |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt (NativeIntSource.WaitHandlePtr id)) ctx.Thread
+            |> Tuple.withRight WhatWeDid.Executed
+            |> ExecutionResult.stepped
+            |> Some
+
+        | "ReleaseMutex",
+          "System.Private.CoreLib",
+          "Kernel32",
+          [ _ ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
+            // The single argument is declared as `SafeWaitHandle` in
+            // CoreLib's `Interop.Mutex.cs`, but the LibraryImport stub
+            // marshals it as an `IntPtr` at the QCall boundary. Decode
+            // through `waitHandleOfArgument`, which already accepts the
+            // `NativeIntSource.WaitHandlePtr` representation produced
+            // by `PAL_CreateMutexW`.
+            let operation = "ReleaseMutex"
+            let id = waitHandleOfArgument operation instruction.Arguments.[0]
+            let outcome, state = WaitHandle.releaseMutex ctx.Thread id state
+
+            match outcome with
+            | Ok () ->
+                state
+                |> withLastSystemError 0
+                |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 1) ctx.Thread
+                |> Tuple.withRight WhatWeDid.Executed
+                |> ExecutionResult.stepped
+                |> Some
+            | Error WaitHandle.ReleaseMutexFailure.NotOwner ->
+                state
+                |> withLastSystemError errorNotOwner
+                |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread
+                |> Tuple.withRight WhatWeDid.Executed
+                |> ExecutionResult.stepped
+                |> Some
 
         | _ -> None

--- a/WoofWare.PawPrint/Scheduler.fs
+++ b/WoofWare.PawPrint/Scheduler.fs
@@ -96,6 +96,15 @@ module Scheduler =
     ///   `LowLevelMonitor` predicates "thread does not die holding the monitor" on
     ///   higher-level discipline (RAII in `LowLevelMonitorHelper`); we mirror that
     ///   contract with a loud failure rather than a silent deadlock.
+    /// - Fails loudly if `terminated` was still the Owner of any mutex. Full
+    ///   Win32 abandoned-mutex propagation (so the next waiter wakes with
+    ///   `WAIT_ABANDONED` and `AbandonedMutexException`) is structural and
+    ///   not yet implemented: the wake-time return value is pushed onto
+    ///   blocked waiters' eval stacks at park time, so changing it requires
+    ///   deferred-return-value materialisation. Until that lands, failing
+    ///   loud here is correct-by-detection — a real guest reaching this case
+    ///   surfaces as a clean crash rather than a silent permanent ownership
+    ///   transfer.
     let onThreadTerminated (terminated : ThreadId) (state : IlMachineState) : IlMachineState =
         let orphanedInits =
             state.TypeInitTable
@@ -153,6 +162,32 @@ module Scheduler =
         | _ ->
             failwith
                 $"Thread {terminated} terminated while still holding {orphanedSyncBlocks.Length} SyncBlock(s) (%A{orphanedSyncBlocks}); any thread parked in BlockedOnSyncBlockAcquire on those objects would deadlock on a dead owner. The guest must Monitor.Exit before terminating."
+
+        // Same contract for Win32-shaped mutexes (Mutex.WaitOne / ReleaseMutex):
+        // a terminating thread must not still own any mutex, because abandoned-
+        // mutex wake-up propagation is not yet implemented. Real CoreCLR sets
+        // a sticky abandoned flag and wakes waiters with WAIT_ABANDONED; we
+        // can't (yet) rewrite the wake-time return value of already-blocked
+        // waiters because their `WAIT_OBJECT_0` slot is pushed at park time.
+        // Failing loud is correct-by-detection until that gap is closed.
+        let orphanedMutexes =
+            state.Kernel.WaitHandles
+            |> Map.toSeq
+            |> Seq.choose (fun (id, handle) ->
+                match handle with
+                | WaitHandleState.Mutex mutex ->
+                    match mutex.Ownership with
+                    | MutexOwnership.Held (owner, _) when owner = terminated -> Some id
+                    | _ -> None
+                | WaitHandleState.Semaphore _ -> None
+            )
+            |> Seq.toList
+
+        match orphanedMutexes with
+        | [] -> ()
+        | _ ->
+            failwith
+                $"Thread {terminated} terminated while still owning {orphanedMutexes.Length} mutex(es) (%A{orphanedMutexes}); abandoned-mutex propagation is not yet implemented (the wake-time return value is pushed onto blocked waiters' eval stacks at park time, so producing WAIT_ABANDONED for them requires deferred-return-value materialisation). The guest must ReleaseMutex before terminating until that gap is closed."
 
         let threadState =
             state.ThreadState

--- a/WoofWare.PawPrint/WaitHandle.fs
+++ b/WoofWare.PawPrint/WaitHandle.fs
@@ -2,18 +2,21 @@ namespace WoofWare.PawPrint
 
 /// Deterministic state machine for the Win32-shaped wait-handle kernel
 /// objects exposed to managed code through `CreateSemaphoreExW`,
-/// `ReleaseSemaphore`, `CloseHandle`, and `WaitHandle_WaitOneCore`. On
-/// .NET 10 CoreCLR-on-Unix the BCL compiles `Semaphore.Windows.cs`
-/// regardless of host, with `Libraries.Kernel32` rebound to
-/// `RuntimeHelpers.QCall`; every Kernel32 LibraryImport therefore routes
-/// to the runtime as a QCall whose entry point uses the Win32 wide-string
-/// name. PawPrint reproduces the observable semantics through
-/// `WaitHandleState` (registry value, kind-tagged) and one new
-/// `ThreadStatus` case (`BlockedOnWaitHandle`).
+/// `ReleaseSemaphore`, `CloseHandle`, `WaitHandle_WaitOneCore`,
+/// `WaitHandle_WaitOnePrioritized`, `PAL_CreateMutexW`, and
+/// `ReleaseMutex`. On .NET 10 CoreCLR-on-Unix the BCL compiles
+/// `Semaphore.Windows.cs` / `Mutex.CoreCLR.Unix.cs` regardless of host,
+/// with `Libraries.Kernel32` rebound to `RuntimeHelpers.QCall`; every
+/// Kernel32 LibraryImport therefore routes to the runtime as a QCall
+/// whose entry point uses the Win32 wide-string name. PawPrint
+/// reproduces the observable semantics through `WaitHandleState`
+/// (registry value, kind-tagged) and one `ThreadStatus` case
+/// (`BlockedOnWaitHandle`).
 ///
-/// This first slice supports the semaphore variant only. The DU's job is
-/// to keep "kind dispatch in WaitOne/Close" exhaustive so the compiler
-/// catches a missing branch when `Event` or `Mutex` lands.
+/// Two kinds are supported today: semaphore (`Count`-based) and mutex
+/// (ownership-based, re-entrant on owner, abandoned-flag-aware). The
+/// DU's job is to keep "kind dispatch in WaitOne/Close" exhaustive so
+/// the compiler catches a missing branch when `Event` lands.
 ///
 /// The module is pure: every transition is `IlMachineState ->
 /// IlMachineState` (or returns an outcome carrying the next state) and
@@ -31,6 +34,16 @@ namespace WoofWare.PawPrint
 /// (`tryWaitOne`): it does not park, never touches the queue, and
 /// returns `WAIT_OBJECT_0` or `WAIT_TIMEOUT` depending on whether the
 /// fast path applied.
+///
+/// Abandoned-mutex propagation: full support (rewriting the wake-time
+/// return value of already-blocked waiters when their owner thread
+/// terminates) is structural and out of scope for this slice — the
+/// scheduler pushes `WAIT_OBJECT_0` at park time, so making the wake
+/// produce `WAIT_ABANDONED` requires deferred-return-value
+/// materialisation. Until that lands, `Scheduler.onThreadTerminated`
+/// fails loud if a terminating thread still owns any mutex, so a real
+/// guest reaching that case surfaces as a clean failure rather than a
+/// silent permanent ownership.
 [<RequireQualifiedAccess>]
 module WaitHandle =
 
@@ -46,26 +59,55 @@ module WaitHandle =
         /// check itself is done without computing the sum.
         | WouldExceedMaximum of attemptedTotal : int64 * maximum : int
 
-    /// Outcome of a `waitOne` call. The native handler treats both
-    /// constructors identically — advance IL and return `WAIT_OBJECT_0` —
-    /// because the IL `WaitOne` call site has already moved past itself
-    /// by the time the scheduler picks the woken thread. The split
-    /// exists so callers (notably future multi-handle waits) can
-    /// distinguish "took ownership on the fast path" from "parked".
+    /// Why `releaseMutex` rejected a request. The Win32 `ReleaseMutex`
+    /// returns FALSE and sets `ERROR_NOT_OWNER (0x120 = 288)` for both
+    /// "free mutex" and "held by another thread" cases; the BCL's
+    /// `Mutex.ReleaseMutex` translates that into
+    /// `ApplicationException` / `SynchronizationLockException`.
+    [<RequireQualifiedAccess>]
+    type ReleaseMutexFailure =
+        /// The mutex is free, or held by a thread other than the caller.
+        | NotOwner
+
+    /// Outcome of a `waitOne` call.
+    ///
+    /// `Acquired` and `AcquiredAbandoned` are both fast-path successes
+    /// (the thread stays Runnable); the only observable difference is
+    /// the integer return code (`WAIT_OBJECT_0` vs `WAIT_ABANDONED`),
+    /// which the native handler unpacks. `AcquiredAbandoned` is only
+    /// produced by the mutex variant on a `Free wasAbandoned=true`
+    /// transition; semaphore acquires never produce it. The
+    /// non-mutex-aware caller can still pattern-match against the
+    /// constructor (it'd never fire) — that's tolerable because
+    /// `waitOne` is the operation as a whole, and the abandoned outcome
+    /// is properly a wait-handle-level concept rather than a
+    /// kind-specific one.
+    ///
+    /// `Blocked` means the thread is parked at the wait queue and its
+    /// status flipped to `BlockedOnWaitHandle`. The IL site advances in
+    /// every case; when the parked thread is later woken its
+    /// `WAIT_OBJECT_0` slot has already been pushed onto its eval stack
+    /// at park time.
     [<RequireQualifiedAccess>]
     type WaitOutcome =
         | Acquired of IlMachineState
+        | AcquiredAbandoned of IlMachineState
         | Blocked of IlMachineState
 
     /// Outcome of a non-blocking `tryWaitOne` probe (zero-timeout wait).
-    /// `Acquired` means the fast path applied — count was decremented.
-    /// `TimedOut` means count was 0; the state is unchanged (no enqueue,
+    /// `Acquired` means the fast path applied — count was decremented or
+    /// the mutex was taken. `AcquiredAbandoned` is the mutex-on-abandoned
+    /// flag analogue (still a fast-path success, but the caller pushes
+    /// `WAIT_ABANDONED` rather than `WAIT_OBJECT_0`). `TimedOut` means
+    /// the fast path could not apply; state is unchanged (no enqueue,
     /// no thread-status flip — that's the entire point of distinguishing
     /// this from `waitOne`). The native handler maps these to
-    /// `WAIT_OBJECT_0` (0) and `WAIT_TIMEOUT` (0x102) respectively.
+    /// `WAIT_OBJECT_0` (0), `WAIT_ABANDONED` (0x80), and `WAIT_TIMEOUT`
+    /// (0x102) respectively.
     [<RequireQualifiedAccess>]
     type TryWaitOutcome =
         | Acquired of IlMachineState
+        | AcquiredAbandoned of IlMachineState
         | TimedOut of IlMachineState
 
     /// Look up the handle for `id`, or fail loud. A retained IntPtr that
@@ -88,6 +130,16 @@ module WaitHandle =
     let private expectSemaphore (operation : string) (id : WaitHandleId) (handle : WaitHandleState) : SemaphoreState =
         match handle with
         | WaitHandleState.Semaphore s -> s
+        | WaitHandleState.Mutex _ ->
+            failwith
+                $"%s{operation}: WaitHandle %O{id} is a Mutex, but this operation only accepts a Semaphore (e.g. ReleaseSemaphore / WaitOnePrioritized). This is a guest bug — the BCL would have failed in its own wrapper before reaching the runtime."
+
+    let private expectMutex (operation : string) (id : WaitHandleId) (handle : WaitHandleState) : MutexState =
+        match handle with
+        | WaitHandleState.Mutex m -> m
+        | WaitHandleState.Semaphore _ ->
+            failwith
+                $"%s{operation}: WaitHandle %O{id} is a Semaphore, but this operation only accepts a Mutex (e.g. ReleaseMutex). This is a guest bug — the BCL would have failed in its own wrapper before reaching the runtime."
 
     /// Allocate a fresh semaphore kernel object. Returns the new handle
     /// alongside the updated state. The handle is non-zero (counters
@@ -136,23 +188,51 @@ module WaitHandle =
 
         id, state
 
-    /// Try to take one unit from the semaphore on behalf of `thread`.
-    ///
-    /// Returns `Acquired` if the fast path applied: count was > 0 and we
-    /// decremented it. The IL `WaitOne` site advances and the thread
-    /// stays Runnable.
-    ///
-    /// Returns `Blocked` if count was 0: the thread is parked at the
-    /// FIFO tail of `WaitQueue` and its status flips to
-    /// `BlockedOnWaitHandle`. The IL site still advances (the native
-    /// handler returns `Stepped/Executed` in both cases); when the
-    /// thread is later woken by `releaseSemaphore`, its count slot has
-    /// already been consumed by the wake step, so resuming past the
-    /// `WaitOne` call is correct without re-decrementing.
-    let waitOne (thread : ThreadId) (id : WaitHandleId) (state : IlMachineState) : WaitOutcome =
-        let handle = lookup id state
-        let semaphore = expectSemaphore "WaitHandle.waitOne" id handle
+    /// Allocate a fresh mutex kernel object. Returns the new handle
+    /// alongside the updated state. If `initialOwner = true`, the caller
+    /// (`creator`) becomes the initial owner with `recursionCount = 1`,
+    /// matching the Win32 `CreateMutex(bInitialOwner = TRUE)` contract;
+    /// otherwise the mutex starts free.
+    let createMutex
+        (initialOwner : bool)
+        (creator : ThreadId)
+        (state : IlMachineState)
+        : WaitHandleId * IlMachineState
+        =
+        let id = WaitHandleId state.Kernel.NextWaitHandleId
 
+        let ownership =
+            if initialOwner then
+                MutexOwnership.Held (creator, 1)
+            else
+                MutexOwnership.Free false
+
+        let mutex : MutexState =
+            {
+                Ownership = ownership
+                WaitQueue = []
+            }
+
+        let state =
+            state.MapKernel (fun kernel ->
+                { kernel with
+                    WaitHandles = kernel.WaitHandles |> Map.add id (WaitHandleState.Mutex mutex)
+                    NextWaitHandleId = kernel.NextWaitHandleId + 1
+                }
+            )
+
+        id, state
+
+    /// Internal: kind-private semaphore waitOne. Used by the kind
+    /// dispatcher in `waitOne` and the property tests that exercise the
+    /// semaphore path directly.
+    let private waitOneSemaphore
+        (thread : ThreadId)
+        (id : WaitHandleId)
+        (semaphore : SemaphoreState)
+        (state : IlMachineState)
+        : WaitOutcome
+        =
         if semaphore.Count > 0 then
             // Fast path: consume one unit and stay Runnable. The new
             // count is in `[0, Maximum - 1]`, preserving the invariant.
@@ -178,6 +258,72 @@ module WaitHandle =
             |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnWaitHandle id)
             |> WaitOutcome.Blocked
 
+    /// Internal: kind-private mutex waitOne. Re-entrant on owner; the
+    /// `Free wasAbandoned=true` transition produces `AcquiredAbandoned`
+    /// and clears the flag.
+    let private waitOneMutex
+        (thread : ThreadId)
+        (id : WaitHandleId)
+        (mutex : MutexState)
+        (state : IlMachineState)
+        : WaitOutcome
+        =
+        match mutex.Ownership with
+        | MutexOwnership.Free wasAbandoned ->
+            // Take ownership; clear the abandoned flag.
+            let mutex =
+                { mutex with
+                    Ownership = MutexOwnership.Held (thread, 1)
+                }
+
+            let state = writeHandle id (WaitHandleState.Mutex mutex) state
+
+            if wasAbandoned then
+                WaitOutcome.AcquiredAbandoned state
+            else
+                WaitOutcome.Acquired state
+        | MutexOwnership.Held (owner, recursionCount) when owner = thread ->
+            // Re-entrant acquisition: bump recursion count.
+            let mutex =
+                { mutex with
+                    Ownership = MutexOwnership.Held (owner, recursionCount + 1)
+                }
+
+            state |> writeHandle id (WaitHandleState.Mutex mutex) |> WaitOutcome.Acquired
+        | MutexOwnership.Held _ ->
+            // Held by another thread: park at FIFO tail.
+            let mutex =
+                { mutex with
+                    WaitQueue = mutex.WaitQueue @ [ thread ]
+                }
+
+            state
+            |> writeHandle id (WaitHandleState.Mutex mutex)
+            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnWaitHandle id)
+            |> WaitOutcome.Blocked
+
+    /// Try to take ownership of `id` on behalf of `thread`. Dispatches
+    /// by kind:
+    ///
+    ///  - Semaphore: decrement the count if positive; otherwise park at
+    ///    the FIFO tail of `WaitQueue` and flip the thread's status to
+    ///    `BlockedOnWaitHandle`.
+    ///  - Mutex: re-entrant fast path on the owning thread; take the
+    ///    free mutex (producing `AcquiredAbandoned` iff the abandoned
+    ///    flag was set, clearing it); otherwise park at the FIFO tail.
+    ///
+    /// The IL `WaitOne` site advances in every case (the native handler
+    /// returns `Stepped/Executed` for all three outcomes). When a parked
+    /// thread is later woken, its `WAIT_OBJECT_0` slot has already been
+    /// pushed onto its eval stack at park time — see the
+    /// abandoned-mutex-propagation note on the module docstring.
+    let waitOne (thread : ThreadId) (id : WaitHandleId) (state : IlMachineState) : WaitOutcome =
+        let handle = lookup id state
+
+        match handle with
+        | WaitHandleState.Semaphore semaphore -> waitOneSemaphore thread id semaphore state
+        | WaitHandleState.Mutex mutex -> waitOneMutex thread id mutex state
+
     /// Non-blocking probe used to model the zero-timeout `WaitOne(0)`
     /// path. CoreCLR's contract for a zero millisecond timeout: try the
     /// fast path; if it cannot succeed, return `WAIT_TIMEOUT` without
@@ -185,9 +331,62 @@ module WaitHandle =
     /// caller is *not* parked — leaving the thread Runnable is the entire
     /// observable difference from a guest's point of view, and silently
     /// parking would deadlock guests that rely on `WaitOne(0)` as a poll.
-    let tryWaitOne (id : WaitHandleId) (state : IlMachineState) : TryWaitOutcome =
+    ///
+    /// `thread` is consumed by the mutex kind (for re-entrancy and
+    /// ownership identity); the semaphore kind ignores it.
+    let tryWaitOne (thread : ThreadId) (id : WaitHandleId) (state : IlMachineState) : TryWaitOutcome =
         let handle = lookup id state
-        let semaphore = expectSemaphore "WaitHandle.tryWaitOne" id handle
+
+        match handle with
+        | WaitHandleState.Semaphore semaphore ->
+            if semaphore.Count > 0 then
+                let semaphore =
+                    { semaphore with
+                        Count = semaphore.Count - 1
+                    }
+
+                state
+                |> writeHandle id (WaitHandleState.Semaphore semaphore)
+                |> TryWaitOutcome.Acquired
+            else
+                // State must be returned verbatim: no enqueue, no status flip.
+                TryWaitOutcome.TimedOut state
+        | WaitHandleState.Mutex mutex ->
+            match mutex.Ownership with
+            | MutexOwnership.Free wasAbandoned ->
+                let mutex =
+                    { mutex with
+                        Ownership = MutexOwnership.Held (thread, 1)
+                    }
+
+                let state = writeHandle id (WaitHandleState.Mutex mutex) state
+
+                if wasAbandoned then
+                    TryWaitOutcome.AcquiredAbandoned state
+                else
+                    TryWaitOutcome.Acquired state
+            | MutexOwnership.Held (owner, recursionCount) when owner = thread ->
+                let mutex =
+                    { mutex with
+                        Ownership = MutexOwnership.Held (owner, recursionCount + 1)
+                    }
+
+                state |> writeHandle id (WaitHandleState.Mutex mutex) |> TryWaitOutcome.Acquired
+            | MutexOwnership.Held _ ->
+                // Held by another thread: no enqueue, no status flip.
+                TryWaitOutcome.TimedOut state
+
+    /// Semaphore-only non-blocking probe used by the prioritized
+    /// dispatch path. Keeping the two `tryWait` variants split (rather
+    /// than letting prioritized fall through to the kind-generic
+    /// `tryWaitOne`) lets the prioritized native handler keep its
+    /// "mutexes are not legal on this entry point" guarantee — passing
+    /// a mutex handle to `WaitHandle_WaitOnePrioritized` is a guest bug,
+    /// and we want it to fail loud rather than accidentally succeed via
+    /// the kind-generic probe.
+    let internal tryWaitOneSemaphore (id : WaitHandleId) (state : IlMachineState) : TryWaitOutcome =
+        let handle = lookup id state
+        let semaphore = expectSemaphore "WaitHandle.tryWaitOneSemaphore" id handle
 
         if semaphore.Count > 0 then
             let semaphore =
@@ -199,7 +398,6 @@ module WaitHandle =
             |> writeHandle id (WaitHandleState.Semaphore semaphore)
             |> TryWaitOutcome.Acquired
         else
-            // State must be returned verbatim: no enqueue, no status flip.
             TryWaitOutcome.TimedOut state
 
     /// Prioritized variant of `waitOne` matching the
@@ -317,12 +515,76 @@ module WaitHandle =
 
             Ok previousCount, state
 
+    /// Decrement the recursion count, or — if it was the outermost
+    /// release — either mark the mutex free (no waiters) or hand
+    /// ownership directly to the FIFO head of `WaitQueue` (the
+    /// "direct-handoff" posture also used by `Monitor.Exit` and
+    /// `LowLevelMonitor.release`; the woken thread resumes past its
+    /// `WaitOne` call site already owning the mutex).
+    ///
+    /// Returns `Error NotOwner` if the mutex is free, or held by a
+    /// thread other than `thread`; the state is unchanged in that case.
+    /// `Error NotOwner` is what the Win32 `ReleaseMutex` returns for
+    /// either case (with `ERROR_NOT_OWNER = 0x120`); the BCL maps the
+    /// FALSE return into `SynchronizationLockException`.
+    let releaseMutex
+        (thread : ThreadId)
+        (id : WaitHandleId)
+        (state : IlMachineState)
+        : Result<unit, ReleaseMutexFailure> * IlMachineState
+        =
+        let handle = lookup id state
+        let mutex = expectMutex "WaitHandle.releaseMutex" id handle
+
+        match mutex.Ownership with
+        | MutexOwnership.Free _ -> Error ReleaseMutexFailure.NotOwner, state
+        | MutexOwnership.Held (owner, _) when owner <> thread -> Error ReleaseMutexFailure.NotOwner, state
+        | MutexOwnership.Held (_, recursionCount) when recursionCount > 1 ->
+            // Inner release: drop the count by one, ownership unchanged.
+            let mutex =
+                { mutex with
+                    Ownership = MutexOwnership.Held (thread, recursionCount - 1)
+                }
+
+            Ok (), writeHandle id (WaitHandleState.Mutex mutex) state
+        | MutexOwnership.Held (_, _) ->
+            // Outermost release: either mark free, or direct-handoff to
+            // the FIFO head of the wait queue.
+            match mutex.WaitQueue with
+            | [] ->
+                let mutex =
+                    { mutex with
+                        Ownership = MutexOwnership.Free false
+                    }
+
+                Ok (), writeHandle id (WaitHandleState.Mutex mutex) state
+            | head :: rest ->
+                let mutex =
+                    { mutex with
+                        Ownership = MutexOwnership.Held (head, 1)
+                        WaitQueue = rest
+                    }
+
+                let state =
+                    state
+                    |> writeHandle id (WaitHandleState.Mutex mutex)
+                    |> Scheduler.setThreadStatus head ThreadStatus.Runnable
+
+                Ok (), state
+
     /// Tear down a wait handle. The Win32 contract is that `CloseHandle`
     /// runs after the handle is fully quiescent — no thread is currently
     /// waiting on it. We enforce that contract loudly: closing a handle
     /// with a non-empty wait queue is a guest bug that would otherwise
     /// present as the waiters being permanently parked on a recycled
     /// object.
+    ///
+    /// For mutexes, we additionally require the mutex to be free.
+    /// Closing a still-held mutex is a guest bug: real CoreCLR closes
+    /// the handle and the kernel reaps the mutex, but any waiter that
+    /// somehow held a separate handle would deadlock. We don't model
+    /// shared/duplicated handles, so the contract is "release before
+    /// dispose", and we fail loud otherwise.
     ///
     /// IDs are never reused; the entry is removed from the table, so a
     /// retained `IntPtr` to the closed handle fails loudly at the next
@@ -337,6 +599,18 @@ module WaitHandle =
             | waiters ->
                 failwith
                     $"WaitHandle %O{id}: refusing to Close a semaphore with %d{List.length waiters} thread(s) parked in BlockedOnWaitHandle (%A{waiters}); the guest must Release before Disposing."
+        | WaitHandleState.Mutex mutex ->
+            match mutex.WaitQueue with
+            | [] -> ()
+            | waiters ->
+                failwith
+                    $"WaitHandle %O{id}: refusing to Close a mutex with %d{List.length waiters} thread(s) parked in BlockedOnWaitHandle (%A{waiters}); the guest must Release before Disposing."
+
+            match mutex.Ownership with
+            | MutexOwnership.Free _ -> ()
+            | MutexOwnership.Held (owner, recursionCount) ->
+                failwith
+                    $"WaitHandle %O{id}: refusing to Close a mutex still held by thread %O{owner} (recursion count = %d{recursionCount}); the guest must ReleaseMutex before Disposing."
 
         state.MapKernel (fun kernel ->
             { kernel with


### PR DESCRIPTION
## Summary

- Adds the Mutex variant of `WaitHandleState`: re-entrant ownership tracked as a DU (`Free of wasAbandoned : bool | Held of owner * recursionCount`), a `WaitQueue` for parked waiters, and FIFO direct-handoff on `ReleaseMutex`.
- Implements the `PAL_CreateMutexW` and `ReleaseMutex` QCalls on top of the existing semaphore plumbing (`dispatchWait` now takes blocking/try functions separately so the prioritized waiter stays semaphore-only).
- Extends `waitOne` / `tryWaitOne` to dispatch by handle kind, surfaces an `AcquiredAbandoned` outcome that returns `WAIT_ABANDONED` to the guest, and fails loud in `Scheduler` when a thread terminates while still owning a mutex (full abandoned-flag propagation through parked waiters is deferred — see commit notes).
- Adds ~25 property tests across `TestWaitHandle.fs` covering create / wait / re-entrancy / parking / release / direct-handoff / abandoned-flag / close invariants / cross-kind safety / use-after-free.

Follow-up commit (`4a8fc99`) accepts an empty UTF-16 name in `PAL_CreateMutexW` — `Mutex.CoreCLR.Unix.cs` treats `string.IsNullOrEmpty(name)` as unnamed at the options layer but flows the original string through the LibraryImport marshaller, so `new Mutex(..., \"\")` arrives at the QCall as a non-null pointer to a NUL char.

## Test plan

- [x] `nix develop -c dotnet build` clean (warnings-as-errors)
- [x] `nix develop -c dotnet fantomas .`
- [x] `nix develop -c dotnet test --filter \"Name~WaitHandle\"` — 61/61 pass, 6 properties at 200 cases each
- [x] Full suite — 1075/1075 pass, no regressions
- [x] `codex review --base main` — first pass flagged the empty-name issue (now fixed); second pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)