### PR TITLE
Render parameter types and names in exception stack frames

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -25,7 +25,6 @@ module TestPureCases =
             "IsAssignableFromOpenGenericDefinition.cs" // TypeHandle.CanCastTo_NoCacheLookup for open generic
             "InterfaceDispatch.cs" // expected: 0; was: 1024
             "ComplexTryCatch.cs" // refusing byte view over value type containing object references in an array
-            "RethrowStackTraceBoundary.cs" // expected: 0; was: 11
             "Threads.cs" // blocked by pointer arithmetic over a generated Data field after Interlocked.CompareExchange
             "IsAssignableToBasic.cs" // MethodTable field projection for MethodTable::PerInstInfo
             "RuntimeTypeHandleGetInstantiationOpenGeneric.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringMethodForGenericParameter

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -616,11 +616,16 @@ module IlMachineRuntimeMetadata =
         | None when String.IsNullOrEmpty ty.Namespace -> ty.Name
         | None -> $"{ty.Namespace}.{ty.Name}"
 
-    /// Render a parameter's type using the CLR's stack-trace convention:
-    /// `Type.Name` (no namespace, no assembly) with structural wrappers applied recursively.
-    /// Matches CoreCLR's `StackTrace.ToString` which appends each parameter type's `.Name`,
-    /// and is distinct from full reflection name rendering (cf. `NativeRuntimeType.fs`
-    /// `concreteTypeHandleName`, which honours the FormatNamespace / FormatAssembly bits).
+    /// Render a parameter's type using the CLR's stack-trace convention: just `Type.Name`.
+    /// `Type.Name` for a constructed generic such as `List<int>` is `"List`1"` — the
+    /// instantiation is NOT appended (verified against `typeof(List<int>).Name` in CoreCLR),
+    /// so this differs from full reflection name rendering (cf. `NativeRuntimeType.fs`
+    /// `concreteTypeHandleName`, which appends `[args]` under FormatNamespace/Assembly).
+    /// Array, pointer, and byref wrappers do show up in `Type.Name`, so we render those.
+    /// FIXME: For generic-method/generic-type parameters, CoreCLR renders the formal
+    /// parameter name (e.g. `Foo(T x)`); we lose that here because the concretized
+    /// signature has already substituted in the concrete handle. Switching to
+    /// `RawSignature` plus assembly-side generic-param metadata is a separate change.
     let rec private renderParameterTypeName (state : IlMachineState) (handle : ConcreteTypeHandle) : string =
         match handle with
         | ConcreteTypeHandle.Byref inner -> renderParameterTypeName state inner + "&"
@@ -635,14 +640,7 @@ module IlMachineRuntimeMetadata =
         | ConcreteTypeHandle.Concrete _ ->
             match AllConcreteTypes.lookup handle state.ConcreteTypes with
             | None -> "<unresolved>"
-            | Some ct ->
-                if ct.Generics.IsEmpty then
-                    ct.Name
-                else
-                    let args =
-                        ct.Generics |> Seq.map (renderParameterTypeName state) |> String.concat ","
-
-                    $"%s{ct.Name}[%s{args}]"
+            | Some ct -> ct.Name
 
     let private renderExceptionStackFrame
         (state : IlMachineState)

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -616,13 +616,60 @@ module IlMachineRuntimeMetadata =
         | None when String.IsNullOrEmpty ty.Namespace -> ty.Name
         | None -> $"{ty.Namespace}.{ty.Name}"
 
+    /// Render a parameter's type using the CLR's stack-trace convention:
+    /// `Type.Name` (no namespace, no assembly) with structural wrappers applied recursively.
+    /// Matches CoreCLR's `StackTrace.ToString` which appends each parameter type's `.Name`,
+    /// and is distinct from full reflection name rendering (cf. `NativeRuntimeType.fs`
+    /// `concreteTypeHandleName`, which honours the FormatNamespace / FormatAssembly bits).
+    let rec private renderParameterTypeName (state : IlMachineState) (handle : ConcreteTypeHandle) : string =
+        match handle with
+        | ConcreteTypeHandle.Byref inner -> renderParameterTypeName state inner + "&"
+        | ConcreteTypeHandle.Pointer inner -> renderParameterTypeName state inner + "*"
+        | ConcreteTypeHandle.OneDimArrayZero inner -> renderParameterTypeName state inner + "[]"
+        | ConcreteTypeHandle.Array (inner, rank) ->
+            let dims = if rank <= 1 then "*" else System.String (',', rank - 1)
+            renderParameterTypeName state inner + "[" + dims + "]"
+        // CoreCLR's TypeString::AppendType emits the empty string for FnPtr when FormatNamespace
+        // is unset; stack-trace parameter rendering uses the no-namespace form, so match that.
+        | ConcreteTypeHandle.FunctionPointer _ -> ""
+        | ConcreteTypeHandle.Concrete _ ->
+            match AllConcreteTypes.lookup handle state.ConcreteTypes with
+            | None -> "<unresolved>"
+            | Some ct ->
+                if ct.Generics.IsEmpty then
+                    ct.Name
+                else
+                    let args =
+                        ct.Generics |> Seq.map (renderParameterTypeName state) |> String.concat ","
+
+                    $"%s{ct.Name}[%s{args}]"
+
     let private renderExceptionStackFrame
         (state : IlMachineState)
         (frame : ExceptionStackFrame<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>)
         : string
         =
         let typeName = concreteTypeFullName state frame.Method.DeclaringType
-        $"   at %s{typeName}.%s{frame.Method.Name}()"
+
+        // Metadata Parameters skip SequenceNumber=0 (`this` / ref return), so signature index `i`
+        // pairs with the parameter whose SequenceNumber is `i + 1` regardless of static-ness.
+        let parameterByPosition =
+            frame.Method.Parameters
+            |> Seq.map (fun p -> p.SequenceNumber, p.Name)
+            |> Map.ofSeq
+
+        let paramText =
+            frame.Method.Signature.ParameterTypes
+            |> List.mapi (fun i ty ->
+                let typeStr = renderParameterTypeName state ty
+
+                match Map.tryFind (i + 1) parameterByPosition with
+                | Some name when not (String.IsNullOrEmpty name) -> $"%s{typeStr} %s{name}"
+                | _ -> typeStr
+            )
+            |> String.concat ", "
+
+        $"   at %s{typeName}.%s{frame.Method.Name}(%s{paramText})"
 
     let private renderExceptionStackTrace
         (state : IlMachineState)


### PR DESCRIPTION
## Summary
- `renderExceptionStackFrame` was emitting `Type.Method()` with empty parentheses for every frame. Walk `Signature.ParameterTypes` and pair each entry with `Parameters[SequenceNumber = i + 1]` (skipping `this` per `Parameter.readAll`), formatting types with CLR `Type.Name` semantics: simple name plus structural wrappers for arrays/pointers/byrefs. Constructed generics render as their bare metadata name (e.g. `List\`1`), matching `typeof(List<int>).Name` — no `[args]` suffix.
- Activates `RethrowStackTraceBoundary.cs` (removed from the `unimplemented` set), which exercises a captured trace through a rethrow plus an outer `ApplicationException` wrap. The BCL's `Exception.ToString` composes both traces using the boundary text from the populated `_stackTraceString` and `_innerException` fields, and all asserted substrings now appear.
- A `FIXME` is left in the renderer noting that for generic-method/type formal parameter names (e.g. `Foo(T x)` rather than `Foo(Int32 x)`), the renderer should walk `RawSignature : TypeMethodSignature<TypeDefn>` and resolve generic-param indices against assembly metadata — out of scope for this PR.

## Test plan
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --filter "Name~RethrowStackTraceBoundary"` passes (exit 0).
- [x] Full suite: 1082 passed, 0 failed.
- [x] `nix develop -c dotnet fantomas .` is a no-op.
- [x] `codex review --base main` (two passes): first round flagged two divergences from CoreCLR; Finding 1 (drop generic-instantiation expansion) addressed in this PR, Finding 2 (raw-signature rendering for generic-param formal names) noted as a follow-up. Second pass found no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)