### PR TITLE
Make array-store-variance gate authoritative (remove TODO fallback)

### DIFF
--- a/WoofWare.PawPrint/IlMachineStateExecution.fs
+++ b/WoofWare.PawPrint/IlMachineStateExecution.fs
@@ -1563,9 +1563,6 @@ module IlMachineStateExecution =
     /// storable. Value-typed-element arrays bypass the gate: there is no covariance
     /// for value types, the verifier rejects mismatching value-store opcodes at
     /// load time, and primitive coercion is handled by `EvalStackValue.toCliTypeCoerced`.
-    /// (ECMA-335 also recognises a primitive-equivalence rule, e.g. `int[]` /
-    /// `uint[]`, which is intentionally not modelled yet — see the TODO at
-    /// `IlMachineRuntimeMetadata.checkArraySpecificRules`.)
     let checkArrayStoreVariance
         (loggerFactory : ILoggerFactory)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
@@ -1615,41 +1612,17 @@ module IlMachineStateExecution =
         | EvalStackValue.ObjectRef addr ->
             let valueRuntimeType = ManagedHeap.getObjectConcreteType addr state.ManagedHeap
 
-            // `isConcreteTypeAssignableTo` still `failwith`s on one remaining
-            // combination it doesn't yet model: `walk` traversing a Concrete
-            // type whose definition has variant generic parameters (the
-            // `TODO: generic variance check needed` site in
-            // IlMachineRuntimeMetadata). This arises from legitimate covariant
-            // assignments like `Func<int>` into a `Func<int>[]` element when
-            // other instantiations also exist. Before this gate such stores
-            // silently succeeded — they don't go through any assignability
-            // check at all in the previous code. Turning them into host
-            // failures would regress previously-working programs, so we
-            // degrade to "permit" when the walk can't reach a definitive
-            // answer. The variance gate is therefore best-effort until that
-            // remaining TODO is implemented; at that point this try/with can
-            // be removed and the check becomes precise. The array-source →
-            // generic-interface case (e.g. `string[]` into `IEnumerable<T>[]`
-            // element) is now precise via the SZ-array implicit-interface
-            // carve-out implemented in `isConcreteTypeAssignableTo`.
-            let state, decision =
-                try
-                    let state, isAssignable =
-                        IlMachineState.isConcreteTypeAssignableTo
-                            loggerFactory
-                            baseClassTypes
-                            state
-                            valueRuntimeType
-                            storedElement
+            let state, isAssignable =
+                IlMachineState.isConcreteTypeAssignableTo
+                    loggerFactory
+                    baseClassTypes
+                    state
+                    valueRuntimeType
+                    storedElement
 
-                    state, ValueSome isAssignable
-                with ex when ex.Message.StartsWith "TODO:" ->
-                    state, ValueNone
-
-            match decision with
-            | ValueNone
-            | ValueSome true -> ArrayStoreVarianceCheck.Allowed state
-            | ValueSome false ->
+            if isAssignable then
+                ArrayStoreVarianceCheck.Allowed state
+            else
                 let state, _whatWeDid =
                     raiseRuntimeException
                         loggerFactory


### PR DESCRIPTION
## Summary

- Removes the `try ... with ex when ex.Message.StartsWith "TODO:"` fallback in `checkArrayStoreVariance` that degraded to "permit" whenever `isConcreteTypeAssignableTo` hit an unmodelled case. The three preceding PRs (#573 enum-underlying integer equivalence, #575 SZ-array implicit interfaces, #578 generic variance walk) eliminated every `failwith "TODO:"` the gate could previously reach, so the oracle is now total on every shape the gate hands it.
- The classifier is now load-bearing: a `false` answer reliably means the store is covariance-incompatible, so we can raise `ArrayTypeMismatchException` without risking false-positive crashes on legitimate covariant stores.
- Drops a stale docstring sentence on `checkArrayStoreVariance` referencing the unmodelled primitive-equivalence rule — that TODO was resolved by #573.

## Test plan
- [x] `nix develop -c dotnet build WoofWare.PawPrint.slnx` (0 warnings, 0 errors)
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — all 1153 tests pass
- [x] `nix develop -c dotnet fantomas .` clean
- [x] `codex review --base main` reports no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)