### PR TITLE
Implement ThreadNative_{Set,Get}IsBackground QCalls

### DIFF
--- a/WoofWare.PawPrint.App/DebuggerServer.fs
+++ b/WoofWare.PawPrint.App/DebuggerServer.fs
@@ -74,6 +74,7 @@ module DebuggerServer =
     let private writeThreadStatus (writer : Utf8JsonWriter) (status : ThreadStatus) : unit =
         match status with
         | ThreadStatus.Runnable -> writer.WriteStringValue "runnable"
+        | ThreadStatus.NotStarted -> writer.WriteStringValue "notStarted"
         | ThreadStatus.BlockedOnJoin target ->
             writer.WriteStartObject ()
             writer.WriteString ("kind", "blockedOnJoin")

--- a/WoofWare.PawPrint.App/DebuggerServer.fs
+++ b/WoofWare.PawPrint.App/DebuggerServer.fs
@@ -148,10 +148,21 @@ module DebuggerServer =
         writer.WriteNumber ("id", threadIdValue threadId)
         writer.WritePropertyName "status"
         writeThreadStatus writer threadState.Status
-        writer.WriteString ("activeAssembly", threadState.ActiveAssembly.FullName)
-        writer.WriteNumber ("activeFrame", frameIdValue threadState.ActiveMethodState)
-        writer.WritePropertyName "activeFrameSummary"
-        writeFrameSummary writer threadState.ActiveMethodState threadState.ActiveMethodState threadState.MethodState
+
+        match threadState.Status with
+        | ThreadStatus.NotStarted ->
+            // A pre-`Start` Thread has no frames yet; the ActiveMethodState/MethodState
+            // accessors would crash. Surface the absence explicitly rather than
+            // skipping the keys, so consumers see a consistent shape.
+            writer.WriteNull "activeAssembly"
+            writer.WriteNull "activeFrame"
+            writer.WriteNull "activeFrameSummary"
+        | _ ->
+            writer.WriteString ("activeAssembly", threadState.ActiveAssembly.FullName)
+            writer.WriteNumber ("activeFrame", frameIdValue threadState.ActiveMethodState)
+            writer.WritePropertyName "activeFrameSummary"
+            writeFrameSummary writer threadState.ActiveMethodState threadState.ActiveMethodState threadState.MethodState
+
         writer.WriteEndObject ()
 
     let private writeValueArray<'a>
@@ -451,8 +462,14 @@ module DebuggerServer =
             writer.WriteNumber ("id", threadIdValue threadId)
             writer.WritePropertyName "status"
             writeThreadStatus writer threadState.Status
-            writer.WriteString ("activeAssembly", threadState.ActiveAssembly.FullName)
-            writer.WriteNumber ("activeFrame", frameIdValue threadState.ActiveMethodState)
+
+            match threadState.Status with
+            | ThreadStatus.NotStarted ->
+                writer.WriteNull "activeAssembly"
+                writer.WriteNull "activeFrame"
+            | _ ->
+                writer.WriteString ("activeAssembly", threadState.ActiveAssembly.FullName)
+                writer.WriteNumber ("activeFrame", frameIdValue threadState.ActiveMethodState)
 
             writeValueArray
                 writer
@@ -527,11 +544,25 @@ module DebuggerServer =
             writer.WriteNumber ("id", threadIdValue threadId)
             writer.WritePropertyName "status"
             writeThreadStatus writer threadState.Status
-            writer.WriteString ("activeAssembly", threadState.ActiveAssembly.FullName)
-            writer.WriteNumber ("activeFrame", frameIdValue threadState.ActiveMethodState)
-            writer.WriteNumber ("frameCount", frames.Length)
-            writer.WritePropertyName "activeFrameSummary"
-            writeFrameSummary writer threadState.ActiveMethodState threadState.ActiveMethodState threadState.MethodState
+
+            match threadState.Status with
+            | ThreadStatus.NotStarted ->
+                writer.WriteNull "activeAssembly"
+                writer.WriteNull "activeFrame"
+                writer.WriteNumber ("frameCount", frames.Length)
+                writer.WriteNull "activeFrameSummary"
+            | _ ->
+                writer.WriteString ("activeAssembly", threadState.ActiveAssembly.FullName)
+                writer.WriteNumber ("activeFrame", frameIdValue threadState.ActiveMethodState)
+                writer.WriteNumber ("frameCount", frames.Length)
+                writer.WritePropertyName "activeFrameSummary"
+
+                writeFrameSummary
+                    writer
+                    threadState.ActiveMethodState
+                    threadState.ActiveMethodState
+                    threadState.MethodState
+
             writeValueArray writer "topMethods" methodCounts writeMethodCount
 
             writeValueArray
@@ -602,6 +633,14 @@ module DebuggerServer =
         | None ->
             writer.WriteStartObject ()
             writer.WriteString ("error", $"thread %d{threadIdValue threadId} does not exist")
+            writer.WriteEndObject ()
+        | Some threadState when threadState.Status = ThreadStatus.NotStarted ->
+            // No frames have been pushed yet; there is no active method whose IL
+            // we could disassemble. Report this rather than dereferencing the
+            // sentinel ActiveMethodState.
+            writer.WriteStartObject ()
+            writer.WriteNumber ("thread", threadIdValue threadId)
+            writer.WriteString ("error", $"thread %d{threadIdValue threadId} has not been started")
             writer.WriteEndObject ()
         | Some threadState ->
             let frameId = threadState.ActiveMethodState

--- a/WoofWare.PawPrint.Test/TestLowLevelMonitor.fs
+++ b/WoofWare.PawPrint.Test/TestLowLevelMonitor.fs
@@ -42,6 +42,7 @@ module TestLowLevelMonitor =
             NextFrameId = 0
             ActiveMethodState = FrameId -1
             Status = status
+            IsBackground = false
         }
 
     let private withThreads (threads : ThreadId list) (state : IlMachineState) : IlMachineState =

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -22,7 +22,7 @@ module TestPureCases =
             "LdtokenField.cs" // past Buffer's reflection-cache copy (cell-aware path); now blocked on the next reflection-cache step at unimplemented InternalCall RuntimeFieldHandle::GetApproxDeclaringMethodTable
             "IsAssignableFromOpenGenericDefinition.cs" // TypeHandle.CanCastTo_NoCacheLookup for open generic
             "InterfaceDispatch.cs" // expected: 0; was: 1024
-            "Threads.cs" // past Buffer's reflection-cache copy (cell-aware path); now blocked on unimplemented QCall ThreadNative_SetIsBackground
+            "Threads.cs" // past Buffer's reflection-cache copy and ThreadNative_SetIsBackground; now blocked on unimplemented QCall ThreadNative_InformThreadNameChange (BCL Thread.Name setter / SetThreadPoolWorkerThreadName)
             "IsAssignableToBasic.cs" // MethodTable field projection for MethodTable::PerInstInfo
         ]
         |> Set.ofList

--- a/WoofWare.PawPrint.Test/TestSyncBlockMonitor.fs
+++ b/WoofWare.PawPrint.Test/TestSyncBlockMonitor.fs
@@ -44,6 +44,7 @@ module TestSyncBlockMonitor =
             NextFrameId = 0
             ActiveMethodState = FrameId -1
             Status = status
+            IsBackground = false
         }
 
     let private withThreads (threads : ThreadId list) (state : IlMachineState) : IlMachineState =

--- a/WoofWare.PawPrint.Test/TestWaitHandle.fs
+++ b/WoofWare.PawPrint.Test/TestWaitHandle.fs
@@ -38,6 +38,7 @@ module TestWaitHandle =
             NextFrameId = 0
             ActiveMethodState = FrameId -1
             Status = status
+            IsBackground = false
         }
 
     let private withThreads (threads : ThreadId list) (state : IlMachineState) : IlMachineState =

--- a/WoofWare.PawPrint.Test/sourcesPure/ThreadIsBackground.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/ThreadIsBackground.cs
@@ -1,0 +1,37 @@
+using System.Threading;
+
+namespace HelloWorldApp
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            // The CLR initialises the main thread's IsBackground to false (it's a foreground
+            // thread; the process is meant to stay alive while main runs). We exercise the
+            // get-only QCall here to cover the read path on a thread that already exists.
+            if (Thread.CurrentThread.IsBackground) return 1;
+
+            // A freshly constructed but not-yet-started Thread also defaults to false. Reading
+            // IsBackground on a NotStarted thread is the precise window the BCL thread-pool
+            // setup writes through, so we cover both directions here without relying on Start.
+            Thread t = new Thread(() => { });
+            if (t.IsBackground) return 2;
+
+            // Set true, round-trip via the getter — covers the SetIsBackground write path
+            // followed by the GetIsBackground read path on the same Thread heap object.
+            t.IsBackground = true;
+            if (!t.IsBackground) return 3;
+
+            // Set back to false — guards against a "first write sticks" bug where the field
+            // would be set-once instead of mutable.
+            t.IsBackground = false;
+            if (t.IsBackground) return 4;
+
+            // Independence: writing on `t` must not affect Thread.CurrentThread's flag.
+            t.IsBackground = true;
+            if (Thread.CurrentThread.IsBackground) return 5;
+
+            return 0;
+        }
+    }
+}

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -89,6 +89,10 @@ module IlMachineState =
 
     let addThread = IlMachineThreadState.addThread
 
+    let allocateUnstartedThread = IlMachineThreadState.allocateUnstartedThread
+
+    let startUnstartedThread = IlMachineThreadState.startUnstartedThread
+
     let allocateArray = IlMachineThreadState.allocateArray
 
     let allocateMultiDimArray = IlMachineThreadState.allocateMultiDimArray

--- a/WoofWare.PawPrint/IlMachineThreadState.fs
+++ b/WoofWare.PawPrint/IlMachineThreadState.fs
@@ -353,6 +353,78 @@ module IlMachineThreadState =
 
         newState, thread
 
+    /// Allocate a fresh `ThreadId` for a Thread heap object that the guest has
+    /// just constructed (i.e. its `Initialize` ran) but not yet started. The
+    /// resulting `ThreadState` is frame-less and has status `NotStarted`; the
+    /// scheduler will not pick it until `Thread.StartInternal` populates the
+    /// bottom frame and flips status to `Runnable` via `startUnstartedThread`.
+    /// Binds the new ThreadId to `threadAddr` in `ManagedThreadObjects` so
+    /// helpers like `threadIdFromThreadAddr` can reverse-look-up the thread
+    /// during the pre-Start window (notably for the `IsBackground` QCalls).
+    let allocateUnstartedThread (threadAddr : ManagedHeapAddress) (state : IlMachineState) : IlMachineState * ThreadId =
+        let thread = ThreadId state.NextThreadId
+
+        // Frame-less stub mirroring the test helpers in TestLowLevelMonitor /
+        // TestWaitHandle / TestSyncBlockMonitor: `ActiveMethodState` points at
+        // a sentinel `FrameId` not present in the empty `MethodStates` map, so
+        // any premature attempt to dereference it crashes loudly rather than
+        // executing arbitrary IL on an unprepared thread.
+        let unstartedState : ThreadState =
+            {
+                MethodStates = Map.empty
+                NextFrameId = 0
+                ActiveMethodState = FrameId -1
+                Status = ThreadStatus.NotStarted
+                IsBackground = false
+            }
+
+        let newState =
+            { state with
+                NextThreadId = state.NextThreadId + 1
+                ThreadState = state.ThreadState |> Map.add thread unstartedState
+                ManagedThreadObjects = state.ManagedThreadObjects |> Map.add thread threadAddr
+            }
+
+        newState, thread
+
+    /// Populate the bottom frame of a `NotStarted` thread with the user's
+    /// delegate target and flip its status to `Runnable`. The thread was
+    /// previously allocated by `allocateUnstartedThread` at `Thread.Initialize`
+    /// time. Fails loud if the thread is missing, in a non-`NotStarted`
+    /// status (double-Start would be the typical cause; the real CLR raises
+    /// `ThreadStateException` here), or already has live frames.
+    let startUnstartedThread
+        (thread : ThreadId)
+        (newMethodState : MethodState)
+        (state : IlMachineState)
+        : IlMachineState
+        =
+        let existing =
+            state.ThreadState
+            |> Map.tryFind thread
+            |> Option.defaultWith (fun () -> failwith $"startUnstartedThread: thread {thread} has no ThreadState")
+
+        match existing.Status with
+        | ThreadStatus.NotStarted -> ()
+        | other ->
+            failwith
+                $"startUnstartedThread: thread {thread} is in status %O{other}, expected NotStarted. Most likely cause: double-Start on a Thread object. The real CLR raises ThreadStateException here, which PawPrint does not yet synthesise."
+
+        if not (Map.isEmpty existing.MethodStates) then
+            failwith $"startUnstartedThread: thread {thread} unexpectedly has live frames before Start"
+
+        let started =
+            existing
+            |> ThreadState.replaceFrames newMethodState
+            |> fun ts ->
+                { ts with
+                    Status = ThreadStatus.Runnable
+                }
+
+        { state with
+            ThreadState = state.ThreadState |> Map.add thread started
+        }
+
     let allocateArray
         (arrayType : ConcreteTypeHandle)
         (zeroOfType : unit -> CliType)

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -39,6 +39,8 @@ module NativeQCall =
             "ThreadNative_GetCurrentThread", NativeThreading.tryExecuteQCall "ThreadNative_GetCurrentThread"
             "ThreadNative_Initialize", NativeThreading.tryExecuteQCall "ThreadNative_Initialize"
             "ThreadNative_Join", NativeThreading.tryExecuteQCall "ThreadNative_Join"
+            "ThreadNative_SetIsBackground", NativeThreading.tryExecuteQCall "ThreadNative_SetIsBackground"
+            "ThreadNative_GetIsBackground", NativeThreading.tryExecuteQCall "ThreadNative_GetIsBackground"
             "Monitor_Wait", NativeMonitor.tryExecuteQCall "Monitor_Wait"
             "Monitor_Pulse", NativeMonitor.tryExecuteQCall "Monitor_Pulse"
             "Monitor_PulseAll", NativeMonitor.tryExecuteQCall "Monitor_PulseAll"

--- a/WoofWare.PawPrint/Native/NativeThreading.fs
+++ b/WoofWare.PawPrint/Native/NativeThreading.fs
@@ -113,6 +113,19 @@ module NativeThreading =
                 failwith $"Thread.Join: target ThreadId {targetThreadId} has no ThreadState"
             )
 
+        // A constructed-but-never-Start()ed Thread used to be unreachable here:
+        // `ManagedThreadObjects` had no entry, so `threadIdFromThreadAddr` would
+        // fail. Pre-allocating the NotStarted slot at Initialize time means the
+        // lookup now succeeds, so we have to reject the case explicitly. The
+        // real CLR raises ThreadStateException; PawPrint can't synthesise that
+        // yet, so fail loud at the call site rather than silently returning
+        // false (timeout=0) or blocking forever on a thread that will never run.
+        match targetState.Status with
+        | ThreadStatus.NotStarted ->
+            failwith
+                $"Thread.Join: target ThreadId {targetThreadId} has never been Start()ed. The real CLR raises ThreadStateException here; PawPrint doesn't synthesise that yet, so this is a guest bug we can't currently report structurally."
+        | _ -> ()
+
         let targetTerminated = targetState.Status = ThreadStatus.Terminated
 
         match timeout with

--- a/WoofWare.PawPrint/Native/NativeThreading.fs
+++ b/WoofWare.PawPrint/Native/NativeThreading.fs
@@ -18,6 +18,57 @@ module NativeThreading =
         =
         FieldIdentity.requiredNonGenericInstanceFieldId state.ConcreteTypes baseClassTypes.DelegateType fieldName
 
+    /// Recover the heap address stored inside a `ThreadHandle` QCall argument.
+    /// `ThreadHandle` is `internal readonly struct ThreadHandle { IntPtr _ptr }`
+    /// in CoreCLR; the QCall marshaller may flatten it to a bare `nativeint`
+    /// or pass the wrapping struct cell. In both cases the underlying value is
+    /// the `_DONT_USE_InternalThread` we wrote in `initializeThreadObject`,
+    /// which is the heap address of the Thread object reinterpreted as a
+    /// `nativeint`.
+    let private threadAddrFromThreadHandle
+        (state : IlMachineState)
+        (operation : string)
+        (handleArg : CliType)
+        : ManagedHeapAddress
+        =
+        match handleArg |> CliType.unwrapPrimitiveLike with
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim addrInt)) ->
+            ManagedHeapAddress (int addrInt)
+        | CliType.ValueType vt ->
+            let ptrField = IlMachineState.requiredOwnInstanceFieldId state vt.Declared "_ptr"
+
+            match CliValueType.DereferenceFieldById ptrField vt |> CliType.unwrapPrimitiveLike with
+            | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim addrInt)) ->
+                ManagedHeapAddress (int addrInt)
+            | other -> failwith $"%s{operation}: expected Verbatim nativeint inside ThreadHandle._ptr, got %O{other}"
+        | other -> failwith $"%s{operation}: unexpected shape for ThreadHandle argument: %O{other}"
+
+    /// Reverse-lookup the interpreter `ThreadId` that owns the given Thread
+    /// heap object. Distinguishes "guest handed a wild pointer" (interpreter
+    /// bug — no heap object exists at the address at all) from "Thread object
+    /// was never Start()ed" (guest bug that the real CLR would surface as
+    /// `ThreadStateException` once exception synthesis lands here). Both
+    /// surface as `failwith` for now because the interpreter cannot yet
+    /// raise managed exceptions on behalf of native helpers.
+    let private threadIdFromThreadAddr
+        (state : IlMachineState)
+        (operation : string)
+        (threadAddr : ManagedHeapAddress)
+        : ThreadId
+        =
+        state.ManagedThreadObjects
+        |> Map.toSeq
+        |> Seq.tryPick (fun (tid, addr) -> if addr = threadAddr then Some tid else None)
+        |> Option.defaultWith (fun () ->
+            match state.ManagedHeap.NonArrayObjects |> Map.tryFind threadAddr with
+            | Some _ ->
+                failwith
+                    $"%s{operation}: Thread object at {threadAddr} was never Start()ed. The real CLR raises ThreadStateException here; PawPrint doesn't synthesise that yet, so this is a guest bug we can't currently report structurally."
+            | None ->
+                failwith
+                    $"%s{operation}: no heap object at {threadAddr} (interpreter bug: stale or invalid Thread reference)."
+        )
+
     /// Core of the Thread.Join semantics shared between the pre-.NET 10 InternalCall and the
     /// .NET 10 ThreadNative_Join QCall. Returns the post-call state (with any necessary scheduler
     /// block applied) and the bool result the caller should push as Join's return value.
@@ -45,25 +96,7 @@ module NativeThreading =
             failwith
                 $"Thread.Join: millisecondsTimeout=%d{other} is not supported. Only -1 (Timeout.Infinite) and 0 (non-blocking poll) are implemented; finite timeouts require a virtual clock PawPrint does not yet model. Negative values other than -1 would raise ArgumentOutOfRangeException in the real CLR, which PawPrint doesn't synthesise yet."
 
-        let targetThreadId =
-            state.ManagedThreadObjects
-            |> Map.toSeq
-            |> Seq.tryPick (fun (tid, addr) -> if addr = threadAddr then Some tid else None)
-            |> Option.defaultWith (fun () ->
-                // Distinguish "guest called Join on a Thread it never Start()ed"
-                // (real CLR would raise ThreadStateException) from "the interpreter's
-                // ManagedThreadObjects bookkeeping is out of sync with a live thread".
-                // Presence of a heap object at `threadAddr` means the guest legitimately
-                // allocated a Thread; absence means we've been handed a wild pointer
-                // and the bug is inside PawPrint.
-                match state.ManagedHeap.NonArrayObjects |> Map.tryFind threadAddr with
-                | Some _ ->
-                    failwith
-                        $"Thread.Join: Thread object at {threadAddr} was never Start()ed. The real CLR raises ThreadStateException here; PawPrint doesn't synthesise that yet, so this is a guest bug we can't currently report structurally."
-                | None ->
-                    failwith
-                        $"Thread.Join: no heap object at {threadAddr} (interpreter bug: stale or invalid Thread reference handed to Join)."
-            )
+        let targetThreadId = threadIdFromThreadAddr state "Thread.Join" threadAddr
 
         // Self-join is an immediate deadlock: blocking ourselves on ourselves means
         // no thread will ever wake us. The real CLR also hangs, but in PawPrint this
@@ -99,10 +132,21 @@ module NativeThreading =
 
             state, true
 
-    /// Sets up the managed thread ID, priority, and native handle sentinel on the Thread object.
-    /// Backs the Initialize InternalCall in pre-.NET 10 BCLs and the ThreadNative_Initialize QCall
-    /// in .NET 10+.
-    let private initializeThreadObject (threadAddr : ManagedHeapAddress) (state : IlMachineState) : IlMachineState =
+    /// Sets up the managed thread ID, priority, and native handle sentinel on the Thread object,
+    /// and pre-allocates a `NotStarted` interpreter `ThreadState` bound to the Thread heap
+    /// address. Backs the Initialize InternalCall in pre-.NET 10 BCLs and the
+    /// ThreadNative_Initialize QCall in .NET 10+.
+    ///
+    /// Pre-allocating the `ThreadState` here (rather than at `StartInternal` time) is what
+    /// lets the `IsBackground` QCalls — which the thread-pool worker setup invokes between
+    /// the constructor and `Start` — find a per-thread record to store their value on. The
+    /// scheduler ignores `NotStarted` threads, so the slot stays inert until `StartInternal`
+    /// populates a bottom frame and flips the status to `Runnable`.
+    let private initializeThreadObject
+        (threadAddr : ManagedHeapAddress)
+        (state : IlMachineState)
+        : IlMachineState * ThreadId
+        =
         let managedThreadId = state.NextManagedThreadId
         let threadPriorityNormal = 2
         let (ManagedHeapAddress addrInt) = threadAddr
@@ -121,10 +165,13 @@ module NativeThreading =
                 (objectOwnFieldId state threadObj "_DONT_USE_InternalThread")
                 (CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim (int64 addrInt))))
 
-        { state with
-            ManagedHeap = ManagedHeap.set threadAddr updatedObj state.ManagedHeap
-            NextManagedThreadId = state.NextManagedThreadId + 1
-        }
+        let state =
+            { state with
+                ManagedHeap = ManagedHeap.set threadAddr updatedObj state.ManagedHeap
+                NextManagedThreadId = state.NextManagedThreadId + 1
+            }
+
+        IlMachineState.allocateUnstartedThread threadAddr state
 
     let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
         let state = ctx.State
@@ -198,7 +245,7 @@ module NativeThreading =
                     failwith $"%s{operation}: ObjectHandleOnStack pointed to a null Thread reference"
                 | other -> failwith $"%s{operation}: expected ObjectRef in ObjectHandleOnStack, got %O{other}"
 
-            let state = initializeThreadObject threadAddr state
+            let state, _newThreadId = initializeThreadObject threadAddr state
             (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "ThreadNative_Join",
           "System.Private.CoreLib",
@@ -248,6 +295,100 @@ module NativeThreading =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 resultInt)) ctx.Thread state
 
             (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+        | "ThreadNative_SetIsBackground",
+          "System.Private.CoreLib",
+          "System.Threading",
+          "Thread",
+          "SetIsBackground",
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Threading",
+                                              "ThreadHandle",
+                                              threadHandleGenerics)
+            ConcreteType state.ConcreteTypes ("System.Private.CoreLib", "", "BOOL", boolGenerics) ],
+          MethodReturnType.Void when threadHandleGenerics.IsEmpty && boolGenerics.IsEmpty ->
+            // .NET 10 QCall backing `Thread.IsBackground = value`. We don't yet model the
+            // "process terminates when the last foreground thread exits" semantics, so the
+            // flag is stored on `ThreadState.IsBackground` purely so the paired getter
+            // round-trips and guest code that reads `Thread.IsBackground` after writing it
+            // sees its own value. The real CLR also raises `ThreadStateException` when the
+            // target is `_isDead`; PawPrint can't synthesise managed exceptions from QCalls
+            // yet, so a Set against a terminated thread would silently succeed here. That
+            // mirrors the existing gap in `executeJoinCore` rather than introducing a new
+            // one — a guest that depends on the throw will need exception synthesis first.
+            let operation = "ThreadNative_SetIsBackground"
+
+            if instruction.Arguments.Length <> 2 then
+                failwith $"%s{operation}: expected two native arguments, got %d{instruction.Arguments.Length}"
+
+            let threadAddr =
+                threadAddrFromThreadHandle state operation instruction.Arguments.[0]
+
+            let targetThreadId = threadIdFromThreadAddr state operation threadAddr
+
+            // Interop.BOOL is int32-backed: FALSE=0, TRUE=1. The IL marshaller flattens the
+            // enum to its underlying value before the QCall, so unwrap the primitive and
+            // treat any non-zero as truthy (matches `result != 0` in the BCL).
+            let value =
+                match instruction.Arguments.[1] |> CliType.unwrapPrimitiveLikeDeep with
+                | CliType.Numeric (CliNumericType.Int32 i) -> i <> 0
+                | other -> failwith $"%s{operation}: expected Interop.BOOL as Int32, got %O{other}"
+
+            let updatedThreadState =
+                state.ThreadState
+                |> Map.tryFind targetThreadId
+                |> Option.defaultWith (fun () ->
+                    failwith $"%s{operation}: target ThreadId {targetThreadId} has no ThreadState"
+                )
+                |> fun ts ->
+                    { ts with
+                        IsBackground = value
+                    }
+
+            let state =
+                { state with
+                    ThreadState = state.ThreadState |> Map.add targetThreadId updatedThreadState
+                }
+
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+        | "ThreadNative_GetIsBackground",
+          "System.Private.CoreLib",
+          "System.Threading",
+          "Thread",
+          "GetIsBackground",
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Threading",
+                                              "ThreadHandle",
+                                              threadHandleGenerics) ],
+          MethodReturnType.Returns (ConcreteType state.ConcreteTypes ("System.Private.CoreLib", "", "BOOL", boolGenerics)) when
+            threadHandleGenerics.IsEmpty && boolGenerics.IsEmpty
+            ->
+            // .NET 10 QCall backing the `Thread.IsBackground` getter. Returns Interop.BOOL
+            // (int32-backed: TRUE=1, FALSE=0); we push 0/1 directly because the IL caller
+            // reinterprets the return on the stack via `(int)result != 0`.
+            let operation = "ThreadNative_GetIsBackground"
+
+            if instruction.Arguments.Length <> 1 then
+                failwith $"%s{operation}: expected one native argument, got %d{instruction.Arguments.Length}"
+
+            let threadAddr =
+                threadAddrFromThreadHandle state operation instruction.Arguments.[0]
+
+            let targetThreadId = threadIdFromThreadAddr state operation threadAddr
+
+            let isBackground =
+                state.ThreadState
+                |> Map.tryFind targetThreadId
+                |> Option.map (fun ts -> ts.IsBackground)
+                |> Option.defaultWith (fun () ->
+                    failwith $"%s{operation}: target ThreadId {targetThreadId} has no ThreadState"
+                )
+
+            let resultInt = if isBackground then 1 else 0
+
+            let state =
+                IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 resultInt)) ctx.Thread state
+
+            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | _ -> None
 
     let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
@@ -289,7 +430,7 @@ module NativeThreading =
                 | EvalStackValue.ObjectRef addr -> addr
                 | other -> failwith $"Thread.Initialize: expected ObjectRef for 'this', got %O{other}"
 
-            let state = initializeThreadObject threadAddr state
+            let state, _newThreadId = initializeThreadObject threadAddr state
             (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
         | "System.Private.CoreLib", "System.Threading", "Thread", "StartInternal", _, MethodReturnType.Void ->
             // StartInternal (ThreadHandle t, int stackSize, int priority, Interop.BOOL isThreadPool, char* pThreadName) -> void
@@ -297,33 +438,20 @@ module NativeThreading =
             // Thread heap object from the handle and spawn a new interpreter thread that begins
             // executing the user-supplied delegate directly, bypassing the BCL StartCallback
             // path (which otherwise pulls in ExecutionContext/culture/autorelease machinery).
-            let threadHandleArg = instruction.Arguments.[0]
-
             let threadAddr =
-                match threadHandleArg |> CliType.unwrapPrimitiveLike with
-                | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim addrInt)) ->
-                    ManagedHeapAddress (int addrInt)
-                | CliType.ValueType vt ->
-                    let ptrField = IlMachineState.requiredOwnInstanceFieldId state vt.Declared "_ptr"
+                threadAddrFromThreadHandle state "Thread.StartInternal" instruction.Arguments.[0]
 
-                    match CliValueType.DereferenceFieldById ptrField vt |> CliType.unwrapPrimitiveLike with
-                    | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim addrInt)) ->
-                        ManagedHeapAddress (int addrInt)
-                    | other ->
-                        failwith
-                            $"Thread.StartInternal: expected Verbatim nativeint inside ThreadHandle._ptr, got %O{other}"
-                | other -> failwith $"Thread.StartInternal: unexpected shape for ThreadHandle argument: %O{other}"
-
-            // Double-Start detection: if this Thread heap object is already bound to
-            // an interpreter thread, the guest has called Start() twice. The real
-            // runtime nulls out _startHelper on a successful Start so the second
-            // call throws ThreadStateException; we can't synthesise that exception
-            // yet, so fail the interpreter loudly instead of silently spawning a
-            // second worker. When exception synthesis lands, replace this failwith
-            // with the ThreadStateException raise and the _startHelper nulling.
-            if state.ManagedThreadObjects |> Map.exists (fun _ addr -> addr = threadAddr) then
-                failwith
-                    $"Thread.StartInternal: Thread object at {threadAddr} has already been started; the guest would observe ThreadStateException, which is not yet synthesised. Double-Start is a guest bug."
+            // The Thread heap object is always bound to a `NotStarted` interpreter
+            // ThreadId from `Thread.Initialize`; recover that slot here and fill in
+            // its bottom frame below. Double-Start detection rides on the slot's
+            // status: anything other than `NotStarted` means `Start` has already
+            // succeeded (Runnable / blocked / Terminated) — the real runtime nulls
+            // `_startHelper` on a successful Start so the second call would observe
+            // `ThreadStateException`, and `startUnstartedThread` surfaces the same
+            // condition via its status assert. When exception synthesis lands,
+            // replace that loud failure with the ThreadStateException raise plus
+            // the `_startHelper` nulling.
+            let newThreadId = threadIdFromThreadAddr state "Thread.StartInternal" threadAddr
 
             let threadObj = ManagedHeap.get threadAddr state.ManagedHeap
 
@@ -435,14 +563,13 @@ module NativeThreading =
                 | Ok ms -> ms
                 | Error _ -> failwith "Thread.StartInternal: failed to build MethodState for thread delegate target"
 
-            let state, newThreadId = IlMachineState.addThread newMethodState state
-
-            // Link the fresh ThreadId to the pre-existing Thread heap object so that
-            // Thread.CurrentThread on the new thread returns the original Thread reference.
-            let state =
-                { state with
-                    ManagedThreadObjects = state.ManagedThreadObjects |> Map.add newThreadId threadAddr
-                }
+            // The ThreadId slot was minted at `Thread.Initialize` time and bound to
+            // `threadAddr` in `ManagedThreadObjects`; promote it from `NotStarted`
+            // to `Runnable` and install the worker's bottom frame in one step.
+            // Status / frame transitions go through `startUnstartedThread` so the
+            // double-Start guard (status must be `NotStarted`) lives next to the
+            // mutation it protects.
+            let state = IlMachineState.startUnstartedThread newThreadId newMethodState state
 
             // ECMA-335: a type's .cctor must run before any of its static methods
             // or before the first instance is touched. For delegates bound to a

--- a/WoofWare.PawPrint/Native/NativeThreading.fs
+++ b/WoofWare.PawPrint/Native/NativeThreading.fs
@@ -323,11 +323,15 @@ module NativeThreading =
             // "process terminates when the last foreground thread exits" semantics, so the
             // flag is stored on `ThreadState.IsBackground` purely so the paired getter
             // round-trips and guest code that reads `Thread.IsBackground` after writing it
-            // sees its own value. The real CLR also raises `ThreadStateException` when the
-            // target is `_isDead`; PawPrint can't synthesise managed exceptions from QCalls
-            // yet, so a Set against a terminated thread would silently succeed here. That
-            // mirrors the existing gap in `executeJoinCore` rather than introducing a new
-            // one — a guest that depends on the throw will need exception synthesis first.
+            // sees its own value.
+            //
+            // The real CLR raises `ThreadStateException` when the target is dead — the BCL
+            // does this in managed code via the `_isDead` check on `Thread.IsBackground`
+            // before reaching the QCall. PawPrint doesn't currently write `_isDead = true`
+            // when a thread terminates (a separate piece of work — also needed by Priority
+            // and the other `_isDead`-guarded properties), so the BCL check passes and we
+            // reach this handler on a Terminated thread. Reject that here rather than
+            // silently storing an unobservable flag, mirroring the executeJoinCore guard.
             let operation = "ThreadNative_SetIsBackground"
 
             if instruction.Arguments.Length <> 2 then
@@ -346,16 +350,23 @@ module NativeThreading =
                 | CliType.Numeric (CliNumericType.Int32 i) -> i <> 0
                 | other -> failwith $"%s{operation}: expected Interop.BOOL as Int32, got %O{other}"
 
-            let updatedThreadState =
+            let targetState =
                 state.ThreadState
                 |> Map.tryFind targetThreadId
                 |> Option.defaultWith (fun () ->
                     failwith $"%s{operation}: target ThreadId {targetThreadId} has no ThreadState"
                 )
-                |> fun ts ->
-                    { ts with
-                        IsBackground = value
-                    }
+
+            match targetState.Status with
+            | ThreadStatus.Terminated ->
+                failwith
+                    $"%s{operation}: target ThreadId {targetThreadId} has terminated. The real CLR raises ThreadStateException via the BCL's `_isDead` check; PawPrint doesn't synthesise that yet, so this is a guest bug we can't currently report structurally."
+            | _ -> ()
+
+            let updatedThreadState =
+                { targetState with
+                    IsBackground = value
+                }
 
             let state =
                 { state with
@@ -377,7 +388,10 @@ module NativeThreading =
             ->
             // .NET 10 QCall backing the `Thread.IsBackground` getter. Returns Interop.BOOL
             // (int32-backed: TRUE=1, FALSE=0); we push 0/1 directly because the IL caller
-            // reinterprets the return on the stack via `(int)result != 0`.
+            // reinterprets the return on the stack via `(int)result != 0`. Symmetric with
+            // the setter: the BCL's managed `_isDead` check should reject reads against
+            // terminated threads before the QCall fires, but PawPrint doesn't yet flip
+            // `_isDead`, so we guard the case here rather than handing back a stale flag.
             let operation = "ThreadNative_GetIsBackground"
 
             if instruction.Arguments.Length <> 1 then
@@ -388,15 +402,20 @@ module NativeThreading =
 
             let targetThreadId = threadIdFromThreadAddr state operation threadAddr
 
-            let isBackground =
+            let targetState =
                 state.ThreadState
                 |> Map.tryFind targetThreadId
-                |> Option.map (fun ts -> ts.IsBackground)
                 |> Option.defaultWith (fun () ->
                     failwith $"%s{operation}: target ThreadId {targetThreadId} has no ThreadState"
                 )
 
-            let resultInt = if isBackground then 1 else 0
+            match targetState.Status with
+            | ThreadStatus.Terminated ->
+                failwith
+                    $"%s{operation}: target ThreadId {targetThreadId} has terminated. The real CLR raises ThreadStateException via the BCL's `_isDead` check; PawPrint doesn't synthesise that yet, so this is a guest bug we can't currently report structurally."
+            | _ -> ()
+
+            let resultInt = if targetState.IsBackground then 1 else 0
 
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 resultInt)) ctx.Thread state

--- a/WoofWare.PawPrint/ThreadState.fs
+++ b/WoofWare.PawPrint/ThreadState.fs
@@ -7,6 +7,21 @@ open System.Reflection
 /// flips it back to Runnable.
 type ThreadStatus =
     | Runnable
+    /// The managed `Thread` heap object has been constructed (its `Initialize`
+    /// QCall / InternalCall ran, allocating a `ThreadId` slot for it) but
+    /// `Thread.Start` has not yet been called, so no IL has executed on this
+    /// thread. The scheduler never picks `NotStarted` threads; `StartInternal`
+    /// flips the status to `Runnable` after populating the bottom frame with
+    /// the user's delegate target. Lets us model state that lives on the
+    /// managed `Thread` object before its first execution (notably
+    /// `IsBackground`, which the thread-pool worker setup writes between the
+    /// constructor call and `Start`) by keeping the per-thread record alive
+    /// from construction time. Threads that are constructed and never started
+    /// (e.g. a `new Thread(...)` reference that the guest then drops on the
+    /// floor) remain `NotStarted` for the lifetime of the run; they do not
+    /// contribute to deadlock detection beyond appearing in the stuck-threads
+    /// description.
+    | NotStarted
     /// This thread is blocked inside Thread.Join, waiting for the named thread to terminate.
     | BlockedOnJoin of target : ThreadId
     /// This thread tried to access a type whose .cctor is currently being run by another
@@ -66,6 +81,14 @@ type ThreadState =
         NextFrameId : int
         ActiveMethodState : FrameId
         Status : ThreadStatus
+        /// Mirrors the CoreCLR `Thread.IsBackground` flag set via the
+        /// `ThreadNative_SetIsBackground` QCall. The interpreter does not yet
+        /// model the "process terminates when the last foreground thread
+        /// exits" semantics; this field exists so the QCall can store the
+        /// guest's request faithfully and the paired getter can return it,
+        /// preserving round-trip semantics for guest code that reads back
+        /// `Thread.IsBackground`. Default `false` matches the BCL.
+        IsBackground : bool
     }
 
     // --- Frame resolution primitives ---
@@ -141,6 +164,7 @@ type ThreadState =
             MethodStates = Map.empty |> Map.add (FrameId 0) methodState
             NextFrameId = 1
             Status = ThreadStatus.Runnable
+            IsBackground = false
         }
 
     static member peekEvalStack (state : ThreadState) : EvalStackValue option =


### PR DESCRIPTION
## Summary
- Implements the `ThreadNative_SetIsBackground` / `ThreadNative_GetIsBackground` QCalls that the .NET 10 BCL routes `Thread.IsBackground` through, unblocking the next layer of `sourcesPure/Threads.cs` (which still needs `ThreadNative_InformThreadNameChange` before it goes green — left in `unimplemented` with an updated blocker note).
- Adds a focused `ThreadIsBackground.cs` test that round-trips the flag without depending on `Thread.Start`, so the QCalls have coverage independent of the broader thread-pool path.
- Carries the necessary plumbing for the BCL's "construct → set IsBackground → Start" pattern: a new `ThreadStatus.NotStarted` variant, pre-allocation of `ThreadState` at `Thread.Initialize` time via `allocateUnstartedThread`, and a `startUnstartedThread` helper that flips the slot to `Runnable` once a bottom frame is pushed.

## Why the architectural change
The thread-pool worker setup (e.g. `PortableThreadPool.WorkerThread.CreateWorkerThread`) constructs a `Thread`, then writes `IsBackground = true` *before* calling `Start`. So the IsBackground flag needs a home before the thread is scheduled. The options considered:

1. Add an `IsBackground` field somewhere outside `ThreadState` (e.g. on the Thread heap object only).
2. Defer the write until `Start`, buffering it elsewhere.
3. Pre-allocate `ThreadState` at `Initialize` time with a new `NotStarted` status, so the field has a real home from the start.

Option 3 wins because the scheduler can simply ignore `NotStarted` threads (they're skipped by `chooseNext`), and `StartInternal` now finds an existing slot to populate rather than allocating a fresh one. Double-start protection rides on the status check inside `startUnstartedThread`.

## Codex-review fixes folded in
Pre-allocating `ThreadState` made two latent paths reachable, both fixed in follow-up commits:

- **`Thread.Join` on a NotStarted thread** used to fail-fast inside the reverse-lookup; now the lookup succeeds and the Terminated check would wrongly treat NotStarted as live. Explicit `failwith` at the call site mirrors the existing self-join guard (real CLR raises `ThreadStateException`, which PawPrint doesn't yet synthesise).
- **Debugger JSON serializers** (`writeThreadSummary`, `writeThreadResponse`, `writeThreadStackSummaryResponse`, `writeActiveMethodIlResponse`) dereferenced `.ActiveAssembly` / `.MethodState` — frame-less NotStarted slots would crash these. They now emit nulls (or a structured error for the IL endpoint) when the thread has not yet started.
- **IsBackground QCalls on a Terminated thread** would silently store/return a flag the BCL's `_isDead` check is supposed to gate. PawPrint doesn't yet write `_isDead = true` at termination (a wider fix shared with `Priority` and friends), so the QCalls now guard the Terminated case explicitly rather than diverging silently.

## Test plan
- [x] `nix develop -c dotnet build WoofWare.PawPrint.slnx` — clean, no warnings
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 1135/1135 pass on the rebased branch
- [x] `nix develop -c dotnet fantomas .` — no changes
- [x] `codex review --base main` — third pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)