### PR TITLE
Implement ThreadNative_InformThreadNameChange QCall

### DIFF
--- a/WoofWare.PawPrint.Test/TestLowLevelMonitor.fs
+++ b/WoofWare.PawPrint.Test/TestLowLevelMonitor.fs
@@ -43,6 +43,7 @@ module TestLowLevelMonitor =
             ActiveMethodState = FrameId -1
             Status = status
             IsBackground = false
+            Name = None
         }
 
     let private withThreads (threads : ThreadId list) (state : IlMachineState) : IlMachineState =

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -20,7 +20,7 @@ module TestPureCases =
             "AdvancedStructLayout.cs" // past MarshalNative_SizeOfHelper for ByValTStr and SystemNative_Malloc / SystemNative_Free / Marshal.AllocHGlobal / FreeHGlobal; now blocked downstream at the unimplemented MarshalNative_TryGetStructMarshalStub QCall (CoreLib's Marshal.StructureToPtr path)
             "LdtokenField.cs" // past Buffer's reflection-cache copy (cell-aware path); now blocked on the next reflection-cache step at unimplemented InternalCall RuntimeFieldHandle::GetApproxDeclaringMethodTable
             "InterfaceDispatch.cs" // expected: 0; was: 1024
-            "Threads.cs" // past Buffer's reflection-cache copy and ThreadNative_SetIsBackground; now blocked on unimplemented QCall ThreadNative_InformThreadNameChange (BCL Thread.Name setter / SetThreadPoolWorkerThreadName)
+            "Threads.cs" // past ThreadNative_InformThreadNameChange (Thread.Name setter); now blocked on unimplemented PAL call libSystem.Native!SystemNative_GetLowResolutionTimestamp (.Sys::GetLowResolutionTimestamp, used by the Task/ThreadPool scheduler)
             "IsAssignableToBasic.cs" // MethodTable field projection for MethodTable::PerInstInfo
         ]
         |> Set.ofList

--- a/WoofWare.PawPrint.Test/TestSyncBlockMonitor.fs
+++ b/WoofWare.PawPrint.Test/TestSyncBlockMonitor.fs
@@ -45,6 +45,7 @@ module TestSyncBlockMonitor =
             ActiveMethodState = FrameId -1
             Status = status
             IsBackground = false
+            Name = None
         }
 
     let private withThreads (threads : ThreadId list) (state : IlMachineState) : IlMachineState =

--- a/WoofWare.PawPrint.Test/TestWaitHandle.fs
+++ b/WoofWare.PawPrint.Test/TestWaitHandle.fs
@@ -39,6 +39,7 @@ module TestWaitHandle =
             ActiveMethodState = FrameId -1
             Status = status
             IsBackground = false
+            Name = None
         }
 
     let private withThreads (threads : ThreadId list) (state : IlMachineState) : IlMachineState =

--- a/WoofWare.PawPrint/IlMachineThreadState.fs
+++ b/WoofWare.PawPrint/IlMachineThreadState.fs
@@ -376,6 +376,7 @@ module IlMachineThreadState =
                 ActiveMethodState = FrameId -1
                 Status = ThreadStatus.NotStarted
                 IsBackground = false
+                Name = None
             }
 
         let newState =

--- a/WoofWare.PawPrint/Native/NativeCall.fs
+++ b/WoofWare.PawPrint/Native/NativeCall.fs
@@ -266,12 +266,13 @@ module NativeCall =
     /// `ThreadNative_InformThreadNameChange` QCall, whose CoreCLR signature is
     /// `(ThreadHandle, char* name, int32 len) -> void`).
     ///
-    /// `length = 0` returns `""` even when `ptr` is `Null`: that matches what the
-    /// BCL hands us when the guest clears `Thread.Name` (it passes a null pointer
-    /// alongside `len = 0` rather than allocating an empty buffer). `length < 0`
-    /// is a guest contract violation and fails loudly. A null pointer with
-    /// `length > 0` is also a contract violation and fails loudly rather than
-    /// dereferencing the null.
+    /// `length = 0` returns `""` regardless of `ptr` (so this helper safely
+    /// handles both `Thread.Name = ""` — non-null pointer, len=0 — and
+    /// `Thread.Name = null` — null pointer, len=0); callers that need to
+    /// distinguish those two cases must inspect the pointer themselves before
+    /// invoking. `length < 0` is a guest contract violation and fails loudly.
+    /// A null pointer with `length > 0` is also a contract violation and
+    /// fails loudly rather than dereferencing the null.
     let readLengthPrefixedUtf16
         (operation : string)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)

--- a/WoofWare.PawPrint/Native/NativeCall.fs
+++ b/WoofWare.PawPrint/Native/NativeCall.fs
@@ -260,6 +260,47 @@ module NativeCall =
 
             loop 0 []
 
+    /// Read exactly `length` UTF-16 code units from `ptr`, returning the resulting
+    /// `string`. Counterpart to `readNullTerminatedUtf16` for callers whose source
+    /// passes an explicit length alongside the pointer (e.g. the
+    /// `ThreadNative_InformThreadNameChange` QCall, whose CoreCLR signature is
+    /// `(ThreadHandle, char* name, int32 len) -> void`).
+    ///
+    /// `length = 0` returns `""` even when `ptr` is `Null`: that matches what the
+    /// BCL hands us when the guest clears `Thread.Name` (it passes a null pointer
+    /// alongside `len = 0` rather than allocating an empty buffer). `length < 0`
+    /// is a guest contract violation and fails loudly. A null pointer with
+    /// `length > 0` is also a contract violation and fails loudly rather than
+    /// dereferencing the null.
+    let readLengthPrefixedUtf16
+        (operation : string)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (ptr : ManagedPointerSource)
+        (length : int)
+        : string
+        =
+        if length < 0 then
+            failwith $"%s{operation}: UTF-16 length %d{length} is negative"
+        elif length = 0 then
+            ""
+        else
+            match ptr with
+            | ManagedPointerSource.Null ->
+                failwith
+                    $"%s{operation}: cannot read UTF-16 string of length %d{length} from a null pointer; callers must pass length=0 when the pointer is null"
+            | ManagedPointerSource.NativeIntPlaceholder bits ->
+                failwith
+                    $"%s{operation}: cannot read UTF-16 string from fake non-null byref @ 0x%x{bits}; the placeholder must never be dereferenced"
+            | ManagedPointerSource.Byref _ ->
+                let charConcreteType = requiredCharConcreteType operation baseClassTypes state
+                let chars = Array.zeroCreate<char> length
+
+                for i in 0 .. length - 1 do
+                    chars.[i] <- readUtf16Char operation baseClassTypes state charConcreteType ptr i
+
+                System.String chars
+
     let requiredByteConcreteType
         (operation : string)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -41,6 +41,7 @@ module NativeQCall =
             "ThreadNative_Join", NativeThreading.tryExecuteQCall "ThreadNative_Join"
             "ThreadNative_SetIsBackground", NativeThreading.tryExecuteQCall "ThreadNative_SetIsBackground"
             "ThreadNative_GetIsBackground", NativeThreading.tryExecuteQCall "ThreadNative_GetIsBackground"
+            "ThreadNative_InformThreadNameChange", NativeThreading.tryExecuteQCall "ThreadNative_InformThreadNameChange"
             "Monitor_Wait", NativeMonitor.tryExecuteQCall "Monitor_Wait"
             "Monitor_Pulse", NativeMonitor.tryExecuteQCall "Monitor_Pulse"
             "Monitor_PulseAll", NativeMonitor.tryExecuteQCall "Monitor_PulseAll"

--- a/WoofWare.PawPrint/Native/NativeThreading.fs
+++ b/WoofWare.PawPrint/Native/NativeThreading.fs
@@ -471,13 +471,17 @@ module NativeThreading =
                 | other -> failwith $"%s{operation}: expected int32 length, got %O{other}"
 
             let newName : string option =
-                if nameLength = 0 then
-                    // Guest passed length=0; pointer may legally be null (when the guest
-                    // cleared `Thread.Name`). We model "no name set" as `None` rather
-                    // than `Some ""` so the field round-trips cleanly through serialisation
-                    // and so consumers don't have to disambiguate the two empty states.
-                    None
-                else
+                // Disambiguate `Thread.Name = null` from `Thread.Name = ""` by inspecting
+                // the pointer alongside the length: clearing the name passes a null
+                // pointer with len=0, but assigning `""` passes a non-null pointer
+                // (from `String.Empty.GetPinnableReference()`) also with len=0. The
+                // canonical `_name` field stores the two states distinctly, so the
+                // diagnostic mirror must do the same. Anything else delegates to
+                // `readLengthPrefixedUtf16`, which yields `""` for non-null + len=0
+                // and fails loudly on null + len>0.
+                match namePtr with
+                | ManagedPointerSource.Null when nameLength = 0 -> None
+                | _ ->
                     NativeCall.readLengthPrefixedUtf16 operation ctx.BaseClassTypes state namePtr nameLength
                     |> Some
 

--- a/WoofWare.PawPrint/Native/NativeThreading.fs
+++ b/WoofWare.PawPrint/Native/NativeThreading.fs
@@ -421,6 +421,94 @@ module NativeThreading =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 resultInt)) ctx.Thread state
 
             NativeHandlerResult.completed state |> Some
+        | "ThreadNative_InformThreadNameChange",
+          "System.Private.CoreLib",
+          "System.Threading",
+          "Thread",
+          // The C# source uses LibraryImport with StringMarshalling.Utf16 on a non-blittable
+          // `string?` parameter, so Roslyn emits a marshalling stub whose synthesised name
+          // (`<InformThreadNameChange>g____PInvoke|N_M`) carries source-generator counters
+          // not stable across runtime versions. Discard the IL method name and validate the
+          // signature shape on the parameter-types pattern below; the QCall entry-point
+          // tuple element is already an exact match. Same approach as Environment_FailFast.
+          _,
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Threading",
+                                              "ThreadHandle",
+                                              threadHandleGenerics)
+            ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt16)
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32 ],
+          MethodReturnType.Void when threadHandleGenerics.IsEmpty ->
+            // .NET 10 QCall fired by the `Thread.Name` setter after the BCL has already
+            // written the canonical name into the managed `Thread._name` field. In CoreCLR
+            // this hook tells the OS / debugger about the new thread name
+            // (SetThreadDescription on Windows, pthread_setname_np on Linux). PawPrint has
+            // no OS threads to name, so we simply record the value on `ThreadState.Name`
+            // as a diagnostic mirror — guest reads of `Thread.Name` go through `_name` and
+            // never consult our mirror, so the mirror cannot mislead guest code.
+            //
+            // The BCL passes (handle, char* name, int32 length). When the guest clears the
+            // name (`Thread.Name = null`), the call arrives with a null pointer and
+            // length=0; we translate that to `None`. Otherwise length is the count of
+            // UTF-16 code units pointed to by `name` (no null terminator required), which
+            // we read with `readLengthPrefixedUtf16` and store as `Some s`.
+            let operation = "ThreadNative_InformThreadNameChange"
+
+            if instruction.Arguments.Length <> 3 then
+                failwith $"%s{operation}: expected three native arguments, got %d{instruction.Arguments.Length}"
+
+            let threadAddr =
+                threadAddrFromThreadHandle state operation instruction.Arguments.[0]
+
+            let targetThreadId = threadIdFromThreadAddr state operation threadAddr
+
+            let namePtr =
+                NativeCall.managedPointerOfPointerArgument operation "name" instruction.Arguments.[1]
+
+            let nameLength =
+                match instruction.Arguments.[2] |> CliType.unwrapPrimitiveLikeDeep with
+                | CliType.Numeric (CliNumericType.Int32 i) -> i
+                | other -> failwith $"%s{operation}: expected int32 length, got %O{other}"
+
+            let newName : string option =
+                if nameLength = 0 then
+                    // Guest passed length=0; pointer may legally be null (when the guest
+                    // cleared `Thread.Name`). We model "no name set" as `None` rather
+                    // than `Some ""` so the field round-trips cleanly through serialisation
+                    // and so consumers don't have to disambiguate the two empty states.
+                    None
+                else
+                    NativeCall.readLengthPrefixedUtf16 operation ctx.BaseClassTypes state namePtr nameLength
+                    |> Some
+
+            let targetState =
+                state.ThreadState
+                |> Map.tryFind targetThreadId
+                |> Option.defaultWith (fun () ->
+                    failwith $"%s{operation}: target ThreadId {targetThreadId} has no ThreadState"
+                )
+
+            // Mirror the SetIsBackground guard: the real CLR raises ThreadStateException
+            // via the BCL's `_isDead` check on terminated threads before reaching the
+            // QCall; PawPrint doesn't yet flip `_isDead` at thread termination, so we
+            // catch the case here rather than silently storing a name on a dead thread.
+            match targetState.Status with
+            | ThreadStatus.Terminated ->
+                failwith
+                    $"%s{operation}: target ThreadId {targetThreadId} has terminated. The real CLR raises ThreadStateException via the BCL's `_isDead` check; PawPrint doesn't synthesise that yet, so this is a guest bug we can't currently report structurally."
+            | _ -> ()
+
+            let updatedThreadState =
+                { targetState with
+                    Name = newName
+                }
+
+            let state =
+                { state with
+                    ThreadState = state.ThreadState |> Map.add targetThreadId updatedThreadState
+                }
+
+            NativeHandlerResult.completed state |> Some
         | _ -> None
 
     let tryExecute (ctx : NativeCallContext) : NativeHandlerResult option =

--- a/WoofWare.PawPrint/Native/NativeThreading.fs
+++ b/WoofWare.PawPrint/Native/NativeThreading.fs
@@ -488,16 +488,13 @@ module NativeThreading =
                     failwith $"%s{operation}: target ThreadId {targetThreadId} has no ThreadState"
                 )
 
-            // Mirror the SetIsBackground guard: the real CLR raises ThreadStateException
-            // via the BCL's `_isDead` check on terminated threads before reaching the
-            // QCall; PawPrint doesn't yet flip `_isDead` at thread termination, so we
-            // catch the case here rather than silently storing a name on a dead thread.
-            match targetState.Status with
-            | ThreadStatus.Terminated ->
-                failwith
-                    $"%s{operation}: target ThreadId {targetThreadId} has terminated. The real CLR raises ThreadStateException via the BCL's `_isDead` check; PawPrint doesn't synthesise that yet, so this is a guest bug we can't currently report structurally."
-            | _ -> ()
-
+            // Unlike SetIsBackground, `Thread.Name`'s managed setter has no `_isDead`
+            // check and CoreCLR's native InformThreadNameChange just skips the OS-level
+            // naming when the handle is invalid (it does not throw). So setting or
+            // clearing `Thread.Name` on a terminated thread is valid guest behaviour —
+            // we record the requested value unconditionally, matching the BCL's
+            // unconditional update of the canonical `_name` field that runs before
+            // this QCall fires.
             let updatedThreadState =
                 { targetState with
                     Name = newName

--- a/WoofWare.PawPrint/ThreadState.fs
+++ b/WoofWare.PawPrint/ThreadState.fs
@@ -89,6 +89,18 @@ type ThreadState =
         /// preserving round-trip semantics for guest code that reads back
         /// `Thread.IsBackground`. Default `false` matches the BCL.
         IsBackground : bool
+        /// Diagnostic mirror of the thread's name, populated when the guest
+        /// invokes the `ThreadNative_InformThreadNameChange` QCall (i.e. via
+        /// the managed `Thread.Name` setter). The canonical name lives in the
+        /// managed `Thread._name` field; the BCL getter reads that field
+        /// directly without consulting us, so this mirror is *not* an
+        /// authoritative source for guest reads. It exists so PawPrint's
+        /// debugger, tracing, and snapshot tooling can surface a thread's
+        /// name without walking heap fields. Reflection-based writes to
+        /// `_name` would not update this mirror, but such drift is invisible
+        /// to guests because they read `_name`, not this field. `None` means
+        /// the guest has either never set the name or has cleared it.
+        Name : string option
     }
 
     // --- Frame resolution primitives ---
@@ -165,6 +177,7 @@ type ThreadState =
             NextFrameId = 1
             Status = ThreadStatus.Runnable
             IsBackground = false
+            Name = None
         }
 
     static member peekEvalStack (state : ThreadState) : EvalStackValue option =


### PR DESCRIPTION
## Summary

- Wire up the .NET 10 `ThreadNative_InformThreadNameChange` QCall (called by `Thread.Name`'s setter after the BCL updates the canonical `_name`). PawPrint has no OS threads to name, so we record the value on a new `ThreadState.Name : string option` as a diagnostic mirror for debugger/trace surfaces — guest reads of `Thread.Name` go through `_name` and never consult our mirror, so the mirror cannot mislead guest code.
- Match the QCall by signature shape rather than IL method name: the BCL declares it with `[LibraryImport(... StringMarshalling = StringMarshalling.Utf16)]` on a non-blittable `string?`, so Roslyn emits a marshalling stub whose synthesised name (`<InformThreadNameChange>g____PInvoke|N_M`) is not stable across runtime versions. Same approach as the existing `Environment_FailFast` handler.
- Add `NativeCall.readLengthPrefixedUtf16` next to `readNullTerminatedUtf16` for QCalls whose source passes an explicit `(char* name, int32 len)` shape.
- Disambiguate `Thread.Name = ""` (non-null pointer, `len=0`) from `Thread.Name = null` (null pointer, `len=0`) in the mirror — the BCL's `_name` stores those distinctly.

Threads.cs now progresses past this QCall to a new downstream blocker — `SystemNative_GetLowResolutionTimestamp` (libSystem.Native PAL, used by the Task/ThreadPool scheduler) — so it stays on the unimplemented list with an updated comment. Separate work.

## Test plan

- [x] `nix develop -c dotnet build WoofWare.PawPrint.slnx` clean
- [x] `nix develop -c dotnet test ... --filter "FullyQualifiedName~TestPureCases"` — 312 passed, 0 failed
- [x] `nix develop -c dotnet test ... --filter "Name~Thread|Name~Monitor|Name~WaitHandle|Name~SyncBlock|Name~LowLevel"` — 191 passed, 0 failed (covers the test files that construct `ThreadState` directly, since the new `Name` field added a field to that record)
- [x] Verified `Threads.cs` reaches and clears the new QCall handler in isolation; new failure surfaces downstream at `SystemNative_GetLowResolutionTimestamp` as expected
- [x] `codex review --base main` returned clean after addressing two findings (see commit history)

🤖 Generated with [Claude Code](https://claude.com/claude-code)