### PR TITLE
Gate stelem and multi-dim Set on ECMA-335 array-store variance

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/ArrayStoreVarianceEnumNestedArray.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/ArrayStoreVarianceEnumNestedArray.cs
@@ -1,0 +1,29 @@
+// Regression: ECMA-335 / CoreCLR permit enums with an equivalent underlying
+// integer type to interchange with the underlying primitive at array element
+// boundaries. A `MyEnum : int` array element-stored into a slot whose array's
+// stored element type is `int[]` is a valid covariant store. The variance gate
+// must not raise ArrayTypeMismatchException for this case even though the
+// assignability walk doesn't yet model enum-underlying-type equivalence: when
+// either side of the inner element comparison is an enum, the walk reports
+// "unknown" (`None`) and the gate degrades to permit.
+
+public enum NestedEnumKind : int
+{
+    First = 0,
+    Second = 1,
+}
+
+public class TestArrayStoreVarianceEnumNestedArray
+{
+    public static int Main(string[] argv)
+    {
+        object[] view = new int[1][];
+        NestedEnumKind[] payload = new NestedEnumKind[] { NestedEnumKind.Second };
+        view[0] = payload;
+
+        if (!ReferenceEquals(view[0], payload))
+            return 1;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/ArrayStoreVarianceGenericInterface.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/ArrayStoreVarianceGenericInterface.cs
@@ -1,0 +1,29 @@
+// Regression: a covariant store from `string[]` into an `IEnumerable<string>[]`
+// element is legitimate (arrays implement `IEnumerable<T>`). The runtime
+// array-store variance gate must not turn this into a host failure even though
+// the assignability walk in `isConcreteTypeAssignableTo` has not yet been
+// taught the array-to-generic-interface rule. The gate should degrade to
+// "permit" when assignability cannot be definitively decided.
+
+using System;
+using System.Collections.Generic;
+
+public class TestArrayStoreVarianceGenericInterface
+{
+    public static int Main(string[] argv)
+    {
+        IEnumerable<string>[] arr = new IEnumerable<string>[1];
+
+        // The compiler emits `stelem.ref` here; the runtime variance gate sees
+        // value runtime type = string[], stored element type = IEnumerable<string>.
+        string[] payload = new string[] { "x" };
+        arr[0] = payload;
+
+        // Round-trip through `IEnumerable<T>.GetEnumerator()` is a separate
+        // codepath; restrict ourselves to confirming the store survived and
+        // the element identity matches.
+        if (!ReferenceEquals(arr[0], payload)) return 1;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/ArrayStoreVariancePrimitiveIntegerNestedArray.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/ArrayStoreVariancePrimitiveIntegerNestedArray.cs
@@ -1,0 +1,23 @@
+// Regression: ECMA-335 III.8.7 / CoreCLR GetNormalizedIntegralArrayElementType
+// permits signed/unsigned primitive integer arrays to interchange as element
+// types of an outer array — `object[] view = new int[1][]; view[0] = new uint[0];`
+// is a valid covariant store. The runtime variance gate must therefore consider
+// `int[]` and `uint[]` to be assignable when checking the inner element type.
+
+public class TestArrayStoreVariancePrimitiveIntegerNestedArray
+{
+    public static int Main(string[] argv)
+    {
+        // `object[]` aliasing `int[][]`. Storing a `uint[]` into it must succeed
+        // by primitive-integer equivalence.
+        object[] view = new int[1][];
+        uint[] payload = new uint[] { 7u };
+        view[0] = payload;
+
+        // Round-trip identity check to confirm the store landed.
+        if (!ReferenceEquals(view[0], payload))
+            return 1;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/EnumArrayIsNonIntegerPrimitiveArray.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/EnumArrayIsNonIntegerPrimitiveArray.cs
@@ -1,0 +1,40 @@
+// Regression: an enum-array is never assignable to an array of a non-integer
+// primitive (`float[]`, `double[]`, `bool[]`, `char[]`) or any non-integer
+// struct. Enum-underlying equivalence — the rule that lets a `MyEnum : int`
+// array interchange with `int[]` at the array-store / array-cast level — can
+// only succeed when the partner element is itself an enum or a normalized
+// primitive integer. For any other value-typed partner the answer is a
+// definitive "false", not "unknown": `isinst`/`castclass` must observe a
+// managed `false` rather than the interpreter host-failing.
+
+public enum MyOtherKind : int
+{
+    Zero,
+    One,
+}
+
+public class TestEnumArrayIsNonIntegerPrimitiveArray
+{
+    public static int Main(string[] argv)
+    {
+        object o = new MyOtherKind[1];
+
+        if (o is float[])
+            return 1;
+
+        if (o is double[])
+            return 2;
+
+        if (o is bool[])
+            return 3;
+
+        if (o is char[])
+            return 4;
+
+        // Sanity: the value really is non-null and lives in the object slot.
+        if (o == null)
+            return 5;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/EnumArrayIsObjectArray.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/EnumArrayIsObjectArray.cs
@@ -1,0 +1,29 @@
+// Regression: when the assignability check meets an array source with a
+// value-typed element type (here `MyKind : int`) and a target array with a
+// reference-typed element (`object[]`), the answer must be a definitive
+// "false" — the covariance + enum-equivalence rules don't apply across
+// reference/value boundaries. Callers like `isinst` rely on a managed-false
+// answer; an interpreter-level TODO failwith would be a regression.
+
+public enum MyKind : int
+{
+    A,
+    B,
+}
+
+public class TestEnumArrayIsObjectArray
+{
+    public static int Main(string[] argv)
+    {
+        object o = new MyKind[1];
+
+        if (o is object[])
+            return 1;
+
+        // Sanity: the value really is non-null and lives in the object slot.
+        if (o == null)
+            return 2;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/MultiDimensionalArrayCovariance.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/MultiDimensionalArrayCovariance.cs
@@ -1,0 +1,45 @@
+// ECMA-335 II.14.2 / III.4.x: the runtime-synthesized `Set` operation on a
+// multi-dimensional array is variance-checked the same way as `stelem`. A
+// covariant view (`object[,]` aliasing `string[,]`) must accept stores whose
+// value is assignment-compatible with the array's stored element type, and
+// must raise ArrayTypeMismatchException otherwise. Null is always storable
+// into a reference-typed element.
+
+using System;
+
+public class TestMultiDimensionalArrayCovariance
+{
+    public static int Main(string[] argv)
+    {
+        string[,] backing = new string[2, 2];
+        object[,] view = backing;
+
+        // Compatible store: string into string[,]-aliased-as-object[,].
+        view[0, 0] = "ok";
+        if (!ReferenceEquals(backing[0, 0], "ok")) return 1;
+
+        // Null is storable.
+        view[0, 1] = null;
+        if (backing[0, 1] != null) return 2;
+
+        // Incompatible store: boxed Int32 is not assignable to string.
+        try
+        {
+            view[1, 0] = (object)42;
+            return 3;
+        }
+        catch (ArrayTypeMismatchException)
+        {
+            // expected
+        }
+
+        // The failed store must have left the cell untouched.
+        if (backing[1, 0] != null) return 4;
+
+        // A second compatible store afterwards still works.
+        view[1, 1] = "still ok";
+        if (!ReferenceEquals(backing[1, 1], "still ok")) return 5;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/StelemBoundsBeforeVariance.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/StelemBoundsBeforeVariance.cs
@@ -1,0 +1,45 @@
+// Regression: ECMA-335 III.4.x and CoreCLR check the array index bounds
+// BEFORE the array-store variance check. A `stelem` against an out-of-range
+// index on a covariant array must raise IndexOutOfRangeException, not
+// ArrayTypeMismatchException, even when the value's runtime type is also
+// incompatible with the array's element type.
+
+using System;
+
+public class TestStelemBoundsBeforeVariance
+{
+    private static void Store<T>(T[] arr, int index, T value)
+    {
+        // Emits `stelem !!0` with a TypeSpec metadata token, hitting
+        // UnaryMetadataArrayOps.executeStelem.
+        arr[index] = value;
+    }
+
+    public static int Main(string[] argv)
+    {
+        // `string[]` aliased as `object[]`: storing a boxed Int32 would
+        // normally raise ArrayTypeMismatchException, but the index here is
+        // out of range so IndexOutOfRangeException must fire first.
+        object[] arr = new string[1];
+
+        try
+        {
+            Store<object>(arr, 5, 42);
+            return 1; // expected an exception
+        }
+        catch (IndexOutOfRangeException)
+        {
+            // good
+        }
+        catch (ArrayTypeMismatchException)
+        {
+            return 2; // wrong precedence
+        }
+        catch
+        {
+            return 3; // unexpected exception type
+        }
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/StelemRefArrayCovariance.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/StelemRefArrayCovariance.cs
@@ -1,0 +1,44 @@
+// ECMA-335 III.4.x: `stelem` / `stelem.ref` into a reference-typed array must
+// raise ArrayTypeMismatchException when the value's runtime type is not
+// assignment-compatible with the array's stored element type. Covariant
+// reads through a base-typed view are legal; covariant writes are gated on
+// runtime assignability.
+//
+// `object[] view = new string[1]` aliases a string[]. Writing a string is
+// fine; writing a boxed Int32 must trap. Null is always storable.
+
+using System;
+
+public class TestStelemRefArrayCovariance
+{
+    public static int Main(string[] argv)
+    {
+        string[] backing = new string[3];
+        object[] view = backing;
+
+        // Compatible store: string-into-string[]-aliased-as-object[] is fine.
+        view[0] = "ok";
+        if (!ReferenceEquals(backing[0], "ok")) return 1;
+
+        // Null is always storable into a reference array.
+        view[1] = null;
+        if (backing[1] != null) return 2;
+
+        // Incompatible store: Int32 (boxed to satisfy the object element type
+        // statically) is not assignable to string at runtime.
+        try
+        {
+            view[2] = (object)42;
+            return 3;
+        }
+        catch (ArrayTypeMismatchException)
+        {
+            // expected
+        }
+
+        // The failed store must have left the array unchanged.
+        if (backing[2] != null) return 4;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -1380,44 +1380,49 @@ module IlMachineRuntimeMetadata =
                     state, Some false
                 elif objElement = targetElement then
                     state, Some true
-                elif
-                    isReferenceTypeHandle state objElement
-                    && isReferenceTypeHandle state targetElement
-                then
-                    let state, elementAssignable =
-                        isConcreteTypeAssignableTo loggerFactory baseClassTypes state objElement targetElement
-
-                    state, Some elementAssignable
                 else
-                    // Both element types are value-typed (or one of each, in which case
-                    // primitive-integer equivalence cannot hold and we fall through to
-                    // `Some false`). ECMA-335 / CoreCLR permit two complementary rules
-                    // for value-typed array elements:
-                    //   (a) signed/unsigned primitive integers of equal width
-                    //       (`int[]` ↔ `uint[]`, etc.) — `GetNormalizedIntegralArrayElementType`.
-                    //   (b) enums whose underlying integer type matches the partner's
-                    //       (e.g. `MyEnum : int` ↔ `int`, or two enums with the same
-                    //       underlying type).
-                    // (a) is modelled below. (b) requires reading each enum's `value__`
-                    // field to discover its underlying type, which we haven't taught
-                    // the assignability walk yet. When either element is an enum we
-                    // therefore return `None` (undecided) so callers can degrade rather
-                    // than rejecting a valid covariant store. Two non-enum value types
-                    // keep the definitive `Some false` answer.
-                    let state, objIsEnum = isEnumValueType state objElement
-                    let state, targetIsEnum = isEnumValueType state targetElement
+                    let objIsRef = isReferenceTypeHandle state objElement
+                    let targetIsRef = isReferenceTypeHandle state targetElement
 
-                    if objIsEnum || targetIsEnum then
-                        // TODO: model enum-underlying integer equivalence so this case
-                        // becomes a precise answer rather than "unknown".
-                        state, None
+                    if objIsRef && targetIsRef then
+                        let state, elementAssignable =
+                            isConcreteTypeAssignableTo loggerFactory baseClassTypes state objElement targetElement
+
+                        state, Some elementAssignable
+                    elif objIsRef <> targetIsRef then
+                        // One element is reference-typed and the other is value-typed.
+                        // ECMA-335 covariance applies only across reference types, and
+                        // primitive/enum equivalence applies only between value types,
+                        // so the answer is definitively non-assignable here.
+                        state, Some false
                     else
-                        match
-                            normalizedPrimitiveIntegerIdentity objElement,
-                            normalizedPrimitiveIntegerIdentity targetElement
-                        with
-                        | Some a, Some b when a = b -> state, Some true
-                        | _, _ -> state, Some false
+                        // Both element types are value-typed. ECMA-335 / CoreCLR permit
+                        // two complementary rules for value-typed array elements:
+                        //   (a) signed/unsigned primitive integers of equal width
+                        //       (`int[]` ↔ `uint[]`, etc.) — `GetNormalizedIntegralArrayElementType`.
+                        //   (b) enums whose underlying integer type matches the partner's
+                        //       (e.g. `MyEnum : int` ↔ `int`, or two enums with the same
+                        //       underlying type).
+                        // (a) is modelled below. (b) requires reading each enum's `value__`
+                        // field to discover its underlying type, which we haven't taught
+                        // the assignability walk yet. When either element is an enum we
+                        // therefore return `None` (undecided) so callers can degrade rather
+                        // than rejecting a valid covariant store. Two non-enum value types
+                        // keep the definitive `Some false` answer.
+                        let state, objIsEnum = isEnumValueType state objElement
+                        let state, targetIsEnum = isEnumValueType state targetElement
+
+                        if objIsEnum || targetIsEnum then
+                            // TODO: model enum-underlying integer equivalence so this case
+                            // becomes a precise answer rather than "unknown".
+                            state, None
+                        else
+                            match
+                                normalizedPrimitiveIntegerIdentity objElement,
+                                normalizedPrimitiveIntegerIdentity targetElement
+                            with
+                            | Some a, Some b when a = b -> state, Some true
+                            | _, _ -> state, Some false
             | Some _, None -> state, None
             | None, _ -> failwith $"checkArraySpecificRules called with non-array source %O{objType}"
 

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -1405,22 +1405,35 @@ module IlMachineRuntimeMetadata =
                         //       underlying type).
                         // (a) is modelled below. (b) requires reading each enum's `value__`
                         // field to discover its underlying type, which we haven't taught
-                        // the assignability walk yet. When either element is an enum we
-                        // therefore return `None` (undecided) so callers can degrade rather
-                        // than rejecting a valid covariant store. Two non-enum value types
-                        // keep the definitive `Some false` answer.
+                        // the assignability walk yet. Enum-underlying equivalence can only
+                        // make the answer `true` when the partner is either another enum
+                        // or a primitive integer in the normalization table; for any other
+                        // partner (float, double, bool, char, non-integer struct) the
+                        // answer remains definitively false. So we return `None` only when
+                        // both sides plausibly participate in rule (b); otherwise we keep
+                        // the definitive `Some false` answer that callers like `isinst` /
+                        // `castclass` rely on.
                         let state, objIsEnum = isEnumValueType state objElement
                         let state, targetIsEnum = isEnumValueType state targetElement
 
-                        if objIsEnum || targetIsEnum then
+                        let objNormalized = normalizedPrimitiveIntegerIdentity objElement
+                        let targetNormalized = normalizedPrimitiveIntegerIdentity targetElement
+
+                        let enumCandidate (isEnum : bool) (normalized : ResolvedTypeIdentity option) =
+                            isEnum || normalized.IsSome
+
+                        if
+                            (objIsEnum || targetIsEnum)
+                            && enumCandidate objIsEnum objNormalized
+                            && enumCandidate targetIsEnum targetNormalized
+                        then
+                            // At least one element is an enum and the partner could share
+                            // an underlying integer type.
                             // TODO: model enum-underlying integer equivalence so this case
                             // becomes a precise answer rather than "unknown".
                             state, None
                         else
-                            match
-                                normalizedPrimitiveIntegerIdentity objElement,
-                                normalizedPrimitiveIntegerIdentity targetElement
-                            with
+                            match objNormalized, targetNormalized with
                             | Some a, Some b when a = b -> state, Some true
                             | _, _ -> state, Some false
             | Some _, None -> state, None

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -1319,6 +1319,31 @@ module IlMachineRuntimeMetadata =
                     else
                         walkBase state current
 
+        // ECMA-335 III.8.7 / CoreCLR `GetNormalizedIntegralArrayElementType`:
+        // signed and unsigned primitive integers of equal width are interchangeable
+        // as array element types (`int[]` ↔ `uint[]`, `short[]` ↔ `ushort[]`, etc.).
+        // Returns `Some normalizedIdentity` when `handle` is one of those primitive
+        // integers; otherwise `None`. Floating-point, Boolean, and Char have no
+        // normalization partners.
+        let normalizedPrimitiveIntegerIdentity (handle : ConcreteTypeHandle) : ResolvedTypeIdentity option =
+            match tryGetConcreteTypeInfo state handle with
+            | Some (ct, _) when ct.Generics.IsEmpty ->
+                let id = ct.Identity
+
+                if id = baseClassTypes.SByte.Identity || id = baseClassTypes.Byte.Identity then
+                    Some baseClassTypes.SByte.Identity
+                elif id = baseClassTypes.Int16.Identity || id = baseClassTypes.UInt16.Identity then
+                    Some baseClassTypes.Int16.Identity
+                elif id = baseClassTypes.Int32.Identity || id = baseClassTypes.UInt32.Identity then
+                    Some baseClassTypes.Int32.Identity
+                elif id = baseClassTypes.Int64.Identity || id = baseClassTypes.UInt64.Identity then
+                    Some baseClassTypes.Int64.Identity
+                elif id = baseClassTypes.IntPtr.Identity || id = baseClassTypes.UIntPtr.Identity then
+                    Some baseClassTypes.IntPtr.Identity
+                else
+                    None
+            | _ -> None
+
         let checkArraySpecificRules
             (state : IlMachineState)
             (objType : ConcreteTypeHandle)
@@ -1340,11 +1365,22 @@ module IlMachineRuntimeMetadata =
 
                     state, Some elementAssignable
                 else
-                    // TODO: ECMA-335 permits some value-type array assignments when
-                    // the element types have equivalent underlying primitive types
-                    // (for example int[] <-> uint[]). Model that rule explicitly
-                    // before broadening this branch.
-                    state, Some false
+                    // Both element types are value-typed (or one of each, in which case
+                    // primitive-integer equivalence cannot hold and we fall through to
+                    // `Some false`). Apply primitive-integer equivalence; any other
+                    // value-type assignment (notably enums with equivalent underlying
+                    // integer types) is not yet modelled and continues to report
+                    // non-assignable here.
+                    match
+                        normalizedPrimitiveIntegerIdentity objElement, normalizedPrimitiveIntegerIdentity targetElement
+                    with
+                    | Some a, Some b when a = b -> state, Some true
+                    | _, _ ->
+                        // TODO: ECMA-335 also permits arrays whose value-type elements
+                        // share an equivalent enum underlying integer type to be
+                        // interchangeable (e.g. `MyEnum : int` array ↔ `int[]`).
+                        // Model that rule before broadening this branch.
+                        state, Some false
             | Some _, None -> state, None
             | None, _ -> failwith $"checkArraySpecificRules called with non-array source %O{objType}"
 

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -1319,6 +1319,30 @@ module IlMachineRuntimeMetadata =
                     else
                         walkBase state current
 
+        // Returns true if `handle` is a CLR enum value type — a nominal type whose
+        // immediate runtime base is `System.Enum`. Used by the array-element
+        // assignability rule below to detect cases where ECMA-335 / CoreCLR
+        // enum-underlying-type equivalence (e.g. `MyEnum : int` ↔ `int`, or two
+        // enums sharing an underlying integer) might permit a store, but the
+        // underlying-type lookup itself isn't yet modelled.
+        let isEnumValueType (state : IlMachineState) (handle : ConcreteTypeHandle) : IlMachineState * bool =
+            match handle with
+            | ConcreteTypeHandle.OneDimArrayZero _
+            | ConcreteTypeHandle.Array _
+            | ConcreteTypeHandle.Byref _
+            | ConcreteTypeHandle.Pointer _
+            | ConcreteTypeHandle.FunctionPointer _ -> state, false
+            | ConcreteTypeHandle.Concrete _ ->
+                let state, baseHandle =
+                    resolveBaseConcreteType loggerFactory baseClassTypes state handle
+
+                match baseHandle with
+                | None -> state, false
+                | Some bh ->
+                    match AllConcreteTypes.lookup bh state.ConcreteTypes with
+                    | Some baseTy -> state, baseTy.Identity = baseClassTypes.Enum.Identity
+                    | None -> state, false
+
         // ECMA-335 III.8.7 / CoreCLR `GetNormalizedIntegralArrayElementType`:
         // signed and unsigned primitive integers of equal width are interchangeable
         // as array element types (`int[]` ↔ `uint[]`, `short[]` ↔ `ushort[]`, etc.).
@@ -1367,20 +1391,33 @@ module IlMachineRuntimeMetadata =
                 else
                     // Both element types are value-typed (or one of each, in which case
                     // primitive-integer equivalence cannot hold and we fall through to
-                    // `Some false`). Apply primitive-integer equivalence; any other
-                    // value-type assignment (notably enums with equivalent underlying
-                    // integer types) is not yet modelled and continues to report
-                    // non-assignable here.
-                    match
-                        normalizedPrimitiveIntegerIdentity objElement, normalizedPrimitiveIntegerIdentity targetElement
-                    with
-                    | Some a, Some b when a = b -> state, Some true
-                    | _, _ ->
-                        // TODO: ECMA-335 also permits arrays whose value-type elements
-                        // share an equivalent enum underlying integer type to be
-                        // interchangeable (e.g. `MyEnum : int` array ↔ `int[]`).
-                        // Model that rule before broadening this branch.
-                        state, Some false
+                    // `Some false`). ECMA-335 / CoreCLR permit two complementary rules
+                    // for value-typed array elements:
+                    //   (a) signed/unsigned primitive integers of equal width
+                    //       (`int[]` ↔ `uint[]`, etc.) — `GetNormalizedIntegralArrayElementType`.
+                    //   (b) enums whose underlying integer type matches the partner's
+                    //       (e.g. `MyEnum : int` ↔ `int`, or two enums with the same
+                    //       underlying type).
+                    // (a) is modelled below. (b) requires reading each enum's `value__`
+                    // field to discover its underlying type, which we haven't taught
+                    // the assignability walk yet. When either element is an enum we
+                    // therefore return `None` (undecided) so callers can degrade rather
+                    // than rejecting a valid covariant store. Two non-enum value types
+                    // keep the definitive `Some false` answer.
+                    let state, objIsEnum = isEnumValueType state objElement
+                    let state, targetIsEnum = isEnumValueType state targetElement
+
+                    if objIsEnum || targetIsEnum then
+                        // TODO: model enum-underlying integer equivalence so this case
+                        // becomes a precise answer rather than "unknown".
+                        state, None
+                    else
+                        match
+                            normalizedPrimitiveIntegerIdentity objElement,
+                            normalizedPrimitiveIntegerIdentity targetElement
+                        with
+                        | Some a, Some b when a = b -> state, Some true
+                        | _, _ -> state, Some false
             | Some _, None -> state, None
             | None, _ -> failwith $"checkArraySpecificRules called with non-array source %O{objType}"
 

--- a/WoofWare.PawPrint/IlMachineStateExecution.fs
+++ b/WoofWare.PawPrint/IlMachineStateExecution.fs
@@ -1542,3 +1542,109 @@ module IlMachineStateExecution =
             false // wrapExceptionInTargetInvocation
             state,
         WhatWeDid.Executed
+
+    /// Result of the ECMA-335 III.4.x runtime array-store variance gate.
+    [<RequireQualifiedAccess>]
+    type ArrayStoreVarianceCheck =
+        /// The store may proceed. The state may have been updated as a side effect of
+        /// the assignability walk (which may concretize additional metadata), so the
+        /// caller must use the state carried here, not its pre-check state.
+        | Allowed of state : IlMachineState
+        /// The store was rejected as covariance-incompatible; `ArrayTypeMismatchException`
+        /// has been raised on the current thread. The caller must return
+        /// `(state, WhatWeDid.Executed)` immediately without advancing PC: exception
+        /// dispatch needs the faulting instruction's offset.
+        | Raised of state : IlMachineState
+
+    /// ECMA-335 III.4.x runtime-assignment-compatibility gate for `stelem` /
+    /// runtime-synthesized `T[<rank>]::Set`. For reference-typed array elements, the
+    /// value's runtime type must be assignment-compatible with the array's stored
+    /// element type; otherwise raise `ArrayTypeMismatchException`. Null is always
+    /// storable. Value-typed-element arrays bypass the gate: there is no covariance
+    /// for value types, the verifier rejects mismatching value-store opcodes at
+    /// load time, and primitive coercion is handled by `EvalStackValue.toCliTypeCoerced`.
+    /// (ECMA-335 also recognises a primitive-equivalence rule, e.g. `int[]` /
+    /// `uint[]`, which is intentionally not modelled yet — see the TODO at
+    /// `IlMachineRuntimeMetadata.checkArraySpecificRules`.)
+    let checkArrayStoreVariance
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (currentThread : ThreadId)
+        (arrayAddress : ManagedHeapAddress)
+        (value : EvalStackValue)
+        (state : IlMachineState)
+        : ArrayStoreVarianceCheck
+        =
+        let arrayObj =
+            match state.ManagedHeap.Arrays.TryGetValue arrayAddress with
+            | true, v -> v
+            | false, _ ->
+                failwith
+                    $"checkArrayStoreVariance: no array allocation at %O{arrayAddress}; helper called with a non-array heap address"
+
+        let storedElement =
+            match arrayObj.ConcreteType with
+            | ConcreteTypeHandle.OneDimArrayZero elt -> elt
+            | ConcreteTypeHandle.Array (elt, _) -> elt
+            | other ->
+                failwith
+                    $"checkArrayStoreVariance: array allocation at %O{arrayAddress} has non-array ConcreteType %O{other}"
+
+        let storedElementIsReference =
+            match storedElement with
+            | ConcreteTypeHandle.OneDimArrayZero _
+            | ConcreteTypeHandle.Array _ -> true
+            | ConcreteTypeHandle.Byref _
+            | ConcreteTypeHandle.Pointer _
+            | ConcreteTypeHandle.FunctionPointer _ -> false
+            | ConcreteTypeHandle.Concrete _ ->
+                match IlMachineState.tryGetConcreteTypeInfo state storedElement with
+                | Some (_, typeInfo) -> DumpedAssembly.isReferenceType baseClassTypes state._LoadedAssemblies typeInfo
+                | None -> failwith $"checkArrayStoreVariance: array element handle %O{storedElement} has no TypeDef row"
+
+        if not storedElementIsReference then
+            // Value-type element store: variance does not apply. Numeric coercion
+            // happens in toCliTypeCoerced; the verifier guards value-type identity.
+            ArrayStoreVarianceCheck.Allowed state
+        else
+
+        match value with
+        | EvalStackValue.NullObjectRef ->
+            // Null is always storable into a reference-typed array slot.
+            ArrayStoreVarianceCheck.Allowed state
+        | EvalStackValue.ObjectRef addr ->
+            let valueRuntimeType = ManagedHeap.getObjectConcreteType addr state.ManagedHeap
+
+            let state, isAssignable =
+                IlMachineState.isConcreteTypeAssignableTo
+                    loggerFactory
+                    baseClassTypes
+                    state
+                    valueRuntimeType
+                    storedElement
+
+            if isAssignable then
+                ArrayStoreVarianceCheck.Allowed state
+            else
+                let state, _whatWeDid =
+                    raiseRuntimeException
+                        loggerFactory
+                        baseClassTypes
+                        baseClassTypes.ArrayTypeMismatchException
+                        currentThread
+                        state
+
+                ArrayStoreVarianceCheck.Raised state
+        | EvalStackValue.ManagedPointer _
+        | EvalStackValue.Int32 _
+        | EvalStackValue.Int64 _
+        | EvalStackValue.NativeInt _
+        | EvalStackValue.Float _
+        | EvalStackValue.UserDefinedValueType _ ->
+            // Reference-typed-element arrays only accept ObjectRef / NullObjectRef stack
+            // values. The verifier rejects other shapes at load time, so reaching this
+            // arm means either the verifier was skipped or the interpreter produced a
+            // value of the wrong shape. Surface the gap explicitly rather than letting
+            // the store silently mis-coerce.
+            failwith
+                $"TODO: array-store variance check for reference-typed-element array with stack value form %O{value}; expected ObjectRef or NullObjectRef"

--- a/WoofWare.PawPrint/IlMachineStateExecution.fs
+++ b/WoofWare.PawPrint/IlMachineStateExecution.fs
@@ -1615,17 +1615,39 @@ module IlMachineStateExecution =
         | EvalStackValue.ObjectRef addr ->
             let valueRuntimeType = ManagedHeap.getObjectConcreteType addr state.ManagedHeap
 
-            let state, isAssignable =
-                IlMachineState.isConcreteTypeAssignableTo
-                    loggerFactory
-                    baseClassTypes
-                    state
-                    valueRuntimeType
-                    storedElement
+            // `isConcreteTypeAssignableTo` currently `failwith`s on two combinations
+            // it doesn't yet model: (a) `walk` traversing a Concrete type whose
+            // definition has variant generic parameters (line 1175 in
+            // IlMachineRuntimeMetadata), and (b) an array source being checked
+            // against a generic-interface target (line 1243). Both arise from
+            // legitimate covariant array stores (e.g. `string[]` into an
+            // `IEnumerable<string>[]` element; `Func<int>` into a `Func<int>[]`
+            // element when other instantiations also exist). Before this gate
+            // those stores silently succeeded — they don't go through any
+            // assignability check at all in the previous code. Turning them into
+            // host failures would regress previously-working programs, so we
+            // degrade to "permit" when the walk can't reach a definitive answer.
+            // The variance gate is therefore best-effort until those TODOs in
+            // `IlMachineRuntimeMetadata` are implemented; at that point this
+            // try/with can be removed and the check becomes precise.
+            let state, decision =
+                try
+                    let state, isAssignable =
+                        IlMachineState.isConcreteTypeAssignableTo
+                            loggerFactory
+                            baseClassTypes
+                            state
+                            valueRuntimeType
+                            storedElement
 
-            if isAssignable then
-                ArrayStoreVarianceCheck.Allowed state
-            else
+                    state, ValueSome isAssignable
+                with ex when ex.Message.StartsWith "TODO:" ->
+                    state, ValueNone
+
+            match decision with
+            | ValueNone
+            | ValueSome true -> ArrayStoreVarianceCheck.Allowed state
+            | ValueSome false ->
                 let state, _whatWeDid =
                     raiseRuntimeException
                         loggerFactory

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -646,6 +646,8 @@ module NullaryIlOp =
         | value -> failwith $"Endfilter requires an int32 result on the stack; got %O{value}"
 
     let internal stElem
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (targetCliTypeZero : CliType)
         (value : EvalStackValue)
         (index : EvalStackValue)
@@ -685,12 +687,26 @@ module NullaryIlOp =
             | EvalStackValue.ObjectRef addr -> addr
             | EvalStackValue.NullObjectRef -> failwith "TODO: throw NRE"
             | _ -> failwith $"Invalid array: %O{arr}"
-        // TODO: throw ArrayTypeMismatchException if incorrect types
 
         let arr = state.ManagedHeap.Arrays.[arrAddr]
 
         if index < 0 || index >= arr.Length then
             failwith "TODO: throw IndexOutOfRangeException"
+
+        // ECMA-335 III.4.x runtime-assignment-compatibility gate (see
+        // IlMachineStateExecution.checkArrayStoreVariance).
+        match
+            IlMachineStateExecution.checkArrayStoreVariance
+                loggerFactory
+                baseClassTypes
+                currentThread
+                arrAddr
+                value
+                state
+        with
+        | IlMachineStateExecution.ArrayStoreVarianceCheck.Raised state ->
+            ExecutionResult.stepped (state, WhatWeDid.Executed)
+        | IlMachineStateExecution.ArrayStoreVarianceCheck.Allowed state ->
 
         let state =
             state
@@ -2211,6 +2227,8 @@ module NullaryIlOp =
             let arr, state = IlMachineState.popEvalStack currentThread state
 
             stElem
+                loggerFactory
+                corelib
                 (CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim 0L)))
                 value
                 index
@@ -2221,19 +2239,22 @@ module NullaryIlOp =
             let value, state = IlMachineState.popEvalStack currentThread state
             let index, state = IlMachineState.popEvalStack currentThread state
             let arr, state = IlMachineState.popEvalStack currentThread state
-            stElem (CliType.Numeric (CliNumericType.Int8 0y)) value index arr currentThread state
+
+            stElem loggerFactory corelib (CliType.Numeric (CliNumericType.Int8 0y)) value index arr currentThread state
         | Stelem_u1 -> failwith "TODO: Stelem_u1 unimplemented"
         | Stelem_i2 ->
             let value, state = IlMachineState.popEvalStack currentThread state
             let index, state = IlMachineState.popEvalStack currentThread state
             let arr, state = IlMachineState.popEvalStack currentThread state
-            stElem (CliType.Numeric (CliNumericType.Int16 0s)) value index arr currentThread state
+
+            stElem loggerFactory corelib (CliType.Numeric (CliNumericType.Int16 0s)) value index arr currentThread state
         | Stelem_u2 -> failwith "TODO: Stelem_u2 unimplemented"
         | Stelem_i4 ->
             let value, state = IlMachineState.popEvalStack currentThread state
             let index, state = IlMachineState.popEvalStack currentThread state
             let arr, state = IlMachineState.popEvalStack currentThread state
-            stElem (CliType.Numeric (CliNumericType.Int32 0)) value index arr currentThread state
+
+            stElem loggerFactory corelib (CliType.Numeric (CliNumericType.Int32 0)) value index arr currentThread state
         | Stelem_u4 -> failwith "TODO: Stelem_u4 unimplemented"
         | Stelem_i8 ->
             let value, state = IlMachineState.popEvalStack currentThread state
@@ -2241,6 +2262,8 @@ module NullaryIlOp =
             let arr, state = IlMachineState.popEvalStack currentThread state
 
             stElem
+                loggerFactory
+                corelib
                 (CliType.Numeric (CliNumericType.Int64 (Int64Source.Verbatim 0L)))
                 value
                 index
@@ -2252,17 +2275,35 @@ module NullaryIlOp =
             let value, state = IlMachineState.popEvalStack currentThread state
             let index, state = IlMachineState.popEvalStack currentThread state
             let arr, state = IlMachineState.popEvalStack currentThread state
-            stElem (CliType.Numeric (CliNumericType.Float32 0.0f)) value index arr currentThread state
+
+            stElem
+                loggerFactory
+                corelib
+                (CliType.Numeric (CliNumericType.Float32 0.0f))
+                value
+                index
+                arr
+                currentThread
+                state
         | Stelem_r8 ->
             let value, state = IlMachineState.popEvalStack currentThread state
             let index, state = IlMachineState.popEvalStack currentThread state
             let arr, state = IlMachineState.popEvalStack currentThread state
-            stElem (CliType.Numeric (CliNumericType.Float64 0.0)) value index arr currentThread state
+
+            stElem
+                loggerFactory
+                corelib
+                (CliType.Numeric (CliNumericType.Float64 0.0))
+                value
+                index
+                arr
+                currentThread
+                state
         | Stelem_ref ->
             let value, state = IlMachineState.popEvalStack currentThread state
             let index, state = IlMachineState.popEvalStack currentThread state
             let arr, state = IlMachineState.popEvalStack currentThread state
-            stElem (CliType.ObjectRef None) value index arr currentThread state
+            stElem loggerFactory corelib (CliType.ObjectRef None) value index arr currentThread state
         | Cpblk -> failwith "TODO: Cpblk unimplemented"
         | Initblk -> failwith "TODO: Initblk unimplemented"
         | Conv_ovf_u1 -> failwith "TODO: Conv_ovf_u1 unimplemented"

--- a/WoofWare.PawPrint/UnaryMetadataArrayOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataArrayOps.fs
@@ -220,6 +220,24 @@ module internal UnaryMetadataArrayOps =
             | Some addr -> addr
             | None -> failwith "expected heap allocation for array, got null"
 
+        // ECMA-335 III.4.x: bounds check fires before the array-store variance
+        // check, matching CoreCLR ordering (e.g. `Store<object>(new string[0], 0, new object())`
+        // must raise IndexOutOfRangeException, not ArrayTypeMismatchException).
+        let arrAlloc =
+            match state.ManagedHeap.Arrays.TryGetValue arr with
+            | true, v -> v
+            | false, _ -> failwith $"executeStelem: array allocation not found at %O{arr}"
+
+        if index < 0 || index >= arrAlloc.Length then
+            // Don't advance PC: exception dispatch needs the faulting instruction's offset.
+            IlMachineStateExecution.raiseRuntimeException
+                loggerFactory
+                baseClassTypes
+                baseClassTypes.IndexOutOfRangeException
+                thread
+                state
+        else
+
         let elementType =
             DumpedAssembly.typeInfoToTypeDefn baseClassTypes state._LoadedAssemblies elementType
 

--- a/WoofWare.PawPrint/UnaryMetadataArrayOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataArrayOps.fs
@@ -233,6 +233,14 @@ module internal UnaryMetadataArrayOps =
                 ImmutableArray.Empty
                 state
 
+        // ECMA-335 III.4.x runtime-assignment-compatibility gate (see
+        // IlMachineStateExecution.checkArrayStoreVariance).
+        match
+            IlMachineStateExecution.checkArrayStoreVariance loggerFactory baseClassTypes thread arr contents state
+        with
+        | IlMachineStateExecution.ArrayStoreVarianceCheck.Raised state -> state, WhatWeDid.Executed
+        | IlMachineStateExecution.ArrayStoreVarianceCheck.Allowed state ->
+
         let contents = EvalStackValue.toCliTypeCoerced zeroOfType contents
 
         IlMachineState.setArrayValue arr contents index state

--- a/WoofWare.PawPrint/UnaryMetadataCallOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataCallOps.fs
@@ -149,13 +149,17 @@ module internal UnaryMetadataCallOps =
                 methodGenerics
                 state
 
-        // Array covariance check (ECMA-335 III.4.x) is intentionally not modelled here, to
-        // match the szarray `stelem` precedent in UnaryMetadataArrayOps.executeStelem (and the
-        // wider tech debt acknowledged at NullaryIlOp.fs's stelem.ref TODO at line 586). For a
-        // reference array accessed through a base-typed view (e.g. `object[,]` aliasing a
-        // `string[,]`), the metadata-derived element type legitimately differs from the array's
-        // stored element handle, so an exact-handle check would reject valid C# code; the
-        // correct runtime-assignment-compatibility check requires machinery not yet wired in.
+        // ECMA-335 III.4.x runtime-assignment-compatibility gate. A covariant
+        // view (e.g. `object[,]` aliasing `string[,]`) must reject stores whose
+        // value's runtime type is not assignable to the array's stored element
+        // type, raising ArrayTypeMismatchException. Null and value-typed-element
+        // arrays pass through unchanged.
+        match
+            IlMachineStateExecution.checkArrayStoreVariance loggerFactory baseClassTypes thread arrAddr value state
+        with
+        | IlMachineStateExecution.ArrayStoreVarianceCheck.Raised state -> state, WhatWeDid.Executed
+        | IlMachineStateExecution.ArrayStoreVarianceCheck.Allowed state ->
+
         let coerced = EvalStackValue.toCliTypeCoerced zeroOfType value
 
         let state =


### PR DESCRIPTION
## Summary

- Add a runtime array-store variance gate (ECMA-335 III.4.x): both `stelem`/`stelem.ref` and multi-dim `Set` now consult the assignability walk before writing into a reference-typed array slot, raising `ArrayTypeMismatchException` when the store would violate covariance.
- Bounds-check `stelem<T>` and friends *before* the variance gate, so out-of-range indices raise `IndexOutOfRangeException` (matching CoreCLR's precedence) rather than `ArrayTypeMismatchException`.
- Teach `isConcreteTypeAssignableTo`'s array-element rules about the two ECMA-335 value-typed equivalences:
  - **Primitive-integer normalisation** (`int[]` ↔ `uint[]`, `short[]` ↔ `ushort[]`, etc.).
  - **Enum-underlying-integer equivalence**, which we cannot yet decide precisely. We return `None` (undecided) only when *both* sides plausibly participate — i.e. one element is an enum and the partner is either another enum or a normalised primitive integer. The variance gate degrades a `None` to "permit" (matching CoreCLR's permissive default on this corner); for any other partner (`float[]`, `double[]`, `bool[]`, `char[]`, non-integer struct) we keep the definitive `Some false` so `isinst`/`castclass` answers `false` instead of host-failing.
- New regression tests in `WoofWare.PawPrint.Test/sourcesPure/` cover: szarray covariance, multi-dim covariance, generic-interface aliasing (degrade-to-permit), bounds-before-variance ordering, primitive-integer nested-array stores, enum nested-array stores, `MyEnum[] is object[]` returning `false`, and `MyEnum[] is float[]/double[]/bool[]/char[]` returning `false`.

## Test plan

- [x] `nix develop -c dotnet build` — 0 warnings, 0 errors.
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 1134 passed, 0 failed.
- [x] Focused filter for the new regression tests passes.
- [x] `nix develop -c dotnet fantomas .` — no changes.
- [x] `codex review --base main` — no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)