### PR TITLE
Introduce NativeHandlerResult to model native dispatcher outcomes

### DIFF
--- a/WoofWare.PawPrint.Test/TestFieldHandleRegistry.fs
+++ b/WoofWare.PawPrint.Test/TestFieldHandleRegistry.fs
@@ -575,7 +575,7 @@ public class DerivedWithField : BaseWithField
 
         let state =
             match NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_GetFields" ctx with
-            | Some (ExecutionResult.Stepped (state, WhatWeDid.Executed, _)) -> state
+            | Some (NativeHandlerResult.Completed (state, _)) -> state
             | Some result -> failwith $"unexpected RuntimeTypeHandle_GetFields execution result: %O{result}"
             | None -> failwith "RuntimeTypeHandle_GetFields did not match"
 
@@ -647,7 +647,7 @@ public class DerivedWithField : BaseWithField
 
         let state =
             match NativeRuntimeFieldHandle.tryExecute ctx with
-            | Some (ExecutionResult.Stepped (state, WhatWeDid.Executed, _)) -> state
+            | Some (NativeHandlerResult.Completed (state, _)) -> state
             | Some result -> failwith $"unexpected RuntimeFieldHandle.GetAttributes execution result: %O{result}"
             | None -> failwith "RuntimeFieldHandle.GetAttributes did not match"
 

--- a/WoofWare.PawPrint.Test/TestManifestResources.fs
+++ b/WoofWare.PawPrint.Test/TestManifestResources.fs
@@ -319,7 +319,7 @@ public static class Entry
 
         let state =
             match NativeRuntimeAssembly.tryExecuteQCall "AssemblyNative_GetResource" ctx with
-            | Some (ExecutionResult.Stepped (state, WhatWeDid.Executed, _)) -> state
+            | Some (NativeHandlerResult.Completed (state, _)) -> state
             | Some result -> failwith $"unexpected AssemblyNative_GetResource execution result: %O{result}"
             | None -> failwith "AssemblyNative_GetResource QCall did not match"
 

--- a/WoofWare.PawPrint.Test/TestNativeCustomAttribute.fs
+++ b/WoofWare.PawPrint.Test/TestNativeCustomAttribute.fs
@@ -460,7 +460,7 @@ public sealed class CctorAttribute : System.Attribute
             State = state
         |}
 
-    let private invokeHandler (fixture : Fixture) (thread : ThreadId) (state : IlMachineState) : ExecutionResult =
+    let private invokeHandler (fixture : Fixture) (thread : ThreadId) (state : IlMachineState) : NativeHandlerResult =
         let ctx : NativeCallContext =
             {
                 LoggerFactory = fixture.LoggerFactory
@@ -486,8 +486,8 @@ public sealed class CctorAttribute : System.Attribute
 
         let state =
             match result with
-            | ExecutionResult.Stepped (state, WhatWeDid.SuspendedForManagedCall, _) -> state
-            | other -> failwithf "Phase 1 expected SuspendedForManagedCall, got %A" other
+            | NativeHandlerResult.PushedManagedCallee (state, _) -> state
+            | other -> failwithf "Phase 1 expected PushedManagedCallee, got %A" other
 
         // The blob cursor cell now points one-past-end of the blob: fixed-args consumed
         // 12 bytes, then the named-arg count uint16 added 2 more.
@@ -576,8 +576,8 @@ public sealed class CctorAttribute : System.Attribute
 
         let state =
             match result with
-            | ExecutionResult.Stepped (state, WhatWeDid.Executed, _) -> state
-            | other -> failwithf "Phase 2 expected Executed, got %A" other
+            | NativeHandlerResult.Completed (state, _) -> state
+            | other -> failwithf "Phase 2 expected Completed, got %A" other
 
         // The instance ObjectHandleOnStack slot now points at the marker.
         match IlMachineState.getArrayValue prep.InstanceArr 0 state with
@@ -603,7 +603,7 @@ public sealed class CctorAttribute : System.Attribute
 
         let state =
             match result with
-            | ExecutionResult.Stepped (state, WhatWeDid.SuspendedForClassInit, _) -> state
+            | NativeHandlerResult.SuspendedForClassInit (state, _) -> state
             | other -> failwithf "Class-init suspension test expected SuspendedForClassInit, got %A" other
 
         // The blob cursor cell must still be the starting byref into cell 0 of the blob.

--- a/WoofWare.PawPrint.Test/TestNativeEnum.fs
+++ b/WoofWare.PawPrint.Test/TestNativeEnum.fs
@@ -323,7 +323,7 @@ public static class Entry
 
         let state =
             match NativeQCall.tryExecute ctx with
-            | Some (ExecutionResult.Stepped (state, WhatWeDid.Executed, _)) -> state
+            | Some (NativeHandlerResult.Completed (state, _)) -> state
             | Some result -> failwith $"unexpected Enum_GetValuesAndNames execution result: %O{result}"
             | None -> failwith "Enum_GetValuesAndNames QCall did not match"
 

--- a/WoofWare.PawPrint.Test/TestNativeMetadataImport.fs
+++ b/WoofWare.PawPrint.Test/TestNativeMetadataImport.fs
@@ -431,7 +431,7 @@ public class TypesWithMembers
             }
 
         match NativeMetadataImport.tryExecute ctx with
-        | Some (ExecutionResult.Stepped (state, WhatWeDid.Executed, _)) -> state
+        | Some (NativeHandlerResult.Completed (state, _)) -> state
         | Some result -> failwith $"unexpected MetadataImport execution result: %O{result}"
         | None -> failwith "MetadataImport native method did not match"
 

--- a/WoofWare.PawPrint.Test/TestNativeSignature.fs
+++ b/WoofWare.PawPrint.Test/TestNativeSignature.fs
@@ -404,7 +404,7 @@ public sealed class GenericFieldHost<T>
 
         let state =
             match NativeSignature.tryExecuteQCall "Signature_Init" ctx with
-            | Some (ExecutionResult.Stepped (state, WhatWeDid.Executed, _)) -> state
+            | Some (NativeHandlerResult.Completed (state, _)) -> state
             | Some result -> failwith $"unexpected Signature_Init execution result: %O{result}"
             | None -> failwith "Signature_Init did not match"
 

--- a/WoofWare.PawPrint/AbstractMachine.fs
+++ b/WoofWare.PawPrint/AbstractMachine.fs
@@ -45,33 +45,46 @@ module AbstractMachine =
                 | Some result -> result
                 | None -> NativeDispatch.failUnimplemented nativeContext
 
-
             match outcome with
-            | ExecutionResult.Terminated (state, terminating) -> ExecutionResult.Terminated (state, terminating)
-            | ExecutionResult.ProcessExit _ -> outcome
-            | ExecutionResult.FailFast _ -> outcome
-            | ExecutionResult.UnhandledException _ -> outcome
-            | ExecutionResult.Stepped (state, WhatWeDid.SuspendedForClassInit, effect) ->
-                // A cctor was pushed; the native frame must stay on the stack so the dispatch loop
-                // runs the cctor first, then re-enters this native method on the next step.
-                ExecutionResult.Stepped (state, WhatWeDid.SuspendedForClassInit, effect)
-            | ExecutionResult.Stepped (state, WhatWeDid.SuspendedForManagedCall, effect) ->
-                // The native handler pushed a managed callee on top of itself; the native frame
-                // must stay on the stack so the dispatch loop runs the callee, then re-enters this
-                // native method on the next step.
+            | NativeHandlerResult.Completed (state, effect) ->
+                // Native handler ran to completion. Pop the native frame and surface
+                // WhatWeDid.Executed; this is the common case.
+                match IlMachineState.returnStackFrame loggerFactory baseClassTypes thread state with
+                | ReturnFrameResult.NormalReturn state -> ExecutionResult.Stepped (state, WhatWeDid.Executed, effect)
+                | result -> failwith $"unexpected ReturnFrameResult from extern method return: %A{result}"
+            | NativeHandlerResult.PushedManagedCallee (state, effect) ->
+                // The handler pushed a managed callee on top of itself for re-entry: leave
+                // the native frame on the stack so the dispatch loop runs the callee, then
+                // re-enters this native method on a future step.
                 ExecutionResult.Stepped (state, WhatWeDid.SuspendedForManagedCall, effect)
-            | ExecutionResult.Stepped (state, WhatWeDid.ThrowingTypeInitializationException, effect) ->
-                // Exception dispatch has already unwound past this native frame to the matching
-                // handler, so returnStackFrame would pop the wrong frame.
-                ExecutionResult.Stepped (state, WhatWeDid.ThrowingTypeInitializationException, effect)
-            | ExecutionResult.Stepped (state, WhatWeDid.BlockedOnClassInit blockedBy, effect) ->
+            | NativeHandlerResult.RaiseException (state, exnType, effect) ->
+                // The handler wants to raise `exnType`. Allocate the exception, call its
+                // parameterless ctor, and arm dispatch-on-return; leave the native frame
+                // on the stack so exception dispatch can unwind through it on the ctor's
+                // `Ret`. The handler is never re-entered. We surface
+                // SuspendedForManagedCall because, from the Scheduler's point of view, a
+                // managed callee (the ctor) has been pushed on top of the native frame.
+                let state, _whatWeDid =
+                    IlMachineStateExecution.raiseRuntimeException loggerFactory baseClassTypes exnType thread state
+
+                ExecutionResult.Stepped (state, WhatWeDid.SuspendedForManagedCall, effect)
+            | NativeHandlerResult.SuspendedForClassInit (state, effect) ->
+                // A cctor was pushed; the native frame must stay on the stack so the dispatch
+                // loop runs the cctor first, then re-enters this native method on the next step.
+                ExecutionResult.Stepped (state, WhatWeDid.SuspendedForClassInit, effect)
+            | NativeHandlerResult.BlockedOnClassInit (state, blockedBy, effect) ->
                 // Another thread owns this type's .cctor lock; the native frame must persist
                 // until that thread finishes, then we re-enter.
                 ExecutionResult.Stepped (state, WhatWeDid.BlockedOnClassInit blockedBy, effect)
-            | ExecutionResult.Stepped (state, whatWeDid, effect) ->
-                match IlMachineState.returnStackFrame loggerFactory baseClassTypes thread state with
-                | ReturnFrameResult.NormalReturn state -> ExecutionResult.Stepped (state, whatWeDid, effect)
-                | result -> failwith $"unexpected ReturnFrameResult from extern method return: %A{result}"
+            | NativeHandlerResult.ThrowingTypeInitializationException (state, effect) ->
+                // A sub-call's exception has already unwound past this native frame to the
+                // matching handler; returnStackFrame would pop the wrong frame.
+                ExecutionResult.Stepped (state, WhatWeDid.ThrowingTypeInitializationException, effect)
+            | NativeHandlerResult.Terminating executionResult ->
+                // The handler delegated to an ExternImpl that produced a terminating
+                // outcome (ProcessExit, FailFast, Terminated, UnhandledException). Surface
+                // it verbatim — frame management is irrelevant because the run is over.
+                executionResult
 
         let dispatchDelegateCtor () =
             IlMachineState.executeDelegateConstructor baseClassTypes instruction state

--- a/WoofWare.PawPrint/IlMachineStateModel.fs
+++ b/WoofWare.PawPrint/IlMachineStateModel.fs
@@ -252,6 +252,60 @@ type ExecutionResult =
         terminatingThread : ThreadId *
         CliException<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>
 
+/// Outcome of invoking a native handler (QCall, P/Invoke shim, or other host-provided
+/// primitive registered under `WoofWare.PawPrint.Native`). Each variant names a single
+/// dispatcher decision, so the dispatcher's pattern match is total and the convention
+/// "remember to set the right `WhatWeDid`" that the legacy `ExecutionResult` shape relied
+/// on is eliminated.
+///
+/// The native dispatcher (`AbstractMachine.executeOneStep.dispatchNative`) translates each
+/// variant into an `ExecutionResult`, performing frame-management on the handler's behalf
+/// (popping the native frame when it has finished, or leaving it on the stack so exception
+/// dispatch / re-entry / cctor unwinding can walk through it).
+type NativeHandlerResult =
+    /// Native handler ran to completion. Dispatcher pops the native frame and reports
+    /// `WhatWeDid.Executed` to the Scheduler.
+    | Completed of IlMachineState * StepEffect
+    /// Native handler synchronously pushed a managed callee on top of itself for re-entry:
+    /// the handler will be invoked again after the callee returns, typically via re-entry
+    /// markers placed on the eval stack so the handler can distinguish first entry from
+    /// resumption. Dispatcher leaves the native frame on the stack and reports
+    /// `WhatWeDid.SuspendedForManagedCall` to the Scheduler.
+    | PushedManagedCallee of IlMachineState * StepEffect
+    /// Native handler is raising a runtime exception. The dispatcher invokes
+    /// `IlMachineStateExecution.raiseRuntimeException` for the supplied exception type
+    /// (which must be a non-generic BCL exception with a parameterless ctor), allocating
+    /// the object, calling its ctor, and arming dispatch-on-return. The native frame stays
+    /// on the stack so exception dispatch can unwind it on the ctor's `Ret`; the handler
+    /// is never re-entered. Reports `WhatWeDid.SuspendedForManagedCall` to the Scheduler.
+    | RaiseException of IlMachineState * exnType : TypeInfo<GenericParamFromMetadata, TypeDefn> * StepEffect
+    /// A type's `.cctor` has been pushed on top of the native frame (typically because a
+    /// sub-call into managed code needed to initialise an uninitialised type). Dispatcher
+    /// leaves the native frame on the stack until the `.cctor` completes, then re-enters
+    /// the handler. Reports `WhatWeDid.SuspendedForClassInit` to the Scheduler.
+    | SuspendedForClassInit of IlMachineState * StepEffect
+    /// Another thread owns the `.cctor` lock for a type the handler needs initialised;
+    /// this thread yields. Dispatcher leaves the native frame on the stack so the handler
+    /// can be re-entered when the lock is released. Reports `WhatWeDid.BlockedOnClassInit`
+    /// to the Scheduler.
+    | BlockedOnClassInit of IlMachineState * blockedBy : ThreadId * StepEffect
+    /// A sub-call's exception (typically a `TypeInitializationException` raised by a
+    /// previously-failed `.cctor`) has already been dispatched into the guest and unwound
+    /// past this native frame to a matching handler. The state already reflects the
+    /// unwind; dispatcher leaves it alone. Reports
+    /// `WhatWeDid.ThrowingTypeInitializationException` to the Scheduler.
+    | ThrowingTypeInitializationException of IlMachineState * StepEffect
+    /// The handler produced a terminating `ExecutionResult` (one of `Terminated`,
+    /// `ProcessExit`, `FailFast`, or `UnhandledException`) that the dispatcher should
+    /// surface to the run loop verbatim, bypassing native-frame management. This variant
+    /// only arises from native bridges that delegate to ExternImpls whose interface is
+    /// typed in terms of `ExecutionResult` (e.g. `ISystem_Environment._Exit`/`FailFast`).
+    /// The embedded `ExecutionResult` is never a `Stepped` value — use
+    /// `NativeHandlerResult.ofExecutionResult` to construct one from an arbitrary
+    /// ExternImpl result, which routes `Stepped(Executed)` to `Completed` and rejects
+    /// other `Stepped` shapes as logic errors.
+    | Terminating of ExecutionResult
+
 /// Result of returning from a method frame via `Ret`.
 type ReturnFrameResult =
     /// No caller frame to return to (entry-point method hit Ret).
@@ -309,3 +363,99 @@ module ExecutionResult =
     /// other by inserting `|> steppedWith effect` in place of `|> stepped`.
     let steppedWith (effect : StepEffect) ((state, whatWeDid) : IlMachineState * WhatWeDid) : ExecutionResult =
         ExecutionResult.Stepped (state, whatWeDid, effect)
+
+[<RequireQualifiedAccess>]
+module NativeHandlerResult =
+    /// Native handler completed normally with no externally-observable effect.
+    /// The default for the overwhelming majority of native handlers.
+    let completed (state : IlMachineState) : NativeHandlerResult =
+        NativeHandlerResult.Completed (state, StepEffect.NoEffect)
+
+    /// Native handler completed normally and emitted `effect`. Use this for handlers
+    /// that performed an externally-observable side effect (e.g. `SystemNative_Write`).
+    let completedWith (effect : StepEffect) (state : IlMachineState) : NativeHandlerResult =
+        NativeHandlerResult.Completed (state, effect)
+
+    /// Native handler pushed a managed callee on top of itself for re-entry. The
+    /// handler will be re-invoked on a future step (typically distinguishing first
+    /// entry from re-entry via markers placed on the eval stack).
+    let pushedManagedCallee (state : IlMachineState) : NativeHandlerResult =
+        NativeHandlerResult.PushedManagedCallee (state, StepEffect.NoEffect)
+
+    /// Native handler is raising the given exception type. The dispatcher allocates
+    /// the exception, calls its parameterless ctor, arms dispatch-on-return, and
+    /// leaves the native frame on the stack so exception dispatch can unwind it.
+    /// The exception type must be a non-generic BCL exception (typically a field on
+    /// `BaseClassTypes`); use this for runtime-synthesised exceptions only, not for
+    /// guest-thrown exceptions (which go through `newobj` + `throw`).
+    let raiseException
+        (exnType : TypeInfo<GenericParamFromMetadata, TypeDefn>)
+        (state : IlMachineState)
+        : NativeHandlerResult
+        =
+        NativeHandlerResult.RaiseException (state, exnType, StepEffect.NoEffect)
+
+    /// Forward a `WhatWeDid.SuspendedForClassInit` outcome from a sub-call. Use this
+    /// at the leaf of a passthrough branch when the dispatcher should keep the native
+    /// frame on the stack while a `.cctor` runs.
+    let suspendedForClassInit (state : IlMachineState) : NativeHandlerResult =
+        NativeHandlerResult.SuspendedForClassInit (state, StepEffect.NoEffect)
+
+    /// Forward a `WhatWeDid.BlockedOnClassInit` outcome from a sub-call. Use this
+    /// at the leaf of a passthrough branch when another thread owns the cctor lock.
+    let blockedOnClassInit (blockedBy : ThreadId) (state : IlMachineState) : NativeHandlerResult =
+        NativeHandlerResult.BlockedOnClassInit (state, blockedBy, StepEffect.NoEffect)
+
+    /// Forward a `WhatWeDid.ThrowingTypeInitializationException` outcome from a sub-call.
+    /// Use this at the leaf of a passthrough branch when an exception has already been
+    /// dispatched past this native frame.
+    let throwingTypeInitializationException (state : IlMachineState) : NativeHandlerResult =
+        NativeHandlerResult.ThrowingTypeInitializationException (state, StepEffect.NoEffect)
+
+    /// Translate the outcome of a managed sub-call (e.g. `ensureTypeInitialised`,
+    /// `callMethod`) into a `NativeHandlerResult` the native handler can return early
+    /// with. Returns `Some` when the sub-call's outcome means the native handler must
+    /// stop work and propagate (cctor pending, blocked on another thread, exception
+    /// already dispatched). Returns `None` when the sub-call ran to completion
+    /// (`WhatWeDid.Executed`) so the handler should continue.
+    ///
+    /// `WhatWeDid.SuspendedForManagedCall` is rejected as a logic error: that variant
+    /// is produced only by native handlers themselves pushing a managed callee, never
+    /// by managed sub-calls returning to a native handler.
+    let tryEarlyReturn ((state, whatWeDid) : IlMachineState * WhatWeDid) : NativeHandlerResult option =
+        match whatWeDid with
+        | WhatWeDid.Executed -> None
+        | WhatWeDid.SuspendedForClassInit -> Some (suspendedForClassInit state)
+        | WhatWeDid.BlockedOnClassInit blockedBy -> Some (blockedOnClassInit blockedBy state)
+        | WhatWeDid.ThrowingTypeInitializationException -> Some (throwingTypeInitializationException state)
+        | WhatWeDid.SuspendedForManagedCall ->
+            failwith
+                "logic error: managed sub-call produced SuspendedForManagedCall; that variant is only valid as a native handler's own outcome"
+
+    /// Translate an `ExecutionResult` produced by an ExternImpl (`ISystem_Environment`,
+    /// `System_Threading_Monitor`, etc.) into a `NativeHandlerResult` suitable for return
+    /// from a native handler. ExternImpls produce a constrained subset of `ExecutionResult`
+    /// values:
+    ///
+    /// * `Stepped(state, WhatWeDid.Executed, effect)` — the handler ran a normal step;
+    ///   routed to `Completed(state, effect)` so the dispatcher pops the native frame.
+    /// * `Terminated`, `ProcessExit`, `FailFast`, `UnhandledException` — terminating
+    ///   outcomes wrapped in `NativeHandlerResult.Terminating` so the dispatcher surfaces
+    ///   them verbatim to the run loop, bypassing frame management.
+    ///
+    /// Any `Stepped` value with a `WhatWeDid` other than `Executed` is rejected as a logic
+    /// error: ExternImpls are not authorised to drive cctor / managed-call / exception
+    /// re-entry directly, because those decisions require structural support (re-entry
+    /// markers, `dispatchAsExceptionOnReturn` arming) that ExternImpls don't have access to.
+    /// Such cases should instead use the dedicated `NativeHandlerResult` constructors from
+    /// the native handler that called the ExternImpl.
+    let ofExecutionResult (executionResult : ExecutionResult) : NativeHandlerResult =
+        match executionResult with
+        | ExecutionResult.Stepped (state, WhatWeDid.Executed, effect) -> NativeHandlerResult.Completed (state, effect)
+        | ExecutionResult.Stepped (_, other, _) ->
+            failwith
+                $"logic error: ExternImpl produced Stepped with WhatWeDid=%A{other}; ExternImpls may only produce Executed steps or terminating outcomes. Use a dedicated NativeHandlerResult constructor from the native handler instead."
+        | ExecutionResult.Terminated _
+        | ExecutionResult.ProcessExit _
+        | ExecutionResult.FailFast _
+        | ExecutionResult.UnhandledException _ -> NativeHandlerResult.Terminating executionResult

--- a/WoofWare.PawPrint/Native/NativeArray.fs
+++ b/WoofWare.PawPrint/Native/NativeArray.fs
@@ -55,7 +55,7 @@ module NativeArray =
                 failwith
                     $"TODO: %s{operation} for rank %d{rank}; PawPrint array allocation currently models rank-1 zero-lower-bound arrays"
 
-    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -146,5 +146,5 @@ module NativeArray =
                     retArray
                     (CliType.ObjectRef (Some arrayAddr))
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeBuffer.fs
+++ b/WoofWare.PawPrint/Native/NativeBuffer.fs
@@ -366,7 +366,7 @@ module NativeBuffer =
 
         state
 
-    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -417,7 +417,7 @@ module NativeBuffer =
                 else
                     copy ctx.BaseClassTypes state dest src byteCount
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | _ -> None
 
     /// Dispatches the InternalCall (FCall) variants of `System.Buffer` that
@@ -435,7 +435,7 @@ module NativeBuffer =
     /// whole typed cells through `readManagedByref` /
     /// `writeManagedByrefWithBase` so the dest cell's CLI shape and the
     /// stored ObjectRef provenance are preserved.
-    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecute (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -481,5 +481,5 @@ module NativeBuffer =
                 else
                     copy ctx.BaseClassTypes state dest src byteCount
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeCall.fs
+++ b/WoofWare.PawPrint/Native/NativeCall.fs
@@ -482,7 +482,7 @@ module NativeCall =
 
             assemblyNameOfHandle concreteTypeHandle
 
-    let failUnimplemented (ctx : NativeCallContext) : ExecutionResult =
+    let failUnimplemented (ctx : NativeCallContext) : NativeHandlerResult =
         let instruction = ctx.Instruction
         let state = ctx.State
 

--- a/WoofWare.PawPrint/Native/NativeCustomAttribute.fs
+++ b/WoofWare.PawPrint/Native/NativeCustomAttribute.fs
@@ -70,7 +70,7 @@ module NativeCustomAttribute =
             failwith
                 $"TODO: %s{operation} %s{label} pointer must be a plain ArrayElement byref (no projections); other shapes (e.g. raw native pointers, byte-view projections) are not yet supported, got %O{other}"
 
-    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -152,7 +152,7 @@ module NativeCustomAttribute =
                         resultHandle
                         (CliType.ObjectRef (Some addr))
 
-                (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+                NativeHandlerResult.completed state |> Some
             | [] ->
                 // QCallModule is not consulted on the success path; CoreCLR threads it through
                 // `GetDataFromBlob` for SERIALIZATION_TYPE_TYPE / TAGGED_OBJECT, which the
@@ -348,13 +348,11 @@ module NativeCustomAttribute =
                         state
 
                 match typeInit with
-                | WhatWeDid.SuspendedForClassInit ->
-                    ExecutionResult.stepped (state, WhatWeDid.SuspendedForClassInit) |> Some
+                | WhatWeDid.SuspendedForClassInit -> NativeHandlerResult.suspendedForClassInit state |> Some
                 | WhatWeDid.BlockedOnClassInit blockedBy ->
-                    ExecutionResult.stepped (state, WhatWeDid.BlockedOnClassInit blockedBy) |> Some
+                    NativeHandlerResult.blockedOnClassInit blockedBy state |> Some
                 | WhatWeDid.ThrowingTypeInitializationException ->
-                    ExecutionResult.stepped (state, WhatWeDid.ThrowingTypeInitializationException)
-                    |> Some
+                    NativeHandlerResult.throwingTypeInitializationException state |> Some
                 | WhatWeDid.SuspendedForManagedCall ->
                     failwith "logic error: ensureTypeInitialised cannot suspend for an arbitrary managed call"
                 | WhatWeDid.Executed ->
@@ -454,7 +452,7 @@ module NativeCustomAttribute =
                         false // wrapExceptionInTargetInvocation
                         state
 
-                ExecutionResult.stepped (state, WhatWeDid.SuspendedForManagedCall) |> Some
+                NativeHandlerResult.pushedManagedCallee state |> Some
             | other ->
                 failwith
                     $"%s{operation}: expected at most one re-entry marker on the eval stack, got %d{other.Length} value(s): %A{other}"

--- a/WoofWare.PawPrint/Native/NativeDebugger.fs
+++ b/WoofWare.PawPrint/Native/NativeDebugger.fs
@@ -2,7 +2,7 @@ namespace WoofWare.PawPrint
 
 [<RequireQualifiedAccess>]
 module NativeDebugger =
-    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -29,10 +29,10 @@ module NativeDebugger =
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 isAttached)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | _ -> None
 
-    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecute (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -57,5 +57,5 @@ module NativeDebugger =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ofBool isAttached) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeDependentHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeDependentHandle.fs
@@ -2,7 +2,7 @@ namespace WoofWare.PawPrint
 
 [<RequireQualifiedAccess>]
 module NativeDependentHandle =
-    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecute (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -42,7 +42,7 @@ module NativeDependentHandle =
 
             let state = NativeCall.pushGcHandleAddress handle ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System.Runtime",
           "DependentHandle",
@@ -58,7 +58,7 @@ module NativeDependentHandle =
 
             let state = NativeCall.pushObjectTarget target ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System.Runtime",
           "DependentHandle",
@@ -88,7 +88,7 @@ module NativeDependentHandle =
 
             let state = NativeCall.pushObjectTarget dependent ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System.Runtime",
           "DependentHandle",
@@ -129,7 +129,7 @@ module NativeDependentHandle =
 
             let state = NativeCall.pushObjectTarget target ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System.Runtime",
           "DependentHandle",
@@ -154,7 +154,7 @@ module NativeDependentHandle =
                     GcHandles = state.GcHandles |> GcHandleRegistry.setDependent handle dependent
                 }
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System.Runtime",
           "DependentHandle",
@@ -171,7 +171,7 @@ module NativeDependentHandle =
                     GcHandles = state.GcHandles |> GcHandleRegistry.setTarget handle None
                 }
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System.Runtime",
           "DependentHandle",
@@ -192,5 +192,5 @@ module NativeDependentHandle =
             // PawPrint has no GC and free always succeeds, so we report true.
             let state = IlMachineState.pushToEvalStack (CliType.ofBool true) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeDispatch.fs
+++ b/WoofWare.PawPrint/Native/NativeDispatch.fs
@@ -2,7 +2,7 @@ namespace WoofWare.PawPrint
 
 [<RequireQualifiedAccess>]
 module NativeDispatch =
-    let private nativeHandlers : (NativeCallContext -> ExecutionResult option) list =
+    let private nativeHandlers : (NativeCallContext -> NativeHandlerResult option) list =
         [
             NativeEnvironment.tryExecute
             NativeMonitor.tryExecute
@@ -29,7 +29,7 @@ module NativeDispatch =
             NativeDebugger.tryExecute
         ]
 
-    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecute (ctx : NativeCallContext) : NativeHandlerResult option =
         nativeHandlers |> List.tryPick (fun handler -> handler ctx)
 
-    let failUnimplemented (ctx : NativeCallContext) : ExecutionResult = NativeCall.failUnimplemented ctx
+    let failUnimplemented (ctx : NativeCallContext) : NativeHandlerResult = NativeCall.failUnimplemented ctx

--- a/WoofWare.PawPrint/Native/NativeEnum.fs
+++ b/WoofWare.PawPrint/Native/NativeEnum.fs
@@ -227,7 +227,7 @@ module NativeEnum =
         | CliType.Bool value -> value <> 0uy
         | other -> failwith $"%s{operation}: expected Interop.BOOL argument as Int32, got %O{other}"
 
-    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -323,5 +323,5 @@ module NativeEnum =
                 else
                     state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeEnvironment.fs
+++ b/WoofWare.PawPrint/Native/NativeEnvironment.fs
@@ -20,7 +20,7 @@ module NativeEnvironment =
             NativeCall.readNullTerminatedUtf16 operation ctx.BaseClassTypes ctx.State ptr
             |> Some
 
-    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecute (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -39,7 +39,10 @@ module NativeEnvironment =
           [],
           MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
             let env = ISystem_Environment_Env.get ctx.Implementations
-            env.GetProcessorCount ctx.Thread state |> Some
+
+            env.GetProcessorCount ctx.Thread state
+            |> NativeHandlerResult.ofExecutionResult
+            |> Some
         | "System.Private.CoreLib",
           "System",
           "Environment",
@@ -47,7 +50,10 @@ module NativeEnvironment =
           [],
           MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
             let env = ISystem_Environment_Env.get ctx.Implementations
-            env.GetCurrentManagedThreadId ctx.Thread state |> Some
+
+            env.GetCurrentManagedThreadId ctx.Thread state
+            |> NativeHandlerResult.ofExecutionResult
+            |> Some
         | "System.Private.CoreLib",
           "System",
           "Environment",
@@ -55,7 +61,7 @@ module NativeEnvironment =
           [ ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32 ],
           MethodReturnType.Void ->
             let env = ISystem_Environment_Env.get ctx.Implementations
-            env._Exit ctx.Thread state |> Some
+            env._Exit ctx.Thread state |> NativeHandlerResult.ofExecutionResult |> Some
         | "System.Private.CoreLib", "System", "Environment", _, _, _ when
             NativeCall.tryQCallEntryPoint ctx = Some "Environment_FailFast"
             ->
@@ -98,7 +104,10 @@ module NativeEnvironment =
                     tryReadOptionalUtf16 operation "errorSource" ctx instruction.Arguments.[3]
 
                 let env = ISystem_Environment_Env.get ctx.Implementations
-                env.FailFast ctx.Thread message errorSource state |> Some
+
+                env.FailFast ctx.Thread message errorSource state
+                |> NativeHandlerResult.ofExecutionResult
+                |> Some
             | paramTypes, returnType ->
                 failwith
                     $"%s{operation}: matched QCall entry point but signature unexpected: params=%A{paramTypes}, return=%A{returnType}"

--- a/WoofWare.PawPrint/Native/NativeEventPipe.fs
+++ b/WoofWare.PawPrint/Native/NativeEventPipe.fs
@@ -40,41 +40,35 @@ module NativeEventPipe =
         | CliType.Numeric (CliNumericType.Int32 i) -> uint32 i
         | other -> failwith $"%s{operation}: expected %s{argName} to be UInt32 argument, got %O{other}"
 
-    let private pushIntPtrZero (thread : ThreadId) (state : IlMachineState) : ExecutionResult =
+    let private pushIntPtrZero (thread : ThreadId) (state : IlMachineState) : NativeHandlerResult =
         state
         |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt (NativeIntSource.Verbatim 0L)) thread
-        |> Tuple.withRight WhatWeDid.Executed
-        |> ExecutionResult.stepped
+        |> NativeHandlerResult.completed
 
-    let private pushProviderHandle (id : int64) (thread : ThreadId) (state : IlMachineState) : ExecutionResult =
+    let private pushProviderHandle (id : int64) (thread : ThreadId) (state : IlMachineState) : NativeHandlerResult =
         state
         |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt (NativeIntSource.EventPipeProviderPtr id)) thread
-        |> Tuple.withRight WhatWeDid.Executed
-        |> ExecutionResult.stepped
+        |> NativeHandlerResult.completed
 
-    let private pushEventHandle (id : int64) (thread : ThreadId) (state : IlMachineState) : ExecutionResult =
+    let private pushEventHandle (id : int64) (thread : ThreadId) (state : IlMachineState) : NativeHandlerResult =
         state
         |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt (NativeIntSource.EventPipeEventPtr id)) thread
-        |> Tuple.withRight WhatWeDid.Executed
-        |> ExecutionResult.stepped
+        |> NativeHandlerResult.completed
 
-    let private pushUInt64Zero (thread : ThreadId) (state : IlMachineState) : ExecutionResult =
+    let private pushUInt64Zero (thread : ThreadId) (state : IlMachineState) : NativeHandlerResult =
         // The CLI evaluation stack stores UInt64 in the same Int64 cell, two's-complement.
         state
         |> IlMachineState.pushToEvalStack' (EvalStackValue.Int64 (Int64Source.Verbatim 0L)) thread
-        |> Tuple.withRight WhatWeDid.Executed
-        |> ExecutionResult.stepped
+        |> NativeHandlerResult.completed
 
-    let private pushInt32 (value : int32) (thread : ThreadId) (state : IlMachineState) : ExecutionResult =
+    let private pushInt32 (value : int32) (thread : ThreadId) (state : IlMachineState) : NativeHandlerResult =
         state
         |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 value) thread
-        |> Tuple.withRight WhatWeDid.Executed
-        |> ExecutionResult.stepped
+        |> NativeHandlerResult.completed
 
-    let private justStep (state : IlMachineState) : ExecutionResult =
-        (state, WhatWeDid.Executed) |> ExecutionResult.stepped
+    let private justStep (state : IlMachineState) : NativeHandlerResult = NativeHandlerResult.completed state
 
-    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 

--- a/WoofWare.PawPrint/Native/NativeException.fs
+++ b/WoofWare.PawPrint/Native/NativeException.fs
@@ -17,7 +17,7 @@ module NativeException =
             failwith
                 $"%s{operation}: unknown ExceptionMessageKind value %d{other} (expected 1=ThreadAbort, 2=ThreadInterrupted, 3=OutOfMemory)"
 
-    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -64,5 +64,5 @@ module NativeException =
                     retString
                     (CliType.ObjectRef (Some messageAddr))
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeGcHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeGcHandle.fs
@@ -2,7 +2,7 @@ namespace WoofWare.PawPrint
 
 [<RequireQualifiedAccess>]
 module NativeGcHandle =
-    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -49,7 +49,7 @@ module NativeGcHandle =
 
             let state = NativeCall.pushGcHandleAddress handle ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "QCall_FreeGCHandleForTypeHandle",
           "System.Private.CoreLib",
           "System",
@@ -79,17 +79,16 @@ module NativeGcHandle =
                 }
 
             match returnType with
-            | MethodReturnType.Void -> (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            | MethodReturnType.Void -> NativeHandlerResult.completed state |> Some
             | MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr) ->
                 state
                 |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt (NativeIntSource.Verbatim 0L)) ctx.Thread
-                |> Tuple.withRight WhatWeDid.Executed
-                |> ExecutionResult.stepped
+                |> NativeHandlerResult.completed
                 |> Some
             | other -> failwith $"%s{operation}: unexpected return type %O{other}"
         | _ -> None
 
-    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecute (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -134,7 +133,7 @@ module NativeGcHandle =
 
             let state = NativeCall.pushGcHandleAddress handle ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System.Runtime.InteropServices",
           "GCHandle",
@@ -153,7 +152,7 @@ module NativeGcHandle =
 
             let state = IlMachineState.pushToEvalStack (CliType.ofBool true) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System.Runtime.InteropServices",
           "GCHandle",
@@ -170,7 +169,7 @@ module NativeGcHandle =
                     GcHandles = state.GcHandles |> GcHandleRegistry.free handle
                 }
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System.Runtime.InteropServices",
           "GCHandle",
@@ -193,7 +192,7 @@ module NativeGcHandle =
                     GcHandles = state.GcHandles |> GcHandleRegistry.setTarget handle target
                 }
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System.Runtime.InteropServices",
           "GCHandle",
@@ -227,5 +226,5 @@ module NativeGcHandle =
 
             let state = NativeCall.pushObjectTarget oldTarget ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeKernel32.fs
+++ b/WoofWare.PawPrint/Native/NativeKernel32.fs
@@ -104,13 +104,12 @@ module NativeKernel32 =
 
         int value
 
-    let private pushUInt32 (value : uint32) (thread : ThreadId) (state : IlMachineState) : ExecutionResult =
+    let private pushUInt32 (value : uint32) (thread : ThreadId) (state : IlMachineState) : NativeHandlerResult =
         state
         |> IlMachineState.pushToEvalStack (NativeCall.cliUInt32 value) thread
-        |> Tuple.withRight WhatWeDid.Executed
-        |> ExecutionResult.stepped
+        |> NativeHandlerResult.completed
 
-    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 

--- a/WoofWare.PawPrint/Native/NativeLowLevelMonitor.fs
+++ b/WoofWare.PawPrint/Native/NativeLowLevelMonitor.fs
@@ -28,7 +28,7 @@ module NativeLowLevelMonitor =
                 $"%s{operation}: monitor argument was IntPtr.Zero, but LowLevelMonitor invariants require a non-null handle (the wrapper would have thrown OOM at Initialize)."
         | other -> failwith $"%s{operation}: expected LowLevelMonitor handle, got %O{other}"
 
-    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecute (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -49,8 +49,7 @@ module NativeLowLevelMonitor =
             |> IlMachineState.pushToEvalStack'
                 (EvalStackValue.NativeInt (NativeIntSource.LowLevelMonitorPtr id))
                 ctx.Thread
-            |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.stepped
+            |> NativeHandlerResult.completed
             |> Some
 
         | Some "SystemNative_LowLevelMonitor_Destroy",
@@ -59,7 +58,7 @@ module NativeLowLevelMonitor =
             let operation = "SystemNative_LowLevelMonitor_Destroy"
             let id = monitorOfArgument operation instruction.Arguments.[0]
             let state = LowLevelMonitor.destroy id state
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
 
         | Some "SystemNative_LowLevelMonitor_Acquire",
           [ ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr ],
@@ -78,7 +77,7 @@ module NativeLowLevelMonitor =
                 | LowLevelMonitor.AcquireOutcome.Acquired state
                 | LowLevelMonitor.AcquireOutcome.Blocked state -> state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
 
         | Some "SystemNative_LowLevelMonitor_Release",
           [ ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr ],
@@ -86,7 +85,7 @@ module NativeLowLevelMonitor =
             let operation = "SystemNative_LowLevelMonitor_Release"
             let id = monitorOfArgument operation instruction.Arguments.[0]
             let state = LowLevelMonitor.release ctx.Thread id state
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
 
         | Some "SystemNative_LowLevelMonitor_Wait",
           [ ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr ],
@@ -94,7 +93,7 @@ module NativeLowLevelMonitor =
             let operation = "SystemNative_LowLevelMonitor_Wait"
             let id = monitorOfArgument operation instruction.Arguments.[0]
             let state = LowLevelMonitor.wait ctx.Thread id state
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
 
         | Some "SystemNative_LowLevelMonitor_TimedWait",
           [ ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr
@@ -121,6 +120,6 @@ module NativeLowLevelMonitor =
             let operation = "SystemNative_LowLevelMonitor_Signal_Release"
             let id = monitorOfArgument operation instruction.Arguments.[0]
             let state = LowLevelMonitor.signalRelease ctx.Thread id state
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
 
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeMarshal.fs
+++ b/WoofWare.PawPrint/Native/NativeMarshal.fs
@@ -2,7 +2,7 @@ namespace WoofWare.PawPrint
 
 [<RequireQualifiedAccess>]
 module NativeMarshal =
-    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecute (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -22,8 +22,7 @@ module NativeMarshal =
           MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
             state
             |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 state.Kernel.LastPInvokeError) ctx.Thread
-            |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.stepped
+            |> NativeHandlerResult.completed
             |> Some
         | "System.Private.CoreLib",
           "System.Runtime.InteropServices",
@@ -33,8 +32,7 @@ module NativeMarshal =
           MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
             state
             |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 state.Kernel.LastSystemError) ctx.Thread
-            |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.stepped
+            |> NativeHandlerResult.completed
             |> Some
         | "System.Private.CoreLib",
           "System.Runtime.InteropServices",
@@ -45,13 +43,12 @@ module NativeMarshal =
             let error =
                 NativeCall.int32Argument "Marshal.SetLastPInvokeError" instruction.Arguments.[0]
 
-            (state.MapKernel (fun kernel ->
+            state.MapKernel (fun kernel ->
                 { kernel with
                     LastPInvokeError = error
                 }
-             ),
-             WhatWeDid.Executed)
-            |> ExecutionResult.stepped
+            )
+            |> NativeHandlerResult.completed
             |> Some
         | "System.Private.CoreLib",
           "System.Runtime.InteropServices",
@@ -62,17 +59,16 @@ module NativeMarshal =
             let error =
                 NativeCall.int32Argument "Marshal.SetLastSystemError" instruction.Arguments.[0]
 
-            (state.MapKernel (fun kernel ->
+            state.MapKernel (fun kernel ->
                 { kernel with
                     LastSystemError = error
                 }
-             ),
-             WhatWeDid.Executed)
-            |> ExecutionResult.stepped
+            )
+            |> NativeHandlerResult.completed
             |> Some
         | _ -> None
 
-    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -117,24 +113,8 @@ module NativeMarshal =
                 // `ArgumentException` (resource `IDS_CANNOT_MARSHAL`) for types it can't
                 // marshal as unmanaged structures when `throwIfNotMarshalable` is set.
                 // Mirror that with a guest exception so the caller's `try/catch` can handle it.
-                //
-                // `raiseRuntimeException` pushes the exception's ctor frame on top of the
-                // current (native) frame. The native dispatcher must NOT pop us via
-                // `returnStackFrame` on the way back: when the ctor returns, exception
-                // dispatch needs the native frame still present so it can be unwound while
-                // searching for a handler. Signal that by overriding the returned
-                // `WhatWeDid` with `SuspendedForManagedCall`, matching the same convention
-                // the dispatcher uses for native handlers that synchronously push a managed
-                // callee on top of themselves.
-                let state, _ =
-                    IlMachineStateExecution.raiseRuntimeException
-                        ctx.LoggerFactory
-                        ctx.BaseClassTypes
-                        ctx.BaseClassTypes.ArgumentException
-                        ctx.Thread
-                        state
-
-                (state, WhatWeDid.SuspendedForManagedCall) |> ExecutionResult.stepped |> Some
+                NativeHandlerResult.raiseException ctx.BaseClassTypes.ArgumentException state
+                |> Some
             | Result.Error (MarshalSizeError.NotMarshalable reason) ->
                 // `throwIfNotMarshalable=false` path: CoreCLR falls through to
                 // `MethodTable::GetNativeSize` and returns whatever the type loader recorded.
@@ -151,5 +131,5 @@ module NativeMarshal =
                 let state =
                     IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 size.Size)) ctx.Thread state
 
-                (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+                NativeHandlerResult.completed state |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeMetadataImport.fs
+++ b/WoofWare.PawPrint/Native/NativeMetadataImport.fs
@@ -375,7 +375,7 @@ module NativeMetadataImport =
 
         valueType, state
 
-    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecute (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -413,7 +413,7 @@ module NativeMetadataImport =
                     ctx.Thread
                     state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System.Reflection",
           "MetadataImport",
@@ -485,7 +485,7 @@ module NativeMetadataImport =
 
             let state = writeInt32AtPointer ctx.BaseClassTypes state lengthOut values.Length
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System.Reflection",
           "MetadataImport",
@@ -520,7 +520,7 @@ module NativeMetadataImport =
             let state =
                 IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System.Reflection",
           "MetadataImport",
@@ -552,7 +552,7 @@ module NativeMetadataImport =
             let state =
                 IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System.Reflection",
           "MetadataImport",
@@ -611,7 +611,7 @@ module NativeMetadataImport =
             let state =
                 IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System.Reflection",
           "MetadataImport",
@@ -664,7 +664,7 @@ module NativeMetadataImport =
             let state =
                 IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System.Reflection",
           "MetadataImport",
@@ -804,7 +804,7 @@ module NativeMetadataImport =
             let state =
                 IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System.Reflection",
           "MetadataImport",
@@ -840,5 +840,5 @@ module NativeMetadataImport =
             let state =
                 IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeMetadataUpdater.fs
+++ b/WoofWare.PawPrint/Native/NativeMetadataUpdater.fs
@@ -2,7 +2,7 @@ namespace WoofWare.PawPrint
 
 [<RequireQualifiedAccess>]
 module NativeMetadataUpdater =
-    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -27,5 +27,5 @@ module NativeMetadataUpdater =
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 0)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeMonitor.fs
+++ b/WoofWare.PawPrint/Native/NativeMonitor.fs
@@ -14,7 +14,7 @@ module NativeMonitor =
             Some ()
         | _ -> None
 
-    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecute (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -33,6 +33,7 @@ module NativeMonitor =
           [ ConcretePrimitive state.ConcreteTypes PrimitiveType.Object ],
           MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Boolean) ->
             System_Threading_Monitor.TryEnter_FastPath ctx.BaseClassTypes ctx.Thread state
+            |> NativeHandlerResult.ofExecutionResult
             |> Some
         | "System.Private.CoreLib",
           "System.Threading",
@@ -42,6 +43,7 @@ module NativeMonitor =
             ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32 ],
           MethodReturnType.Returns (MonitorNestedEnum state.ConcreteTypes "EnterHelperResult") ->
             System_Threading_Monitor.TryEnter_FastPath_WithTimeout ctx.BaseClassTypes ctx.Thread state
+            |> NativeHandlerResult.ofExecutionResult
             |> Some
         | "System.Private.CoreLib",
           "System.Threading",
@@ -50,6 +52,7 @@ module NativeMonitor =
           [ ConcretePrimitive state.ConcreteTypes PrimitiveType.Object ],
           MethodReturnType.Returns (MonitorNestedEnum state.ConcreteTypes "LeaveHelperAction") ->
             System_Threading_Monitor.Exit_FastPath ctx.BaseClassTypes ctx.Thread state
+            |> NativeHandlerResult.ofExecutionResult
             |> Some
         | "System.Private.CoreLib",
           "System.Threading",
@@ -58,6 +61,7 @@ module NativeMonitor =
           [ ConcretePrimitive state.ConcreteTypes PrimitiveType.Object ],
           MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Boolean) ->
             System_Threading_Monitor.IsEnteredNative ctx.BaseClassTypes ctx.Thread state
+            |> NativeHandlerResult.ofExecutionResult
             |> Some
         | _ -> None
 
@@ -80,7 +84,7 @@ module NativeMonitor =
         | CliType.ObjectRef None -> failwith $"%s{operation}: ObjectHandleOnStack pointed to a null object reference"
         | other -> failwith $"%s{operation}: expected ObjectRef in ObjectHandleOnStack, got %O{other}"
 
-    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -145,7 +149,7 @@ module NativeMonitor =
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 1)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
 
         | "Monitor_Pulse",
           "System.Private.CoreLib",
@@ -167,7 +171,7 @@ module NativeMonitor =
                 addressFromObjectHandle operation ctx.BaseClassTypes state instruction.Arguments.[0]
 
             let state = SyncBlockMonitor.pulse ctx.Thread addr state
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
 
         | "Monitor_PulseAll",
           "System.Private.CoreLib",
@@ -189,6 +193,6 @@ module NativeMonitor =
                 addressFromObjectHandle operation ctx.BaseClassTypes state instruction.Arguments.[0]
 
             let state = SyncBlockMonitor.pulseAll ctx.Thread addr state
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
 
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -2,7 +2,7 @@ namespace WoofWare.PawPrint
 
 [<RequireQualifiedAccess>]
 module NativeQCall =
-    let private handlers : Map<string, NativeCallContext -> ExecutionResult option> =
+    let private handlers : Map<string, NativeCallContext -> NativeHandlerResult option> =
         [
             "ReflectionInvocation_RunClassConstructor",
             NativeRuntimeHelpers.tryExecuteQCall "ReflectionInvocation_RunClassConstructor"
@@ -109,7 +109,7 @@ module NativeQCall =
         ]
         |> Map.ofList
 
-    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecute (ctx : NativeCallContext) : NativeHandlerResult option =
         match NativeCall.tryQCallEntryPoint ctx with
         | None -> None
         | Some entryPoint -> handlers |> Map.tryFind entryPoint |> Option.bind (fun handler -> handler ctx)

--- a/WoofWare.PawPrint/Native/NativeRuntimeAssembly.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeAssembly.fs
@@ -50,7 +50,7 @@ module NativeRuntimeAssembly =
             assemblyFullName
         | other -> failwith $"%s{operation}: expected AssemblyHandle in RuntimeAssembly.m_assembly, got %O{other}"
 
-    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecute (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -85,7 +85,7 @@ module NativeRuntimeAssembly =
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 mdAssemblyToken)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System.Reflection",
           "RuntimeAssembly",
@@ -117,10 +117,10 @@ module NativeRuntimeAssembly =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ObjectRef (Some runtimeModuleAddr)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | _ -> None
 
-    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -203,7 +203,7 @@ module NativeRuntimeAssembly =
                     failwith
                         $"TODO: %s{operation} does not support assembly-forwarded manifest resource %s{actualResourceName} in %s{assemblyFullName} forwarded to %s{assemblyReference.Name.FullName}"
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "AssemblyNative_GetTypeCore",
           "System.Private.CoreLib",
           "System.Reflection",
@@ -350,7 +350,7 @@ module NativeRuntimeAssembly =
 
                 // Caller's local was preinitialized to null (Type? type = null);
                 // leaving retType untouched preserves that.
-                (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+                NativeHandlerResult.completed state |> Some
             | Some typeInfo ->
                 let runtimeTypeAddr, state =
                     if typeInfo.Generics.IsEmpty then
@@ -377,5 +377,5 @@ module NativeRuntimeAssembly =
                         retType
                         (CliType.ObjectRef (Some runtimeTypeAddr))
 
-                (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+                NativeHandlerResult.completed state |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeRuntimeFieldHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeFieldHandle.fs
@@ -59,7 +59,7 @@ module NativeRuntimeFieldHandle =
 
         IlMachineState.peByteRangeForFieldRva loggerFactory baseClassTypes assembly fieldInfo typeGenerics state
 
-    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecute (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -101,7 +101,7 @@ module NativeRuntimeFieldHandle =
             let state =
                 IlMachineState.pushToEvalStack' (EvalStackValue.ManagedPointer namePtr) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeFieldHandle",
@@ -129,10 +129,10 @@ module NativeRuntimeFieldHandle =
                     ctx.Thread
                     state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | _ -> None
 
-    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -197,5 +197,5 @@ module NativeRuntimeFieldHandle =
 
                             state |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 1) ctx.Thread
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeRuntimeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeHelpers.fs
@@ -2,7 +2,7 @@ namespace WoofWare.PawPrint
 
 [<RequireQualifiedAccess>]
 module NativeRuntimeHelpers =
-    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -47,7 +47,7 @@ module NativeRuntimeHelpers =
                 | ConcreteTypeHandle.Array _ ->
                     // Pointer, byref, fnptr, and array type descriptors have no .cctor;
                     // CoreCLR treats this as a no-op. Return immediately.
-                    (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+                    NativeHandlerResult.completed state |> Some
                 | ConcreteTypeHandle.Concrete _ ->
                     let state, typeInit =
                         IlMachineStateExecution.ensureTypeInitialised
@@ -58,7 +58,7 @@ module NativeRuntimeHelpers =
                             state
 
                     match typeInit with
-                    | WhatWeDid.Executed -> (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+                    | WhatWeDid.Executed -> NativeHandlerResult.completed state |> Some
                     | WhatWeDid.SuspendedForClassInit ->
                         // The cctor was pushed as a new frame. We must NOT go through the normal
                         // returnStackFrame path (which would pop the cctor frame we just pushed).
@@ -66,17 +66,15 @@ module NativeRuntimeHelpers =
                         // When the cctor finishes, returnStackFrame pops it, bringing us back to
                         // this native method frame. executeOneStep re-enters here and
                         // ensureTypeInitialised will return Executed.
-                        ExecutionResult.stepped (state, WhatWeDid.SuspendedForClassInit) |> Some
+                        NativeHandlerResult.suspendedForClassInit state |> Some
                     | WhatWeDid.SuspendedForManagedCall ->
                         failwith "logic error: ensureTypeInitialised cannot suspend for an arbitrary managed call"
                     | WhatWeDid.ThrowingTypeInitializationException ->
-                        (state, WhatWeDid.ThrowingTypeInitializationException)
-                        |> ExecutionResult.stepped
-                        |> Some
+                        NativeHandlerResult.throwingTypeInitializationException state |> Some
                     | WhatWeDid.BlockedOnClassInit blockedBy ->
                         // Another thread owns this type's .cctor lock. Yield so the scheduler
                         // can run that thread to completion before re-entering.
-                        ExecutionResult.stepped (state, WhatWeDid.BlockedOnClassInit blockedBy) |> Some
+                        NativeHandlerResult.blockedOnClassInit blockedBy state |> Some
         | _ -> None
 
     /// Identity hash for a managed object reference. Heap addresses are positive and
@@ -91,7 +89,7 @@ module NativeRuntimeHelpers =
         | EvalStackValue.ObjectRef (ManagedHeapAddress addr) -> addr
         | other -> failwith $"%s{operation}: expected ObjectRef or NullObjectRef, got %O{other}"
 
-    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecute (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -115,7 +113,7 @@ module NativeRuntimeHelpers =
             let state =
                 IlMachineState.pushToEvalStack' (EvalStackValue.Int32 hash) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System.Runtime.CompilerServices",
           "RuntimeHelpers",
@@ -138,5 +136,5 @@ module NativeRuntimeHelpers =
             let state =
                 IlMachineState.pushToEvalStack' (EvalStackValue.Int32 hash) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeRuntimeMethodHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeMethodHandle.fs
@@ -142,7 +142,7 @@ module NativeRuntimeMethodHandle =
 
         List.ofSeq acc
 
-    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -299,10 +299,10 @@ module NativeRuntimeMethodHandle =
                 let ret = if visible then 1 else 0
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 ret)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | _ -> None
 
-    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecute (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -340,7 +340,7 @@ module NativeRuntimeMethodHandle =
             let state =
                 IlMachineState.pushToEvalStack' (EvalStackValue.ManagedPointer namePtr) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeMethodHandle",
@@ -370,7 +370,7 @@ module NativeRuntimeMethodHandle =
                     ctx.Thread
                     state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeMethodHandle",
@@ -482,7 +482,7 @@ module NativeRuntimeMethodHandle =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ValueType returnValue) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeMethodHandle",
@@ -522,5 +522,5 @@ module NativeRuntimeMethodHandle =
 
             let state = IlMachineState.pushToEvalStack (CliType.ObjectRef None) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeFCall.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeFCall.fs
@@ -7,7 +7,7 @@ open NativeRuntimeTypeHelpers
 
 [<RequireQualifiedAccess>]
 module NativeRuntimeTypeFCall =
-    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecute (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -36,7 +36,7 @@ module NativeRuntimeTypeFCall =
             let state =
                 IlMachineState.pushToEvalStack (NativeCall.cliUInt32 bytes) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System.Runtime.CompilerServices",
           "MethodTable",
@@ -59,7 +59,7 @@ module NativeRuntimeTypeFCall =
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 elementType)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -122,7 +122,7 @@ module NativeRuntimeTypeFCall =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ofBool (count <= capacity)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -150,7 +150,7 @@ module NativeRuntimeTypeFCall =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ObjectRef (Some arrayAddr)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -174,7 +174,7 @@ module NativeRuntimeTypeFCall =
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 elementType)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -196,7 +196,7 @@ module NativeRuntimeTypeFCall =
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 token)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -222,7 +222,7 @@ module NativeRuntimeTypeFCall =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ofBool isGenericVariable) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -254,7 +254,7 @@ module NativeRuntimeTypeFCall =
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 index)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -282,7 +282,7 @@ module NativeRuntimeTypeFCall =
             | RuntimeTypeHandleTarget.Closed _ ->
                 // Type-level generic parameters and non-parameter targets return null.
                 let state = NativeCall.pushObjectTarget None ctx.Thread state
-                (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+                NativeHandlerResult.completed state |> Some
             | RuntimeTypeHandleTarget.MethodGenericParameter (declaringType, declaringMethod, position) ->
                 failwith
                     $"TODO: %s{operation} for method generic parameter #%i{position} of method %O{declaringMethod.Get} on %O{declaringType.TypeDefinition.Get}; need to allocate/return IRuntimeMethodInfo"
@@ -309,7 +309,7 @@ module NativeRuntimeTypeFCall =
 
             let state = NativeCall.pushObjectTarget declaringTypeAddr ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -329,7 +329,7 @@ module NativeRuntimeTypeFCall =
 
             let state = IlMachineState.pushToEvalStack (CliType.ofBool result) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -353,7 +353,7 @@ module NativeRuntimeTypeFCall =
 
             let state = NativeCall.pushObjectTarget baseTypeAddr ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -377,7 +377,7 @@ module NativeRuntimeTypeFCall =
 
             let state = NativeCall.pushObjectTarget elementTypeAddr ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -405,7 +405,7 @@ module NativeRuntimeTypeFCall =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ObjectRef (Some addr)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -433,7 +433,7 @@ module NativeRuntimeTypeFCall =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ObjectRef (Some addr)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -464,7 +464,7 @@ module NativeRuntimeTypeFCall =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ObjectRef (Some addr)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -493,7 +493,7 @@ module NativeRuntimeTypeFCall =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ObjectRef (Some addr)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -530,7 +530,7 @@ module NativeRuntimeTypeFCall =
             let state =
                 IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt elementTypeSource) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -617,7 +617,7 @@ module NativeRuntimeTypeFCall =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ofBool isAssignable) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -692,7 +692,7 @@ module NativeRuntimeTypeFCall =
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 attributes)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -720,7 +720,7 @@ module NativeRuntimeTypeFCall =
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 count)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -787,7 +787,7 @@ module NativeRuntimeTypeFCall =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ValueType returnValue) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System",
           "RuntimeTypeHandle",
@@ -882,5 +882,5 @@ module NativeRuntimeTypeFCall =
                     methodPtr
                     (CliType.ValueType nextValue)
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
@@ -678,8 +678,7 @@ module NativeRuntimeTypeQCall =
                         state
 
                 match typeInit with
-                | WhatWeDid.SuspendedForClassInit ->
-                    NativeHandlerResult.suspendedForClassInit state |> Some
+                | WhatWeDid.SuspendedForClassInit -> NativeHandlerResult.suspendedForClassInit state |> Some
                 | WhatWeDid.BlockedOnClassInit blockedBy ->
                     NativeHandlerResult.blockedOnClassInit blockedBy state |> Some
                 | WhatWeDid.ThrowingTypeInitializationException ->

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
@@ -7,7 +7,7 @@ open NativeRuntimeTypeHelpers
 
 [<RequireQualifiedAccess>]
 module NativeRuntimeTypeQCall =
-    let tryExecute (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecute (entryPoint : string) (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -61,7 +61,7 @@ module NativeRuntimeTypeQCall =
                     retString
                     (CliType.ObjectRef (Some nameAddr))
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "TypeHandle_GetCorElementType",
           "System.Private.CoreLib",
           "System.Runtime.CompilerServices",
@@ -84,7 +84,7 @@ module NativeRuntimeTypeQCall =
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 elementType)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "TypeHandle_CanCastTo_NoCacheLookup",
           "System.Private.CoreLib",
           "System.Runtime.CompilerServices",
@@ -148,7 +148,7 @@ module NativeRuntimeTypeQCall =
                 let ret = if isAssignable then 1 else 0
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 ret)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "MethodTable_CanCompareBitsOrUseFastGetHashCode",
           "System.Private.CoreLib",
           "System",
@@ -180,7 +180,7 @@ module NativeRuntimeTypeQCall =
 
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 ret)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "RuntimeTypeHandle_Instantiate",
           "System.Private.CoreLib",
           "System",
@@ -239,26 +239,8 @@ module NativeRuntimeTypeQCall =
 
             match constraintViolation with
             | Some _message ->
-                // raiseRuntimeException pushes the ArgumentException ctor frame on top of
-                // this native QCall frame and arms `dispatchAsExceptionOnReturn`, so when
-                // the ctor finishes its `Ret` will dispatch.  From the QCall dispatch
-                // loop's point of view we have set up a managed continuation, exactly the
-                // shape described by `SuspendedForManagedCall`: the native frame must
-                // stay on the stack while the ctor runs.  We override the
-                // `WhatWeDid.Executed` that `raiseRuntimeException` returns (which is
-                // the right answer for IL-handler callers, where the ctor frame becomes
-                // the new active frame and no QCall return-frame logic runs over it).
-                // Exception dispatch on the ctor's `Ret` will eventually unwind the
-                // native QCall frame too, so we never re-enter this handler.
-                let state, _ =
-                    IlMachineStateExecution.raiseRuntimeException
-                        ctx.LoggerFactory
-                        ctx.BaseClassTypes
-                        ctx.BaseClassTypes.ArgumentException
-                        ctx.Thread
-                        state
-
-                ExecutionResult.stepped (state, WhatWeDid.SuspendedForManagedCall) |> Some
+                NativeHandlerResult.raiseException ctx.BaseClassTypes.ArgumentException state
+                |> Some
             | None ->
 
             let instantiatedHandle, state =
@@ -284,7 +266,7 @@ module NativeRuntimeTypeQCall =
                     retType
                     (CliType.ObjectRef (Some runtimeTypeAddr))
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "RuntimeTypeHandle_GetInstantiation",
           "System.Private.CoreLib",
           "System",
@@ -368,7 +350,7 @@ module NativeRuntimeTypeQCall =
             // Empty: leave the caller's local null. RuntimeType.GetGenericArguments handles
             // null via `?? EmptyTypes`, matching native CopyRuntimeTypeHandles for 0 args.
             if genericArgumentTargets.IsEmpty then
-                (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+                NativeHandlerResult.completed state |> Some
             else
                 let elementTypeName = if asRuntimeTypeArray then "RuntimeType" else "Type"
 
@@ -406,7 +388,7 @@ module NativeRuntimeTypeQCall =
                         retTypes
                         (CliType.ObjectRef (Some arrayAddr))
 
-                (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+                NativeHandlerResult.completed state |> Some
         | "RuntimeTypeHandle_GetConstraints",
           "System.Private.CoreLib",
           "System",
@@ -551,7 +533,7 @@ module NativeRuntimeTypeQCall =
                     // CopyRuntimeTypeHandles writes NULL when count = 0; the managed wrapper turns
                     // the resulting null into Type.EmptyTypes via `?? EmptyTypes`. Leave the
                     // caller's local null untouched.
-                    (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+                    NativeHandlerResult.completed state |> Some
                 else
                     // CopyRuntimeTypeHandles allocates Type[] (CLASS__TYPE) — not RuntimeType[].
                     let state, _, typeHandle =
@@ -588,7 +570,7 @@ module NativeRuntimeTypeQCall =
                             retTypes
                             (CliType.ObjectRef (Some arrayAddr))
 
-                    (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+                    NativeHandlerResult.completed state |> Some
 
             | RuntimeTypeHandleTarget.MethodGenericParameter (declaringType, declaringMethod, position) ->
                 failwith
@@ -656,7 +638,7 @@ module NativeRuntimeTypeQCall =
                         outHandle
                         (CliType.ObjectRef (Some addr))
 
-                (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+                NativeHandlerResult.completed state |> Some
             | [] ->
                 let typeHandleTarget =
                     NativeCall.qCallTypeHandleToRuntimeTypeHandleTarget
@@ -697,12 +679,11 @@ module NativeRuntimeTypeQCall =
 
                 match typeInit with
                 | WhatWeDid.SuspendedForClassInit ->
-                    ExecutionResult.stepped (state, WhatWeDid.SuspendedForClassInit) |> Some
+                    NativeHandlerResult.suspendedForClassInit state |> Some
                 | WhatWeDid.BlockedOnClassInit blockedBy ->
-                    ExecutionResult.stepped (state, WhatWeDid.BlockedOnClassInit blockedBy) |> Some
+                    NativeHandlerResult.blockedOnClassInit blockedBy state |> Some
                 | WhatWeDid.ThrowingTypeInitializationException ->
-                    ExecutionResult.stepped (state, WhatWeDid.ThrowingTypeInitializationException)
-                    |> Some
+                    NativeHandlerResult.throwingTypeInitializationException state |> Some
                 | WhatWeDid.SuspendedForManagedCall ->
                     failwith "logic error: ensureTypeInitialised cannot suspend for an arbitrary managed call"
                 | WhatWeDid.Executed ->
@@ -787,7 +768,7 @@ module NativeRuntimeTypeQCall =
                         false // wrapExceptionInTargetInvocation
                         state
 
-                ExecutionResult.stepped (state, WhatWeDid.SuspendedForManagedCall) |> Some
+                NativeHandlerResult.pushedManagedCallee state |> Some
             | other ->
                 failwith
                     $"%s{operation}: expected at most one re-entry marker on the eval stack, got %d{other.Length} value(s): %A{other}"
@@ -873,7 +854,7 @@ module NativeRuntimeTypeQCall =
             let state =
                 IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt returnSource) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "RuntimeTypeHandle_GetDeclaringTypeHandleForGenericVariable",
           "System.Private.CoreLib",
           "System",
@@ -948,7 +929,7 @@ module NativeRuntimeTypeQCall =
                     ctx.Thread
                     state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "RuntimeTypeHandle_GetDeclaringMethodForGenericParameter",
           "System.Private.CoreLib",
           "System",
@@ -988,7 +969,7 @@ module NativeRuntimeTypeQCall =
             | RuntimeTypeHandleTarget.GenericParameter _ ->
                 // Type-level generic parameter: CoreCLR's `defToken` is mdtTypeDef,
                 // so the early-exit branch leaves `result` null. Mirror that.
-                (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+                NativeHandlerResult.completed state |> Some
             | RuntimeTypeHandleTarget.MethodGenericParameter (declaringType, declaringMethod, position) ->
                 failwith
                     $"TODO: %s{operation} for method generic parameter #%i{position} of method %O{declaringMethod.Get} on %O{declaringType.TypeDefinition.Get}; need to allocate and return an IRuntimeMethodInfo for the declaring method (same gap as the RuntimeTypeHandle.GetDeclaringMethod InternalCall)"
@@ -1149,7 +1130,7 @@ module NativeRuntimeTypeQCall =
                     retType
                     (CliType.ObjectRef (Some runtimeTypeAddr))
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "ModuleHandle_ResolveMethod",
           "System.Private.CoreLib",
           "System",
@@ -1373,7 +1354,7 @@ module NativeRuntimeTypeQCall =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ValueType handleValue) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "RuntimeTypeHandle_GetFields",
           "System.Private.CoreLib",
           "System",
@@ -1468,7 +1449,7 @@ module NativeRuntimeTypeQCall =
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 result)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "RuntimeTypeHandle_GetInterfaces",
           "System.Private.CoreLib",
           "System",
@@ -1601,7 +1582,7 @@ module NativeRuntimeTypeQCall =
 
             if List.isEmpty interfaceHandles then
                 // Mirror CoreCLR: skip the allocation and leave the caller's `[]` local intact.
-                (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+                NativeHandlerResult.completed state |> Some
             else
                 let state, _, runtimeTypeElementHandle =
                     concretizeNonGenericCorelibType ctx.LoggerFactory ctx.BaseClassTypes state "System" "RuntimeType"
@@ -1641,5 +1622,5 @@ module NativeRuntimeTypeQCall =
                         retArray
                         (CliType.ObjectRef (Some arrayAddr))
 
-                (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+                NativeHandlerResult.completed state |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeSignature.fs
+++ b/WoofWare.PawPrint/Native/NativeSignature.fs
@@ -135,7 +135,7 @@ module NativeSignature =
 
         state
 
-    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -221,10 +221,10 @@ module NativeSignature =
                     "_sig"
                     state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | _ -> None
 
-    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecute (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -306,5 +306,5 @@ module NativeSignature =
                     "m_sig"
                     state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeString.fs
+++ b/WoofWare.PawPrint/Native/NativeString.fs
@@ -46,7 +46,7 @@ module NativeString =
         | CliType.Numeric (CliNumericType.Int32 count) -> checkedLength (int64 count)
         | other -> failwith $"%s{operation}: expected nint length, got %O{other}"
 
-    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecute (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -75,7 +75,7 @@ module NativeString =
 
             state
             |> allocateAndPushBlankString ctx length
-            |> fun state -> (state, WhatWeDid.Executed) |> ExecutionResult.stepped
+            |> fun state -> NativeHandlerResult.completed state
             |> Some
         | "System.Private.CoreLib",
           "System",
@@ -112,7 +112,7 @@ module NativeString =
 
             state
             |> allocateAndPushBlankString ctx length
-            |> fun state -> (state, WhatWeDid.Executed) |> ExecutionResult.stepped
+            |> fun state -> NativeHandlerResult.completed state
             |> Some
         | "System.Private.CoreLib",
           "System",
@@ -245,7 +245,7 @@ module NativeString =
             // the placeholder allocated by executeNewobj is left as garbage.
             state
             |> IlMachineState.withReplacedConstructedObject newAddr ctx.Thread
-            |> fun state -> (state, WhatWeDid.Executed) |> ExecutionResult.stepped
+            |> fun state -> NativeHandlerResult.completed state
             |> Some
         | "System.Private.CoreLib",
           "System",
@@ -295,6 +295,6 @@ module NativeString =
             // the placeholder allocated by executeNewobj is left as garbage.
             state
             |> IlMachineState.withReplacedConstructedObject newAddr ctx.Thread
-            |> fun state -> (state, WhatWeDid.Executed) |> ExecutionResult.stepped
+            |> fun state -> NativeHandlerResult.completed state
             |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeSystemNative.fs
+++ b/WoofWare.PawPrint/Native/NativeSystemNative.fs
@@ -9,11 +9,10 @@ module NativeSystemNative =
         | Some import when import.ModuleName = "libSystem.Native" -> Some import.EntryPointName
         | _ -> None
 
-    let private pushInt32 (value : int) (ctx : NativeCallContext) : ExecutionResult =
+    let private pushInt32 (value : int) (ctx : NativeCallContext) : NativeHandlerResult =
         ctx.State
         |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 value) ctx.Thread
-        |> Tuple.withRight WhatWeDid.Executed
-        |> ExecutionResult.stepped
+        |> NativeHandlerResult.completed
 
     /// Decode an `nint`-shaped Unix file-descriptor argument. CoreLib passes
     /// fds across the SystemNative boundary as plain `IntPtr` values (the low
@@ -74,7 +73,7 @@ module NativeSystemNative =
         | CliType.Numeric (CliNumericType.Int32 count) -> checkedCount (int64 count)
         | other -> failwith $"%s{operation}: expected UIntPtr allocation size, got %O{other}"
 
-    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecute (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -99,13 +98,12 @@ module NativeSystemNative =
             let error =
                 NativeCall.int32Argument "SystemNative_SetErrNo" instruction.Arguments.[0]
 
-            (state.MapKernel (fun kernel ->
+            state.MapKernel (fun kernel ->
                 { kernel with
                     LastSystemError = error
                 }
-             ),
-             WhatWeDid.Executed)
-            |> ExecutionResult.stepped
+            )
+            |> NativeHandlerResult.completed
             |> Some
         | Some "SystemNative_Malloc",
           [ ConcreteUIntPtr state.ConcreteTypes ],
@@ -124,8 +122,7 @@ module NativeSystemNative =
 
             state
             |> IlMachineState.pushToEvalStack' (EvalStackValue.ManagedPointer ptrSrc) ctx.Thread
-            |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.stepped
+            |> NativeHandlerResult.completed
             |> Some
         | Some "SystemNative_Calloc",
           [ ConcreteUIntPtr state.ConcreteTypes ; ConcreteUIntPtr state.ConcreteTypes ],
@@ -153,8 +150,7 @@ module NativeSystemNative =
 
             state
             |> IlMachineState.pushToEvalStack' (EvalStackValue.ManagedPointer ptrSrc) ctx.Thread
-            |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.stepped
+            |> NativeHandlerResult.completed
             |> Some
         | Some "SystemNative_Dup",
           [ ConcreteIntPtr state.ConcreteTypes ],
@@ -187,8 +183,7 @@ module NativeSystemNative =
 
             state
             |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt (NativeIntSource.Verbatim resultFd)) ctx.Thread
-            |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.stepped
+            |> NativeHandlerResult.completed
             |> Some
         | Some "SystemNative_Close",
           [ ConcreteIntPtr state.ConcreteTypes ],
@@ -221,8 +216,7 @@ module NativeSystemNative =
 
             state
             |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 resultCode) ctx.Thread
-            |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.stepped
+            |> NativeHandlerResult.completed
             |> Some
         | Some "SystemNative_Write",
           [ ConcreteIntPtr state.ConcreteTypes
@@ -392,8 +386,7 @@ module NativeSystemNative =
 
             state
             |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 result) ctx.Thread
-            |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.steppedWith effect
+            |> NativeHandlerResult.completedWith effect
             |> Some
         | Some "SystemNative_GetNonCryptographicallySecureRandomBytes",
           [ ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.Byte)
@@ -468,7 +461,7 @@ module NativeSystemNative =
                             }
                         )
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | Some "SystemNative_Free", [ ConcretePointer _ ], MethodReturnType.Void ->
             let ptr =
                 NativeCall.managedPointerOfPointerArgument "SystemNative_Free" "ptr" instruction.Arguments.[0]
@@ -504,5 +497,5 @@ module NativeSystemNative =
                     failwith
                         $"SystemNative_Free: expected null or native-heap pointer, got %O{other} (only pointers from SystemNative_Malloc/Calloc may be freed here)"
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeThreading.fs
+++ b/WoofWare.PawPrint/Native/NativeThreading.fs
@@ -186,7 +186,7 @@ module NativeThreading =
 
         IlMachineState.allocateUnstartedThread threadAddr state
 
-    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -228,7 +228,7 @@ module NativeThreading =
                     threadOut
                     (CliType.ObjectRef (Some addr))
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "ThreadNative_Initialize",
           "System.Private.CoreLib",
           "System.Threading",
@@ -259,7 +259,7 @@ module NativeThreading =
                 | other -> failwith $"%s{operation}: expected ObjectRef in ObjectHandleOnStack, got %O{other}"
 
             let state, _newThreadId = initializeThreadObject threadAddr state
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "ThreadNative_Join",
           "System.Private.CoreLib",
           "System.Threading",
@@ -307,7 +307,7 @@ module NativeThreading =
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 resultInt)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "ThreadNative_SetIsBackground",
           "System.Private.CoreLib",
           "System.Threading",
@@ -373,7 +373,7 @@ module NativeThreading =
                     ThreadState = state.ThreadState |> Map.add targetThreadId updatedThreadState
                 }
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "ThreadNative_GetIsBackground",
           "System.Private.CoreLib",
           "System.Threading",
@@ -420,10 +420,10 @@ module NativeThreading =
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 resultInt)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | _ -> None
 
-    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecute (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -450,7 +450,7 @@ module NativeThreading =
             let state =
                 IlMachineState.pushToEvalStack (CliType.ObjectRef (Some addr)) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib", "System.Threading", "Thread", "Initialize", [], MethodReturnType.Void ->
             // Pre-.NET 10 InternalCall backing `new Thread(...)` constructor. .NET 10 routes the
             // same logic through the ThreadNative_Initialize QCall above.
@@ -463,7 +463,7 @@ module NativeThreading =
                 | other -> failwith $"Thread.Initialize: expected ObjectRef for 'this', got %O{other}"
 
             let state, _newThreadId = initializeThreadObject threadAddr state
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib", "System.Threading", "Thread", "StartInternal", _, MethodReturnType.Void ->
             // StartInternal (ThreadHandle t, int stackSize, int priority, Interop.BOOL isThreadPool, char* pThreadName) -> void
             // We don't yet model stack size / priority / thread-pool / native name; we recover the
@@ -652,7 +652,7 @@ module NativeThreading =
 
             let state = Scheduler.onWorkerSpawned newThreadId workerInitOutcome state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System.Threading",
           "Thread",
@@ -679,5 +679,5 @@ module NativeThreading =
 
             let state = IlMachineState.pushToEvalStack (CliType.ofBool result) ctx.Thread state
 
-            (state, WhatWeDid.Executed) |> ExecutionResult.stepped |> Some
+            NativeHandlerResult.completed state |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeType.fs
+++ b/WoofWare.PawPrint/Native/NativeType.fs
@@ -2,7 +2,7 @@ namespace WoofWare.PawPrint
 
 [<RequireQualifiedAccess>]
 module NativeType =
-    let tryExecute (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecute (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 

--- a/WoofWare.PawPrint/Native/NativeWaitHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeWaitHandle.fs
@@ -335,7 +335,7 @@ module NativeWaitHandle =
         | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.ManagedPointer ptr)) -> Some ptr
         | other -> failwith $"%s{operation}: expected %s{argName} to be a managed int pointer or null, got %O{other}"
 
-    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : ExecutionResult option =
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
 
@@ -377,8 +377,7 @@ module NativeWaitHandle =
             state
             |> withLastSystemError 0
             |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt (NativeIntSource.WaitHandlePtr id)) ctx.Thread
-            |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.stepped
+            |> NativeHandlerResult.completed
             |> Some
 
         | "ReleaseSemaphore",
@@ -413,16 +412,14 @@ module NativeWaitHandle =
                 state
                 |> withLastSystemError 0
                 |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 1) ctx.Thread
-                |> Tuple.withRight WhatWeDid.Executed
-                |> ExecutionResult.stepped
+                |> NativeHandlerResult.completed
                 |> Some
 
             | Error (WaitHandle.ReleaseFailure.WouldExceedMaximum _) ->
                 state
                 |> withLastSystemError errorTooManyPosts
                 |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread
-                |> Tuple.withRight WhatWeDid.Executed
-                |> ExecutionResult.stepped
+                |> NativeHandlerResult.completed
                 |> Some
 
         | "CloseHandle",
@@ -437,8 +434,7 @@ module NativeWaitHandle =
             state
             |> withLastSystemError 0
             |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 1) ctx.Thread
-            |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.stepped
+            |> NativeHandlerResult.completed
             |> Some
 
         | "WaitHandle_WaitOneCore",
@@ -469,8 +465,7 @@ module NativeWaitHandle =
 
             state
             |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 ret) ctx.Thread
-            |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.stepped
+            |> NativeHandlerResult.completed
             |> Some
 
         | "WaitHandle_WaitOnePrioritized",
@@ -507,8 +502,7 @@ module NativeWaitHandle =
 
             state
             |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 ret) ctx.Thread
-            |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.stepped
+            |> NativeHandlerResult.completed
             |> Some
 
         | "PAL_CreateMutexW",
@@ -554,8 +548,7 @@ module NativeWaitHandle =
             state
             |> withLastSystemError 0
             |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt (NativeIntSource.WaitHandlePtr id)) ctx.Thread
-            |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.stepped
+            |> NativeHandlerResult.completed
             |> Some
 
         | "ReleaseMutex",
@@ -578,15 +571,13 @@ module NativeWaitHandle =
                 state
                 |> withLastSystemError 0
                 |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 1) ctx.Thread
-                |> Tuple.withRight WhatWeDid.Executed
-                |> ExecutionResult.stepped
+                |> NativeHandlerResult.completed
                 |> Some
             | Error WaitHandle.ReleaseMutexFailure.NotOwner ->
                 state
                 |> withLastSystemError errorNotOwner
                 |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread
-                |> Tuple.withRight WhatWeDid.Executed
-                |> ExecutionResult.stepped
+                |> NativeHandlerResult.completed
                 |> Some
 
         | "CreateEventExW",
@@ -628,8 +619,7 @@ module NativeWaitHandle =
             state
             |> withLastSystemError 0
             |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt (NativeIntSource.WaitHandlePtr id)) ctx.Thread
-            |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.stepped
+            |> NativeHandlerResult.completed
             |> Some
 
         | "SetEvent",
@@ -649,8 +639,7 @@ module NativeWaitHandle =
             state
             |> withLastSystemError 0
             |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 1) ctx.Thread
-            |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.stepped
+            |> NativeHandlerResult.completed
             |> Some
 
         | "ResetEvent",
@@ -665,8 +654,7 @@ module NativeWaitHandle =
             state
             |> withLastSystemError 0
             |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 1) ctx.Thread
-            |> Tuple.withRight WhatWeDid.Executed
-            |> ExecutionResult.stepped
+            |> NativeHandlerResult.completed
             |> Some
 
         | _ -> None


### PR DESCRIPTION
## Summary

- Native handlers previously returned `ExecutionResult` and relied on the convention "remember to set the right `WhatWeDid` so the dispatcher doesn't pop your frame at the wrong moment." That convention was footgun-bait: every `raiseRuntimeException` call site needed a multi-line comment explaining that the `WhatWeDid.Executed` it returns must be overridden to `SuspendedForManagedCall`, or exception dispatch would unwind the wrong frame.
- This PR replaces that contract with a structured discriminated union, `NativeHandlerResult`, whose seven variants each name a single dispatcher action: pop the frame; leave it for a managed callee; raise a runtime exception; leave it for a cctor; record a cctor block; record an unwound type-init exception; or surface a terminating `ExecutionResult` from an ExternImpl. `AbstractMachine.dispatchNative` does a total pattern match — no default arm into which a misclassified handler can fall.
- The new `RaiseException` variant makes the original bug class structurally impossible: handlers describe "raise this exception type" and the dispatcher synthesises the exception object and arms dispatch-on-return on their behalf, so the legacy "manual `raiseRuntimeException` + override `WhatWeDid`" dance is gone.

## Test plan

- [x] `nix develop -c dotnet build WoofWare.PawPrint.slnx` — 0 warnings, 0 errors
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --no-build` — 1142/1142 pass
- [x] `codex review --base main` — clean (no blocking findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)