### PR TITLE
Anchor byte-view on reference-typed and jagged array byrefs

### DIFF
--- a/WoofWare.PawPrint.Domain/FriendAssemblies.fs
+++ b/WoofWare.PawPrint.Domain/FriendAssemblies.fs
@@ -262,11 +262,9 @@ module FriendAssemblyName =
 
         if not defIsStrongNamed then
             false
-        else if
 
-            // CompareRefToDef name comparison.
-            not (namesEqual ref.Name def.Name)
-        then
+        // CompareRefToDef name comparison.
+        else if not (namesEqual ref.Name def.Name) then
             false
         else
 

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -25,7 +25,6 @@ module TestPureCases =
             "Threads.cs" // past Buffer's reflection-cache copy (cell-aware path); now blocked on unimplemented QCall ThreadNative_SetIsBackground
             "IsAssignableToBasic.cs" // MethodTable field projection for MethodTable::PerInstInfo
             "RuntimeTypeHandleGetInstantiationOpenGeneric.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringMethodForGenericParameter
-            "IndirectMemoryOperations.cs" // raise IndexOutOfRangeException: array index 8 >= length 3 on array
         ]
         |> Set.ofList
 

--- a/WoofWare.PawPrint.Test/sourcesPure/FixedArrayPointerArithmetic.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/FixedArrayPointerArithmetic.cs
@@ -217,6 +217,38 @@ public unsafe class FixedArrayPointerArithmetic
         return 0;
     }
 
+    // Jagged arrays (`object[][]`) carry a structural element handle
+    // (`OneDimArrayZero` over the inner element type), which isn't registered
+    // in `AllConcreteTypes`. Without anchoring those cells too, the same
+    // element-stride bug bites `fixed (object[]* p = jagged)`: the trailing
+    // `sizeof object[]; add` for `p[1]` would produce an out-of-bounds cell
+    // index. The byte-view anchor uses `System.Object` as the reinterpret
+    // target — the cells share `ObjectRef` shape with plain `object[]`, so
+    // the cell-aligned read/write short-circuits reuse the same path.
+    public static int TestJaggedArrayPointerArithmetic()
+    {
+        object[] a = new object[] { "a0" };
+        object[] b = new object[] { "b0", "b1" };
+        object[] c = new object[] { "c0", "c1", "c2" };
+        object[][] arr = new object[][] { a, b, c };
+        fixed (object[]* p = arr)
+        {
+            if (!object.ReferenceEquals(p[0], a)) return 120;
+            if (!object.ReferenceEquals(p[1], b)) return 121;
+            if (!object.ReferenceEquals(p[2], c)) return 122;
+
+            p[0] = c;
+            if (!object.ReferenceEquals(p[0], c)) return 123;
+
+            p[2] = null;
+            if (p[2] != null) return 124;
+        }
+        if (!object.ReferenceEquals(arr[0], c)) return 125;
+        if (!object.ReferenceEquals(arr[1], b)) return 126;
+        if (arr[2] != null) return 127;
+        return 0;
+    }
+
     // `fixed (object* p = arr) { p[k]; p[k] = value; }` over a reference-type
     // array exercises both `Ldind_ref`/`Stind_ref` and the byte-stride
     // pointer arithmetic that `p[k]` lowers to (`sizeof object; mul; add`,
@@ -276,6 +308,8 @@ public unsafe class FixedArrayPointerArithmetic
         r = TestObjectArrayFixedStore();
         if (r != 0) return r;
         r = TestObjectArrayPointerArithmetic();
+        if (r != 0) return r;
+        r = TestJaggedArrayPointerArithmetic();
         if (r != 0) return r;
         return 0;
     }

--- a/WoofWare.PawPrint.Test/sourcesPure/FixedArrayPointerArithmetic.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/FixedArrayPointerArithmetic.cs
@@ -200,9 +200,9 @@ public unsafe class FixedArrayPointerArithmetic
     // `fixed (object* p = arr) { *p = value; }` over a reference-type array
     // must remain a typed `ArrayElement` store: `stind.ref` over the native
     // pointer cannot byte-flatten an `ObjectRef`. The Conv_U/Conv_I anchor
-    // must therefore skip reference-typed element arrays — byte-stride
-    // pointer arithmetic over object cells would have no useful semantics
-    // anyway, since reference cells aren't byte-addressable.
+    // therefore lands a byte-view on the reference-array byref, but the
+    // cell-aligned dispatch in `tryWriteArrayElementPrecise` routes the
+    // store through `setArrayValue` and preserves the `ObjectRef` payload.
     public static int TestObjectArrayFixedStore()
     {
         object obj1 = new object();
@@ -214,6 +214,41 @@ public unsafe class FixedArrayPointerArithmetic
         }
         if (!object.ReferenceEquals(arr[0], obj2)) return 60;
         if (!object.ReferenceEquals(arr[1], obj1)) return 61;
+        return 0;
+    }
+
+    // `fixed (object* p = arr) { p[k]; p[k] = value; }` over a reference-type
+    // array exercises both `Ldind_ref`/`Stind_ref` and the byte-stride
+    // pointer arithmetic that `p[k]` lowers to (`sizeof object; mul; add`,
+    // or `sizeof object; add` for `k = 1`). Without the byte-view anchor on
+    // the reference-array byref, the trailing `add` would be element-stride
+    // and produce an out-of-bounds cell index, e.g. index 8 for `p[1]` on a
+    // length-3 array. The anchor makes the arithmetic byte-stride; cell-
+    // aligned reads land back on the right element through
+    // `readArrayBytesAs`'s `Rejected` short-circuit, and cell-aligned writes
+    // through `tryWriteArrayElementPrecise`.
+    public static int TestObjectArrayPointerArithmetic()
+    {
+        object obj0 = new object();
+        object obj1 = "hello";
+        object obj2 = new object();
+        object[] arr = new object[] { obj0, obj1, obj2 };
+        fixed (object* p = arr)
+        {
+            if (!object.ReferenceEquals(p[0], obj0)) return 100;
+            if (!object.ReferenceEquals(p[1], obj1)) return 101;
+            if (!object.ReferenceEquals(p[2], obj2)) return 102;
+
+            object replacement = "world";
+            p[1] = replacement;
+            if (!object.ReferenceEquals(p[1], replacement)) return 103;
+
+            p[2] = null;
+            if (p[2] != null) return 104;
+        }
+        if (!object.ReferenceEquals(arr[0], obj0)) return 105;
+        if (arr[1] as string != "world") return 106;
+        if (arr[2] != null) return 107;
         return 0;
     }
 
@@ -239,6 +274,8 @@ public unsafe class FixedArrayPointerArithmetic
         r = TestStructWithProvenanceFixedStore();
         if (r != 0) return r;
         r = TestObjectArrayFixedStore();
+        if (r != 0) return r;
+        r = TestObjectArrayPointerArithmetic();
         if (r != 0) return r;
         return 0;
     }

--- a/WoofWare.PawPrint/ManagedPointerByteView.fs
+++ b/WoofWare.PawPrint/ManagedPointerByteView.fs
@@ -42,27 +42,6 @@ module ManagedPointerByteView =
         let handle = arrayElementHandle obj
         AllConcreteTypes.lookup handle state.ConcreteTypes
 
-    /// `true` when the array's element handle is a reference type. Structural
-    /// array element handles (`OneDimArrayZero`, `Array`) are themselves
-    /// reference types; structural pointer/byref/fnptr handles are not. For
-    /// `Concrete` element handles, dispatch through the loaded `TypeInfo`.
-    let private isReferenceElementHandle
-        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
-        (state : IlMachineState)
-        (handle : ConcreteTypeHandle)
-        : bool
-        =
-        match handle with
-        | ConcreteTypeHandle.OneDimArrayZero _
-        | ConcreteTypeHandle.Array _ -> true
-        | ConcreteTypeHandle.Byref _
-        | ConcreteTypeHandle.Pointer _
-        | ConcreteTypeHandle.FunctionPointer _ -> false
-        | ConcreteTypeHandle.Concrete _ ->
-            match IlMachineState.tryGetConcreteTypeInfo state handle with
-            | Some (_, typeInfo) -> DumpedAssembly.isReferenceType baseClassTypes state._LoadedAssemblies typeInfo
-            | None -> failwith $"isReferenceElementHandle: concrete type handle %O{handle} has no TypeDef row"
-
     let arrayBytePosition
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (state : IlMachineState)
@@ -130,6 +109,18 @@ module ManagedPointerByteView =
     /// semantics, matching `Unsafe.Add<T>` intrinsic behaviour. Apply at the
     /// byref-to-native-pointer transition (`Conv_U`, `Conv_I`).
     ///
+    /// Reference-typed element arrays (e.g. `object[]`) are anchored too: the
+    /// C# `fixed (object* p = arr) { p[k] = ...; }` pattern lowers to a
+    /// byref-to-native-pointer transition followed by `sizeof object; add;
+    /// stind.ref`, so without the anchor the trailing `add` would be
+    /// element-stride and produce out-of-bounds element indices. The cells
+    /// themselves are non-byte-addressable (`ObjectRef`); cell-aligned typed
+    /// reads route through `readArrayBytesAs`'s shape-matching short-circuit
+    /// and cell-aligned typed writes route through
+    /// `tryWriteArrayElementPrecise`, both of which preserve identity.
+    /// Mid-cell access would still fail at the byte-scatter walks, which is
+    /// correct — reference cells aren't byte-addressable.
+    ///
     /// When the array element handle is structural (e.g. `int*[]`,
     /// `delegate*<...>[]`), the element type is not registered in
     /// `AllConcreteTypes` and the cells themselves carry non-byte-addressable
@@ -141,15 +132,6 @@ module ManagedPointerByteView =
     /// Subsequent pointer arithmetic on the structural-element byref will
     /// still use element-stride semantics — extending byte-stride support to
     /// pointer-element arrays is future work.
-    ///
-    /// Reference-typed element arrays (e.g. `object[]`) are also left
-    /// un-anchored: `stind.ref` through a byte-view byref would try to
-    /// byte-flatten the `ObjectRef` payload, which the byte-scatter path
-    /// rejects. Keeping reference arrays on the typed-cell path preserves
-    /// the existing `fixed (object* p = arr) { *p = value; }` shape;
-    /// byte-stride pointer arithmetic over reference arrays would also
-    /// have no useful semantics, since reference cells aren't
-    /// byte-addressable.
     let anchorByteViewIfPlainArrayByref
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (state : IlMachineState)
@@ -161,10 +143,7 @@ module ManagedPointerByteView =
             let arrObj = state.ManagedHeap.Arrays.[arr]
             let handle = arrayElementHandle arrObj
 
-            if isReferenceElementHandle baseClassTypes state handle then
-                ptr
-            else
-                match AllConcreteTypes.lookup handle state.ConcreteTypes with
-                | Some elementType -> addByteOffset baseClassTypes state elementType 0 ptr
-                | None -> ptr
+            match AllConcreteTypes.lookup handle state.ConcreteTypes with
+            | Some elementType -> addByteOffset baseClassTypes state elementType 0 ptr
+            | None -> ptr
         | _ -> ptr

--- a/WoofWare.PawPrint/ManagedPointerByteView.fs
+++ b/WoofWare.PawPrint/ManagedPointerByteView.fs
@@ -121,29 +121,55 @@ module ManagedPointerByteView =
     /// Mid-cell access would still fail at the byte-scatter walks, which is
     /// correct — reference cells aren't byte-addressable.
     ///
-    /// When the array element handle is structural (e.g. `int*[]`,
-    /// `delegate*<...>[]`), the element type is not registered in
-    /// `AllConcreteTypes` and the cells themselves carry non-byte-addressable
-    /// pointer provenance, so the byte-view machinery cannot be safely
-    /// extended over them today. Leave such byrefs un-anchored: `Conv_U`
-    /// merely transports them onto the native-int eval stack, which is what
-    /// the Codex-flagged `ldelema ptr[int32]; conv.u` legal-IL shape needs,
-    /// without forcing the byte-addressability promise we cannot keep.
-    /// Subsequent pointer arithmetic on the structural-element byref will
-    /// still use element-stride semantics — extending byte-stride support to
-    /// pointer-element arrays is future work.
+    /// Jagged arrays (e.g. `object[][]`) have a structural element handle
+    /// (`OneDimArrayZero` or `Array`); those handles are not registered in
+    /// `AllConcreteTypes` (they're synthetic, derived from the inner element
+    /// type), but the cells are array references — `ObjectRef`-shaped, like
+    /// `object[]`. Anchor those with `System.Object` as the reinterpret
+    /// target: it carries the same CLI shape, the byte-stride context still
+    /// comes from `arrayElementSize` (which uses cell `CliType.sizeOf`,
+    /// independent of the reinterpret target), and the cell-aligned
+    /// read/write short-circuits preserve identity exactly as for `object[]`.
+    ///
+    /// Pointer/byref/fnptr element handles (e.g. `int*[]`,
+    /// `delegate*<...>[]`) carry non-byte-addressable pointer provenance and
+    /// no `ObjectRef`-shaped surrogate type, so the byte-view machinery
+    /// cannot be safely extended over them today. Leave such byrefs
+    /// un-anchored: `Conv_U` merely transports them onto the native-int eval
+    /// stack, which is what the Codex-flagged `ldelema ptr[int32]; conv.u`
+    /// legal-IL shape needs, without forcing the byte-addressability promise
+    /// we cannot keep. Subsequent pointer arithmetic on the structural-element
+    /// byref will still use element-stride semantics — extending byte-stride
+    /// support to pointer-element arrays is future work.
     let anchorByteViewIfPlainArrayByref
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (state : IlMachineState)
         (ptr : ManagedPointerSource)
         : ManagedPointerSource
         =
+        let tryObjectConcreteType () : ConcreteType<ConcreteTypeHandle> option =
+            AllConcreteTypes.findExistingNonGenericConcreteType state.ConcreteTypes baseClassTypes.Object.Identity
+            |> Option.bind (fun handle -> AllConcreteTypes.lookup handle state.ConcreteTypes)
+
         match ptr with
         | ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, _), []) ->
             let arrObj = state.ManagedHeap.Arrays.[arr]
             let handle = arrayElementHandle arrObj
 
-            match AllConcreteTypes.lookup handle state.ConcreteTypes with
-            | Some elementType -> addByteOffset baseClassTypes state elementType 0 ptr
-            | None -> ptr
+            match handle with
+            | ConcreteTypeHandle.Concrete _ ->
+                match AllConcreteTypes.lookup handle state.ConcreteTypes with
+                | Some elementType -> addByteOffset baseClassTypes state elementType 0 ptr
+                | None -> ptr
+            | ConcreteTypeHandle.OneDimArrayZero _
+            | ConcreteTypeHandle.Array _ ->
+                // Jagged-array cells are array references; the byte-view's
+                // reinterpret target only needs to carry the `ObjectRef` shape,
+                // and `System.Object` is the universal surrogate for that shape.
+                match tryObjectConcreteType () with
+                | Some objectType -> addByteOffset baseClassTypes state objectType 0 ptr
+                | None -> ptr
+            | ConcreteTypeHandle.Byref _
+            | ConcreteTypeHandle.Pointer _
+            | ConcreteTypeHandle.FunctionPointer _ -> ptr
         | _ -> ptr


### PR DESCRIPTION
## Summary

- Removes the `isReferenceElementHandle` skip in `anchorByteViewIfPlainArrayByref`, so `Conv_U`/`Conv_I` on a plain `object[]` byref attaches a `ReinterpretAs object` projection. The trailing `sizeof object; add` from `fixed (object* p = arr); p[k]` now uses byte stride and normalises whole-cell offsets back into the element index, instead of falling into element-stride `ArrayTarget` arithmetic (which added the byte count `8` to the element index, producing `ArrayElement(arr, 8)` and an IndexOutOfRangeException on a length-3 array).
- Reference cell identity is preserved through the existing cell-aligned short-circuits: `readArrayBytesAs`'s `Rejected` + `haveSameCliShape` branch and `tryWriteArrayElementPrecise` for `Stind_ref`. Mid-cell access still fails (correctly), since reference cells aren't byte-addressable.
- Extends the anchor to jagged-array element handles (`OneDimArrayZero`, `Array`) using `System.Object` as the reinterpret target — they're `ObjectRef`-shaped like plain `object[]` cells. This fixes the same bug shape for `fixed (object[]* p = jagged)`, which codex's review flagged when reviewing the first commit.
- Switches the anchor's dispatch to be explicit on `ConcreteTypeHandle` constructor so pointer/byref/fnptr element handles continue to fall through un-anchored (their cells carry non-byte-addressable pointer provenance with no `ObjectRef`-shaped surrogate today).
- Removes `IndirectMemoryOperations.cs` from the `unimplemented` set in `TestPureCases.fs` (the test's `TestIndirectReference` sub-case was the original failing path); adds `TestObjectArrayPointerArithmetic` and `TestJaggedArrayPointerArithmetic` to `FixedArrayPointerArithmetic.cs` to lock in the fix.
- Includes a fantomas reformatting of `FriendAssemblies.fs` that surfaced when running the formatter.

## Test plan

- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 1082/1082 passing
- [x] `nix develop -c dotnet test ... --filter "Name~IndirectMemoryOperations"` — passing (previously failed with `IndexOutOfRangeException: array index 8 >= length 3`)
- [x] `nix develop -c dotnet test ... --filter "Name~FixedArrayPointerArithmetic"` — passing, includes the two new sub-tests
- [x] `codex review --base main` — clean on the rebased branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)