### PR TITLE
Add event slice to WaitHandle infrastructure

### DIFF
--- a/WoofWare.PawPrint.Test/TestWaitHandle.fs
+++ b/WoofWare.PawPrint.Test/TestWaitHandle.fs
@@ -56,11 +56,19 @@ module TestWaitHandle =
         match Map.find id state.Kernel.WaitHandles with
         | WaitHandleState.Semaphore s -> s
         | WaitHandleState.Mutex _ -> failwith "expected a Semaphore handle but got a Mutex"
+        | WaitHandleState.Event _ -> failwith "expected a Semaphore handle but got an Event"
 
     let private mutexOf (id : WaitHandleId) (state : IlMachineState) : MutexState =
         match Map.find id state.Kernel.WaitHandles with
         | WaitHandleState.Mutex m -> m
         | WaitHandleState.Semaphore _ -> failwith "expected a Mutex handle but got a Semaphore"
+        | WaitHandleState.Event _ -> failwith "expected a Mutex handle but got an Event"
+
+    let private eventOf (id : WaitHandleId) (state : IlMachineState) : EventState =
+        match Map.find id state.Kernel.WaitHandles with
+        | WaitHandleState.Event e -> e
+        | WaitHandleState.Semaphore _ -> failwith "expected an Event handle but got a Semaphore"
+        | WaitHandleState.Mutex _ -> failwith "expected an Event handle but got a Mutex"
 
     let private acquired (outcome : WaitHandle.WaitOutcome) : IlMachineState =
         match outcome with
@@ -1145,3 +1153,566 @@ module TestWaitHandle =
             Assert.Throws<System.Exception> (fun () -> WaitHandle.releaseMutex t0 id state |> ignore)
 
         exn.Message |> shouldContainText "not registered"
+
+    // -------------------------------------------------------------------
+    // Event — create, set, reset, wait, close
+    // -------------------------------------------------------------------
+
+    [<Test>]
+    let ``createEvent Manual unsignalled starts with empty queue and Signaled=false`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createEvent false EventResetMode.Manual state
+        let e = eventOf id state
+        e.Mode |> shouldEqual EventResetMode.Manual
+        e.Signaled |> shouldEqual false
+        e.WaitQueue |> shouldEqual []
+
+    [<Test>]
+    let ``createEvent Manual signalled starts Signaled=true with empty queue`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createEvent true EventResetMode.Manual state
+        let e = eventOf id state
+        e.Mode |> shouldEqual EventResetMode.Manual
+        e.Signaled |> shouldEqual true
+        e.WaitQueue |> shouldEqual []
+
+    [<Test>]
+    let ``createEvent Auto unsignalled starts with empty queue and Signaled=false`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createEvent false EventResetMode.Auto state
+        let e = eventOf id state
+        e.Mode |> shouldEqual EventResetMode.Auto
+        e.Signaled |> shouldEqual false
+        e.WaitQueue |> shouldEqual []
+
+    [<Test>]
+    let ``createEvent Auto signalled starts Signaled=true with empty queue`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createEvent true EventResetMode.Auto state
+        let e = eventOf id state
+        e.Mode |> shouldEqual EventResetMode.Auto
+        e.Signaled |> shouldEqual true
+        e.WaitQueue |> shouldEqual []
+
+    [<Test>]
+    let ``createEvent mints distinct ids`` () : unit =
+        let state = baseState ()
+        let id1, state = WaitHandle.createEvent false EventResetMode.Manual state
+        let id2, state = WaitHandle.createEvent true EventResetMode.Auto state
+        let id3, _ = WaitHandle.createEvent false EventResetMode.Manual state
+
+        id1 |> shouldNotEqual id2
+        id1 |> shouldNotEqual id3
+        id2 |> shouldNotEqual id3
+
+    [<Test>]
+    let ``minted event ids are never zero (BCL OOM guard never fires)`` () : unit =
+        let state = baseState ()
+        let id, _ = WaitHandle.createEvent false EventResetMode.Manual state
+        let (WaitHandleId i) = id
+        i |> shouldNotEqual 0
+
+    [<Test>]
+    let ``event ids interleave with semaphore + mutex ids on the shared counter`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let semId, state = WaitHandle.createSemaphore 0 1 state
+        let evId1, state = WaitHandle.createEvent false EventResetMode.Manual state
+        let mutexId, state = WaitHandle.createMutex false t0 state
+        let evId2, _ = WaitHandle.createEvent true EventResetMode.Auto state
+
+        semId |> shouldNotEqual evId1
+        evId1 |> shouldNotEqual mutexId
+        mutexId |> shouldNotEqual evId2
+        evId1 |> shouldNotEqual evId2
+
+    // ---- waitOne ----
+
+    [<Test>]
+    let ``waitOne on a signalled Manual event acquires without clearing the signal`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createEvent true EventResetMode.Manual state
+
+        let state = WaitHandle.waitOne t0 id state |> acquired
+
+        let e = eventOf id state
+        e.Signaled |> shouldEqual true
+        e.WaitQueue |> shouldEqual []
+        statusOf t0 state |> shouldEqual ThreadStatus.Runnable
+
+    [<Test>]
+    let ``waitOne on a signalled Auto event acquires and clears the signal`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createEvent true EventResetMode.Auto state
+
+        let state = WaitHandle.waitOne t0 id state |> acquired
+
+        let e = eventOf id state
+        e.Signaled |> shouldEqual false
+        e.WaitQueue |> shouldEqual []
+        statusOf t0 state |> shouldEqual ThreadStatus.Runnable
+
+    [<Test>]
+    let ``waitOne on an unsignalled Manual event parks the caller at the FIFO tail`` () : unit =
+        let state = baseState () |> withThreads [ t0 ; t1 ; t2 ]
+        let id, state = WaitHandle.createEvent false EventResetMode.Manual state
+
+        let state = WaitHandle.waitOne t0 id state |> blocked
+        let state = WaitHandle.waitOne t1 id state |> blocked
+        let state = WaitHandle.waitOne t2 id state |> blocked
+
+        let e = eventOf id state
+        e.Signaled |> shouldEqual false
+        e.WaitQueue |> shouldEqual [ t0 ; t1 ; t2 ]
+        statusOf t0 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+        statusOf t2 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+
+    [<Test>]
+    let ``waitOne on an unsignalled Auto event parks the caller at the FIFO tail`` () : unit =
+        let state = baseState () |> withThreads [ t0 ; t1 ; t2 ]
+        let id, state = WaitHandle.createEvent false EventResetMode.Auto state
+
+        let state = WaitHandle.waitOne t0 id state |> blocked
+        let state = WaitHandle.waitOne t1 id state |> blocked
+
+        let e = eventOf id state
+        e.Signaled |> shouldEqual false
+        e.WaitQueue |> shouldEqual [ t0 ; t1 ]
+
+    // ---- setEvent ----
+
+    [<Test>]
+    let ``setEvent on a Manual event with no waiters latches Signaled=true`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createEvent false EventResetMode.Manual state
+
+        let state = WaitHandle.setEvent id state
+
+        let e = eventOf id state
+        e.Signaled |> shouldEqual true
+        e.WaitQueue |> shouldEqual []
+
+    [<Test>]
+    let ``setEvent on a Manual event wakes every parked waiter and latches Signaled=true`` () : unit =
+        let state = baseState () |> withThreads [ t0 ; t1 ; t2 ]
+        let id, state = WaitHandle.createEvent false EventResetMode.Manual state
+        let state = WaitHandle.waitOne t0 id state |> blocked
+        let state = WaitHandle.waitOne t1 id state |> blocked
+        let state = WaitHandle.waitOne t2 id state |> blocked
+
+        let state = WaitHandle.setEvent id state
+
+        let e = eventOf id state
+        e.Signaled |> shouldEqual true
+        e.WaitQueue |> shouldEqual []
+        statusOf t0 state |> shouldEqual ThreadStatus.Runnable
+        statusOf t1 state |> shouldEqual ThreadStatus.Runnable
+        statusOf t2 state |> shouldEqual ThreadStatus.Runnable
+
+    [<Test>]
+    let ``setEvent on an Auto event with no waiters latches Signaled=true`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createEvent false EventResetMode.Auto state
+
+        let state = WaitHandle.setEvent id state
+
+        let e = eventOf id state
+        e.Signaled |> shouldEqual true
+        e.WaitQueue |> shouldEqual []
+
+    [<Test>]
+    let ``setEvent on an Auto event with waiters wakes only the FIFO head, Signaled stays false`` () : unit =
+        let state = baseState () |> withThreads [ t0 ; t1 ; t2 ]
+        let id, state = WaitHandle.createEvent false EventResetMode.Auto state
+        let state = WaitHandle.waitOne t0 id state |> blocked
+        let state = WaitHandle.waitOne t1 id state |> blocked
+        let state = WaitHandle.waitOne t2 id state |> blocked
+
+        let state = WaitHandle.setEvent id state
+
+        let e = eventOf id state
+        e.Signaled |> shouldEqual false
+        e.WaitQueue |> shouldEqual [ t1 ; t2 ]
+        statusOf t0 state |> shouldEqual ThreadStatus.Runnable
+        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+        statusOf t2 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+
+    [<Test>]
+    let ``repeated setEvent on Auto with a queue drains FIFO one at a time`` () : unit =
+        let state = baseState () |> withThreads [ t0 ; t1 ; t2 ; t3 ]
+        let id, state = WaitHandle.createEvent false EventResetMode.Auto state
+        let state = WaitHandle.waitOne t0 id state |> blocked
+        let state = WaitHandle.waitOne t1 id state |> blocked
+        let state = WaitHandle.waitOne t2 id state |> blocked
+        let state = WaitHandle.waitOne t3 id state |> blocked
+
+        let state = WaitHandle.setEvent id state
+        (eventOf id state).WaitQueue |> shouldEqual [ t1 ; t2 ; t3 ]
+        statusOf t0 state |> shouldEqual ThreadStatus.Runnable
+
+        let state = WaitHandle.setEvent id state
+        (eventOf id state).WaitQueue |> shouldEqual [ t2 ; t3 ]
+        statusOf t1 state |> shouldEqual ThreadStatus.Runnable
+
+        let state = WaitHandle.setEvent id state
+        (eventOf id state).WaitQueue |> shouldEqual [ t3 ]
+        statusOf t2 state |> shouldEqual ThreadStatus.Runnable
+
+        let state = WaitHandle.setEvent id state
+        (eventOf id state).WaitQueue |> shouldEqual []
+        statusOf t3 state |> shouldEqual ThreadStatus.Runnable
+        // Queue drained; the latched signal should now be false (the
+        // last setEvent woke t3 directly rather than latching).
+        (eventOf id state).Signaled |> shouldEqual false
+
+    [<Test>]
+    let ``setEvent on an already-signalled Manual event is idempotent`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createEvent true EventResetMode.Manual state
+        let before = eventOf id state
+
+        let state = WaitHandle.setEvent id state
+
+        eventOf id state |> shouldEqual before
+
+    [<Test>]
+    let ``setEvent on an already-signalled Auto event is idempotent`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createEvent true EventResetMode.Auto state
+        let before = eventOf id state
+
+        let state = WaitHandle.setEvent id state
+
+        eventOf id state |> shouldEqual before
+
+    [<Test>]
+    let ``Auto event: setEvent then waitOne acquires and clears the signal`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createEvent false EventResetMode.Auto state
+        let state = WaitHandle.setEvent id state
+        (eventOf id state).Signaled |> shouldEqual true
+
+        let state = WaitHandle.waitOne t0 id state |> acquired
+
+        let e = eventOf id state
+        e.Signaled |> shouldEqual false
+        statusOf t0 state |> shouldEqual ThreadStatus.Runnable
+
+    // ---- resetEvent ----
+
+    [<Test>]
+    let ``resetEvent clears Signaled on a signalled Manual event`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createEvent true EventResetMode.Manual state
+
+        let state = WaitHandle.resetEvent id state
+
+        (eventOf id state).Signaled |> shouldEqual false
+
+    [<Test>]
+    let ``resetEvent clears Signaled on a signalled Auto event`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createEvent true EventResetMode.Auto state
+
+        let state = WaitHandle.resetEvent id state
+
+        (eventOf id state).Signaled |> shouldEqual false
+
+    [<Test>]
+    let ``resetEvent on an already-unsignalled event is idempotent`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createEvent false EventResetMode.Manual state
+        let before = eventOf id state
+
+        let state = WaitHandle.resetEvent id state
+
+        eventOf id state |> shouldEqual before
+
+    [<Test>]
+    let ``resetEvent on an unsignalled Manual event with parked waiters does not touch the queue`` () : unit =
+        let state = baseState () |> withThreads [ t0 ; t1 ]
+        let id, state = WaitHandle.createEvent false EventResetMode.Manual state
+        let state = WaitHandle.waitOne t0 id state |> blocked
+        let state = WaitHandle.waitOne t1 id state |> blocked
+
+        let state = WaitHandle.resetEvent id state
+
+        let e = eventOf id state
+        e.Signaled |> shouldEqual false
+        e.WaitQueue |> shouldEqual [ t0 ; t1 ]
+        statusOf t0 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+
+    // ---- tryWaitOne ----
+
+    [<Test>]
+    let ``tryWaitOne on a signalled Manual event acquires without clearing the signal`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createEvent true EventResetMode.Manual state
+
+        let state = WaitHandle.tryWaitOne t0 id state |> tryAcquired
+
+        (eventOf id state).Signaled |> shouldEqual true
+
+    [<Test>]
+    let ``tryWaitOne on a signalled Auto event acquires and clears the signal`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createEvent true EventResetMode.Auto state
+
+        let state = WaitHandle.tryWaitOne t0 id state |> tryAcquired
+
+        (eventOf id state).Signaled |> shouldEqual false
+
+    [<Test>]
+    let ``tryWaitOne on an unsignalled event reports TimedOut without parking`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createEvent false EventResetMode.Auto state
+
+        let state = WaitHandle.tryWaitOne t0 id state |> timedOut
+
+        let e = eventOf id state
+        e.WaitQueue |> shouldEqual []
+        statusOf t0 state |> shouldEqual ThreadStatus.Runnable
+
+    // ---- close ----
+
+    [<Test>]
+    let ``close removes a quiescent unsignalled event from the registry`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createEvent false EventResetMode.Manual state
+
+        let state = WaitHandle.close id state
+
+        Map.containsKey id state.Kernel.WaitHandles |> shouldEqual false
+
+    [<Test>]
+    let ``close removes a quiescent signalled event from the registry`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createEvent true EventResetMode.Auto state
+
+        let state = WaitHandle.close id state
+
+        Map.containsKey id state.Kernel.WaitHandles |> shouldEqual false
+
+    [<Test>]
+    let ``close fails loud on an event with parked waiters`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createEvent false EventResetMode.Manual state
+        let state = WaitHandle.waitOne t0 id state |> blocked
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.close id state |> ignore)
+
+        exn.Message |> shouldContainText "parked"
+
+    // ---- cross-kind safety ----
+
+    [<Test>]
+    let ``setEvent on a semaphore id fails loud`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createSemaphore 1 5 state
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.setEvent id state |> ignore)
+
+        exn.Message |> shouldContainText "Semaphore"
+
+    [<Test>]
+    let ``setEvent on a mutex id fails loud`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createMutex false t0 state
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.setEvent id state |> ignore)
+
+        exn.Message |> shouldContainText "Mutex"
+
+    [<Test>]
+    let ``resetEvent on a semaphore id fails loud`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createSemaphore 1 5 state
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.resetEvent id state |> ignore)
+
+        exn.Message |> shouldContainText "Semaphore"
+
+    [<Test>]
+    let ``resetEvent on a mutex id fails loud`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createMutex false t0 state
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.resetEvent id state |> ignore)
+
+        exn.Message |> shouldContainText "Mutex"
+
+    [<Test>]
+    let ``releaseSemaphore on an event id fails loud`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createEvent false EventResetMode.Manual state
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.releaseSemaphore id 1 state |> ignore)
+
+        exn.Message |> shouldContainText "Event"
+
+    [<Test>]
+    let ``releaseMutex on an event id fails loud`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createEvent false EventResetMode.Manual state
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.releaseMutex t0 id state |> ignore)
+
+        exn.Message |> shouldContainText "Event"
+
+    [<Test>]
+    let ``waitOnePrioritized on an event id fails loud`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createEvent false EventResetMode.Manual state
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.waitOnePrioritized t0 id state |> ignore)
+
+        exn.Message |> shouldContainText "Event"
+
+    // ---- use-after-free ----
+
+    [<Test>]
+    let ``setEvent on a closed event fails loud (use-after-free)`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createEvent false EventResetMode.Manual state
+        let state = WaitHandle.close id state
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.setEvent id state |> ignore)
+
+        exn.Message |> shouldContainText "not registered"
+
+    [<Test>]
+    let ``resetEvent on a closed event fails loud (use-after-free)`` () : unit =
+        let state = baseState ()
+        let id, state = WaitHandle.createEvent false EventResetMode.Manual state
+        let state = WaitHandle.close id state
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.resetEvent id state |> ignore)
+
+        exn.Message |> shouldContainText "not registered"
+
+    [<Test>]
+    let ``waitOne on a closed event fails loud (use-after-free)`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createEvent false EventResetMode.Manual state
+        let state = WaitHandle.close id state
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.waitOne t0 id state |> ignore)
+
+        exn.Message |> shouldContainText "not registered"
+
+    [<Test>]
+    let ``tryWaitOne on a closed event fails loud (use-after-free)`` () : unit =
+        let state = baseState () |> withThreads [ t0 ]
+        let id, state = WaitHandle.createEvent false EventResetMode.Manual state
+        let state = WaitHandle.close id state
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.tryWaitOne t0 id state |> ignore)
+
+        exn.Message |> shouldContainText "not registered"
+
+    // ---- property: invariant `Signaled ⇒ WaitQueue = []` ----
+
+    [<RequireQualifiedAccess>]
+    type private EventOp =
+        | Wait of ThreadId
+        | Set
+        | Reset
+
+    let private applyEventOp (id : WaitHandleId) (op : EventOp) (state : IlMachineState) : IlMachineState =
+        match op with
+        | EventOp.Wait tid ->
+            // A thread that is already blocked cannot wait again; in
+            // PawPrint that would re-park it which is a guest bug. Skip.
+            match statusOf tid state with
+            | ThreadStatus.BlockedOnWaitHandle _ -> state
+            | _ ->
+                match WaitHandle.waitOne tid id state with
+                | WaitHandle.WaitOutcome.Acquired s
+                | WaitHandle.WaitOutcome.Blocked s -> s
+                | WaitHandle.WaitOutcome.AcquiredAbandoned _ ->
+                    failwith "Event waitOne unexpectedly produced AcquiredAbandoned"
+        | EventOp.Set -> WaitHandle.setEvent id state
+        | EventOp.Reset -> WaitHandle.resetEvent id state
+
+    let private runEventScript
+        (mode : EventResetMode)
+        (initialSignal : bool)
+        (threadCount : int)
+        (script : EventOp list)
+        : EventState
+        =
+        let threads = [ 0 .. threadCount - 1 ] |> List.map ThreadId
+        let state = baseState () |> withThreads threads
+        let id, state = WaitHandle.createEvent initialSignal mode state
+
+        let final = script |> List.fold (fun s op -> applyEventOp id op s) state
+
+        eventOf id final
+
+    [<Test>]
+    let ``Property: Manual event invariant Signaled implies empty WaitQueue holds across any script`` () : unit =
+        let property (PositiveInt threadCountRaw) (NonNegativeInt seedRaw) : bool =
+            let threadCount = 1 + (threadCountRaw % 6)
+            let rng = System.Random seedRaw
+            let scriptLen = 30
+
+            let threads = [ 0 .. threadCount - 1 ] |> List.map ThreadId
+
+            let script =
+                [
+                    for _ in 1..scriptLen do
+                        let r = rng.Next 3
+
+                        if r = 0 then
+                            yield EventOp.Wait (List.item (rng.Next threadCount) threads)
+                        elif r = 1 then
+                            yield EventOp.Set
+                        else
+                            yield EventOp.Reset
+                ]
+
+            let e = runEventScript EventResetMode.Manual false threadCount script
+            // Signaled ⇒ WaitQueue = []
+            not e.Signaled || e.WaitQueue = []
+
+        Check.One (config, property)
+
+    [<Test>]
+    let ``Property: Auto event invariant Signaled implies empty WaitQueue holds across any script`` () : unit =
+        let property (PositiveInt threadCountRaw) (NonNegativeInt seedRaw) : bool =
+            let threadCount = 1 + (threadCountRaw % 6)
+            let rng = System.Random seedRaw
+            let scriptLen = 30
+
+            let threads = [ 0 .. threadCount - 1 ] |> List.map ThreadId
+
+            let script =
+                [
+                    for _ in 1..scriptLen do
+                        let r = rng.Next 3
+
+                        if r = 0 then
+                            yield EventOp.Wait (List.item (rng.Next threadCount) threads)
+                        elif r = 1 then
+                            yield EventOp.Set
+                        else
+                            yield EventOp.Reset
+                ]
+
+            let e = runEventScript EventResetMode.Auto false threadCount script
+            not e.Signaled || e.WaitQueue = []
+
+        Check.One (config, property)

--- a/WoofWare.PawPrint/EmulatedKernel.fs
+++ b/WoofWare.PawPrint/EmulatedKernel.fs
@@ -192,16 +192,48 @@ type MutexState =
         WaitQueue : ThreadId list
     }
 
+/// Reset mode of a Win32-shaped event kernel object, set at create time and
+/// immutable thereafter. `Manual` events stay signalled across waiters
+/// (one `SetEvent` wakes every parked waiter and leaves the event
+/// signalled until `ResetEvent`); `Auto` events have direct-handoff
+/// semantics (one `SetEvent` wakes exactly one parked waiter, or sets the
+/// signalled flag if none, and `WaitOne` on a signalled `Auto` event
+/// consumes the signal as part of acquiring).
+[<RequireQualifiedAccess>]
+type EventResetMode =
+    | Manual
+    | Auto
+
+/// Deterministic model of a single Win32-shaped event kernel object, as
+/// minted by `CreateEventExW`. `Mode` is set at create time and never
+/// changes. `Signaled` is the current signal state; `WaitQueue` is the
+/// FIFO list of threads parked in `BlockedOnWaitHandle` because the event
+/// was unsignalled when they called `WaitOne`.
+///
+/// Invariant: `Signaled = true ⇒ WaitQueue = []`. The operations enforce
+/// it: `setEvent` on a `Manual` event with parked waiters wakes them all
+/// and sets `Signaled = true` (leaving the queue empty); `setEvent` on an
+/// `Auto` event either wakes the FIFO head (leaving `Signaled = false`) or
+/// — if no waiters — sets `Signaled = true`. `waitOne` on a signalled
+/// `Auto` event consumes the signal as part of acquiring, so a thread can
+/// never observe `Signaled = true` while there is a parked waiter.
+type EventState =
+    {
+        Mode : EventResetMode
+        Signaled : bool
+        WaitQueue : ThreadId list
+    }
+
 /// Kind-tagged state for a single Win32-shaped wait-handle kernel object
 /// resident in `EmulatedKernel.WaitHandles`. Kind-agnostic operations
 /// (`WaitHandle_WaitOneCore`, `CloseHandle`) take one map lookup and then
-/// match on kind; new kinds (Event) slot in as additional cases without
-/// disturbing the table or the wait/close handlers.
+/// match on kind; new kinds slot in as additional cases without disturbing
+/// the table or the wait/close handlers.
 [<RequireQualifiedAccess>]
 type WaitHandleState =
     | Semaphore of SemaphoreState
     | Mutex of MutexState
-// future: | Event of EventState
+    | Event of EventState
 
 /// One entry in `EmulatedKernel.OutputLog`: the role the guest targeted (a
 /// writable standard stream — stdout or stderr) and the byte payload of

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -92,6 +92,16 @@ module NativeQCall =
             // in `WaitHandle.fs`.
             "PAL_CreateMutexW", NativeWaitHandle.tryExecuteQCall "PAL_CreateMutexW"
             "ReleaseMutex", NativeWaitHandle.tryExecuteQCall "ReleaseMutex"
+            // `EventWaitHandle.Windows.cs` runs on .NET 10 CoreCLR
+            // regardless of host; `Libraries.Kernel32 = RuntimeHelpers
+            // .QCall` routes the three Kernel32 LibraryImports
+            // (`CreateEventEx` / `SetEvent` / `ResetEvent`) to the
+            // runtime as QCalls under their Win32 wide-string entry
+            // points. Both `Manual` and `Auto` reset modes dispatch into
+            // the deterministic state machine in `WaitHandle.fs`.
+            "CreateEventExW", NativeWaitHandle.tryExecuteQCall "CreateEventExW"
+            "SetEvent", NativeWaitHandle.tryExecuteQCall "SetEvent"
+            "ResetEvent", NativeWaitHandle.tryExecuteQCall "ResetEvent"
         ]
         |> Map.ofList
 

--- a/WoofWare.PawPrint/Native/NativeWaitHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeWaitHandle.fs
@@ -3,9 +3,10 @@ namespace WoofWare.PawPrint
 /// Native handler for the Win32-shaped wait-handle QCalls reachable from
 /// CoreCLR-on-Unix: `CreateSemaphoreExW`, `ReleaseSemaphore`,
 /// `CloseHandle`, `WaitHandle_WaitOneCore`,
-/// `WaitHandle_WaitOnePrioritized`, `PAL_CreateMutexW`, and
-/// `ReleaseMutex`. On .NET 10 the BCL compiles `Semaphore.Windows.cs`
-/// and `Mutex.CoreCLR.Unix.cs` regardless of host, with
+/// `WaitHandle_WaitOnePrioritized`, `PAL_CreateMutexW`, `ReleaseMutex`,
+/// `CreateEventExW`, `SetEvent`, and `ResetEvent`. On .NET 10 the BCL
+/// compiles `Semaphore.Windows.cs`, `Mutex.CoreCLR.Unix.cs`, and
+/// `EventWaitHandle.Windows.cs` regardless of host, with
 /// `Libraries.Kernel32` rebound to `RuntimeHelpers.QCall`, so every
 /// Kernel32 LibraryImport routes to the runtime as a QCall whose entry
 /// point uses the Win32 wide-string name. `LowLevelLifoSemaphore.Unix
@@ -15,11 +16,11 @@ namespace WoofWare.PawPrint
 /// catches each entry point here and forwards it to the deterministic
 /// state machine in `WaitHandle.fs`.
 ///
-/// Semaphore and mutex variants are supported today; events,
-/// multi-handle waits, named handles (`PAL_OpenMutexW`), and non-zero
-/// finite timeouts are out of scope pending future PRs and a virtual
-/// clock. Zero-timeout waits (the deterministic non-blocking probe
-/// `WaitOne(0)` emits) are handled inline — no clock is needed.
+/// Semaphore, mutex, and event variants are supported today;
+/// multi-handle waits, named handles (`PAL_OpenMutexW`, `OpenEventW`),
+/// and non-zero finite timeouts are out of scope pending future PRs and
+/// a virtual clock. Zero-timeout waits (the deterministic non-blocking
+/// probe `WaitOne(0)` emits) are handled inline — no clock is needed.
 [<RequireQualifiedAccess>]
 module NativeWaitHandle =
 
@@ -92,6 +93,27 @@ module NativeWaitHandle =
         | other -> failwith $"%s{operation}: expected WaitHandle handle, got %O{other}"
 
     /// Decode the `IntPtr handle` argument and additionally require
+    /// that it refer to an Event (rather than a Semaphore, a Mutex, or
+    /// any future kind). Used by `SetEvent` and `ResetEvent`: these are
+    /// only legal against an event handle; routing a foreign-kind handle
+    /// through them is a guest bug that should fail loud at the decoder
+    /// rather than fall through to a kind-generic probe.
+    let private eventHandleOfArgument (operation : string) (arg : CliType) (state : IlMachineState) : WaitHandleId =
+        let id = waitHandleOfArgument operation arg
+
+        match Map.tryFind id state.Kernel.WaitHandles with
+        | Some (WaitHandleState.Event _) -> id
+        | Some (WaitHandleState.Semaphore _) ->
+            failwith
+                $"%s{operation}: WaitHandle %O{id} is a Semaphore, but this entry point is only legal against an Event. This is a guest bug — the BCL only calls this through EventWaitHandle."
+        | Some (WaitHandleState.Mutex _) ->
+            failwith
+                $"%s{operation}: WaitHandle %O{id} is a Mutex, but this entry point is only legal against an Event. This is a guest bug — the BCL only calls this through EventWaitHandle."
+        | None ->
+            failwith
+                $"%s{operation}: WaitHandle %O{id} is not registered (use-after-free on a closed handle, or never created)."
+
+    /// Decode the `IntPtr handle` argument and additionally require
     /// that it refer to a Semaphore (rather than a Mutex or any future
     /// kind). Used by `WaitHandle_WaitOnePrioritized`: the
     /// PAL-prioritized waiter is the LowLevelLifoSemaphore park
@@ -106,6 +128,9 @@ module NativeWaitHandle =
         | Some (WaitHandleState.Mutex _) ->
             failwith
                 $"%s{operation}: WaitHandle %O{id} is a Mutex, but this entry point is only legal against a Semaphore (the BCL's LowLevelLifoSemaphore is the sole caller). This is a guest bug."
+        | Some (WaitHandleState.Event _) ->
+            failwith
+                $"%s{operation}: WaitHandle %O{id} is an Event, but this entry point is only legal against a Semaphore (the BCL's LowLevelLifoSemaphore is the sole caller). This is a guest bug."
         | None ->
             failwith
                 $"%s{operation}: WaitHandle %O{id} is not registered (use-after-free on a closed handle, or never created)."
@@ -130,6 +155,46 @@ module NativeWaitHandle =
         match CliType.unwrapPrimitiveLikeDeep arg with
         | CliType.Numeric (CliNumericType.Int32 i) -> i <> 0
         | other -> failwith $"%s{operation}: expected %s{argName} to be Int32 BOOL, got %O{other}"
+
+    /// Decode a UInt32 argument. PawPrint models a CLI UInt32 as a
+    /// signed Int32 cell while preserving the low 32 bits (see
+    /// `NativeCall.cliUInt32`); we reverse that here.
+    let private uint32OfArgument (operation : string) (argName : string) (arg : CliType) : uint32 =
+        match CliType.unwrapPrimitiveLikeDeep arg with
+        | CliType.Numeric (CliNumericType.Int32 i) -> uint32 i
+        | other -> failwith $"%s{operation}: expected %s{argName} to be UInt32, got %O{other}"
+
+    /// `CREATE_EVENT_MANUAL_RESET = 0x1` — when set on `CreateEventExW`'s
+    /// `flags`, the new event is `Manual`; cleared means `Auto`. See
+    /// `Interop.EventWaitHandle.cs`.
+    let private createEventManualReset : uint32 = 0x1u
+
+    /// `CREATE_EVENT_INITIAL_SET = 0x2` — when set, the new event is
+    /// created in the signalled state. See `Interop.EventWaitHandle.cs`.
+    let private createEventInitialSet : uint32 = 0x2u
+
+    /// Parse `CreateEventExW`'s `flags` argument into the two documented
+    /// bits (`CREATE_EVENT_MANUAL_RESET`, `CREATE_EVENT_INITIAL_SET`).
+    /// Any unknown bit fails loud — a guest passing a flag CoreLib does
+    /// not produce is using an unsupported Win32 extension we have not
+    /// modelled. The two known bits compose freely.
+    let private parseCreateEventFlags (operation : string) (flags : uint32) : bool * EventResetMode =
+        let known = createEventManualReset ||| createEventInitialSet
+        let unknown = flags &&& ~~~known
+
+        if unknown <> 0u then
+            failwith
+                $"%s{operation}: unrecognised CreateEventExW flag bits: 0x%x{unknown} (known bits: CREATE_EVENT_MANUAL_RESET=0x1, CREATE_EVENT_INITIAL_SET=0x2)"
+
+        let initialState = (flags &&& createEventInitialSet) <> 0u
+
+        let mode =
+            if (flags &&& createEventManualReset) <> 0u then
+                EventResetMode.Manual
+            else
+                EventResetMode.Auto
+
+        initialState, mode
 
     /// Decode the UTF-16 `name` pointer for `CreateSemaphoreExW`. CoreLib
     /// passes `null` for unnamed semaphores; named semaphores are out of
@@ -523,5 +588,85 @@ module NativeWaitHandle =
                 |> Tuple.withRight WhatWeDid.Executed
                 |> ExecutionResult.stepped
                 |> Some
+
+        | "CreateEventExW",
+          "System.Private.CoreLib",
+          "Kernel32",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr
+            ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt16)
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt32
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt32 ],
+          MethodReturnType.Returns _ ->
+            // `EventWaitHandle.Windows.cs` declares the return as
+            // `SafeWaitHandle`, a reference type at the IL boundary; the
+            // LibraryImport stub marshals it as `IntPtr` over the wire.
+            // We don't constrain the return type pattern beyond "has a
+            // return" for the same reason as `PAL_CreateMutexW`.
+            let operation = "CreateEventExW"
+            // CoreLib's `CreateEventCore(initialState, mode)` passes
+            // `lpSecurityAttributes = 0`. Non-null is reserved for the
+            // named CurrentUserOnly path which is unreachable on Unix
+            // (named events PNSE before reaching the QCall).
+            requireNullIntPtr operation "lpSecurityAttributes" instruction.Arguments.[0]
+            // Named events on Unix throw `PlatformNotSupportedException`
+            // at `EventWaitHandle.Windows.cs:55`, so a non-null name
+            // reaching this QCall is a guest bug — strict null until the
+            // named-handle registry lands alongside named semaphores /
+            // mutexes.
+            requireNullName operation instruction.Arguments.[1]
+
+            let flags = uint32OfArgument operation "flags" instruction.Arguments.[2]
+            let initialState, mode = parseCreateEventFlags operation flags
+            // `dwDesiredAccess` is hardcoded to MAXIMUM_ALLOWED |
+            // SYNCHRONIZE | EVENT_MODIFY_STATE by the BCL; we don't
+            // model access rights, so decode for shape validation only.
+            let _desiredAccess =
+                uint32OfArgument operation "dwDesiredAccess" instruction.Arguments.[3]
+
+            let id, state = WaitHandle.createEvent initialState mode state
+
+            state
+            |> withLastSystemError 0
+            |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt (NativeIntSource.WaitHandlePtr id)) ctx.Thread
+            |> Tuple.withRight WhatWeDid.Executed
+            |> ExecutionResult.stepped
+            |> Some
+
+        | "SetEvent",
+          "System.Private.CoreLib",
+          "Kernel32",
+          [ _ ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
+            // The single argument is declared as `SafeWaitHandle` in
+            // `Interop.EventWaitHandle.cs`; the LibraryImport stub
+            // marshals it as `IntPtr` at the QCall boundary. Decode
+            // through `eventHandleOfArgument`, which kind-checks the
+            // handle and rejects null / non-event handles loudly.
+            let operation = "SetEvent"
+            let id = eventHandleOfArgument operation instruction.Arguments.[0] state
+            let state = WaitHandle.setEvent id state
+
+            state
+            |> withLastSystemError 0
+            |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 1) ctx.Thread
+            |> Tuple.withRight WhatWeDid.Executed
+            |> ExecutionResult.stepped
+            |> Some
+
+        | "ResetEvent",
+          "System.Private.CoreLib",
+          "Kernel32",
+          [ _ ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
+            let operation = "ResetEvent"
+            let id = eventHandleOfArgument operation instruction.Arguments.[0] state
+            let state = WaitHandle.resetEvent id state
+
+            state
+            |> withLastSystemError 0
+            |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 1) ctx.Thread
+            |> Tuple.withRight WhatWeDid.Executed
+            |> ExecutionResult.stepped
+            |> Some
 
         | _ -> None

--- a/WoofWare.PawPrint/Scheduler.fs
+++ b/WoofWare.PawPrint/Scheduler.fs
@@ -180,6 +180,7 @@ module Scheduler =
                     | MutexOwnership.Held (owner, _) when owner = terminated -> Some id
                     | _ -> None
                 | WaitHandleState.Semaphore _ -> None
+                | WaitHandleState.Event _ -> None
             )
             |> Seq.toList
 

--- a/WoofWare.PawPrint/WaitHandle.fs
+++ b/WoofWare.PawPrint/WaitHandle.fs
@@ -3,20 +3,23 @@ namespace WoofWare.PawPrint
 /// Deterministic state machine for the Win32-shaped wait-handle kernel
 /// objects exposed to managed code through `CreateSemaphoreExW`,
 /// `ReleaseSemaphore`, `CloseHandle`, `WaitHandle_WaitOneCore`,
-/// `WaitHandle_WaitOnePrioritized`, `PAL_CreateMutexW`, and
-/// `ReleaseMutex`. On .NET 10 CoreCLR-on-Unix the BCL compiles
-/// `Semaphore.Windows.cs` / `Mutex.CoreCLR.Unix.cs` regardless of host,
-/// with `Libraries.Kernel32` rebound to `RuntimeHelpers.QCall`; every
-/// Kernel32 LibraryImport therefore routes to the runtime as a QCall
-/// whose entry point uses the Win32 wide-string name. PawPrint
+/// `WaitHandle_WaitOnePrioritized`, `PAL_CreateMutexW`, `ReleaseMutex`,
+/// `CreateEventExW`, `SetEvent`, and `ResetEvent`. On .NET 10
+/// CoreCLR-on-Unix the BCL compiles `Semaphore.Windows.cs` /
+/// `Mutex.CoreCLR.Unix.cs` / `EventWaitHandle.Windows.cs` regardless of
+/// host, with `Libraries.Kernel32` rebound to `RuntimeHelpers.QCall`;
+/// every Kernel32 LibraryImport therefore routes to the runtime as a
+/// QCall whose entry point uses the Win32 wide-string name. PawPrint
 /// reproduces the observable semantics through `WaitHandleState`
 /// (registry value, kind-tagged) and one `ThreadStatus` case
 /// (`BlockedOnWaitHandle`).
 ///
-/// Two kinds are supported today: semaphore (`Count`-based) and mutex
-/// (ownership-based, re-entrant on owner, abandoned-flag-aware). The
-/// DU's job is to keep "kind dispatch in WaitOne/Close" exhaustive so
-/// the compiler catches a missing branch when `Event` lands.
+/// Three kinds are supported today: semaphore (`Count`-based), mutex
+/// (ownership-based, re-entrant on owner, abandoned-flag-aware), and
+/// event (Manual or Auto reset, with a `Signaled` flag and a FIFO
+/// `WaitQueue`). The DU's job is to keep "kind dispatch in WaitOne /
+/// Close" exhaustive so the compiler catches a missing branch when a
+/// further kind lands.
 ///
 /// The module is pure: every transition is `IlMachineState ->
 /// IlMachineState` (or returns an outcome carrying the next state) and
@@ -133,6 +136,9 @@ module WaitHandle =
         | WaitHandleState.Mutex _ ->
             failwith
                 $"%s{operation}: WaitHandle %O{id} is a Mutex, but this operation only accepts a Semaphore (e.g. ReleaseSemaphore / WaitOnePrioritized). This is a guest bug — the BCL would have failed in its own wrapper before reaching the runtime."
+        | WaitHandleState.Event _ ->
+            failwith
+                $"%s{operation}: WaitHandle %O{id} is an Event, but this operation only accepts a Semaphore (e.g. ReleaseSemaphore / WaitOnePrioritized). This is a guest bug — the BCL would have failed in its own wrapper before reaching the runtime."
 
     let private expectMutex (operation : string) (id : WaitHandleId) (handle : WaitHandleState) : MutexState =
         match handle with
@@ -140,6 +146,19 @@ module WaitHandle =
         | WaitHandleState.Semaphore _ ->
             failwith
                 $"%s{operation}: WaitHandle %O{id} is a Semaphore, but this operation only accepts a Mutex (e.g. ReleaseMutex). This is a guest bug — the BCL would have failed in its own wrapper before reaching the runtime."
+        | WaitHandleState.Event _ ->
+            failwith
+                $"%s{operation}: WaitHandle %O{id} is an Event, but this operation only accepts a Mutex (e.g. ReleaseMutex). This is a guest bug — the BCL would have failed in its own wrapper before reaching the runtime."
+
+    let private expectEvent (operation : string) (id : WaitHandleId) (handle : WaitHandleState) : EventState =
+        match handle with
+        | WaitHandleState.Event e -> e
+        | WaitHandleState.Semaphore _ ->
+            failwith
+                $"%s{operation}: WaitHandle %O{id} is a Semaphore, but this operation only accepts an Event (e.g. SetEvent / ResetEvent). This is a guest bug — the BCL would have failed in its own wrapper before reaching the runtime."
+        | WaitHandleState.Mutex _ ->
+            failwith
+                $"%s{operation}: WaitHandle %O{id} is a Mutex, but this operation only accepts an Event (e.g. SetEvent / ResetEvent). This is a guest bug — the BCL would have failed in its own wrapper before reaching the runtime."
 
     /// Allocate a fresh semaphore kernel object. Returns the new handle
     /// alongside the updated state. The handle is non-zero (counters
@@ -217,6 +236,37 @@ module WaitHandle =
             state.MapKernel (fun kernel ->
                 { kernel with
                     WaitHandles = kernel.WaitHandles |> Map.add id (WaitHandleState.Mutex mutex)
+                    NextWaitHandleId = kernel.NextWaitHandleId + 1
+                }
+            )
+
+        id, state
+
+    /// Allocate a fresh event kernel object. Returns the new handle
+    /// alongside the updated state. `initialState = true` corresponds to
+    /// `CREATE_EVENT_INITIAL_SET` (the event starts signalled) — by the
+    /// `Signaled ⇒ WaitQueue = []` invariant the queue is necessarily
+    /// empty at create time, so there is no waiter to wake. `mode` is
+    /// fixed for the lifetime of the handle.
+    let createEvent
+        (initialState : bool)
+        (mode : EventResetMode)
+        (state : IlMachineState)
+        : WaitHandleId * IlMachineState
+        =
+        let id = WaitHandleId state.Kernel.NextWaitHandleId
+
+        let event : EventState =
+            {
+                Mode = mode
+                Signaled = initialState
+                WaitQueue = []
+            }
+
+        let state =
+            state.MapKernel (fun kernel ->
+                { kernel with
+                    WaitHandles = kernel.WaitHandles |> Map.add id (WaitHandleState.Event event)
                     NextWaitHandleId = kernel.NextWaitHandleId + 1
                 }
             )
@@ -302,6 +352,43 @@ module WaitHandle =
             |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnWaitHandle id)
             |> WaitOutcome.Blocked
 
+    /// Internal: kind-private event waitOne. Acquiring a signalled `Auto`
+    /// event consumes the signal (clears `Signaled`); acquiring a
+    /// signalled `Manual` event leaves it signalled (every concurrent
+    /// waiter passes through). On an unsignalled event the thread parks
+    /// at the FIFO tail.
+    let private waitOneEvent
+        (thread : ThreadId)
+        (id : WaitHandleId)
+        (event : EventState)
+        (state : IlMachineState)
+        : WaitOutcome
+        =
+        if event.Signaled then
+            let event =
+                match event.Mode with
+                | EventResetMode.Auto ->
+                    { event with
+                        Signaled = false
+                    }
+                | EventResetMode.Manual -> event
+
+            state |> writeHandle id (WaitHandleState.Event event) |> WaitOutcome.Acquired
+        else
+            // Slow path: park at the tail of the FIFO wait queue.
+            // `setEvent` will wake (all parked waiters for Manual, the
+            // FIFO head for Auto); a guest can never observe Signaled =
+            // true while there is a parked waiter by invariant.
+            let event =
+                { event with
+                    WaitQueue = event.WaitQueue @ [ thread ]
+                }
+
+            state
+            |> writeHandle id (WaitHandleState.Event event)
+            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnWaitHandle id)
+            |> WaitOutcome.Blocked
+
     /// Try to take ownership of `id` on behalf of `thread`. Dispatches
     /// by kind:
     ///
@@ -323,6 +410,7 @@ module WaitHandle =
         match handle with
         | WaitHandleState.Semaphore semaphore -> waitOneSemaphore thread id semaphore state
         | WaitHandleState.Mutex mutex -> waitOneMutex thread id mutex state
+        | WaitHandleState.Event event -> waitOneEvent thread id event state
 
     /// Non-blocking probe used to model the zero-timeout `WaitOne(0)`
     /// path. CoreCLR's contract for a zero millisecond timeout: try the
@@ -374,6 +462,20 @@ module WaitHandle =
                 state |> writeHandle id (WaitHandleState.Mutex mutex) |> TryWaitOutcome.Acquired
             | MutexOwnership.Held _ ->
                 // Held by another thread: no enqueue, no status flip.
+                TryWaitOutcome.TimedOut state
+        | WaitHandleState.Event event ->
+            if event.Signaled then
+                let event =
+                    match event.Mode with
+                    | EventResetMode.Auto ->
+                        { event with
+                            Signaled = false
+                        }
+                    | EventResetMode.Manual -> event
+
+                state |> writeHandle id (WaitHandleState.Event event) |> TryWaitOutcome.Acquired
+            else
+                // No enqueue, no status flip.
                 TryWaitOutcome.TimedOut state
 
     /// Semaphore-only non-blocking probe used by the prioritized
@@ -572,6 +674,77 @@ module WaitHandle =
 
                 Ok (), state
 
+    /// Signal an event. Behaviour depends on `Mode`:
+    ///
+    ///  - `Manual`: wake every parked waiter and set `Signaled = true`,
+    ///    so further waiters that arrive before a `ResetEvent` pass
+    ///    through immediately. The invariant `Signaled ⇒ WaitQueue = []`
+    ///    is preserved because we clear the queue as we wake.
+    ///  - `Auto`: if any waiter is parked, hand the signal directly to
+    ///    the FIFO head — wake exactly that thread and leave `Signaled =
+    ///    false`. If no waiter is parked, set `Signaled = true`; the next
+    ///    `WaitOne` will consume the signal as part of acquiring.
+    ///
+    /// Idempotent on already-signalled events. Never fails — the Win32
+    /// `SetEvent` only returns FALSE on an invalid handle, which is
+    /// caught by `expectEvent`.
+    let setEvent (id : WaitHandleId) (state : IlMachineState) : IlMachineState =
+        let handle = lookup id state
+        let event = expectEvent "WaitHandle.setEvent" id handle
+
+        match event.Mode with
+        | EventResetMode.Manual ->
+            // Wake every parked waiter, clear the queue, mark signalled.
+            let waiters = event.WaitQueue
+
+            let event =
+                { event with
+                    Signaled = true
+                    WaitQueue = []
+                }
+
+            let state = writeHandle id (WaitHandleState.Event event) state
+
+            waiters
+            |> List.fold (fun acc tid -> Scheduler.setThreadStatus tid ThreadStatus.Runnable acc) state
+        | EventResetMode.Auto ->
+            match event.WaitQueue with
+            | [] ->
+                // No waiter: latch the signal.
+                let event =
+                    { event with
+                        Signaled = true
+                    }
+
+                state |> writeHandle id (WaitHandleState.Event event)
+            | head :: rest ->
+                // Direct-handoff: wake the FIFO head only; Signaled stays
+                // false (the signal was consumed by the wakeup).
+                let event =
+                    { event with
+                        Signaled = false
+                        WaitQueue = rest
+                    }
+
+                state
+                |> writeHandle id (WaitHandleState.Event event)
+                |> Scheduler.setThreadStatus head ThreadStatus.Runnable
+
+    /// Clear the signalled flag. By invariant `WaitQueue` is empty if
+    /// `Signaled` was true, so there is nothing to do beyond flipping the
+    /// flag; if `Signaled` was already false `WaitQueue` may be non-empty
+    /// but the waiters are untouched. Idempotent.
+    let resetEvent (id : WaitHandleId) (state : IlMachineState) : IlMachineState =
+        let handle = lookup id state
+        let event = expectEvent "WaitHandle.resetEvent" id handle
+
+        let event =
+            { event with
+                Signaled = false
+            }
+
+        state |> writeHandle id (WaitHandleState.Event event)
+
     /// Tear down a wait handle. The Win32 contract is that `CloseHandle`
     /// runs after the handle is fully quiescent — no thread is currently
     /// waiting on it. We enforce that contract loudly: closing a handle
@@ -611,6 +784,12 @@ module WaitHandle =
             | MutexOwnership.Held (owner, recursionCount) ->
                 failwith
                     $"WaitHandle %O{id}: refusing to Close a mutex still held by thread %O{owner} (recursion count = %d{recursionCount}); the guest must ReleaseMutex before Disposing."
+        | WaitHandleState.Event event ->
+            match event.WaitQueue with
+            | [] -> ()
+            | waiters ->
+                failwith
+                    $"WaitHandle %O{id}: refusing to Close an event with %d{List.length waiters} thread(s) parked in BlockedOnWaitHandle (%A{waiters}); the guest must Set/Reset and let waiters drain before Disposing."
 
         state.MapKernel (fun kernel ->
             { kernel with


### PR DESCRIPTION
## Summary

Extends the kind-tagged `WaitHandleState` DU with an `Event` variant
(`ManualReset` and `AutoReset` modes) and wires up the three Win32-shaped
QCalls that `EventWaitHandle.Windows.cs` reaches on CoreCLR-on-Unix:
`CreateEventExW`, `SetEvent`, and `ResetEvent`. The kind-agnostic
dispatchers in `waitOne` / `tryWaitOne` / `close` gain an `Event` arm;
the existing `WaitHandle_WaitOneCore` / `CloseHandle` entry points pick
up event support without further wiring.

* **Manual** events broadcast on `Set` — wake all parked waiters, latch
  `Signaled = true`. Subsequent `WaitOne` calls fast-path through until
  `Reset` clears the signal.
* **Auto** events do direct-handoff on `Set` — wake exactly the FIFO
  head, leave `Signaled = false`. If no waiter is parked, latch
  `Signaled = true`; the next `WaitOne` consumes the signal as part of
  acquiring.
* Invariant `Signaled = true ⇒ WaitQueue = []` is enforced by every
  operation and asserted by FsCheck property tests over arbitrary
  `Wait` / `Set` / `Reset` scripts (200 cases per property).

Named events (`OpenEventW`) remain unimplemented — they throw `PNSE` at
the BCL layer on Unix, so a non-null name pointer at `CreateEventExW`
would be a guest bug and we fail loud. Multi-handle waits and finite
timeouts are still gated on a shared named-handle registry and a
virtual clock respectively.

## Test plan

- [x] `nix develop -c dotnet build WoofWare.PawPrint.slnx` clean
- [x] `nix develop -c dotnet fantomas .` — no diffs
- [x] `nix develop -c dotnet test ... --filter "Name~WaitHandle"` — 103 tests pass (44 new event tests + 59 existing)
- [x] Full `nix develop -c dotnet test` — 1124 tests pass, no regressions
- [x] `codex review --base main` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)