### PR TITLE
Add System.Double.Abs to safeIntrinsics

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/DoubleAbs.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/DoubleAbs.cs
@@ -1,0 +1,81 @@
+using System;
+
+public class DoubleAbsTests
+{
+    public static int TestFinite()
+    {
+        if (double.Abs(1.5) != 1.5) return 1;
+        if (double.Abs(-1.5) != 1.5) return 2;
+        if (double.Abs(0.0) != 0.0) return 3;
+        if (double.Abs(double.MaxValue) != double.MaxValue) return 4;
+        if (double.Abs(-double.MaxValue) != double.MaxValue) return 5;
+        if (double.Abs(double.Epsilon) != double.Epsilon) return 6;
+        if (double.Abs(-double.Epsilon) != double.Epsilon) return 7;
+        return 0;
+    }
+
+    public static int TestNegativeZero()
+    {
+        // 0.0 == -0.0 per IEEE 754, so direct equality won't catch a sign-bit bug.
+        // Compare the bit pattern: Abs(-0.0) must be +0.0 (all-zero bits).
+        double r = double.Abs(-0.0);
+        long bits = BitConverter.DoubleToInt64Bits(r);
+        if (bits != 0L) return 1;
+        return 0;
+    }
+
+    public static int TestInfinities()
+    {
+        if (double.Abs(double.PositiveInfinity) != double.PositiveInfinity) return 1;
+        if (double.Abs(double.NegativeInfinity) != double.PositiveInfinity) return 2;
+        return 0;
+    }
+
+    public static int TestNaN()
+    {
+        if (!double.IsNaN(double.Abs(double.NaN))) return 1;
+        if (!double.IsNaN(double.Abs(-double.NaN))) return 2;
+        return 0;
+    }
+
+    public static int TestAgreesWithMathAbs()
+    {
+        // double.Abs is documented to delegate to Math.Abs; exercise that the two
+        // produce identical results on a handful of finite values.
+        double[] samples = { 0.0, -0.0, 1.0, -1.0, 3.14159, -2.71828, 1e300, -1e-300 };
+        for (int i = 0; i < samples.Length; i++)
+        {
+            double a = double.Abs(samples[i]);
+            double b = Math.Abs(samples[i]);
+            // Bit-exact comparison so we catch any divergence on -0.0 specifically.
+            if (BitConverter.DoubleToInt64Bits(a) != BitConverter.DoubleToInt64Bits(b))
+                return i + 1;
+        }
+        return 0;
+    }
+}
+
+class Program
+{
+    static int Main(string[] args)
+    {
+        int result;
+
+        result = DoubleAbsTests.TestFinite();
+        if (result != 0) return 1000 + result;
+
+        result = DoubleAbsTests.TestNegativeZero();
+        if (result != 0) return 2000 + result;
+
+        result = DoubleAbsTests.TestInfinities();
+        if (result != 0) return 3000 + result;
+
+        result = DoubleAbsTests.TestNaN();
+        if (result != 0) return 4000 + result;
+
+        result = DoubleAbsTests.TestAgreesWithMathAbs();
+        if (result != 0) return 5000 + result;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/IntrinsicMethodKeys.fs
+++ b/WoofWare.PawPrint/IntrinsicMethodKeys.fs
@@ -343,6 +343,10 @@ module IntrinsicMethodKeys =
             // https://github.com/dotnet/runtime/blob/d258af50034c192bf7f0a18856bf83d2903d98ae/src/libraries/System.Private.CoreLib/src/System/Math.cs#L127
             // https://github.com/dotnet/runtime/blob/d258af50034c192bf7f0a18856bf83d2903d98ae/src/libraries/System.Private.CoreLib/src/System/Math.cs#L137
             anyParams "System.Private.CoreLib" "System.Math" "Abs"
+            // Single-line delegation to Math.Abs above; the [Intrinsic] marker is for the JIT,
+            // but the IL body is just a tail call we can safely execute.
+            // https://github.com/dotnet/runtime/blob/7706f546bac1a99b3d891afe3591dc88c67f0cc4/src/libraries/System.Private.CoreLib/src/System/Double.cs#L1041-L1043
+            anyParams "System.Private.CoreLib" "System.Double" "Abs"
             // https://github.com/dotnet/runtime/blob/d258af50034c192bf7f0a18856bf83d2903d98ae/src/libraries/System.Private.CoreLib/src/System/Math.cs#L965C10-L1062C19
             anyParams "System.Private.CoreLib" "System.Math" "Max"
             // Mirror of Math.Max above: most overloads have a `(val1 <= val2) ? val1 : val2`


### PR DESCRIPTION
## Summary

- `System.Double.Abs` is marked `[Intrinsic]` in CoreLib but had no JIT-intrinsic fallback, so calling it (e.g. via the `INumberBase<double>.Abs` static-abstract path) crashed with `TODO: implement JIT intrinsic ... or add it to safeIntrinsics after reviewing its IL`.
- Its IL body in .NET 10 is a one-line `=> Math.Abs(value)` ([Double.cs#L1041-L1043](https://github.com/dotnet/runtime/blob/7706f546bac1a99b3d891afe3591dc88c67f0cc4/src/libraries/System.Private.CoreLib/src/System/Double.cs#L1041-L1043)). `System.Math.Abs` is already on `safeIntrinsics`, and its IL in turn uses the already-implemented `BitConverter.DoubleToUInt64Bits` / `UInt64BitsToDouble` JIT intrinsics. So adding `Double.Abs` to `safeIntrinsics` lets the existing interpreter handle it without duplicating sign-bit logic.
- Added a pure C# test covering finite values, ±0 (bit-exact check), ±∞, NaN, and bit-exact agreement with `Math.Abs`.

## Test plan

- [x] `nix develop -c dotnet build WoofWare.PawPrint.slnx`
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --filter "Name~DoubleAbs"` — passes
- [x] Full pure-test suite (`nix develop -c dotnet test ...`) — 1083/1083 pass
- [x] `nix develop -c dotnet fantomas .` — clean
- [x] `codex review --base main` — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)