### PR TITLE
Add cell-aware fast path to Buffer copy for non-byte-addressable cells

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -19,14 +19,11 @@ module TestPureCases =
         [
             "AdvancedStructLayout.cs" // past MarshalNative_SizeOfHelper for ByValTStr and SystemNative_Malloc / SystemNative_Free / Marshal.AllocHGlobal / FreeHGlobal; now blocked downstream at the unimplemented MarshalNative_TryGetStructMarshalStub QCall (CoreLib's Marshal.StructureToPtr path)
             "MarshalSizeOfAutoLayoutStruct.cs" // refusing to compute unmanaged marshalled size because LayoutKind.Auto but throwIfNotMarshalable=true
-            "LdtokenField.cs" // past InternalCall System.Buffer::BulkMoveWithWriteBarrierInternal; now blocked during reflection-cache update because Buffer's byte-wise copy refuses to byte-view object-reference array cells (`validateByteAddressableCell` rejects ObjectRef storage)
-            "RuntimeFieldHandleGetUtf8Name.cs" // exercises RuntimeFieldHandle::GetUtf8NameInternal, RuntimeTypeHandle::GetInterfaces, and Volatile.Write of object refs successfully; now blocked at the next step in the reflection-cache copy by `validateByteAddressableCell` refusing to byte-view object-reference cells inside Buffer::BulkMoveWithWriteBarrierInternal
-            "RuntimeTypeGetInterfacesInherited.cs" // exercises the QCall's inherited-base + transitive-interface walk; now blocked during the reflection-cache update by `validateByteAddressableCell` refusing to byte-view object-reference cells inside Buffer::BulkMoveWithWriteBarrierInternal
+            "LdtokenField.cs" // past Buffer's reflection-cache copy (cell-aware path); now blocked on the next reflection-cache step at unimplemented InternalCall RuntimeFieldHandle::GetApproxDeclaringMethodTable
             "IsAssignableFromOpenGenericDefinition.cs" // TypeHandle.CanCastTo_NoCacheLookup for open generic
             "InterfaceDispatch.cs" // expected: 0; was: 1024
-            "ComplexTryCatch.cs" // refusing byte view over value type containing object references in an array
             "RethrowStackTraceBoundary.cs" // expected: 0; was: 11
-            "Threads.cs" // blocked by pointer arithmetic over a generated Data field after Interlocked.CompareExchange
+            "Threads.cs" // past Buffer's reflection-cache copy (cell-aware path); now blocked on unimplemented QCall ThreadNative_SetIsBackground
             "IsAssignableToBasic.cs" // MethodTable field projection for MethodTable::PerInstInfo
             "RuntimeTypeHandleGetInstantiationOpenGeneric.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringMethodForGenericParameter
             "IndirectMemoryOperations.cs" // raise IndexOutOfRangeException: array index 8 >= length 3 on array

--- a/WoofWare.PawPrint/Native/NativeBuffer.fs
+++ b/WoofWare.PawPrint/Native/NativeBuffer.fs
@@ -286,7 +286,16 @@ module NativeBuffer =
                 else
                     srcInCell = 0
 
-            if not aligned || cellSize > bytesRemaining then
+            // Reject `cellSize <= 0`: a zero-sized value-type cell (PawPrint
+            // gives fieldless default-layout structs `sizeOf = 0`) would
+            // return `Some (newState, 0)`, and the caller would advance `i`
+            // by zero — spinning the copy loop forever for any positive
+            // requested byte count. Falling back to the byte step is also
+            // wrong here (we'd read a byte off a non-existent cell), so the
+            // caller's byte step would itself fail loudly — which is the
+            // intended behaviour, since a positive byte copy against a
+            // zero-sized cell anchor is an interpreter-bug shape.
+            if not aligned || cellSize <= 0 || cellSize > bytesRemaining then
                 None
             else
                 let destCell = IlMachineState.readManagedByref baseClassTypes state destPlain

--- a/WoofWare.PawPrint/Native/NativeBuffer.fs
+++ b/WoofWare.PawPrint/Native/NativeBuffer.fs
@@ -131,24 +131,52 @@ module NativeBuffer =
             srcOffset < destOffset && destOffset < srcOffset + int64 byteCount
         | _ -> false
 
+    /// All residual projections must be plain `Field` projections. The
+    /// fast-path uses `readManagedByref` on the residual, which dispatches
+    /// through `readProjectedValue`: that helper supports `Field` cleanly,
+    /// short-circuits `ReinterpretAs` only for same-width primitive families
+    /// (and throws otherwise), and unconditionally throws on `ByteOffset`.
+    /// Allowing interior `ReinterpretAs` here would turn the fast path into
+    /// a host failure for shapes the byte-walk fallback would otherwise
+    /// service (e.g. a byte view built from a non-trailing `ReinterpretAs`
+    /// such as `Unsafe.As<int, S>(ref arr[0]).B`), so the fast path
+    /// declines and lets the byte-walk peel the projection.
+    let private isPlainResidual (projs : ByrefProjection list) : bool =
+        projs
+        |> List.forall (fun proj ->
+            match proj with
+            | ByrefProjection.Field _ -> true
+            | ByrefProjection.ReinterpretAs _
+            | ByrefProjection.ByteOffset _ -> false
+        )
+
     /// Strip a trailing byte-view suffix (`[..., ReinterpretAs _]` or
     /// `[..., ReinterpretAs _; ByteOffset n]`) and return the residual byref
-    /// together with the intra-cell byte offset. Returns `None` for
-    /// non-Byref pointers or for byrefs whose trailing projections are not a
-    /// clean byte-view suffix (e.g. a trailing `Field` or `ByteOffset`
-    /// without a preceding `ReinterpretAs` — the latter would already be an
-    /// interpreter-bug shape).
+    /// together with the intra-cell byte offset. Returns `None` for non-Byref
+    /// pointers, for byrefs whose trailing projections are not a clean
+    /// byte-view suffix (e.g. a trailing `Field` or `ByteOffset` without a
+    /// preceding `ReinterpretAs` — the latter would already be an
+    /// interpreter-bug shape), or for byrefs whose residual after stripping
+    /// would still contain an interior `ReinterpretAs` / `ByteOffset`
+    /// projection (see `isPlainResidual` for why those must fall back to the
+    /// byte-walk).
     let private inCellOffsetAndStripByteView (ptr : ManagedPointerSource) : (ManagedPointerSource * int) option =
+        let tryReturn (root : ByrefRoot) (residualRev : ByrefProjection list) (inCellOffset : int) =
+            let residual = List.rev residualRev
+
+            if isPlainResidual residual then
+                Some (ManagedPointerSource.Byref (root, residual), inCellOffset)
+            else
+                None
+
         match ptr with
         | ManagedPointerSource.Null
         | ManagedPointerSource.NativeIntPlaceholder _ -> None
         | ManagedPointerSource.Byref (root, projs) ->
             match List.rev projs with
             | [] -> Some (ptr, 0)
-            | ByrefProjection.ByteOffset n :: ByrefProjection.ReinterpretAs _ :: revRest ->
-                Some (ManagedPointerSource.Byref (root, List.rev revRest), n)
-            | ByrefProjection.ReinterpretAs _ :: revRest ->
-                Some (ManagedPointerSource.Byref (root, List.rev revRest), 0)
+            | ByrefProjection.ByteOffset n :: ByrefProjection.ReinterpretAs _ :: revRest -> tryReturn root revRest n
+            | ByrefProjection.ReinterpretAs _ :: revRest -> tryReturn root revRest 0
             | _ -> None
 
     /// True when copying the src cell wholesale into the dest cell would

--- a/WoofWare.PawPrint/Native/NativeBuffer.fs
+++ b/WoofWare.PawPrint/Native/NativeBuffer.fs
@@ -131,6 +131,149 @@ module NativeBuffer =
             srcOffset < destOffset && destOffset < srcOffset + int64 byteCount
         | _ -> false
 
+    /// Strip a trailing byte-view suffix (`[..., ReinterpretAs _]` or
+    /// `[..., ReinterpretAs _; ByteOffset n]`) and return the residual byref
+    /// together with the intra-cell byte offset. Returns `None` for
+    /// non-Byref pointers or for byrefs whose trailing projections are not a
+    /// clean byte-view suffix (e.g. a trailing `Field` or `ByteOffset`
+    /// without a preceding `ReinterpretAs` — the latter would already be an
+    /// interpreter-bug shape).
+    let private inCellOffsetAndStripByteView (ptr : ManagedPointerSource) : (ManagedPointerSource * int) option =
+        match ptr with
+        | ManagedPointerSource.Null
+        | ManagedPointerSource.NativeIntPlaceholder _ -> None
+        | ManagedPointerSource.Byref (root, projs) ->
+            match List.rev projs with
+            | [] -> Some (ptr, 0)
+            | ByrefProjection.ByteOffset n :: ByrefProjection.ReinterpretAs _ :: revRest ->
+                Some (ManagedPointerSource.Byref (root, List.rev revRest), n)
+            | ByrefProjection.ReinterpretAs _ :: revRest ->
+                Some (ManagedPointerSource.Byref (root, List.rev revRest), 0)
+            | _ -> None
+
+    /// True when copying the src cell wholesale into the dest cell would
+    /// preserve the dest cell's CLI shape: same primitive constructor for
+    /// primitives/refs/pointers, same declared concrete type for
+    /// value-type structs. This matters because the typed write paths
+    /// (`writeRootValue` for `ArrayElement`/`HeapObjectField`/`HeapValue`)
+    /// overwrite wholesale and would silently rewrite the cell's shape on
+    /// a mismatch.
+    let private cellsHaveCompatibleShape (a : CliType) (b : CliType) : bool =
+        match a, b with
+        | CliType.Bool _, CliType.Bool _
+        | CliType.Char _, CliType.Char _
+        | CliType.ObjectRef _, CliType.ObjectRef _
+        | CliType.RuntimePointer _, CliType.RuntimePointer _ -> true
+        | CliType.Numeric a, CliType.Numeric b ->
+            match a, b with
+            | CliNumericType.Int8 _, CliNumericType.Int8 _
+            | CliNumericType.UInt8 _, CliNumericType.UInt8 _
+            | CliNumericType.Int16 _, CliNumericType.Int16 _
+            | CliNumericType.UInt16 _, CliNumericType.UInt16 _
+            | CliNumericType.Int32 _, CliNumericType.Int32 _
+            | CliNumericType.Int64 _, CliNumericType.Int64 _
+            | CliNumericType.NativeInt _, CliNumericType.NativeInt _
+            | CliNumericType.NativeFloat _, CliNumericType.NativeFloat _
+            | CliNumericType.Float32 _, CliNumericType.Float32 _
+            | CliNumericType.Float64 _, CliNumericType.Float64 _ -> true
+            | _ -> false
+        | CliType.ValueType a, CliType.ValueType b -> a.Declared = b.Declared
+        | _ -> false
+
+    /// True for byref roots whose cell shape is non-trivial (each root
+    /// designates a typed cell, possibly non-byte-addressable). The byte-walk
+    /// path through `readManagedByrefBytesAs` works for byte-addressable
+    /// cells under these roots, but fails for non-byte-addressable cells
+    /// (ObjectRef, RuntimePointer, value types containing those); the
+    /// cell-aware fast path handles both. Byte-storage roots
+    /// (`StackMemoryByte`, `NativeMemoryByte`, `PeByteRange`,
+    /// `StringCharAt`) and stack-slot roots (`LocalVariable`, `Argument`,
+    /// `StaticField`) are not considered here — the byte-walk path is the
+    /// modelled access shape for them, and stripping to a `[]` residual
+    /// for a `readManagedByref` call into a byte-storage root would fail
+    /// because the root carries no typed cell at arbitrary byte offsets.
+    let private rootIsCellAware (root : ByrefRoot) : bool =
+        match root with
+        | ByrefRoot.ArrayElement _
+        | ByrefRoot.HeapValue _
+        | ByrefRoot.HeapObjectField _
+        | ByrefRoot.MethodTableExposedClassObject _ -> true
+        | ByrefRoot.LocalVariable _
+        | ByrefRoot.Argument _
+        | ByrefRoot.StackMemoryByte _
+        | ByrefRoot.NativeMemoryByte _
+        | ByrefRoot.PeByteRange _
+        | ByrefRoot.StaticField _
+        | ByrefRoot.StringCharAt _ -> false
+
+    /// True if the residual byref (after stripping its byte-view suffix)
+    /// is anchored on a cell-aware root. Used to decide whether to attempt
+    /// a whole-cell typed read; for byte-storage roots the byte-walk path
+    /// is the modelled access shape and we must not bypass it.
+    let private byrefAnchorsCellAwareRoot (ptr : ManagedPointerSource) : bool =
+        match ptr with
+        | ManagedPointerSource.Byref (root, _) -> rootIsCellAware root
+        | _ -> false
+
+    /// Attempt to copy a single whole cell, starting at byte offset `i` in
+    /// the buffer. Returns `Some cellSize` when the move succeeded; in that
+    /// case `state` has been updated and the caller must advance `i` by
+    /// `cellSize` bytes. Returns `None` when the cell-aware path is not
+    /// applicable; the caller must then fall back to a single byte step.
+    ///
+    /// The path is taken iff both src and dest byrefs are anchored on
+    /// cell-aware roots (see `rootIsCellAware`), strip to a typed
+    /// residual at the same intra-cell byte offset (which must be 0 for a
+    /// forward step, or `cellSize - 1` for a backward step), the residual
+    /// cells have compatible CLI shape (so the wholesale typed write does
+    /// not silently change the dest's shape), and there are at least
+    /// `cellSize` bytes remaining in the requested copy. The path is the
+    /// only correct option for non-byte-addressable cells (`ObjectRef`,
+    /// `RuntimePointer`, value-type cells containing those); for
+    /// byte-addressable cells under cell-aware roots it remains correct
+    /// (and faster than the byte-by-byte loop), so we take it
+    /// unconditionally when the preconditions hold rather than
+    /// restricting to non-byte-addressable cells only.
+    let private tryWholeCellMoveAt
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (src : ManagedPointerSource)
+        (dest : ManagedPointerSource)
+        (bytesRemaining : int)
+        (backwards : bool)
+        : (IlMachineState * int) option
+        =
+        if not (byrefAnchorsCellAwareRoot src && byrefAnchorsCellAwareRoot dest) then
+            None
+        else
+
+        match inCellOffsetAndStripByteView src, inCellOffsetAndStripByteView dest with
+        | Some (srcPlain, srcInCell), Some (destPlain, destInCell) when srcInCell = destInCell ->
+            let srcCell = IlMachineState.readManagedByref baseClassTypes state srcPlain
+            let cellSize = CliType.sizeOf srcCell
+
+            let aligned =
+                if backwards then
+                    srcInCell = cellSize - 1
+                else
+                    srcInCell = 0
+
+            if not aligned || cellSize > bytesRemaining then
+                None
+            else
+                let destCell = IlMachineState.readManagedByref baseClassTypes state destPlain
+
+                if CliType.sizeOf destCell <> cellSize then
+                    None
+                elif not (cellsHaveCompatibleShape srcCell destCell) then
+                    None
+                else
+                    let newState =
+                        IlMachineState.writeManagedByrefWithBase baseClassTypes state destPlain srcCell
+
+                    Some (newState, cellSize)
+        | _ -> None
+
     let private copy
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (state : IlMachineState)
@@ -143,25 +286,46 @@ module NativeBuffer =
         let mutable state = state
 
         if shouldCopyBackwards baseClassTypes state src dest byteCount then
-            for i = byteCount - 1 downto 0 do
-                let src =
+            let mutable i = byteCount - 1
+
+            while i >= 0 do
+                let srcAtI =
                     ManagedPointerByteView.addByteOffset baseClassTypes state byteConcreteType i src
 
-                let dest =
+                let destAtI =
                     ManagedPointerByteView.addByteOffset baseClassTypes state byteConcreteType i dest
 
-                let value = readByte baseClassTypes state src
-                state <- writeByte baseClassTypes state dest value
+                // For a backward step we are at byte `i`, which must be the
+                // *last* byte of its cell (intra-cell offset `cellSize - 1`)
+                // for a whole-cell move to be safe; the move covers bytes
+                // `[i - cellSize + 1, i]` and advances `i` backwards by
+                // `cellSize`.
+                match tryWholeCellMoveAt baseClassTypes state srcAtI destAtI (i + 1) true with
+                | Some (newState, cellSize) ->
+                    state <- newState
+                    i <- i - cellSize
+                | None ->
+                    let value = readByte baseClassTypes state srcAtI
+                    state <- writeByte baseClassTypes state destAtI value
+                    i <- i - 1
         else
-            for i = 0 to byteCount - 1 do
-                let src =
+            let mutable i = 0
+
+            while i < byteCount do
+                let srcAtI =
                     ManagedPointerByteView.addByteOffset baseClassTypes state byteConcreteType i src
 
-                let dest =
+                let destAtI =
                     ManagedPointerByteView.addByteOffset baseClassTypes state byteConcreteType i dest
 
-                let value = readByte baseClassTypes state src
-                state <- writeByte baseClassTypes state dest value
+                match tryWholeCellMoveAt baseClassTypes state srcAtI destAtI (byteCount - i) false with
+                | Some (newState, cellSize) ->
+                    state <- newState
+                    i <- i + cellSize
+                | None ->
+                    let value = readByte baseClassTypes state srcAtI
+                    state <- writeByte baseClassTypes state destAtI value
+                    i <- i + 1
 
         state
 
@@ -225,17 +389,15 @@ module NativeBuffer =
     /// This handler wires `BulkMoveWithWriteBarrierInternal` into native
     /// dispatch and implements CoreCLR's FCall short-circuits
     /// (`dst != src && byteCount != 0`, see comutilnative.cpp); the actual
-    /// move reuses the byte-wise `copy` helper. That is sufficient for
-    /// byte-addressable endpoints, but the BCL's primary callers
+    /// move reuses the shared `copy` helper. The BCL's primary callers
     /// (`Buffer.Memmove<T>` for `T` containing references, `Array.Copy` of
-    /// reference-typed arrays, the reflection-cache growth path, etc.) hand
-    /// in byrefs that land on object-reference cells, which are not
-    /// byte-addressable in PawPrint and so are rejected by
-    /// `validateByteAddressableCell` inside `copy`. Making those callers
-    /// pass requires a cell-aware copy path that reads and writes whole
-    /// object-reference cells when the byte offsets and `byteCount` align
-    /// to the cell boundary; that work is intentionally deferred to a
-    /// separate change so this PR stays a focused dispatch increment.
+    /// reference-typed arrays, the reflection-cache growth path, etc.)
+    /// hand in byrefs that land on non-byte-addressable cells (object
+    /// references, value types containing object references); `copy`
+    /// detects cell-aligned ranges via `tryWholeCellMoveAt` and moves
+    /// whole typed cells through `readManagedByref` /
+    /// `writeManagedByrefWithBase` so the dest cell's CLI shape and the
+    /// stored ObjectRef provenance are preserved.
     let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
         let state = ctx.State
         let instruction = ctx.Instruction


### PR DESCRIPTION
## Summary

- Add a cell-aware fast path to `NativeBuffer.copy` so `Buffer.MemMove` / `BulkMoveWithWriteBarrierInternal` can move whole typed cells (`ObjectRef`, `RuntimePointer`, value types containing those) that the byte-walk path correctly rejects via `validateByteAddressableCell`. Cell-aligned ranges between cell-aware roots (`ArrayElement`, `HeapValue`, `HeapObjectField`, `MethodTableExposedClassObject`) now route through `readManagedByref` / `writeManagedByrefWithBase`, preserving CLI shape and ObjectRef provenance.
- Unblocks `ComplexTryCatch.cs`, `RuntimeTypeGetInterfacesInherited.cs`, `RuntimeFieldHandleGetUtf8Name.cs` (moved out of `unimplemented`). `Threads.cs` and `LdtokenField.cs` advance past the Buffer step and now block on unrelated unimplemented natives (`ThreadNative_SetIsBackground` and `RuntimeFieldHandle::GetApproxDeclaringMethodTable`); their comments are refreshed accordingly.
- Fast path is conservatively gated: byte-storage roots (`StackMemoryByte`, `NativeMemoryByte`, `PeByteRange`, `StringCharAt`) and stack-slot roots keep the byte-walk path; residuals carrying interior `ReinterpretAs` / `ByteOffset` projections decline back to the byte-walk; zero-sized value-type cells are rejected to avoid spinning the copy loop forever.

## Test plan

- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — all 1082 tests pass
- [x] `LocallocMemmoveOverlap.cs` still passes (regression check for the byte-storage root gating)
- [x] `nix develop -c dotnet fantomas .` reports no changes
- [x] `codex review --base main` returns clean ("did not find a discrete correctness issue") after two rounds of P2 fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)