### PR TITLE
Extend cast oracle to open generic-definition source handles

### DIFF
--- a/WoofWare.PawPrint.Test/TestCrossAssemblyIsAssignableFrom.fs
+++ b/WoofWare.PawPrint.Test/TestCrossAssemblyIsAssignableFrom.fs
@@ -1,0 +1,86 @@
+namespace WoofWare.PawPrint.Test
+
+open NUnit.Framework
+
+[<TestFixture>]
+module TestCrossAssemblyIsAssignableFrom =
+
+    [<Test>]
+    let ``IsAssignableFrom open generic with cross-assembly partially substituted base`` () : unit =
+        // Three assemblies, deliberately fanning out the type references the cast oracle
+        // has to thread through:
+        //   ArgLib  defines `Arg`              (used as the closed slot of the partial substitution)
+        //   BaseLib defines `Anchor<X>` and `Base<X,Y> : Anchor<X>` (BaseLib does NOT reference ArgLib)
+        //   Entry   defines `Derived<T> : Base<Arg,T>` and runs the IsAssignableFrom check.
+        //
+        // When the open walk starts at `Derived<>` it threads `[Arg, GP(0)]` into Base's
+        // walk. The `Arg` TypeRef is interpreted in Entry's reference tables, so deep down
+        // when the walk asks BaseLib to materialise `Anchor<Arg>` the substitution must
+        // already have been canonicalised to a `FromDefinition` carrying ArgLib's identity;
+        // otherwise BaseLib's TypeRef tables (which never name ArgLib) would fail to
+        // resolve `Arg`. Regression test for that cross-assembly thread.
+        {
+            Assemblies =
+                [
+                    CrossAssemblySpec.library
+                        "IsAssignableFromCrossOpenGeneric.ArgLib"
+                        []
+                        [
+                            """
+namespace IsAssignableFromCrossOpenGeneric.ArgLib;
+
+public class Arg
+{
+}
+"""
+                        ]
+                    CrossAssemblySpec.library
+                        "IsAssignableFromCrossOpenGeneric.BaseLib"
+                        []
+                        [
+                            """
+namespace IsAssignableFromCrossOpenGeneric.BaseLib;
+
+public class Anchor<X>
+{
+}
+
+public class Base<X, Y> : Anchor<X>
+{
+}
+"""
+                        ]
+                    CrossAssemblySpec.entryPoint
+                        "IsAssignableFromCrossOpenGeneric.Entry"
+                        [
+                            "IsAssignableFromCrossOpenGeneric.ArgLib"
+                            "IsAssignableFromCrossOpenGeneric.BaseLib"
+                        ]
+                        [
+                            """
+using IsAssignableFromCrossOpenGeneric.ArgLib;
+using IsAssignableFromCrossOpenGeneric.BaseLib;
+
+public class Derived<T> : Base<Arg, T>
+{
+}
+
+class Program
+{
+    static int Main(string[] args)
+    {
+        if (!typeof(Anchor<Arg>).IsAssignableFrom(typeof(Derived<>))) return 1;
+        // Negative direction: Derived's binding fixes Base's X to Arg, not some other type;
+        // asking against Anchor<int> must reject the same chain.
+        if (typeof(Anchor<int>).IsAssignableFrom(typeof(Derived<>))) return 2;
+        return 0;
+    }
+}
+"""
+                        ]
+                ]
+            EntryAssemblyName = "IsAssignableFromCrossOpenGeneric.Entry"
+            ExpectedReturnCode = 0
+            NativeImpls = MockEnv.make ()
+        }
+        |> CrossAssemblyHarness.runTest

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -19,7 +19,6 @@ module TestPureCases =
         [
             "AdvancedStructLayout.cs" // past MarshalNative_SizeOfHelper for ByValTStr and SystemNative_Malloc / SystemNative_Free / Marshal.AllocHGlobal / FreeHGlobal; now blocked downstream at the unimplemented MarshalNative_TryGetStructMarshalStub QCall (CoreLib's Marshal.StructureToPtr path)
             "LdtokenField.cs" // past Buffer's reflection-cache copy (cell-aware path); now blocked on the next reflection-cache step at unimplemented InternalCall RuntimeFieldHandle::GetApproxDeclaringMethodTable
-            "IsAssignableFromOpenGenericDefinition.cs" // TypeHandle.CanCastTo_NoCacheLookup for open generic
             "InterfaceDispatch.cs" // expected: 0; was: 1024
             "Threads.cs" // past Buffer's reflection-cache copy and ThreadNative_SetIsBackground; now blocked on unimplemented QCall ThreadNative_InformThreadNameChange (BCL Thread.Name setter / SetThreadPoolWorkerThreadName)
             "IsAssignableToBasic.cs" // MethodTable field projection for MethodTable::PerInstInfo

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -39,6 +39,7 @@
     <Compile Include="TestCrossAssemblyTypeInitialisation.fs" />
     <Compile Include="TestCrossAssemblyCastclass.fs" />
     <Compile Include="TestCrossAssemblyDispatch.fs" />
+    <Compile Include="TestCrossAssemblyIsAssignableFrom.fs" />
     <Compile Include="TestNativeMethodDetection.fs" />
     <Compile Include="TestUnsafeAccessorRead.fs" />
     <Compile Include="TestNativeKernel32.fs" />

--- a/WoofWare.PawPrint.Test/sourcesPure/IsAssignableFromOpenGenericClosedBase.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/IsAssignableFromOpenGenericClosedBase.cs
@@ -1,0 +1,22 @@
+class GenericBase<T> { }
+
+class ConstBase<T> : GenericBase<int> { }
+
+public class Program
+{
+    public static int Main(string[] args)
+    {
+        // The source is the open definition `ConstBase<>`; the target is the closed
+        // generic instantiation `GenericBase<int>`. `ConstBase<T>`'s base is
+        // `GenericBase<int>`, which contains no unbound generic parameter and can be
+        // materialised directly as a `ConcreteTypeHandle`. The cast oracle then
+        // delegates to the Closed/Closed branch, which succeeds. Exercises that the
+        // closed-generic target case isn't blanket-rejected by the open-source walk.
+        if (!typeof(GenericBase<int>).IsAssignableFrom(typeof(ConstBase<>))) return 1;
+
+        // And the negative direction: `ConstBase<>`'s base is `GenericBase<int>`, not
+        // `GenericBase<string>`, so the cast must reject.
+        if (typeof(GenericBase<string>).IsAssignableFrom(typeof(ConstBase<>))) return 2;
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/IsAssignableFromOpenGenericInterface.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/IsAssignableFromOpenGenericInterface.cs
@@ -1,0 +1,21 @@
+using System;
+
+class DisposableThing<T> : IDisposable
+{
+    public void Dispose() { }
+}
+
+public class Program
+{
+    public static int Main(string[] args)
+    {
+        // The source is the open generic definition `DisposableThing<>` (TypeDesc-shaped
+        // RuntimeTypeHandleTarget). The cast oracle has to walk the source's interface
+        // list, recognise that the `IDisposable` edge contains no unbound generic
+        // parameter, materialise it as a closed `ConcreteTypeHandle`, and delegate the
+        // edge check to the existing Closed/Closed oracle. Exercises the
+        // materialise-and-check branch of the open-source walk.
+        if (!typeof(IDisposable).IsAssignableFrom(typeof(DisposableThing<>))) return 1;
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/IsAssignableFromOpenGenericInterfaceObject.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/IsAssignableFromOpenGenericInterfaceObject.cs
@@ -1,0 +1,17 @@
+interface IFoo<T> { }
+
+public class Program
+{
+    public static int Main(string[] args)
+    {
+        // `IFoo<T>` is an open generic interface with NO non-generic parent interfaces:
+        // its metadata `extends` clause is empty and `ImplementedInterfaces` is empty.
+        // The open-source cast walk must still recognise that every reference type
+        // (including interfaces) is assignable to `System.Object`, mirroring the
+        // closed cast oracle's `walkBase` fallback when the inheritance chain runs out.
+        // Without that fallback the walk would emit false here even though CoreCLR
+        // returns true.
+        if (!typeof(object).IsAssignableFrom(typeof(IFoo<>))) return 1;
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/IsAssignableFromOpenGenericOpenTarget.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/IsAssignableFromOpenGenericOpenTarget.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+
+class Derived<T> : List<T> { }
+
+public class Program
+{
+    public static int Main(string[] args)
+    {
+        // Open-generic *target* handles in CoreCLR are identity-only: even if a closed
+        // instantiation would be assignable, asking whether the open definition of one
+        // type is assignable from the open definition of another is always false unless
+        // the two definitions are the same. Concretely, every List<T> derives from
+        // IEnumerable<T>, but `typeof(IEnumerable<>).IsAssignableFrom(typeof(List<>))`
+        // is false because the question being asked is whether the type token "the open
+        // definition of IEnumerable<>" can be assigned a value of "the open definition
+        // of List<>", and open definitions are not instantiable types.
+        if (typeof(IEnumerable<>).IsAssignableFrom(typeof(List<>))) return 1;
+
+        // Identity does succeed: an open definition is assignable from itself.
+        if (!typeof(List<>).IsAssignableFrom(typeof(List<>))) return 2;
+
+        // Even a derived open definition is not assignable to its open base.
+        if (typeof(List<>).IsAssignableFrom(typeof(Derived<>))) return 3;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/IsAssignableFromOpenGenericPartialSubstitution.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/IsAssignableFromOpenGenericPartialSubstitution.cs
@@ -1,0 +1,28 @@
+class IFooBox<T> { }
+
+class FooBox<X, Y> : IFooBox<X> { }
+
+class FixedFooBox<T> : FooBox<int, T> { }
+
+public class Program
+{
+    public static int Main(string[] args)
+    {
+        // `FixedFooBox<T>` inherits from `FooBox<int, T>`, which itself inherits from
+        // `IFooBox<X>` (where X is FooBox's first generic parameter). The cast oracle has
+        // to follow this chain while preserving the partial substitution: walking from
+        // `FixedFooBox<>` to `FooBox<int, T>` binds FooBox's X to `int` and FooBox's Y to
+        // T (still open). When the walk then inspects FooBox's parent class
+        // `IFooBox<X>`, the X reference must substitute to `int`, yielding the closed
+        // `IFooBox<int>`, which matches the target. Without substitution threading the
+        // walk would strip `FooBox<int, T>` to `FooBox<,>` and then walk an unsubstituted
+        // `IFooBox<X>` that never closes — incorrectly returning false.
+        if (!typeof(IFooBox<int>).IsAssignableFrom(typeof(FixedFooBox<>))) return 1;
+
+        // Negative direction: the binding is FooBox's X = int, not string. Asking
+        // `IFooBox<string>` must reject the same chain.
+        if (typeof(IFooBox<string>).IsAssignableFrom(typeof(FixedFooBox<>))) return 2;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -1580,25 +1580,71 @@ module IlMachineRuntimeMetadata =
         | TypeDefn.FromDefinition _
         | TypeDefn.Void -> false
 
+    /// Apply a `TypeDefn` substitution to every `GenericTypeParameter` reference inside `ty`.
+    /// This is purely syntactic; assembly identifiers and primitives pass through unchanged.
+    /// `GenericMethodParameter` references are left in place because they have no legitimate
+    /// appearance in a type definition's base or interface signatures (method generics belong
+    /// to method signatures, not type metadata edges).
+    let rec private substituteTypeDefn (subs : ImmutableArray<TypeDefn>) (ty : TypeDefn) : TypeDefn =
+        match ty with
+        | TypeDefn.GenericTypeParameter idx ->
+            if idx < subs.Length then
+                subs.[idx]
+            else
+                failwithf
+                    "substituteTypeDefn: GenericTypeParameter %d out of bounds (substitution arity %d)"
+                    idx
+                    subs.Length
+        | TypeDefn.GenericMethodParameter _ -> ty
+        | TypeDefn.GenericInstantiation (generic, args) ->
+            let builder = ImmutableArray.CreateBuilder args.Length
+
+            for arg in args do
+                builder.Add (substituteTypeDefn subs arg)
+
+            TypeDefn.GenericInstantiation (substituteTypeDefn subs generic, builder.ToImmutable ())
+        | TypeDefn.Array (element, rank) -> TypeDefn.Array (substituteTypeDefn subs element, rank)
+        | TypeDefn.OneDimensionalArrayLowerBoundZero element ->
+            TypeDefn.OneDimensionalArrayLowerBoundZero (substituteTypeDefn subs element)
+        | TypeDefn.Pointer element -> TypeDefn.Pointer (substituteTypeDefn subs element)
+        | TypeDefn.Byref element -> TypeDefn.Byref (substituteTypeDefn subs element)
+        | TypeDefn.Pinned element -> TypeDefn.Pinned (substituteTypeDefn subs element)
+        | TypeDefn.Modified (original, modifier, required) ->
+            TypeDefn.Modified (substituteTypeDefn subs original, substituteTypeDefn subs modifier, required)
+        | TypeDefn.FunctionPointer _
+        | TypeDefn.PrimitiveType _
+        | TypeDefn.FromReference _
+        | TypeDefn.FromDefinition _
+        | TypeDefn.Void -> ty
+
     /// Strip outer `GenericInstantiation` layers and resolve the underlying definition to
-    /// `(assembly, TypeInfo)`. Returns `None` when the stripped TypeDefn is not a nominal type
-    /// definition (e.g. an array, pointer, byref, primitive, or generic parameter) — none of
-    /// which is a legitimate `BaseType` or interface implementation, so the caller treats them
-    /// as dead-end edges for the identity walk.
+    /// `(assembly, TypeInfo, genericArgs)`. Returns `None` when the stripped TypeDefn is not a
+    /// nominal type definition (e.g. an array, pointer, byref, primitive, or generic
+    /// parameter) — none of which is a legitimate `BaseType` or interface implementation, so
+    /// the caller treats them as dead-end edges for the identity walk. The returned
+    /// `genericArgs` are the args from the outermost `GenericInstantiation` (already
+    /// substituted by the caller), or `ImmutableArray.Empty` when the type was a plain
+    /// definition without an explicit generic instantiation around it.
     let rec private stripToTypeInfo
         (loggerFactory : ILoggerFactory)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (state : IlMachineState)
         (declaringAssembly : DumpedAssembly)
         (ty : TypeDefn)
-        : IlMachineState * (DumpedAssembly * TypeInfo<GenericParamFromMetadata, TypeDefn>) option
+        : IlMachineState *
+          (DumpedAssembly * TypeInfo<GenericParamFromMetadata, TypeDefn> * ImmutableArray<TypeDefn>) option
         =
         match ty with
-        | TypeDefn.GenericInstantiation (generic, _) ->
-            stripToTypeInfo loggerFactory baseClassTypes state declaringAssembly generic
+        | TypeDefn.GenericInstantiation (generic, args) ->
+            let state, inner =
+                stripToTypeInfo loggerFactory baseClassTypes state declaringAssembly generic
+
+            match inner with
+            | Some (assy, typeInfo, _) -> state, Some (assy, typeInfo, args)
+            | None -> state, None
         | TypeDefn.FromDefinition (identity, _) ->
             match state.LoadedAssembly identity.Assembly with
-            | Some assy -> state, Some (assy, assy.TypeDefs.[identity.TypeDefinition.Get])
+            | Some assy -> state, Some (assy, assy.TypeDefs.[identity.TypeDefinition.Get], ImmutableArray.Empty)
             | None ->
                 failwithf "stripToTypeInfo: assembly for type definition %s was not loaded" identity.AssemblyFullName
         | TypeDefn.FromReference _ ->
@@ -1618,7 +1664,7 @@ module IlMachineRuntimeMetadata =
             let identity = resolved.Identity
 
             match state.LoadedAssembly identity.Assembly with
-            | Some assy -> state, Some (assy, assy.TypeDefs.[identity.TypeDefinition.Get])
+            | Some assy -> state, Some (assy, assy.TypeDefs.[identity.TypeDefinition.Get], ImmutableArray.Empty)
             | None ->
                 failwithf
                     "stripToTypeInfo: assembly for resolved type reference %s was not loaded"
@@ -1646,10 +1692,15 @@ module IlMachineRuntimeMetadata =
     ///   closed can be assigned to a type token that names "the open def" itself)
     /// - OpenGenericTypeDefinition s / OpenGenericTypeDefinition t → s = t (identity only;
     ///   stripping during a parent walk is for traversal, not for matching an open target)
-    /// - OpenGenericTypeDefinition / Closed → identity-walk source's base chain and
-    ///   implemented interfaces; at each edge, materialise to a `ConcreteTypeHandle` when no
-    ///   `GenericTypeParameter` is referenced and delegate to Closed/Closed, otherwise strip
-    ///   the outer `GenericInstantiation` to its definition identity and continue walking
+    /// - OpenGenericTypeDefinition / Closed → walk the source's base chain and implemented
+    ///   interfaces, threading a substitution context so that partially-closed inheritance
+    ///   like `class C<T> : B<int,T>` propagates the `int` binding into B's own walk. At
+    ///   each edge: substitute with the current context, then if no `GenericTypeParameter`
+    ///   reference remains, materialise to a `ConcreteTypeHandle` and delegate to
+    ///   Closed/Closed; otherwise strip to the definition's `TypeInfo` and recurse with the
+    ///   (substituted) generic args as the new context. The fallback when both the base and
+    ///   the interface chain are exhausted is to accept iff the target is System.Object,
+    ///   matching the closed oracle's `walkBase` `None` branch for interfaces.
     /// - GenericParameter / MethodGenericParameter (either side) → TODO until constraints
     ///   are modelled in the cast oracle
     let isRuntimeTypeHandleTargetAssignableTo
@@ -1680,9 +1731,22 @@ module IlMachineRuntimeMetadata =
 
             let sTypeInfo = sAssy.TypeDefs.[s.TypeDefinition.Get]
 
+            // The walk begins by treating every one of the source's generic parameters as
+            // unbound: each `GenericTypeParameter i` substitutes to itself, so the source's
+            // own metadata edges keep their original parameter references when first
+            // inspected, and only fully-bound positions get materialised as we descend.
+            let initialSubstitutions =
+                let builder = ImmutableArray.CreateBuilder sTypeInfo.Generics.Length
+
+                for i in 0 .. sTypeInfo.Generics.Length - 1 do
+                    builder.Add (TypeDefn.GenericTypeParameter i)
+
+                builder.ToImmutable ()
+
             let rec walkOpen
                 (state : IlMachineState)
                 (visited : Set<ResolvedTypeIdentity>)
+                (substitutions : ImmutableArray<TypeDefn>)
                 (currentAssy : DumpedAssembly)
                 (currentTypeInfo : TypeInfo<GenericParamFromMetadata, TypeDefn>)
                 : IlMachineState * bool
@@ -1695,20 +1759,18 @@ module IlMachineRuntimeMetadata =
 
                 let visited = Set.add currentIdentity visited
 
-                let tryMaterialiseAndCheck
+                let tryEdge
                     (state : IlMachineState)
                     (edgeAssy : DumpedAssembly)
                     (edgeTypeDefn : TypeDefn)
                     : IlMachineState * bool
                     =
-                    if containsAnyGenericParameter edgeTypeDefn then
-                        let state, stripped =
-                            stripToTypeInfo loggerFactory baseClassTypes state edgeAssy edgeTypeDefn
+                    let substituted = substituteTypeDefn substitutions edgeTypeDefn
 
-                        match stripped with
-                        | None -> state, false
-                        | Some (strippedAssy, strippedTypeInfo) -> walkOpen state visited strippedAssy strippedTypeInfo
-                    else
+                    if not (containsAnyGenericParameter substituted) then
+                        // Edge is fully closed under the current substitution. Materialise and
+                        // delegate to the closed oracle, which handles all variance, array, and
+                        // base-chain rules.
                         let state, edgeHandle =
                             IlMachineTypeResolution.concretizeType
                                 loggerFactory
@@ -1717,9 +1779,22 @@ module IlMachineRuntimeMetadata =
                                 edgeAssy.Name
                                 ImmutableArray.Empty
                                 ImmutableArray.Empty
-                                edgeTypeDefn
+                                substituted
 
                         isConcreteTypeAssignableTo loggerFactory baseClassTypes state edgeHandle t
+                    else
+                        // Edge still mentions an unbound parameter from the original open
+                        // source. It can never be identical to a closed target, but its own
+                        // base/interface chain might be. Strip to the edge's `TypeInfo` and
+                        // recurse, threading the (already-substituted) generic args as the
+                        // edge's substitution context.
+                        let state, stripped =
+                            stripToTypeInfo loggerFactory baseClassTypes state edgeAssy substituted
+
+                        match stripped with
+                        | None -> state, false
+                        | Some (strippedAssy, strippedTypeInfo, strippedArgs) ->
+                            walkOpen state visited strippedArgs strippedAssy strippedTypeInfo
 
                 let state, interfaceMatch =
                     ((state, false), currentTypeInfo.ImplementedInterfaces)
@@ -1741,7 +1816,7 @@ module IlMachineRuntimeMetadata =
                                     ImmutableArray.Empty
                                     impl.InterfaceHandle
 
-                            tryMaterialiseAndCheck state implResolvedAssy implTypeDefn
+                            tryEdge state implResolvedAssy implTypeDefn
                     )
 
                 if interfaceMatch then
@@ -1765,9 +1840,9 @@ module IlMachineRuntimeMetadata =
                     let state, baseAssy, baseTypeDefn =
                         resolveBaseTypeInfo loggerFactory baseClassTypes state currentAssy baseTypeInfo
 
-                    tryMaterialiseAndCheck state baseAssy baseTypeDefn
+                    tryEdge state baseAssy baseTypeDefn
 
-            walkOpen state Set.empty sAssy sTypeInfo
+            walkOpen state Set.empty initialSubstitutions sAssy sTypeInfo
         | RuntimeTypeHandleTarget.GenericParameter (declaringType, position), _ ->
             failwithf
                 "TODO: isRuntimeTypeHandleTargetAssignableTo: generic parameter source #%d of %O; need to model constraint-based assignability"

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -1749,7 +1749,18 @@ module IlMachineRuntimeMetadata =
                 else
 
                 match currentTypeInfo.BaseType with
-                | None -> state, false
+                | None ->
+                    // Interfaces (and System.Object itself) carry no `extends` clause, so
+                    // `BaseType` is `None` in metadata. Every reference type is assignable
+                    // to System.Object, so mirror the closed oracle's `walkBase` fallback
+                    // (lines 1183-1187): when the chain runs out, accept iff the target is
+                    // System.Object. Open generic *classes* and *structs* never hit this
+                    // branch — their metadata BaseType is always System.Object or
+                    // System.ValueType — so in practice this fires for open interfaces with
+                    // no further parent interfaces.
+                    match t with
+                    | ConcreteActivePatterns.ConcreteObj state.ConcreteTypes -> state, true
+                    | _ -> state, false
                 | Some baseTypeInfo ->
                     let state, baseAssy, baseTypeDefn =
                         resolveBaseTypeInfo loggerFactory baseClassTypes state currentAssy baseTypeInfo

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -1681,6 +1681,78 @@ module IlMachineRuntimeMetadata =
         | TypeDefn.GenericMethodParameter _
         | TypeDefn.Void -> state, None
 
+    /// Walk a `TypeDefn` and rewrite every `FromReference` (assembly-relative) into the
+    /// equivalent `FromDefinition` (carrying a fully-resolved identity), preserving structure
+    /// elsewhere. The caller supplies the assembly whose TypeRef tables interpret the input;
+    /// after this transform the result is assembly-independent and can be substituted into a
+    /// TypeDefn that lives in a different assembly without resolution errors.
+    ///
+    /// Used by the open-generic cast walk at the strip boundary: when a recursion crosses
+    /// from `currentAssy` to a different `strippedAssy`, the args carried into the deeper
+    /// walk may contain TypeRefs declared in the outer assembly (e.g. `Derived<T> :
+    /// Base<Arg, T>` in assembly E, where `Arg` lives in A and `Base` in B). Without
+    /// canonicalisation, deeper materialisations would try to resolve those TypeRefs against
+    /// the wrong assembly's reference tables and fail. `GenericTypeParameter` positions are
+    /// positional and assembly-independent, so they pass through unchanged.
+    let rec private canonicalizeTypeDefn
+        (loggerFactory : ILoggerFactory)
+        (state : IlMachineState)
+        (sourceAssy : DumpedAssembly)
+        (ty : TypeDefn)
+        : IlMachineState * TypeDefn
+        =
+        match ty with
+        | TypeDefn.PrimitiveType _
+        | TypeDefn.Void
+        | TypeDefn.GenericTypeParameter _
+        | TypeDefn.GenericMethodParameter _
+        | TypeDefn.FromDefinition _ -> state, ty
+        | TypeDefn.FromReference (typeRef, sigKind) ->
+            let state, _, resolved =
+                IlMachineTypeResolution.resolveTypeFromRef loggerFactory sourceAssy typeRef ImmutableArray.Empty state
+
+            state, TypeDefn.FromDefinition (resolved.Identity, sigKind)
+        | TypeDefn.GenericInstantiation (generic, args) ->
+            let state, generic' = canonicalizeTypeDefn loggerFactory state sourceAssy generic
+
+            let state, argsList =
+                ((state, []), args)
+                ||> Seq.fold (fun (state, acc) arg ->
+                    let state, arg' = canonicalizeTypeDefn loggerFactory state sourceAssy arg
+                    state, arg' :: acc
+                )
+
+            let argsArr = argsList |> List.rev |> ImmutableArray.CreateRange
+            state, TypeDefn.GenericInstantiation (generic', argsArr)
+        | TypeDefn.Array (element, rank) ->
+            let state, element' = canonicalizeTypeDefn loggerFactory state sourceAssy element
+            state, TypeDefn.Array (element', rank)
+        | TypeDefn.OneDimensionalArrayLowerBoundZero element ->
+            let state, element' = canonicalizeTypeDefn loggerFactory state sourceAssy element
+            state, TypeDefn.OneDimensionalArrayLowerBoundZero element'
+        | TypeDefn.Pointer element ->
+            let state, element' = canonicalizeTypeDefn loggerFactory state sourceAssy element
+            state, TypeDefn.Pointer element'
+        | TypeDefn.Byref element ->
+            let state, element' = canonicalizeTypeDefn loggerFactory state sourceAssy element
+            state, TypeDefn.Byref element'
+        | TypeDefn.Pinned element ->
+            let state, element' = canonicalizeTypeDefn loggerFactory state sourceAssy element
+            state, TypeDefn.Pinned element'
+        | TypeDefn.Modified (original, modifier, required) ->
+            let state, original' = canonicalizeTypeDefn loggerFactory state sourceAssy original
+            let state, modifier' = canonicalizeTypeDefn loggerFactory state sourceAssy modifier
+            state, TypeDefn.Modified (original', modifier', required)
+        | TypeDefn.FunctionPointer _ ->
+            // FunctionPointer carries a TypeMethodSignature with parameter and return TypeDefns;
+            // canonicalising those requires walking the signature shape. None of the current
+            // open-generic walk targets exercises this case (you can't author
+            // `delegate*<X, void>` as a generic argument in C#), so defer until a real test
+            // case forces it.
+            failwithf
+                "TODO: canonicalizeTypeDefn: FunctionPointer not yet supported in cross-assembly substitutions (%O)"
+                ty
+
     /// Cast oracle entry point over the full `RuntimeTypeHandleTarget` DU. The Closed/Closed case
     /// delegates to `isConcreteTypeAssignableTo`; the open-generic and generic-parameter variants
     /// are handled at this layer so that callers (e.g. the `TypeHandle_CanCastTo_NoCacheLookup`
@@ -1824,7 +1896,27 @@ module IlMachineRuntimeMetadata =
                         match stripped with
                         | None -> state, false
                         | Some (strippedAssy, strippedTypeInfo, strippedArgs) ->
-                            walkOpen state visited strippedArgs strippedAssy strippedTypeInfo
+                            // Canonicalise each arg against the edge's authoring assembly
+                            // before recursing. `strippedArgs` are the GenericInstantiation
+                            // args from `substituted`, which inherits TypeRefs from
+                            // `edgeAssy` (where the edge was authored) plus whatever the
+                            // outer substitutions had filled in (already canonical by this
+                            // function's invariant at this point of the recursion). The
+                            // deeper walk's currentAssy becomes `strippedAssy`, which is a
+                            // different assembly's reference tables, so unresolved TypeRefs
+                            // must be turned into `FromDefinition` here to remain
+                            // interpretable downstream.
+                            let state, canonicalisedArgs =
+                                ((state, []), strippedArgs)
+                                ||> Seq.fold (fun (state, acc) arg ->
+                                    let state, arg' = canonicalizeTypeDefn loggerFactory state edgeAssy arg
+
+                                    state, arg' :: acc
+                                )
+
+                            let canonicalisedArgs = canonicalisedArgs |> List.rev |> ImmutableArray.CreateRange
+
+                            walkOpen state visited canonicalisedArgs strippedAssy strippedTypeInfo
 
                 let state, interfaceMatch =
                     ((state, false), currentTypeInfo.ImplementedInterfaces)

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -1546,3 +1546,236 @@ module IlMachineRuntimeMetadata =
         | ConcreteTypeHandle.Byref _
         | ConcreteTypeHandle.Pointer _
         | ConcreteTypeHandle.FunctionPointer _ -> walk state objType
+
+    /// True iff `ty` references any `GenericTypeParameter` / `GenericMethodParameter`. The
+    /// open-generic source cast walk uses this to decide whether a base/interface edge can be
+    /// materialised to a closed `ConcreteTypeHandle` (when false) or only stripped to its
+    /// definition identity for continued identity-walking (when true). A method generic
+    /// parameter has no legitimate appearance in a type definition's base or interfaces,
+    /// but treating it as unbound is the safe default.
+    let rec private containsAnyGenericParameter (ty : TypeDefn) : bool =
+        match ty with
+        | TypeDefn.GenericTypeParameter _
+        | TypeDefn.GenericMethodParameter _ -> true
+        | TypeDefn.Array (element, _)
+        | TypeDefn.Pinned element
+        | TypeDefn.Pointer element
+        | TypeDefn.Byref element
+        | TypeDefn.OneDimensionalArrayLowerBoundZero element -> containsAnyGenericParameter element
+        | TypeDefn.Modified (original, modifier, _) ->
+            containsAnyGenericParameter original || containsAnyGenericParameter modifier
+        | TypeDefn.GenericInstantiation (generic, args) ->
+            containsAnyGenericParameter generic
+            || (args |> Seq.exists containsAnyGenericParameter)
+        | TypeDefn.FunctionPointer signature ->
+            let returnContains =
+                match signature.ReturnType with
+                | MethodReturnType.Void -> false
+                | MethodReturnType.Returns ret -> containsAnyGenericParameter ret
+
+            returnContains
+            || (signature.ParameterTypes |> List.exists containsAnyGenericParameter)
+        | TypeDefn.PrimitiveType _
+        | TypeDefn.FromReference _
+        | TypeDefn.FromDefinition _
+        | TypeDefn.Void -> false
+
+    /// Strip outer `GenericInstantiation` layers and resolve the underlying definition to
+    /// `(assembly, TypeInfo)`. Returns `None` when the stripped TypeDefn is not a nominal type
+    /// definition (e.g. an array, pointer, byref, primitive, or generic parameter) — none of
+    /// which is a legitimate `BaseType` or interface implementation, so the caller treats them
+    /// as dead-end edges for the identity walk.
+    let rec private stripToTypeInfo
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (declaringAssembly : DumpedAssembly)
+        (ty : TypeDefn)
+        : IlMachineState * (DumpedAssembly * TypeInfo<GenericParamFromMetadata, TypeDefn>) option
+        =
+        match ty with
+        | TypeDefn.GenericInstantiation (generic, _) ->
+            stripToTypeInfo loggerFactory baseClassTypes state declaringAssembly generic
+        | TypeDefn.FromDefinition (identity, _) ->
+            match state.LoadedAssembly identity.Assembly with
+            | Some assy -> state, Some (assy, assy.TypeDefs.[identity.TypeDefinition.Get])
+            | None ->
+                failwithf "stripToTypeInfo: assembly for type definition %s was not loaded" identity.AssemblyFullName
+        | TypeDefn.FromReference _ ->
+            // resolveTypeFromDefn handles FromReference and returns a TypeInfo<TypeDefn,TypeDefn>;
+            // the un-substituted raw TypeInfo<GenericParamFromMetadata,TypeDefn> is what the walk
+            // wants, so re-fetch from the resolved identity's assembly TypeDefs table.
+            let state, _, resolved =
+                IlMachineTypeResolution.resolveTypeFromDefn
+                    loggerFactory
+                    baseClassTypes
+                    ty
+                    ImmutableArray.Empty
+                    ImmutableArray.Empty
+                    declaringAssembly
+                    state
+
+            let identity = resolved.Identity
+
+            match state.LoadedAssembly identity.Assembly with
+            | Some assy -> state, Some (assy, assy.TypeDefs.[identity.TypeDefinition.Get])
+            | None ->
+                failwithf
+                    "stripToTypeInfo: assembly for resolved type reference %s was not loaded"
+                    identity.AssemblyFullName
+        | TypeDefn.PrimitiveType _
+        | TypeDefn.Array _
+        | TypeDefn.OneDimensionalArrayLowerBoundZero _
+        | TypeDefn.Pointer _
+        | TypeDefn.Byref _
+        | TypeDefn.Pinned _
+        | TypeDefn.Modified _
+        | TypeDefn.FunctionPointer _
+        | TypeDefn.GenericTypeParameter _
+        | TypeDefn.GenericMethodParameter _
+        | TypeDefn.Void -> state, None
+
+    /// Cast oracle entry point over the full `RuntimeTypeHandleTarget` DU. The Closed/Closed case
+    /// delegates to `isConcreteTypeAssignableTo`; the open-generic and generic-parameter variants
+    /// are handled at this layer so that callers (e.g. the `TypeHandle_CanCastTo_NoCacheLookup`
+    /// QCall) need not coerce open handles back to closed ones.
+    ///
+    /// The rule table:
+    /// - Closed / Closed                 → existing oracle
+    /// - Closed / OpenGenericTypeDefinition → false (open defs are not instantiable; nothing
+    ///   closed can be assigned to a type token that names "the open def" itself)
+    /// - OpenGenericTypeDefinition s / OpenGenericTypeDefinition t → s = t (identity only;
+    ///   stripping during a parent walk is for traversal, not for matching an open target)
+    /// - OpenGenericTypeDefinition / Closed → identity-walk source's base chain and
+    ///   implemented interfaces; at each edge, materialise to a `ConcreteTypeHandle` when no
+    ///   `GenericTypeParameter` is referenced and delegate to Closed/Closed, otherwise strip
+    ///   the outer `GenericInstantiation` to its definition identity and continue walking
+    /// - GenericParameter / MethodGenericParameter (either side) → TODO until constraints
+    ///   are modelled in the cast oracle
+    let isRuntimeTypeHandleTargetAssignableTo
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (source : RuntimeTypeHandleTarget)
+        (target : RuntimeTypeHandleTarget)
+        : IlMachineState * bool
+        =
+        match source, target with
+        | RuntimeTypeHandleTarget.Closed s, RuntimeTypeHandleTarget.Closed t ->
+            isConcreteTypeAssignableTo loggerFactory baseClassTypes state s t
+        | RuntimeTypeHandleTarget.Closed _, RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
+            // An OpenGenericTypeDefinition handle represents "the open generic definition itself"
+            // (e.g. typeof(Box<>)), which is not an instantiable type. No closed type is assignable
+            // to it. CoreCLR's managed wrapper short-circuits the "ref-type → TypeDesc" case before
+            // ever invoking the QCall; this branch is the analogue at the cast-oracle level.
+            state, false
+        | RuntimeTypeHandleTarget.OpenGenericTypeDefinition s, RuntimeTypeHandleTarget.OpenGenericTypeDefinition t ->
+            state, s = t
+        | RuntimeTypeHandleTarget.OpenGenericTypeDefinition s, RuntimeTypeHandleTarget.Closed t ->
+            let sAssy =
+                match state.LoadedAssembly s.Assembly with
+                | Some assy -> assy
+                | None ->
+                    failwithf "isRuntimeTypeHandleTargetAssignableTo: source assembly %s not loaded" s.AssemblyFullName
+
+            let sTypeInfo = sAssy.TypeDefs.[s.TypeDefinition.Get]
+
+            let rec walkOpen
+                (state : IlMachineState)
+                (visited : Set<ResolvedTypeIdentity>)
+                (currentAssy : DumpedAssembly)
+                (currentTypeInfo : TypeInfo<GenericParamFromMetadata, TypeDefn>)
+                : IlMachineState * bool
+                =
+                let currentIdentity = currentTypeInfo.Identity
+
+                if Set.contains currentIdentity visited then
+                    state, false
+                else
+
+                let visited = Set.add currentIdentity visited
+
+                let tryMaterialiseAndCheck
+                    (state : IlMachineState)
+                    (edgeAssy : DumpedAssembly)
+                    (edgeTypeDefn : TypeDefn)
+                    : IlMachineState * bool
+                    =
+                    if containsAnyGenericParameter edgeTypeDefn then
+                        let state, stripped =
+                            stripToTypeInfo loggerFactory baseClassTypes state edgeAssy edgeTypeDefn
+
+                        match stripped with
+                        | None -> state, false
+                        | Some (strippedAssy, strippedTypeInfo) -> walkOpen state visited strippedAssy strippedTypeInfo
+                    else
+                        let state, edgeHandle =
+                            IlMachineTypeResolution.concretizeType
+                                loggerFactory
+                                baseClassTypes
+                                state
+                                edgeAssy.Name
+                                ImmutableArray.Empty
+                                ImmutableArray.Empty
+                                edgeTypeDefn
+
+                        isConcreteTypeAssignableTo loggerFactory baseClassTypes state edgeHandle t
+
+                let state, interfaceMatch =
+                    ((state, false), currentTypeInfo.ImplementedInterfaces)
+                    ||> Seq.fold (fun (state, found) impl ->
+                        if found then
+                            state, true
+                        else
+                            let implAssy =
+                                match state.LoadedAssembly impl.RelativeToAssembly with
+                                | Some a -> a
+                                | None -> currentAssy
+
+                            let state, implTypeDefn, implResolvedAssy =
+                                resolveTypeMetadataToken
+                                    loggerFactory
+                                    baseClassTypes
+                                    state
+                                    implAssy
+                                    ImmutableArray.Empty
+                                    impl.InterfaceHandle
+
+                            tryMaterialiseAndCheck state implResolvedAssy implTypeDefn
+                    )
+
+                if interfaceMatch then
+                    state, true
+                else
+
+                match currentTypeInfo.BaseType with
+                | None -> state, false
+                | Some baseTypeInfo ->
+                    let state, baseAssy, baseTypeDefn =
+                        resolveBaseTypeInfo loggerFactory baseClassTypes state currentAssy baseTypeInfo
+
+                    tryMaterialiseAndCheck state baseAssy baseTypeDefn
+
+            walkOpen state Set.empty sAssy sTypeInfo
+        | RuntimeTypeHandleTarget.GenericParameter (declaringType, position), _ ->
+            failwithf
+                "TODO: isRuntimeTypeHandleTargetAssignableTo: generic parameter source #%d of %O; need to model constraint-based assignability"
+                position
+                declaringType.TypeDefinition.Get
+        | RuntimeTypeHandleTarget.MethodGenericParameter (declaringType, declaringMethod, position), _ ->
+            failwithf
+                "TODO: isRuntimeTypeHandleTargetAssignableTo: method generic parameter source #%d of method %O on %O; need to model constraint-based assignability"
+                position
+                declaringMethod.Get
+                declaringType.TypeDefinition.Get
+        | _, RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
+            failwithf
+                "TODO: isRuntimeTypeHandleTargetAssignableTo: generic parameter target #%d of %O; need to model constraint-based assignability"
+                position
+                declaringType.TypeDefinition.Get
+        | _, RuntimeTypeHandleTarget.MethodGenericParameter (declaringType, declaringMethod, position) ->
+            failwithf
+                "TODO: isRuntimeTypeHandleTargetAssignableTo: method generic parameter target #%d of method %O on %O; need to model constraint-based assignability"
+                position
+                declaringMethod.Get
+                declaringType.TypeDefinition.Get

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -1731,6 +1731,28 @@ module IlMachineRuntimeMetadata =
 
             let sTypeInfo = sAssy.TypeDefs.[s.TypeDefinition.Get]
 
+            // Capture target's identity and whether any of its generic parameters carry
+            // variance. CoreCLR can assign an open generic interface to a closed
+            // instantiation of itself when the parameter is variant and its constraints
+            // are satisfied (e.g. `IOut<out T> where T : class` makes
+            // `typeof(IOut<object>).IsAssignableFrom(typeof(IOut<>))` true). We don't yet
+            // model constraint-aware variance during an open walk, so when the walk
+            // encounters a node whose identity matches a variant target we crash loudly
+            // rather than silently returning false. The mirror at the closed/closed oracle
+            // (lines 1215-1220) uses the same shape.
+            let targetIdentityWithVariance =
+                match AllConcreteTypes.lookup t state.ConcreteTypes with
+                | Some targetCt ->
+                    let targetAssy = state._LoadedAssemblies.[targetCt.Identity.AssemblyFullName]
+                    let targetTypeInfo = targetAssy.TypeDefs.[targetCt.Identity.TypeDefinition.Get]
+
+                    let hasVariantGenericParams =
+                        targetTypeInfo.Generics
+                        |> Seq.exists (fun (_, metadata) -> metadata.Variance.IsSome)
+
+                    Some (targetCt.Identity, hasVariantGenericParams)
+                | None -> None
+
             // The walk begins by treating every one of the source's generic parameters as
             // unbound: each `GenericTypeParameter i` substitutes to itself, so the source's
             // own metadata edges keep their original parameter references when first
@@ -1756,6 +1778,14 @@ module IlMachineRuntimeMetadata =
                 if Set.contains currentIdentity visited then
                     state, false
                 else
+
+                match targetIdentityWithVariance with
+                | Some (targetIdentity, true) when currentIdentity = targetIdentity ->
+                    failwithf
+                        "TODO: isRuntimeTypeHandleTargetAssignableTo: open source %O reaches target identity %O which has variant generic parameters; need constraint-aware variance check"
+                        s.TypeDefinition.Get
+                        targetIdentity.TypeDefinition.Get
+                | _ ->
 
                 let visited = Set.add currentIdentity visited
 

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -208,3 +208,6 @@ module IlMachineState =
     let requiredOwnInstanceFieldId = IlMachineRuntimeMetadata.requiredOwnInstanceFieldId
 
     let isConcreteTypeAssignableTo = IlMachineRuntimeMetadata.isConcreteTypeAssignableTo
+
+    let isRuntimeTypeHandleTargetAssignableTo =
+        IlMachineRuntimeMetadata.isRuntimeTypeHandleTargetAssignableTo

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
@@ -119,28 +119,13 @@ module NativeRuntimeTypeQCall =
                     operation
                     (instruction.Arguments.[1] |> EvalStackValue.ofCliType)
 
-            // Non-Closed handles correspond to CoreCLR TypeDescs (generic parameters, open
-            // generic definitions). The full cast oracle for those involves variance/identity
-            // rules that PawPrint does not yet model; fail loudly so the missing case surfaces
-            // rather than silently returning a wrong answer.
-            let toConcreteHandle (label : string) (target : RuntimeTypeHandleTarget) : ConcreteTypeHandle =
-                match target with
-                | RuntimeTypeHandleTarget.Closed handle -> handle
-                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
-                    failwith
-                        $"TODO: %s{operation} for open generic %s{label} type definition %O{identity}; need to model variance/identity rules"
-                | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
-                    failwith
-                        $"TODO: %s{operation} for generic parameter %s{label} #%i{position} of %O{declaringType.TypeDefinition.Get}"
-                | RuntimeTypeHandleTarget.MethodGenericParameter (declaringType, declaringMethod, position) ->
-                    failwith
-                        $"TODO: %s{operation} for method generic parameter %s{label} #%i{position} of method %O{declaringMethod.Get} on %O{declaringType.TypeDefinition.Get}"
-
-            let fromHandle = toConcreteHandle "from" fromTarget
-            let toHandle = toConcreteHandle "to" toTarget
-
             let state, isAssignable =
-                IlMachineState.isConcreteTypeAssignableTo ctx.LoggerFactory ctx.BaseClassTypes state fromHandle toHandle
+                IlMachineState.isRuntimeTypeHandleTargetAssignableTo
+                    ctx.LoggerFactory
+                    ctx.BaseClassTypes
+                    state
+                    fromTarget
+                    toTarget
 
             // Interop.BOOL is int-backed with FALSE = 0 and TRUE = 1, so a raw Int32 is the
             // correct representation on the eval stack.


### PR DESCRIPTION
## Summary
- `TypeHandle.CanCastTo_NoCacheLookup` previously crashed on any non-Closed `RuntimeTypeHandleTarget`, so `typeof(object).IsAssignableFrom(typeof(Box<>))` and similar lit up TODO crashes. Introduce `isRuntimeTypeHandleTargetAssignableTo` as a dispatcher over the full `RuntimeTypeHandleTarget` DU, with Closed/Closed delegating to the existing oracle and Open/Closed implementing the actual open-source walk.
- The Open/Closed walk threads a substitution context through the source's base + interface chain. At each edge it substitutes, materialises the result when fully closed (delegating to the closed oracle), or strips the outer `GenericInstantiation` and recurses. To make recursion work across assembly boundaries, args are canonicalised to `FromDefinition` form before being threaded into a different assembly's walk. The walk falls back to System.Object for chains that exhaust without finding a match.
- Open/Open is strict identity; Closed/Open is always false; the generic-parameter variants remain explicit TODOs. Variant generic identities are also explicit TODOs — the walk fails loudly when it would silently mishandle them.

## Test plan
- [x] New pure-source tests cover the materialise-via-interface, materialise-via-closed-base, open-target identity, System.Object fallback, and cross-instantiation partial-substitution paths.
- [x] New cross-assembly test in `TestCrossAssemblyIsAssignableFrom` covers the case where the partial substitution carries a TypeRef from one assembly into a walk in a different assembly (the canonicalisation regression).
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` passes (1148/1148).

🤖 Generated with [Claude Code](https://claude.com/claude-code)