### PR TITLE
Anchor byte-view on plain string-char byrefs at Conv_U/Conv_I

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/StringCharByref.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/StringCharByref.cs
@@ -99,6 +99,26 @@ public class StringCharByref
         return 0;
     }
 
+    public static unsafe int TestStringFixedPointerByteAdd()
+    {
+        // Use a string literal not shared with other tests so this case is
+        // robust against in-place byte-view mutations elsewhere in the
+        // assembly that would otherwise alias through the intern pool.
+        string s = "fp";
+        ReadOnlySpan<char> span = s;
+        fixed (char* p = &MemoryMarshal.GetReference(span))
+        {
+            ref byte b0 = ref Unsafe.AsRef<byte>(p);
+            ref byte b2 = ref Unsafe.Add(ref b0, 2);
+            if (b2 != (byte)'p')
+                return 14;
+            if (b0 != (byte)'f')
+                return 15;
+        }
+
+        return 0;
+    }
+
     public static int Main(string[] argv)
     {
         int result = TestSecondCharByUnsafeAdd();
@@ -118,6 +138,10 @@ public class StringCharByref
             return result;
 
         result = TestStringByteViewWrite();
+        if (result != 0)
+            return result;
+
+        result = TestStringFixedPointerByteAdd();
         if (result != 0)
             return result;
 

--- a/WoofWare.PawPrint/ManagedPointerByteView.fs
+++ b/WoofWare.PawPrint/ManagedPointerByteView.fs
@@ -103,11 +103,12 @@ module ManagedPointerByteView =
 
         ManagedPointerSource.addByteOffsetToByteView normalisation byteOffset ptr
 
-    /// Anchor a byte-view on a plain `ArrayElement` byref so subsequent pointer
-    /// arithmetic uses byte stride (ECMA-335 §III.1.5: native-pointer +/- int is
-    /// byte arithmetic). Plain byrefs without this anchor keep element-stride
-    /// semantics, matching `Unsafe.Add<T>` intrinsic behaviour. Apply at the
-    /// byref-to-native-pointer transition (`Conv_U`, `Conv_I`).
+    /// Anchor a byte-view on a plain byref (array-element or string-char) so
+    /// subsequent pointer arithmetic uses byte stride (ECMA-335 §III.1.5:
+    /// native-pointer +/- int is byte arithmetic). Plain byrefs without this
+    /// anchor keep element-stride semantics, matching `Unsafe.Add<T>`
+    /// intrinsic behaviour. Apply at the byref-to-native-pointer transition
+    /// (`Conv_U`, `Conv_I`).
     ///
     /// Reference-typed element arrays (e.g. `object[]`) are anchored too: the
     /// C# `fixed (object* p = arr) { p[k] = ...; }` pattern lowers to a
@@ -131,6 +132,13 @@ module ManagedPointerByteView =
     /// independent of the reinterpret target), and the cell-aligned
     /// read/write short-circuits preserve identity exactly as for `object[]`.
     ///
+    /// String-char byrefs (`StringCharAt`) are anchored with `System.Char` so
+    /// that the C# `fixed (char* p = &MemoryMarshal.GetReference(span))`
+    /// pattern, followed by a byte-stride `Unsafe.Add<byte>`, takes the
+    /// byte-cursor branch in `IntrinsicHelpers.offsetManagedPointerByElements`
+    /// rather than the element-stride branch that demands a matching char
+    /// cell size.
+    ///
     /// Pointer/byref/fnptr element handles (e.g. `int*[]`,
     /// `delegate*<...>[]`) carry non-byte-addressable pointer provenance and
     /// no `ObjectRef`-shaped surrogate type, so the byte-view machinery
@@ -149,6 +157,10 @@ module ManagedPointerByteView =
         =
         let tryObjectConcreteType () : ConcreteType<ConcreteTypeHandle> option =
             AllConcreteTypes.findExistingNonGenericConcreteType state.ConcreteTypes baseClassTypes.Object.Identity
+            |> Option.bind (fun handle -> AllConcreteTypes.lookup handle state.ConcreteTypes)
+
+        let tryCharConcreteType () : ConcreteType<ConcreteTypeHandle> option =
+            AllConcreteTypes.findExistingNonGenericConcreteType state.ConcreteTypes baseClassTypes.Char.Identity
             |> Option.bind (fun handle -> AllConcreteTypes.lookup handle state.ConcreteTypes)
 
         match ptr with
@@ -172,4 +184,8 @@ module ManagedPointerByteView =
             | ConcreteTypeHandle.Byref _
             | ConcreteTypeHandle.Pointer _
             | ConcreteTypeHandle.FunctionPointer _ -> ptr
+        | ManagedPointerSource.Byref (ByrefRoot.StringCharAt _, []) ->
+            match tryCharConcreteType () with
+            | Some charType -> addByteOffset baseClassTypes state charType 0 ptr
+            | None -> ptr
         | _ -> ptr


### PR DESCRIPTION
## Summary
- The C# `fixed (char* p = &MemoryMarshal.GetReference(span))` pattern emits a `Conv_U` on a `Byref(StringCharAt(addr, 0), [])`. Without a trailing `ReinterpretAs` anchor, downstream byte-stride `Unsafe.Add<byte>` arithmetic hit the failwith in `offsetManagedPointerByElements`'s `StringCharAt` branch: `TODO: byref element offset where element size of T (1) differs from string char size (2) without a trailing ReinterpretAs projection`. This was the blocker for the `WriteLine` test in `TestImpureCases`, whose path runs through `Buffer.MemoryCopy` → `Buffer.Memmove<byte>` → `SpanHelpers.Memmove`.
- Extend `anchorByteViewIfPlainArrayByref` in `WoofWare.PawPrint/ManagedPointerByteView.fs` to handle a `ByrefRoot.StringCharAt _, []` byref by anchoring `ReinterpretAs(System.Char)`, mirroring the existing array-element anchoring.
- Added a focused pure test `TestStringFixedPointerByteAdd` in `sourcesPure/StringCharByref.cs` exercising the `fixed (char* p = ...)` → `Unsafe.AsRef<byte>` → `Unsafe.Add<byte>` path. The literal uses `"fp"` rather than `"ab"` because `TestStringByteViewWrite` in the same file mutates `"ab"` to `"xy"` through a byte view and string interning otherwise aliases the literal across tests.

## Test plan
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --filter "Name~StringCharByref"` passes
- [x] Full suite: `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 1126/1126 pass
- [x] `nix develop -c dotnet fantomas .` clean
- [x] `codex review --base main` reports no actionable correctness issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)