### PR TITLE
Implement generic variance walk in concrete-type assignability

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/ArrayStoreVarianceDelegate.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/ArrayStoreVarianceDelegate.cs
@@ -1,0 +1,56 @@
+// Regression: the array-store variance gate previously caught `failwith
+// "TODO:"` from `isConcreteTypeAssignableTo`'s generic-variance walk and
+// degraded to "permit". With the variance walk now implemented, the gate
+// gives a definitive answer for both positive and negative cases.
+//
+// Setup: `Func<DelegBase>[]` — element type is a delegate with declared
+// covariance. Storing a `Func<DelegDerived>` should succeed (covariant);
+// storing a `Func<int>` should raise ATME (value-type generic arg disables
+// variance).
+
+using System;
+
+public class DelegBase
+{
+}
+
+public class DelegDerived : DelegBase
+{
+}
+
+public class TestArrayStoreVarianceDelegate
+{
+    public static int Main(string[] argv)
+    {
+        Func<DelegBase>[] arr = new Func<DelegBase>[2];
+
+        // Positive: Func<DelegDerived> is covariantly assignable to Func<DelegBase>.
+        Func<DelegDerived> makeDerived = () => new DelegDerived();
+        object[] view = (object[]) (object) arr;
+        view[0] = makeDerived;
+        if (arr[0] == null) return 1;
+
+        // Sanity: roundtrip the stored delegate.
+        DelegBase produced = arr[0]();
+        if (produced == null) return 2;
+
+        // Negative: Func<int> ⊄ Func<DelegBase> (int is value-type; variance
+        // walk rejects). The stelem.ref gate must raise ATME.
+        Func<int> makeInt = () => 42;
+        bool threw = false;
+        try
+        {
+            view[1] = makeInt;
+        }
+        catch (ArrayTypeMismatchException)
+        {
+            threw = true;
+        }
+        if (!threw) return 3;
+
+        // Slot 1 was rejected; should still be null.
+        if (arr[1] != null) return 4;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/GenericDelegateVariance.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/GenericDelegateVariance.cs
@@ -1,0 +1,77 @@
+// ECMA-335 §I.8.7 also applies the variance walk to delegate types. The BCL
+// `Func<TResult>` is covariant in TResult (`out`); `Action<T>` is contravariant
+// in T (`in`). Mixed delegates like `Func<TArg, TResult>` are contravariant in
+// TArg and covariant in TResult.
+//
+// CoreCLR's `MethodTable::CanCastToClass` walks the inheritance chain when the
+// target has variance — for delegates this descends from MulticastDelegate.
+// The per-step `CanCastByVarianceToInterfaceOrDelegate` applies the same
+// algorithm as for interfaces.
+
+using System;
+
+public class DelegBase
+{
+}
+
+public class DelegDerived : DelegBase
+{
+}
+
+public class TestGenericDelegateVariance
+{
+    public static int Main(string[] argv)
+    {
+        // Covariant delegate: Func<DelegDerived> ⊑ Func<DelegBase>.
+        Func<DelegDerived> makeDerived = () => new DelegDerived();
+        object boxed = makeDerived;
+        if (!(boxed is Func<DelegBase>)) return 1;
+
+        Func<DelegBase> asBase = (Func<DelegBase>) boxed;
+        if (asBase == null) return 2;
+        if (asBase() == null) return 3;
+
+        // Reverse covariant: Func<DelegBase> ⊄ Func<DelegDerived>.
+        Func<DelegBase> makeBase = () => new DelegBase();
+        object boxedBase = makeBase;
+        if (boxedBase is Func<DelegDerived>) return 4;
+        bool threw = false;
+        try
+        {
+            Func<DelegDerived> _ = (Func<DelegDerived>) boxedBase;
+        }
+        catch (InvalidCastException)
+        {
+            threw = true;
+        }
+        if (!threw) return 5;
+
+        // Contravariant delegate: Action<DelegBase> ⊑ Action<DelegDerived>.
+        Action<DelegBase> consumeBase = b => { _ = b; };
+        object boxedConsume = consumeBase;
+        if (!(boxedConsume is Action<DelegDerived>)) return 6;
+
+        Action<DelegDerived> asConsumeDerived = (Action<DelegDerived>) boxedConsume;
+        if (asConsumeDerived == null) return 7;
+        asConsumeDerived(new DelegDerived());
+
+        // Reverse contravariant: Action<DelegDerived> ⊄ Action<DelegBase>.
+        Action<DelegDerived> consumeDerived = d => { _ = d; };
+        object boxedConsumeDerived = consumeDerived;
+        if (boxedConsumeDerived is Action<DelegBase>) return 8;
+
+        // Mixed delegate `Func<TArg, TResult>` — contravariant TArg, covariant TResult.
+        // Func<Base,Derived> ⊑ Func<Derived,Base>: TArg goes base→derived
+        // (contravariant), TResult goes derived→base (covariant).
+        Func<DelegBase, DelegDerived> bToD = _ => new DelegDerived();
+        object boxedMix = bToD;
+        if (!(boxedMix is Func<DelegDerived, DelegBase>)) return 9;
+
+        // Value-type arg disables variance: Func<int> ⊄ Func<object>.
+        Func<int> makeInt = () => 42;
+        object boxedInt = makeInt;
+        if (boxedInt is Func<object>) return 10;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/GenericInterfaceVarianceDirect.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/GenericInterfaceVarianceDirect.cs
@@ -1,0 +1,131 @@
+// ECMA-335 §I.8.7.2 / CoreCLR `MethodTable::CanCastByVarianceToInterfaceOrDelegate`:
+// when two generic instantiations share the same TypeDef and the def declares
+// variance, assignability reduces to a per-parameter check.
+//   - Covariant (`out T`): `from`-arg must be reference-typed and reference-
+//     assignment-compatible with `to`-arg.
+//   - Contravariant (`in T`): `to`-arg must be reference-typed and reference-
+//     assignment-compatible with `from`-arg.
+//   - Invariant: arguments must be identical.
+// A value-typed argument disables variance (CoreCLR's `IsBoxedAndCanCastTo`
+// precondition: `from` must be a reference type).
+
+using System;
+
+public interface ICovariant<out T>
+{
+}
+
+public interface IContravariant<in T>
+{
+}
+
+public interface IInvariant<T>
+{
+}
+
+public class CovariantImpl<T> : ICovariant<T>
+{
+}
+
+public class ContravariantImpl<T> : IContravariant<T>
+{
+}
+
+public class InvariantImpl<T> : IInvariant<T>
+{
+}
+
+public class Base
+{
+}
+
+public class Derived : Base
+{
+}
+
+public class TestGenericInterfaceVarianceDirect
+{
+    public static int Main(string[] argv)
+    {
+        // Covariant positive: ICovariant<Derived> ⊑ ICovariant<Base>.
+        object covDerived = new CovariantImpl<Derived>();
+        ICovariant<Base> asCovBase = (ICovariant<Base>) covDerived;
+        if (asCovBase == null) return 1;
+        if (!(covDerived is ICovariant<Base>)) return 2;
+
+        // Covariant positive transitive: ICovariant<Derived> ⊑ ICovariant<object>.
+        if (!(covDerived is ICovariant<object>)) return 3;
+
+        // Covariant negative: ICovariant<Base> ⊄ ICovariant<Derived>.
+        object covBase = new CovariantImpl<Base>();
+        if (covBase is ICovariant<Derived>) return 4;
+        bool threw = false;
+        try
+        {
+            ICovariant<Derived> _ = (ICovariant<Derived>) covBase;
+        }
+        catch (InvalidCastException)
+        {
+            threw = true;
+        }
+        if (!threw) return 5;
+
+        // Contravariant positive: IContravariant<Base> ⊑ IContravariant<Derived>.
+        object contraBase = new ContravariantImpl<Base>();
+        IContravariant<Derived> asContraDerived = (IContravariant<Derived>) contraBase;
+        if (asContraDerived == null) return 6;
+        if (!(contraBase is IContravariant<Derived>)) return 7;
+
+        // Contravariant negative: IContravariant<Derived> ⊄ IContravariant<Base>.
+        object contraDerived = new ContravariantImpl<Derived>();
+        if (contraDerived is IContravariant<Base>) return 8;
+        threw = false;
+        try
+        {
+            IContravariant<Base> _ = (IContravariant<Base>) contraDerived;
+        }
+        catch (InvalidCastException)
+        {
+            threw = true;
+        }
+        if (!threw) return 9;
+
+        // Invariant: same TypeDef but different generics is always rejected,
+        // even if the args themselves are assignable.
+        object invDerived = new InvariantImpl<Derived>();
+        if (invDerived is IInvariant<Base>) return 10;
+        threw = false;
+        try
+        {
+            IInvariant<Base> _ = (IInvariant<Base>) invDerived;
+        }
+        catch (InvalidCastException)
+        {
+            threw = true;
+        }
+        if (!threw) return 11;
+
+        // Value-type arg disables variance: ICovariant<int> ⊄ ICovariant<object>.
+        // CoreCLR's `IsBoxedAndCanCastTo` rejects a value-typed `from` parameter
+        // regardless of the declared variance.
+        object covInt = new CovariantImpl<int>();
+        if (covInt is ICovariant<object>) return 12;
+        threw = false;
+        try
+        {
+            ICovariant<object> _ = (ICovariant<object>) covInt;
+        }
+        catch (InvalidCastException)
+        {
+            threw = true;
+        }
+        if (!threw) return 13;
+
+        // Identity check still passes through the variance walk: ICovariant<Base>
+        // ⊑ ICovariant<Base>. (Variance walk's per-parameter `fromArg = toArg`
+        // shortcut.)
+        if (!(covBase is ICovariant<Base>)) return 14;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/GenericInterfaceVarianceWalked.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/GenericInterfaceVarianceWalked.cs
@@ -1,0 +1,71 @@
+// The variance check is reached not just by direct same-def queries, but also
+// by the interface walk: a type's `ImplementedInterfaces` may be different
+// instantiations than the cast target, with the variance rule selecting one
+// during the walk. Concretely: `MyHolder<Derived> : ICovariant<Derived>`,
+// and we ask `is ICovariant<Base>`. The walk descends into MyHolder's
+// implemented interfaces, reaches `ICovariant<Derived>`, and applies the
+// covariant rule against the target `ICovariant<Base>`.
+//
+// Also covers transitive walk: `IList<T> : ICollection<T> : IEnumerable<T>`,
+// where `IList` and `ICollection` are invariant but `IEnumerable<T>` is
+// covariant (BCL). A type implementing `IList<Derived>` should answer true
+// for `is IEnumerable<Base>`.
+
+using System.Collections.Generic;
+
+public interface IBag<out T>
+{
+}
+
+public interface IBagDerived<out T> : IBag<T>
+{
+}
+
+public class BagDerivedImpl<T> : IBagDerived<T>
+{
+}
+
+public class WalkedBase
+{
+}
+
+public class WalkedDerived : WalkedBase
+{
+}
+
+public class TestGenericInterfaceVarianceWalked
+{
+    public static int Main(string[] argv)
+    {
+        // Walk-through-implemented-interface variance: BagDerivedImpl<Derived>
+        // implements IBagDerived<Derived> which inherits IBag<Derived>. Target
+        // IBag<Base>: walk finds IBag<Derived> via the inheritance chain and
+        // applies the covariant rule.
+        object bag = new BagDerivedImpl<WalkedDerived>();
+        if (!(bag is IBag<WalkedBase>)) return 1;
+
+        IBag<WalkedBase> asBase = (IBag<WalkedBase>) bag;
+        if (asBase == null) return 2;
+
+        // BCL chain: List<Derived> implements IList<Derived>, ICollection<Derived>,
+        // IEnumerable<Derived>, IReadOnlyList<Derived>, IReadOnlyCollection<Derived>,
+        // plus several non-generic interfaces. IList and ICollection are invariant;
+        // IEnumerable and IReadOnly* are covariant. So `is IEnumerable<Base>` should
+        // succeed; `is IList<Base>` should fail; `is IReadOnlyList<Base>` should
+        // succeed.
+        List<WalkedDerived> list = new List<WalkedDerived>();
+        object listObj = list;
+
+        if (!(listObj is IEnumerable<WalkedBase>)) return 3;
+        if (listObj is IList<WalkedBase>) return 4; // invariant — rejected
+        if (!(listObj is IReadOnlyList<WalkedBase>)) return 5;
+        if (!(listObj is IReadOnlyCollection<WalkedBase>)) return 6;
+        if (listObj is ICollection<WalkedBase>) return 7; // invariant — rejected
+
+        // Direct cast through the covariant chain.
+        IEnumerable<WalkedBase> asEnumerable = (IEnumerable<WalkedBase>) listObj;
+        if (asEnumerable == null) return 8;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/NestedGenericVariance.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/NestedGenericVariance.cs
@@ -1,0 +1,65 @@
+// ECMA-335 §I.8.7's variance rule composes: the per-parameter check is
+// reference-assignability, which itself can require another variance walk
+// when the argument is another variant generic instantiation. Concretely:
+// `Func<Func<Derived>>` ⊑ `Func<Func<Base>>` requires the outer covariant
+// step to ask whether `Func<Derived>` ⊑ `Func<Base>`, which is itself a
+// covariant variance step.
+//
+// CoreCLR `MethodTable::CanCastByVarianceToInterfaceOrDelegate` recurses
+// into `CanCastTo` for each generic argument, so nested instantiations
+// naturally chain through the algorithm.
+
+using System;
+
+public class NestedBase
+{
+}
+
+public class NestedDerived : NestedBase
+{
+}
+
+public class TestNestedGenericVariance
+{
+    public static int Main(string[] argv)
+    {
+        // Two covariant steps: outer Func is covariant, inner Func is covariant.
+        // Func<Func<Derived>> ⊑ Func<Func<Base>>.
+        Func<Func<NestedDerived>> nested = () => () => new NestedDerived();
+        object boxed = nested;
+        if (!(boxed is Func<Func<NestedBase>>)) return 1;
+
+        Func<Func<NestedBase>> asBase = (Func<Func<NestedBase>>) boxed;
+        if (asBase == null) return 2;
+        if (asBase()() == null) return 3;
+
+        // Co/contra mix: Action<Func<Base>> ⊑ Action<Func<Derived>>.
+        //   - Outer Action is contravariant: from-arg `Func<Base>` must be
+        //     reference-assignable *from* to-arg `Func<Derived>`, i.e.
+        //     `Func<Derived>` ⊑ `Func<Base>`.
+        //   - Inner Func is covariant: Derived ⊑ Base. ✓
+        Action<Func<NestedBase>> consumeMaker = m => { _ = m(); };
+        object boxedConsume = consumeMaker;
+        if (!(boxedConsume is Action<Func<NestedDerived>>)) return 4;
+
+        Action<Func<NestedDerived>> asConsumeDerived = (Action<Func<NestedDerived>>) boxedConsume;
+        if (asConsumeDerived == null) return 5;
+        asConsumeDerived(() => new NestedDerived());
+
+        // Negative nested: Func<Func<Base>> ⊄ Func<Func<Derived>>. Outer
+        // covariant asks Func<Base> ⊑ Func<Derived>, which fails because
+        // inner covariant requires Base ⊑ Derived (rejected).
+        Func<Func<NestedBase>> nestedBase = () => () => new NestedBase();
+        object boxedNegative = nestedBase;
+        if (boxedNegative is Func<Func<NestedDerived>>) return 6;
+
+        // Value-type leaf disables variance through the chain:
+        // Func<Func<int>> ⊄ Func<Func<object>> because the inner step rejects
+        // a value-typed `from` argument (CoreCLR `IsBoxedAndCanCastTo`).
+        Func<Func<int>> nestedInt = () => () => 42;
+        object boxedInt = nestedInt;
+        if (boxedInt is Func<Func<object>>) return 7;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -1285,9 +1285,13 @@ module IlMachineRuntimeMetadata =
             match tryGetConcreteTypeInfo state current with
             | None -> walkBase state current
             | Some (currentCt, _) ->
-                // If two types share the same definition but differ in generics, check whether
-                // variance could apply. Classes are invariant so the answer is definitively false.
-                // Interfaces and delegates can have variance, so we must crash rather than guess.
+                // Same TypeDef but different instantiations is the variance hook
+                // (ECMA-335 §I.8.7.2 / CoreCLR
+                // `CanCastByVarianceToInterfaceOrDelegate`). Classes are invariant
+                // by spec, so when none of the parameters declare variance the
+                // answer is definitively false. Interfaces and delegates can
+                // declare `+`/`-` on each parameter; per-parameter assignability
+                // resolves the cast.
                 let sameDefnDifferentGenerics =
                     match AllConcreteTypes.lookup targetType state.ConcreteTypes with
                     | Some targetCt when
@@ -1307,7 +1311,7 @@ module IlMachineRuntimeMetadata =
                         |> Seq.exists (fun (_, metadata) -> metadata.Variance.IsSome)
 
                     if hasVariantGenericParams then
-                        failwith $"TODO: generic variance check needed: is %O{currentCt} assignable to %O{targetCt}?"
+                        checkVariantGenericArgs state currentCt targetCt targetTypeInfo
                     else
                         // All generic parameters are invariant; same definition + different generics = not assignable.
                         state, false
@@ -1318,6 +1322,62 @@ module IlMachineRuntimeMetadata =
                         state, true
                     else
                         walkBase state current
+
+        // ECMA-335 §I.8.7 / CoreCLR `MethodTable::CanCastByVarianceToInterfaceOrDelegate`:
+        // when two generic instantiations share the same TypeDef and the
+        // definition declares variance on at least one parameter, the cast
+        // reduces to a per-parameter check.
+        //   - Identical arguments are always accepted.
+        //   - Covariant (`out`) parameter: `fromArg` must be a reference type
+        //     and reference-assignable to `toArg`. (CoreCLR's `IsBoxedAndCanCastTo`
+        //     rejects value-typed `fromArg` regardless of the declared variance —
+        //     boxing changes identity, and the variance walk assumes the
+        //     argument is in its boxed form.)
+        //   - Contravariant (`in`) parameter: `toArg` must be a reference type
+        //     and reference-assignable to `fromArg`.
+        //   - Invariant parameter: arguments must be identical, so a difference
+        //     here short-circuits to `false`.
+        // Recursion into `isConcreteTypeAssignableTo` for the per-argument check
+        // is necessary because variance composes (e.g. `Func<Func<Derived>>` ⊑
+        // `Func<Func<Base>>` for the nested covariant `out` parameter).
+        and checkVariantGenericArgs
+            (state : IlMachineState)
+            (currentCt : ConcreteType<ConcreteTypeHandle>)
+            (targetCt : ConcreteType<ConcreteTypeHandle>)
+            (targetTypeInfo : TypeInfo<GenericParamFromMetadata, TypeDefn>)
+            : IlMachineState * bool
+            =
+            let rec loop (state : IlMachineState) (i : int) : IlMachineState * bool =
+                if i >= currentCt.Generics.Length then
+                    state, true
+                else
+                    let fromArg = currentCt.Generics.[i]
+                    let toArg = targetCt.Generics.[i]
+
+                    if fromArg = toArg then
+                        loop state (i + 1)
+                    else
+                        let _, paramMetadata = targetTypeInfo.Generics.[i]
+
+                        let state, argOk =
+                            match paramMetadata.Variance with
+                            | None ->
+                                // Invariant parameter with non-identical arguments.
+                                state, false
+                            | Some GenericVariance.Covariant ->
+                                if not (isReferenceTypeHandle state fromArg) then
+                                    state, false
+                                else
+                                    isConcreteTypeAssignableTo loggerFactory baseClassTypes state fromArg toArg
+                            | Some GenericVariance.Contravariant ->
+                                if not (isReferenceTypeHandle state toArg) then
+                                    state, false
+                                else
+                                    isConcreteTypeAssignableTo loggerFactory baseClassTypes state toArg fromArg
+
+                        if argOk then loop state (i + 1) else state, false
+
+            loop state 0
 
         // Returns true if `handle` is a CLR enum value type — a nominal type whose
         // immediate runtime base is `System.Enum`. Used by the array-element


### PR DESCRIPTION
## Summary

- Implements ECMA-335 §I.8.7.2 / CoreCLR `CanCastByVarianceToInterfaceOrDelegate` for distinct instantiations of the same TypeDef: per-parameter check with covariant/contravariant/invariant rules, value-typed `from` argument rejected (CoreCLR `IsBoxedAndCanCastTo` precondition), recursion for composed variance (e.g. `Func<Func<Derived>>` ⊑ `Func<Func<Base>>`).
- Replaces the last `failwith "TODO: generic variance check needed"` in `isConcreteTypeAssignableTo`. The `try/with` gate at `IlMachineStateExecution.fs:1633-1645` still catches that exception and degrades to "permit"; removing that gate is the follow-up PR in this series (preceded by #573 enum-underlying integer equivalence and #575 SZ-array implicit interfaces).
- Adds five C# regression tests covering: direct same-TypeDef cases (custom co/contra/invariant interfaces, value-type arg rejection, identity passthrough), the interface walk (transitive co-variant chain plus BCL `List<Derived>` against `IEnumerable<Base>`/`IReadOnlyList<Base>`/`IList<Base>`/`ICollection<Base>`), delegate variance (`Func`/`Action` plus mixed `Func<TArg,TResult>`), the array-store-variance gate giving a definitive answer for `Func<Base>[]` storing `Func<Derived>`/`Func<int>`, and nested variance composition (`Func<Func<Derived>>` and `Action<Func<Base>>` chains).

## Test plan
- [x] `nix develop -c dotnet build WoofWare.PawPrint.slnx` succeeds with 0 warnings
- [x] All 1146 existing tests still pass (`nix develop -c dotnet test ...`)
- [x] New tests pass: `GenericInterfaceVarianceDirect`, `GenericInterfaceVarianceWalked`, `GenericDelegateVariance`, `ArrayStoreVarianceDelegate`, `NestedGenericVariance`
- [x] `nix develop -c dotnet fantomas .` is clean
- [x] `codex review --base main` reports no actionable issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)