### PR TITLE
Implement RuntimeTypeHandle_GetDeclaringMethodForGenericParameter QCall

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -24,7 +24,6 @@ module TestPureCases =
             "InterfaceDispatch.cs" // expected: 0; was: 1024
             "Threads.cs" // past Buffer's reflection-cache copy (cell-aware path); now blocked on unimplemented QCall ThreadNative_SetIsBackground
             "IsAssignableToBasic.cs" // MethodTable field projection for MethodTable::PerInstInfo
-            "RuntimeTypeHandleGetInstantiationOpenGeneric.cs" // blocked by unimplemented QCall RuntimeTypeHandle::GetDeclaringMethodForGenericParameter
         ]
         |> Set.ofList
 

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -20,6 +20,8 @@ module NativeQCall =
             "RuntimeTypeHandle_CreateInstanceForAnotherGenericParameter",
             NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_CreateInstanceForAnotherGenericParameter"
             "RuntimeTypeHandle_GetConstraints", NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_GetConstraints"
+            "RuntimeTypeHandle_GetDeclaringMethodForGenericParameter",
+            NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_GetDeclaringMethodForGenericParameter"
             "RuntimeTypeHandle_GetDeclaringTypeHandle",
             NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_GetDeclaringTypeHandle"
             "RuntimeTypeHandle_GetDeclaringTypeHandleForGenericVariable",

--- a/WoofWare.PawPrint/Native/NativeRuntimeType.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeType.fs
@@ -2693,6 +2693,53 @@ module NativeRuntimeType =
                     state
 
             (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+        | "RuntimeTypeHandle_GetDeclaringMethodForGenericParameter",
+          "System.Private.CoreLib",
+          "System",
+          "RuntimeTypeHandle",
+          "GetDeclaringMethodForGenericParameter",
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "QCallTypeHandle",
+                                              qCallGenerics)
+            ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "ObjectHandleOnStack",
+                                              objectHandleGenerics) ],
+          MethodReturnType.Void when qCallGenerics.IsEmpty && objectHandleGenerics.IsEmpty ->
+            let operation = "RuntimeTypeHandle.GetDeclaringMethodForGenericParameter"
+
+            if instruction.Arguments.Length <> 2 then
+                failwith $"%s{operation}: expected two native arguments, got %d{instruction.Arguments.Length}"
+
+            let qCallHandle = instruction.Arguments.[0] |> EvalStackValue.ofCliType
+
+            let typeHandleTarget =
+                NativeCall.qCallTypeHandleToRuntimeTypeHandleTarget operation state qCallHandle
+
+            // Validate the ObjectHandleOnStack argument shape eagerly so a malformed
+            // BCL call fails here rather than later. We don't write through the byref
+            // on the type-level branch: the managed wrapper initialises its local
+            // `IRuntimeMethodInfo? method = null` before the QCall, and CoreCLR's
+            // implementation in runtimehandles.cpp:885 leaves `result` untouched when
+            // the generic variable's def-token is not an mdtMethodDef. Returning
+            // without writing therefore yields the same null the managed wrapper
+            // reads back.
+            let _ =
+                NativeCall.objectHandleOnStackTarget operation state "result" instruction.Arguments.[1]
+
+            match typeHandleTarget with
+            | RuntimeTypeHandleTarget.GenericParameter _ ->
+                // Type-level generic parameter: CoreCLR's `defToken` is mdtTypeDef,
+                // so the early-exit branch leaves `result` null. Mirror that.
+                (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            | RuntimeTypeHandleTarget.MethodGenericParameter (declaringType, declaringMethod, position) ->
+                failwith
+                    $"TODO: %s{operation} for method generic parameter #%i{position} of method %O{declaringMethod.Get} on %O{declaringType.TypeDefinition.Get}; need to allocate and return an IRuntimeMethodInfo for the declaring method (same gap as the RuntimeTypeHandle.GetDeclaringMethod InternalCall)"
+            | RuntimeTypeHandleTarget.Closed _
+            | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
+                failwith
+                    $"%s{operation}: BCL contract violation: QCall reached for non-generic-variable target %O{typeHandleTarget}; the managed wrapper guards with Debug.Assert(IsGenericVariable(type))"
         | "ModuleHandle_ResolveType",
           "System.Private.CoreLib",
           "System",


### PR DESCRIPTION
## Summary

- Adds the QCall `RuntimeTypeHandle_GetDeclaringMethodForGenericParameter` to the QCall dispatch table and implements the type-level branch (returns `null`, matching CoreCLR's early-exit in `runtimehandles.cpp:885` when the generic variable's def-token isn't an `mdtMethodDef`).
- Method-level generic parameters and non-generic-variable targets fail loudly: the former is a separate piece of work (allocating an `IRuntimeMethodInfo`, same gap as the existing `RuntimeTypeHandle.GetDeclaringMethod` InternalCall TODO); the latter is a BCL contract violation guarded by `Debug.Assert(IsGenericVariable(type))` in managed code.
- Unblocks `RuntimeTypeHandleGetInstantiationOpenGeneric.cs`, which exercises `IsGenericParameter` / `IsGenericTypeParameter` / `IsGenericMethodParameter` / `GenericParameterPosition` / `Name` on type-level parameters obtained via `typeof(Box<>).GetGenericArguments()`. Removed from the `unimplemented` set.

## Test plan

- [x] `nix develop -c dotnet test ... --filter "Name~RuntimeTypeHandleGetInstantiationOpenGeneric"` passes
- [x] Full pure-test suite (`nix develop -c dotnet test ...`) still passes — 1125/1125
- [x] `codex review --base main` returned with no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)