### PR TITLE
Model enum-underlying integer equivalence in array assignability

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/EnumArrayCastBetweenEnums.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/EnumArrayCastBetweenEnums.cs
@@ -1,0 +1,58 @@
+// ECMA-335 / CoreCLR: two enum-typed SZ arrays are element-compatible iff
+// their enums share a normalized underlying integer width. Two enums on
+// `int` interchange (and with their `uint` partner). Two enums on
+// different underlying widths do not — the `castclass` must raise
+// `InvalidCastException`, `isinst` must answer false.
+
+public enum AKind : int
+{
+    A,
+}
+
+public enum BKind : int
+{
+    B,
+}
+
+public enum CKind : long
+{
+    C,
+}
+
+public class TestEnumArrayCastBetweenEnums
+{
+    public static int Main(string[] argv)
+    {
+        object aPayload = new AKind[] { AKind.A };
+
+        // Same underlying int → succeeds.
+        BKind[] asB = (BKind[]) aPayload;
+        if (asB.Length != 1)
+            return 1;
+
+        // Symmetric (B → A) succeeds.
+        object bPayload = new BKind[] { BKind.B };
+        AKind[] asA = (AKind[]) bPayload;
+        if (asA.Length != 1)
+            return 2;
+
+        // Different underlying width (int → long) is rejected.
+        bool threw = false;
+        try
+        {
+            CKind[] _ = (CKind[]) aPayload;
+        }
+        catch (System.InvalidCastException)
+        {
+            threw = true;
+        }
+
+        if (!threw)
+            return 3;
+
+        if (aPayload is CKind[])
+            return 4;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/EnumArrayCastToUnderlying.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/EnumArrayCastToUnderlying.cs
@@ -1,0 +1,49 @@
+// ECMA-335 / CoreCLR: an enum-typed SZ array and an SZ array of the enum's
+// underlying integer are array-element-compatible. The `castclass` /
+// `isinst` paths in the runtime answer "yes" for both directions and for
+// signed/unsigned partners with the same normalized width (e.g.
+// `MyEnum : int` ↔ `int[]`, ↔ `uint[]`).
+//
+// Today the assignability walk reports "unknown" for the enum case, which
+// is fine for the variance gate (which degrades to permit) but a host
+// failure for `castclass`/`isinst`: those callers must observe a managed
+// boolean. This test exercises the cast paths directly, not the array-
+// store gate.
+
+public enum SignedKind : int
+{
+    Zero,
+    One,
+}
+
+public class TestEnumArrayCastToUnderlying
+{
+    public static int Main(string[] argv)
+    {
+        object payload = new SignedKind[] { SignedKind.One };
+
+        // Enum array → underlying-signed array.
+        int[] asSigned = (int[]) payload;
+        if (asSigned.Length != 1)
+            return 1;
+        if (asSigned[0] != 1)
+            return 2;
+
+        // Enum array → underlying-unsigned partner (same normalized width).
+        uint[] asUnsigned = (uint[]) payload;
+        if (asUnsigned.Length != 1)
+            return 3;
+        if (asUnsigned[0] != 1u)
+            return 4;
+
+        // Symmetric: underlying-signed array → enum array.
+        object asInt = new int[] { 42 };
+        SignedKind[] back = (SignedKind[]) asInt;
+        if (back.Length != 1)
+            return 5;
+        if ((int) back[0] != 42)
+            return 6;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/EnumArrayCastWidthMismatch.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/EnumArrayCastWidthMismatch.cs
@@ -1,0 +1,46 @@
+// ECMA-335 / CoreCLR: array-element compatibility for enum elements is
+// determined by their normalized underlying integer width. An array of an
+// enum whose underlying type is `byte` is NOT element-compatible with
+// `int[]` even though both are integer-typed: the widths differ.
+//
+// Today the assignability walk reports "unknown" for any enum-vs-integer
+// element pair, which would let an invalid cast through if `castclass`
+// degraded to permit. This test verifies the runtime answers a definitive
+// `false` and raises `InvalidCastException`.
+
+public enum ByteKind : byte
+{
+    Zero,
+    One,
+}
+
+public class TestEnumArrayCastWidthMismatch
+{
+    public static int Main(string[] argv)
+    {
+        object payload = new ByteKind[] { ByteKind.One };
+
+        bool threw = false;
+        try
+        {
+            int[] _ = (int[]) payload;
+        }
+        catch (System.InvalidCastException)
+        {
+            threw = true;
+        }
+
+        if (!threw)
+            return 1;
+
+        // `isinst` is the non-throwing partner and must agree.
+        if (payload is int[])
+            return 2;
+
+        // The same payload remains its own type — sanity check.
+        if (!(payload is ByteKind[]))
+            return 3;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -1323,8 +1323,7 @@ module IlMachineRuntimeMetadata =
         // immediate runtime base is `System.Enum`. Used by the array-element
         // assignability rule below to detect cases where ECMA-335 / CoreCLR
         // enum-underlying-type equivalence (e.g. `MyEnum : int` ↔ `int`, or two
-        // enums sharing an underlying integer) might permit a store, but the
-        // underlying-type lookup itself isn't yet modelled.
+        // enums sharing an underlying integer) might permit a store.
         let isEnumValueType (state : IlMachineState) (handle : ConcreteTypeHandle) : IlMachineState * bool =
             match handle with
             | ConcreteTypeHandle.OneDimArrayZero _
@@ -1342,6 +1341,42 @@ module IlMachineRuntimeMetadata =
                     match AllConcreteTypes.lookup bh state.ConcreteTypes with
                     | Some baseTy -> state, baseTy.Identity = baseClassTypes.Enum.Identity
                     | None -> state, false
+
+        // For an enum `ConcreteTypeHandle`, return the `ConcreteTypeHandle` of its
+        // underlying integer type by concretising the signature of its sole instance
+        // field (`value__`, the CLR-reserved name for the integer slot of an enum;
+        // ECMA-335 §II.14.3). Returns `None` if `handle` is not an enum, has no TypeDef
+        // row, or — defensively — has a malformed Fields list. The caller is expected
+        // to have first verified enum-ness via `isEnumValueType`; this helper does the
+        // metadata read.
+        let enumUnderlyingHandle
+            (state : IlMachineState)
+            (handle : ConcreteTypeHandle)
+            : (IlMachineState * ConcreteTypeHandle) option
+            =
+            match tryGetConcreteTypeInfo state handle with
+            | None -> None
+            | Some (ct, typeInfo) ->
+                let instanceFields =
+                    typeInfo.Fields
+                    |> List.filter (fun f -> not (f.Attributes.HasFlag FieldAttributes.Static))
+
+                match instanceFields with
+                | [ valueField ] when valueField.Name = "value__" ->
+                    let assy = state._LoadedAssemblies.[ct.Identity.AssemblyFullName]
+
+                    let state, underlying =
+                        IlMachineTypeResolution.concretizeType
+                            loggerFactory
+                            baseClassTypes
+                            state
+                            assy.Name
+                            ct.Generics
+                            ImmutableArray.Empty
+                            valueField.Signature
+
+                    Some (state, underlying)
+                | _ -> None
 
         // ECMA-335 III.8.7 / CoreCLR `GetNormalizedIntegralArrayElementType`:
         // signed and unsigned primitive integers of equal width are interchangeable
@@ -1367,6 +1402,28 @@ module IlMachineRuntimeMetadata =
                 else
                     None
             | _ -> None
+
+        // ECMA-335 III.4.3 / CoreCLR `CanCastParam`: for value-typed array elements the
+        // assignment-compatibility relation reduces to "the normalised integer identity
+        // of each element matches". The normalised identity of a primitive integer is
+        // the signed canonical (see `normalizedPrimitiveIntegerIdentity`); the normalised
+        // identity of an enum is the normalised identity of its underlying integer.
+        // Anything else (`float`, `double`, `bool`, `char`, non-integer struct) has no
+        // normalised identity. Returns `None` when the input has no equivalence partner;
+        // returns `Some id` otherwise.
+        let valueElementNormalisedIdentity
+            (state : IlMachineState)
+            (handle : ConcreteTypeHandle)
+            : IlMachineState * ResolvedTypeIdentity option
+            =
+            let state, isEnum = isEnumValueType state handle
+
+            if isEnum then
+                match enumUnderlyingHandle state handle with
+                | None -> state, None
+                | Some (state, underlying) -> state, normalizedPrimitiveIntegerIdentity underlying
+            else
+                state, normalizedPrimitiveIntegerIdentity handle
 
         let checkArraySpecificRules
             (state : IlMachineState)
@@ -1396,46 +1453,23 @@ module IlMachineRuntimeMetadata =
                         // so the answer is definitively non-assignable here.
                         state, Some false
                     else
-                        // Both element types are value-typed. ECMA-335 / CoreCLR permit
-                        // two complementary rules for value-typed array elements:
+                        // Both element types are value-typed. ECMA-335 III.4.3 /
+                        // CoreCLR `CanCastParam` reduces the relation to
+                        // "normalised integer identities match", combining two rules:
                         //   (a) signed/unsigned primitive integers of equal width
                         //       (`int[]` ↔ `uint[]`, etc.) — `GetNormalizedIntegralArrayElementType`.
-                        //   (b) enums whose underlying integer type matches the partner's
-                        //       (e.g. `MyEnum : int` ↔ `int`, or two enums with the same
-                        //       underlying type).
-                        // (a) is modelled below. (b) requires reading each enum's `value__`
-                        // field to discover its underlying type, which we haven't taught
-                        // the assignability walk yet. Enum-underlying equivalence can only
-                        // make the answer `true` when the partner is either another enum
-                        // or a primitive integer in the normalization table; for any other
-                        // partner (float, double, bool, char, non-integer struct) the
-                        // answer remains definitively false. So we return `None` only when
-                        // both sides plausibly participate in rule (b); otherwise we keep
-                        // the definitive `Some false` answer that callers like `isinst` /
-                        // `castclass` rely on.
-                        let state, objIsEnum = isEnumValueType state objElement
-                        let state, targetIsEnum = isEnumValueType state targetElement
+                        //   (b) enum equivalence with the underlying integer or with
+                        //       another enum that shares the same underlying integer
+                        //       (e.g. `MyEnum : int` ↔ `int[]` ↔ `uint[]`, or `MyEnum:int` ↔ `OtherEnum:int`).
+                        // `valueElementNormalisedIdentity` looks the underlying integer
+                        // up for enums and applies `normalizedPrimitiveIntegerIdentity`
+                        // to the result, giving a definitive yes/no answer.
+                        let state, objNormalised = valueElementNormalisedIdentity state objElement
+                        let state, targetNormalised = valueElementNormalisedIdentity state targetElement
 
-                        let objNormalized = normalizedPrimitiveIntegerIdentity objElement
-                        let targetNormalized = normalizedPrimitiveIntegerIdentity targetElement
-
-                        let enumCandidate (isEnum : bool) (normalized : ResolvedTypeIdentity option) =
-                            isEnum || normalized.IsSome
-
-                        if
-                            (objIsEnum || targetIsEnum)
-                            && enumCandidate objIsEnum objNormalized
-                            && enumCandidate targetIsEnum targetNormalized
-                        then
-                            // At least one element is an enum and the partner could share
-                            // an underlying integer type.
-                            // TODO: model enum-underlying integer equivalence so this case
-                            // becomes a precise answer rather than "unknown".
-                            state, None
-                        else
-                            match objNormalized, targetNormalized with
-                            | Some a, Some b when a = b -> state, Some true
-                            | _, _ -> state, Some false
+                        match objNormalised, targetNormalised with
+                        | Some a, Some b when a = b -> state, Some true
+                        | _, _ -> state, Some false
             | Some _, None -> state, None
             | None, _ -> failwith $"checkArraySpecificRules called with non-array source %O{objType}"
 


### PR DESCRIPTION
## Summary

- Teach `isConcreteTypeAssignableTo`'s value-typed array-element rule (ECMA-335 III.4.3 / CoreCLR `CanCastParam`) to read each enum's `value__` field and normalise to the signed canonical integer identity. An enum-typed array is now element-compatible with the underlying integer's array, its signed/unsigned partner, and any other enum that shares the same normalised underlying width.
- Replaces the prior `None` (undecided) return in the enum-candidate branch with a definitive yes/no answer. Previously the `None` was tolerable inside the array-store variance gate (which degrades undecided to "permit") but was a host failure for `castclass` / `isinst` — the same TODO failwith reached those callers with no try/with safety net.
- New `enumUnderlyingHandle` helper concretises the signature of an enum's sole instance field; new `valueElementNormalisedIdentity` helper combines enum-underlying lookup with `normalizedPrimitiveIntegerIdentity` to give a single normalised identity per value-typed element.

## Test plan

New `sourcesPure/` regression tests, all of which host-failed today:
- `EnumArrayCastToUnderlying.cs` — `MyEnum:int[]` castclass succeeds to `int[]` and `uint[]`; symmetric direction succeeds.
- `EnumArrayCastBetweenEnums.cs` — two `int`-underlying enums interchange; `int`-underlying to `long`-underlying rejects with `InvalidCastException` and `isinst` answers false.
- `EnumArrayCastWidthMismatch.cs` — `MyByteEnum:byte[]` to `int[]` rejected.

- [x] `nix develop -c dotnet build`
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 1138 passed, 0 failed.
- [x] `nix develop -c dotnet fantomas .` — no changes.
- [x] `codex review --base main` — no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)