### PR TITLE
Project MethodTable::PerInstInfo via synthetic deref chain

### DIFF
--- a/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
+++ b/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
@@ -1258,7 +1258,7 @@ public unsafe struct PointerWrapper
             ImmutableArray.Empty
 
     [<Test>]
-    let ``PerInstInfo projection succeeds for closed generic instantiation`` () : unit =
+    let ``PerInstInfo projection succeeds for System.Nullable`` () : unit =
         let _, loggerFactory = LoggerFactory.makeTest ()
         use _loggerFactoryResource = loggerFactory
         let intHandle = handleFor bct.Int32
@@ -1284,7 +1284,38 @@ public unsafe struct PointerWrapper
             )
 
         ex.Message |> shouldContainText "PerInstInfo"
-        ex.Message |> shouldContainText "non-generic"
+        ex.Message |> shouldContainText "Nullable"
+
+    [<Test>]
+    let ``PerInstInfo projection refuses non-Nullable closed generics`` () : unit =
+        // List<int> has a single dictionary (no generic ancestors) so in
+        // principle the first PerInstInfo slot would hold int's MethodTable,
+        // but PawPrint only commits to the Nullable layout today. The
+        // classifier must refuse this case to keep its contract truthful;
+        // broadening requires explicit dictionary-index modelling for types
+        // whose inheritance chain contributes additional dictionaries.
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+        let intHandle = handleFor bct.Int32
+
+        let state, listIntHandle =
+            topLevelType "System.Collections.Generic" "List`1"
+            |> DumpedAssembly.typeInfoToTypeDefn' bct (stateWithLogger loggerFactory)._LoadedAssemblies
+            |> IlMachineState.concretizeType
+                loggerFactory
+                bct
+                (stateWithLogger loggerFactory)
+                corelib.Name
+                (ImmutableArray.Create intHandle)
+                ImmutableArray.Empty
+
+        let ex =
+            Assert.Throws<System.Exception> (fun () ->
+                projectFromState loggerFactory state "PerInstInfo" listIntHandle |> ignore
+            )
+
+        ex.Message |> shouldContainText "PerInstInfo"
+        ex.Message |> shouldContainText "Nullable"
 
     [<Test>]
     let ``PerInstInfo projection refuses array handles`` () : unit =

--- a/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
+++ b/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
@@ -1241,6 +1241,180 @@ public unsafe struct PointerWrapper
         projectAuxiliaryData "Flags" (handleFor bct.Int32)
         |> shouldEqual (CliType.Numeric (CliNumericType.Int32 0))
 
+    let private concretizeNullableOf
+        (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
+        (argHandle : ConcreteTypeHandle)
+        (state : IlMachineState)
+        : IlMachineState * ConcreteTypeHandle
+        =
+        topLevelType "System" "Nullable`1"
+        |> DumpedAssembly.typeInfoToTypeDefn' bct state._LoadedAssemblies
+        |> IlMachineState.concretizeType
+            loggerFactory
+            bct
+            state
+            corelib.Name
+            (ImmutableArray.Create argHandle)
+            ImmutableArray.Empty
+
+    [<Test>]
+    let ``PerInstInfo projection succeeds for closed generic instantiation`` () : unit =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+        let intHandle = handleFor bct.Int32
+
+        let state, nullableIntHandle =
+            concretizeNullableOf loggerFactory intHandle (stateWithLogger loggerFactory)
+
+        let projected, _ =
+            projectFromState loggerFactory state "PerInstInfo" nullableIntHandle
+
+        projected
+        |> shouldEqual (CliType.RuntimePointer (CliRuntimePointer.PerInstInfoPtr nullableIntHandle))
+
+    [<Test>]
+    let ``PerInstInfo projection refuses non-generic concrete types`` () : unit =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+
+        let ex =
+            Assert.Throws<System.Exception> (fun () ->
+                projectFromState loggerFactory (stateWithLogger loggerFactory) "PerInstInfo" (handleFor bct.Int32)
+                |> ignore
+            )
+
+        ex.Message |> shouldContainText "PerInstInfo"
+        ex.Message |> shouldContainText "non-generic"
+
+    [<Test>]
+    let ``PerInstInfo projection refuses array handles`` () : unit =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+        let intArrayHandle = ConcreteTypeHandle.OneDimArrayZero (handleFor bct.Int32)
+
+        let ex =
+            Assert.Throws<System.Exception> (fun () ->
+                projectFromState loggerFactory (stateWithLogger loggerFactory) "PerInstInfo" intArrayHandle
+                |> ignore
+            )
+
+        ex.Message |> shouldContainText "PerInstInfo"
+        ex.Message |> shouldContainText "array"
+
+    [<Test>]
+    let ``PerInstInfo projection refuses open generic definitions`` () : unit =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+
+        let target =
+            topLevelType "System" "Nullable`1"
+            |> _.Identity
+            |> RuntimeTypeHandleTarget.OpenGenericTypeDefinition
+
+        let ex =
+            Assert.Throws<System.Exception> (fun () ->
+                MethodTableProjection.tryProjectFieldForRuntimeTypeHandleTarget
+                    loggerFactory
+                    bct
+                    (methodTableField "PerInstInfo")
+                    target
+                    (stateWithLogger loggerFactory)
+                |> ignore
+            )
+
+        ex.Message |> shouldContainText "PerInstInfo"
+        ex.Message |> shouldContainText "open generic"
+
+    [<Test>]
+    let ``Ldfld projects PerInstInfo from MethodTable pointer for closed generic`` () : unit =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+        let field = methodTableField "PerInstInfo"
+        let token = MetadataToken.FieldDefinition field.Handle
+        let token = SourcedMetadataToken.make corelib.Name token
+        let op = IlOp.UnaryMetadataToken (UnaryMetadataTokenIlOp.Ldfld, token)
+        let intHandle = handleFor bct.Int32
+
+        let state, nullableIntHandle =
+            concretizeNullableOf loggerFactory intHandle (stateWithLogger loggerFactory)
+
+        let state, thread = stateWithSingleInstructionFromState loggerFactory op state
+
+        let state =
+            state
+            |> IlMachineState.pushToEvalStack'
+                (EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr nullableIntHandle))
+                thread
+
+        let state, whatWeDid =
+            UnaryMetadataIlOp.execute loggerFactory bct UnaryMetadataTokenIlOp.Ldfld token state thread
+
+        whatWeDid |> shouldEqual WhatWeDid.Executed
+
+        IlMachineState.peekEvalStack thread state
+        |> shouldEqual (Some (EvalStackValue.NativeInt (NativeIntSource.PerInstInfoPtr nullableIntHandle)))
+
+        state.ThreadState.[thread].MethodState.IlOpIndex
+        |> shouldEqual (IlOp.NumberOfBytes op)
+
+    [<Test>]
+    let ``Ldind_i on PerInstInfoPtr steps to PerInstDictPtr for same handle`` () : unit =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+        let op = IlOp.Nullary NullaryIlOp.Ldind_i
+        let intHandle = handleFor bct.Int32
+
+        let state, nullableIntHandle =
+            concretizeNullableOf loggerFactory intHandle (stateWithLogger loggerFactory)
+
+        let state, thread = stateWithSingleInstructionFromState loggerFactory op state
+
+        let state =
+            state
+            |> IlMachineState.pushToEvalStack'
+                (EvalStackValue.NativeInt (NativeIntSource.PerInstInfoPtr nullableIntHandle))
+                thread
+
+        let state =
+            match NullaryIlOp.execute loggerFactory bct state thread NullaryIlOp.Ldind_i with
+            | ExecutionResult.Stepped (state, WhatWeDid.Executed, _) -> state
+            | other -> failwith $"Expected stepped execution, got %O{other}"
+
+        IlMachineState.peekEvalStack thread state
+        |> shouldEqual (Some (EvalStackValue.NativeInt (NativeIntSource.PerInstDictPtr nullableIntHandle)))
+
+        state.ThreadState.[thread].MethodState.IlOpIndex
+        |> shouldEqual (IlOp.NumberOfBytes op)
+
+    [<Test>]
+    let ``Ldind_i on PerInstDictPtr resolves first generic argument's MethodTable`` () : unit =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+        let op = IlOp.Nullary NullaryIlOp.Ldind_i
+        let intHandle = handleFor bct.Int32
+
+        let state, nullableIntHandle =
+            concretizeNullableOf loggerFactory intHandle (stateWithLogger loggerFactory)
+
+        let state, thread = stateWithSingleInstructionFromState loggerFactory op state
+
+        let state =
+            state
+            |> IlMachineState.pushToEvalStack'
+                (EvalStackValue.NativeInt (NativeIntSource.PerInstDictPtr nullableIntHandle))
+                thread
+
+        let state =
+            match NullaryIlOp.execute loggerFactory bct state thread NullaryIlOp.Ldind_i with
+            | ExecutionResult.Stepped (state, WhatWeDid.Executed, _) -> state
+            | other -> failwith $"Expected stepped execution, got %O{other}"
+
+        IlMachineState.peekEvalStack thread state
+        |> shouldEqual (Some (EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr intHandle)))
+
+        state.ThreadState.[thread].MethodState.IlOpIndex
+        |> shouldEqual (IlOp.NumberOfBytes op)
+
     [<Test>]
     let ``Ldfld projects MethodTableAuxiliaryData flags from auxiliary-data pointer provenance`` () : unit =
         let _, loggerFactory = LoggerFactory.makeTest ()

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -21,7 +21,6 @@ module TestPureCases =
             "LdtokenField.cs" // past Buffer's reflection-cache copy (cell-aware path); now blocked on the next reflection-cache step at unimplemented InternalCall RuntimeFieldHandle::GetApproxDeclaringMethodTable
             "InterfaceDispatch.cs" // expected: 0; was: 1024
             "Threads.cs" // past ThreadNative_InformThreadNameChange (Thread.Name setter); now blocked on unimplemented PAL call libSystem.Native!SystemNative_GetLowResolutionTimestamp (.Sys::GetLowResolutionTimestamp, used by the Task/ThreadPool scheduler)
-            "IsAssignableToBasic.cs" // MethodTable field projection for MethodTable::PerInstInfo
         ]
         |> Set.ofList
 

--- a/WoofWare.PawPrint/CliNumericType.fs
+++ b/WoofWare.PawPrint/CliNumericType.fs
@@ -333,6 +333,8 @@ type CliNumericType =
             | NativeIntSource.MethodTablePtr _ -> failwith "refusing to express MethodTablePtr as bytes"
             | NativeIntSource.MethodTableAuxiliaryDataPtr _ ->
                 failwith "refusing to express MethodTableAuxiliaryDataPtr as bytes"
+            | NativeIntSource.PerInstInfoPtr _ -> failwith "refusing to express PerInstInfoPtr as bytes"
+            | NativeIntSource.PerInstDictPtr _ -> failwith "refusing to express PerInstDictPtr as bytes"
             | NativeIntSource.GcHandlePtr _ -> failwith "refusing to express GcHandlePtr as bytes"
             | NativeIntSource.EventPipeProviderPtr _ -> failwith "refusing to express EventPipeProviderPtr as bytes"
             | NativeIntSource.EventPipeEventPtr _ -> failwith "refusing to express EventPipeEventPtr as bytes"

--- a/WoofWare.PawPrint/CliType.fs
+++ b/WoofWare.PawPrint/CliType.fs
@@ -94,6 +94,8 @@ module private ByteAddressabilityClassifier =
         | NativeIntSource.TypeHandlePtr _
         | NativeIntSource.MethodTablePtr _
         | NativeIntSource.MethodTableAuxiliaryDataPtr _
+        | NativeIntSource.PerInstInfoPtr _
+        | NativeIntSource.PerInstDictPtr _
         | NativeIntSource.MethodHandlePtr _
         | NativeIntSource.FieldHandlePtr _
         | NativeIntSource.AssemblyHandle _

--- a/WoofWare.PawPrint/EvalStack.fs
+++ b/WoofWare.PawPrint/EvalStack.fs
@@ -47,6 +47,10 @@ module EvalStackValue =
             failwith $"%s{operation}: refusing to convert MethodTable pointer %O{typeHandle} to an integer"
         | NativeIntSource.MethodTableAuxiliaryDataPtr typeHandle ->
             failwith $"%s{operation}: refusing to convert MethodTableAuxiliaryData pointer %O{typeHandle} to an integer"
+        | NativeIntSource.PerInstInfoPtr handle ->
+            failwith $"%s{operation}: refusing to convert PerInstInfo pointer %O{handle} to an integer"
+        | NativeIntSource.PerInstDictPtr handle ->
+            failwith $"%s{operation}: refusing to convert PerInstDict pointer %O{handle} to an integer"
         | NativeIntSource.FieldHandlePtr handle ->
             failwith $"%s{operation}: refusing to convert RuntimeFieldHandle pointer %d{handle} to an integer"
         | NativeIntSource.MethodHandlePtr handle ->
@@ -240,6 +244,10 @@ module EvalStackValue =
             | NativeIntSource.MethodTableAuxiliaryDataPtr typeHandle ->
                 failwith
                     $"Conv_U: refusing to convert MethodTableAuxiliaryData pointer %O{typeHandle} to unsigned native int"
+            | NativeIntSource.PerInstInfoPtr handle ->
+                failwith $"Conv_U: refusing to convert PerInstInfo pointer %O{handle} to unsigned native int"
+            | NativeIntSource.PerInstDictPtr handle ->
+                failwith $"Conv_U: refusing to convert PerInstDict pointer %O{handle} to unsigned native int"
             | NativeIntSource.GcHandlePtr handle ->
                 failwith $"Conv_U: refusing to convert GC handle pointer %O{handle} to unsigned native int"
             | NativeIntSource.EventPipeProviderPtr id ->
@@ -518,6 +526,10 @@ module EvalStackValue =
             | CliRuntimePointer.MethodTableAuxiliaryDataPtr typeHandle ->
                 NativeIntSource.MethodTableAuxiliaryDataPtr typeHandle
                 |> EvalStackValue.NativeInt
+            | CliRuntimePointer.PerInstInfoPtr handle ->
+                NativeIntSource.PerInstInfoPtr handle |> EvalStackValue.NativeInt
+            | CliRuntimePointer.PerInstDictPtr handle ->
+                NativeIntSource.PerInstDictPtr handle |> EvalStackValue.NativeInt
             | CliRuntimePointer.Managed ptr -> ptr |> EvalStackValue.ManagedPointer
             | CliRuntimePointer.GcHandlePtr addr -> NativeIntSource.GcHandlePtr addr |> EvalStackValue.NativeInt
         | CliType.ValueType vt ->
@@ -561,6 +573,10 @@ module EvalStackValue =
                     | NativeIntSource.TypeHandlePtr f -> failwith $"TODO: {f}"
                     | NativeIntSource.MethodTablePtr f -> failwith $"TODO: {f}"
                     | NativeIntSource.MethodTableAuxiliaryDataPtr f -> failwith $"TODO: {f}"
+                    | NativeIntSource.PerInstInfoPtr f ->
+                        failwith $"refusing to coerce PerInstInfo pointer %O{f} to int64"
+                    | NativeIntSource.PerInstDictPtr f ->
+                        failwith $"refusing to coerce PerInstDict pointer %O{f} to int64"
                     | NativeIntSource.GcHandlePtr f -> failwith $"TODO: {f}"
                     | NativeIntSource.EventPipeProviderPtr id ->
                         failwith $"refusing to coerce EventPipe provider handle #%d{id} to int64"
@@ -621,6 +637,10 @@ module EvalStackValue =
                             CliType.Numeric (
                                 CliNumericType.NativeInt (NativeIntSource.MethodTableAuxiliaryDataPtr typeHandle)
                             )
+                        | CliRuntimePointer.PerInstInfoPtr handle ->
+                            CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.PerInstInfoPtr handle))
+                        | CliRuntimePointer.PerInstDictPtr handle ->
+                            CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.PerInstDictPtr handle))
                         | CliRuntimePointer.Managed src ->
                             CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.ManagedPointer src))
                         | CliRuntimePointer.GcHandlePtr addr ->
@@ -668,6 +688,10 @@ module EvalStackValue =
                     failwith "refusing to interpret method table pointer as an object ref"
                 | NativeIntSource.MethodTableAuxiliaryDataPtr _ ->
                     failwith "refusing to interpret method table auxiliary-data pointer as an object ref"
+                | NativeIntSource.PerInstInfoPtr _ ->
+                    failwith "refusing to interpret PerInstInfo pointer as an object ref"
+                | NativeIntSource.PerInstDictPtr _ ->
+                    failwith "refusing to interpret PerInstDict pointer as an object ref"
                 | NativeIntSource.MethodHandlePtr _ ->
                     failwith "refusing to interpret method handle ID as an object ref"
                 | NativeIntSource.FieldHandlePtr _ -> failwith "refusing to interpret field handle ID as an object ref"
@@ -724,6 +748,10 @@ module EvalStackValue =
                     CliType.RuntimePointer (CliRuntimePointer.MethodTablePtr typeHandle)
                 | NativeIntSource.MethodTableAuxiliaryDataPtr typeHandle ->
                     CliType.RuntimePointer (CliRuntimePointer.MethodTableAuxiliaryDataPtr typeHandle)
+                | NativeIntSource.PerInstInfoPtr handle ->
+                    CliType.RuntimePointer (CliRuntimePointer.PerInstInfoPtr handle)
+                | NativeIntSource.PerInstDictPtr handle ->
+                    CliType.RuntimePointer (CliRuntimePointer.PerInstDictPtr handle)
                 | NativeIntSource.FieldHandlePtr ptr ->
                     CliType.RuntimePointer (CliRuntimePointer.FieldRegistryHandle ptr)
                 | NativeIntSource.MethodHandlePtr ptr ->

--- a/WoofWare.PawPrint/EvalStackValueComparisons.fs
+++ b/WoofWare.PawPrint/EvalStackValueComparisons.fs
@@ -443,6 +443,8 @@ module EvalStackValueComparisons =
             | NativeIntSource.TypeHandlePtr f1, NativeIntSource.TypeHandlePtr f2 -> f1 = f2
             | NativeIntSource.MethodTablePtr f1, NativeIntSource.MethodTablePtr f2 -> f1 = f2
             | NativeIntSource.MethodTableAuxiliaryDataPtr f1, NativeIntSource.MethodTableAuxiliaryDataPtr f2 -> f1 = f2
+            | NativeIntSource.PerInstInfoPtr f1, NativeIntSource.PerInstInfoPtr f2 -> f1 = f2
+            | NativeIntSource.PerInstDictPtr f1, NativeIntSource.PerInstDictPtr f2 -> f1 = f2
             | NativeIntSource.MethodHandlePtr f1, NativeIntSource.MethodHandlePtr f2 -> f1 = f2
             | NativeIntSource.FieldHandlePtr f1, NativeIntSource.FieldHandlePtr f2 -> f1 = f2
             | NativeIntSource.AssemblyHandle f1, NativeIntSource.AssemblyHandle f2 -> f1 = f2
@@ -484,6 +486,10 @@ module EvalStackValueComparisons =
             | NativeIntSource.MethodTablePtr _, NativeIntSource.OpaqueHashBits _
             | NativeIntSource.OpaqueHashBits _, NativeIntSource.MethodTableAuxiliaryDataPtr _
             | NativeIntSource.MethodTableAuxiliaryDataPtr _, NativeIntSource.OpaqueHashBits _
+            | NativeIntSource.OpaqueHashBits _, NativeIntSource.PerInstInfoPtr _
+            | NativeIntSource.PerInstInfoPtr _, NativeIntSource.OpaqueHashBits _
+            | NativeIntSource.OpaqueHashBits _, NativeIntSource.PerInstDictPtr _
+            | NativeIntSource.PerInstDictPtr _, NativeIntSource.OpaqueHashBits _
             | NativeIntSource.OpaqueHashBits _, NativeIntSource.MethodHandlePtr _
             | NativeIntSource.MethodHandlePtr _, NativeIntSource.OpaqueHashBits _
             | NativeIntSource.OpaqueHashBits _, NativeIntSource.FieldHandlePtr _
@@ -557,6 +563,10 @@ module EvalStackValueComparisons =
             | _, NativeIntSource.MethodTablePtr _
             | NativeIntSource.MethodTableAuxiliaryDataPtr _, _
             | _, NativeIntSource.MethodTableAuxiliaryDataPtr _
+            | NativeIntSource.PerInstInfoPtr _, _
+            | _, NativeIntSource.PerInstInfoPtr _
+            | NativeIntSource.PerInstDictPtr _, _
+            | _, NativeIntSource.PerInstDictPtr _
             | NativeIntSource.MethodHandlePtr _, _
             | _, NativeIntSource.MethodHandlePtr _
             | NativeIntSource.FieldHandlePtr _, _

--- a/WoofWare.PawPrint/MethodTableProjection.fs
+++ b/WoofWare.PawPrint/MethodTableProjection.fs
@@ -919,6 +919,42 @@ module internal MethodTableProjection =
                 | RuntimeTypeHandleTarget.MethodGenericParameter _ ->
                     failwith
                         $"MethodTable::ParentMethodTable projection refused for TypeDesc target %O{methodTableFor}: generic parameters have no MethodTable in CoreCLR"
+            | "PerInstInfo" ->
+                // ElementType and PerInstInfo share a FieldOffset on the
+                // CoreCLR struct: only one is meaningful per MethodTable.
+                // PerInstInfo holds a `MethodTable***` that walks the type's
+                // per-instance dictionary table (first dictionary contains
+                // the first generic arg, followed by the canonical
+                // dictionary slots). Only generic instantiations have a
+                // meaningful PerInstInfo; refuse other shapes to keep the
+                // union faithful.
+                match methodTableFor with
+                | RuntimeTypeHandleTarget.Closed handle ->
+                    match handle with
+                    | ConcreteTypeHandle.Concrete _ ->
+                        let concreteType, _ = concreteTypeInfoOrFail state handle
+
+                        if concreteType.Generics.IsEmpty then
+                            failwith
+                                $"MethodTable::PerInstInfo projection refused for non-generic %O{handle}: PerInstInfo is meaningful only for generic instantiations (it aliases ElementType on the MethodTable struct)"
+                        else
+                            Some (CliType.RuntimePointer (CliRuntimePointer.PerInstInfoPtr handle), state)
+                    | ConcreteTypeHandle.OneDimArrayZero _
+                    | ConcreteTypeHandle.Array _ ->
+                        failwith
+                            $"MethodTable::PerInstInfo projection refused for array %O{handle}: arrays carry ElementType in this union slot, not PerInstInfo"
+                    | ConcreteTypeHandle.Byref _
+                    | ConcreteTypeHandle.Pointer _
+                    | ConcreteTypeHandle.FunctionPointer _ ->
+                        failwith
+                            $"MethodTable::PerInstInfo projection refused for TypeDesc-shaped handle %O{handle}: TypeDescs have no MethodTable in CoreCLR"
+                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
+                    failwith
+                        $"MethodTable::PerInstInfo projection refused for open generic definition %O{methodTableFor}: PerInstInfo is meaningful only for closed instantiations"
+                | RuntimeTypeHandleTarget.GenericParameter _
+                | RuntimeTypeHandleTarget.MethodGenericParameter _ ->
+                    failwith
+                        $"MethodTable::PerInstInfo projection refused for TypeDesc target %O{methodTableFor}: generic parameters have no MethodTable in CoreCLR"
             | _ ->
                 failwith
                     $"TODO: MethodTable field projection for System.Runtime.CompilerServices.MethodTable::{field.Name} on %O{methodTableFor}"

--- a/WoofWare.PawPrint/MethodTableProjection.fs
+++ b/WoofWare.PawPrint/MethodTableProjection.fs
@@ -922,21 +922,34 @@ module internal MethodTableProjection =
             | "PerInstInfo" ->
                 // ElementType and PerInstInfo share a FieldOffset on the
                 // CoreCLR struct: only one is meaningful per MethodTable.
-                // PerInstInfo holds a `MethodTable***` that walks the type's
-                // per-instance dictionary table (first dictionary contains
-                // the first generic arg, followed by the canonical
-                // dictionary slots). Only generic instantiations have a
-                // meaningful PerInstInfo; refuse other shapes to keep the
-                // union faithful.
+                // PerInstInfo holds `MethodTable***` indexed by dictionary
+                // slot. For a type with `N` per-instance dictionaries the
+                // *first* slot contains the *base* type's dictionary and the
+                // *last* slot contains the type's own — PawPrint only walks
+                // the synthetic chain for types with a single dictionary
+                // whose own generic args occupy that one slot. The current
+                // call site is `CastHelpers.IsNullableForType`, so we gate
+                // strictly to `System.Nullable\`1` to keep the deref correct
+                // by construction; other generic instantiations would need
+                // explicit dictionary-index modelling before this can be
+                // broadened.
                 match methodTableFor with
                 | RuntimeTypeHandleTarget.Closed handle ->
                     match handle with
                     | ConcreteTypeHandle.Concrete _ ->
                         let concreteType, _ = concreteTypeInfoOrFail state handle
 
-                        if concreteType.Generics.IsEmpty then
+                        let isNullable =
+                            concreteType.Namespace = "System"
+                            && concreteType.Name = "Nullable`1"
+                            && concreteType.Assembly.FullName = baseClassTypes.Corelib.Name.FullName
+
+                        if not isNullable then
                             failwith
-                                $"MethodTable::PerInstInfo projection refused for non-generic %O{handle}: PerInstInfo is meaningful only for generic instantiations (it aliases ElementType on the MethodTable struct)"
+                                $"MethodTable::PerInstInfo projection refused for %O{handle}: PawPrint only models the synthetic PerInstInfo dictionary chain for System.Nullable`1 today; broader support requires explicit dictionary-index modelling because the first PerInstInfo slot holds the base type's dictionary in inherited generic chains"
+                        elif concreteType.Generics.IsEmpty then
+                            failwith
+                                $"MethodTable::PerInstInfo projection refused for %O{handle}: System.Nullable`1 instantiation unexpectedly has no generic arguments"
                         else
                             Some (CliType.RuntimePointer (CliRuntimePointer.PerInstInfoPtr handle), state)
                     | ConcreteTypeHandle.OneDimArrayZero _

--- a/WoofWare.PawPrint/NativeIntSource.fs
+++ b/WoofWare.PawPrint/NativeIntSource.fs
@@ -95,6 +95,18 @@ type NativeIntSource =
     | TypeHandlePtr of RuntimeTypeHandleTarget
     | MethodTablePtr of ConcreteTypeHandle
     | MethodTableAuxiliaryDataPtr of RuntimeTypeHandleTarget
+    /// Synthetic `MethodTable*** PerInstInfo` pointer for a generic instantiation.
+    /// First `ldind` step yields `PerInstDictPtr` of the same handle (the
+    /// pointer to the first per-instance dictionary); a second `ldind` step
+    /// yields `MethodTablePtr` of the type's first generic argument. Only the
+    /// `**PerInstInfo` chain used by `CastHelpers.IsNullableForType` is
+    /// modelled today; richer indexing into the dictionary table is not.
+    | PerInstInfoPtr of ConcreteTypeHandle
+    /// Synthetic `MethodTable**` pointing at the first per-instance dictionary
+    /// of the named generic instantiation. Produced by `ldind` on
+    /// `PerInstInfoPtr`; one further `ldind` step yields `MethodTablePtr` of
+    /// the type's first generic argument.
+    | PerInstDictPtr of ConcreteTypeHandle
     | MethodHandlePtr of int64
     | FieldHandlePtr of int64
     | AssemblyHandle of string
@@ -153,6 +165,8 @@ type NativeIntSource =
         | NativeIntSource.TypeHandlePtr ptr -> $"<type ID %O{ptr}>"
         | NativeIntSource.MethodTablePtr ptr -> $"<method table for type %O{ptr}>"
         | NativeIntSource.MethodTableAuxiliaryDataPtr ptr -> $"<method table auxiliary data for type %O{ptr}>"
+        | NativeIntSource.PerInstInfoPtr ptr -> $"<PerInstInfo for type %O{ptr}>"
+        | NativeIntSource.PerInstDictPtr ptr -> $"<PerInstInfo first dictionary for type %O{ptr}>"
         | NativeIntSource.MethodHandlePtr ptr -> $"<method ID %O{ptr}>"
         | NativeIntSource.FieldHandlePtr ptr -> $"<field ID %O{ptr}>"
         | NativeIntSource.AssemblyHandle name -> $"<assembly %s{name}>"
@@ -178,6 +192,8 @@ type NativeIntSource =
             | NativeIntSource.MethodTablePtr left, NativeIntSource.MethodTablePtr right -> left = right
             | NativeIntSource.MethodTableAuxiliaryDataPtr left, NativeIntSource.MethodTableAuxiliaryDataPtr right ->
                 left = right
+            | NativeIntSource.PerInstInfoPtr left, NativeIntSource.PerInstInfoPtr right -> left = right
+            | NativeIntSource.PerInstDictPtr left, NativeIntSource.PerInstDictPtr right -> left = right
             | NativeIntSource.MethodHandlePtr left, NativeIntSource.MethodHandlePtr right -> left = right
             | NativeIntSource.FieldHandlePtr left, NativeIntSource.FieldHandlePtr right -> left = right
             | NativeIntSource.AssemblyHandle left, NativeIntSource.AssemblyHandle right -> left = right
@@ -197,6 +213,8 @@ type NativeIntSource =
             | NativeIntSource.TypeHandlePtr _, _
             | NativeIntSource.MethodTablePtr _, _
             | NativeIntSource.MethodTableAuxiliaryDataPtr _, _
+            | NativeIntSource.PerInstInfoPtr _, _
+            | NativeIntSource.PerInstDictPtr _, _
             | NativeIntSource.MethodHandlePtr _, _
             | NativeIntSource.FieldHandlePtr _, _
             | NativeIntSource.AssemblyHandle _, _
@@ -226,6 +244,8 @@ type NativeIntSource =
         | NativeIntSource.TypeHandlePtr ptr -> HashCode.Combine (3, ptr)
         | NativeIntSource.MethodTablePtr ptr -> HashCode.Combine (4, ptr)
         | NativeIntSource.MethodTableAuxiliaryDataPtr ptr -> HashCode.Combine (5, ptr)
+        | NativeIntSource.PerInstInfoPtr ptr -> HashCode.Combine (18, ptr)
+        | NativeIntSource.PerInstDictPtr ptr -> HashCode.Combine (19, ptr)
         | NativeIntSource.MethodHandlePtr ptr -> HashCode.Combine (6, ptr)
         | NativeIntSource.FieldHandlePtr ptr -> HashCode.Combine (7, ptr)
         | NativeIntSource.AssemblyHandle name -> HashCode.Combine (8, name)
@@ -260,6 +280,8 @@ module NativeIntSource =
         | NativeIntSource.TypeHandlePtr _
         | NativeIntSource.MethodTablePtr _
         | NativeIntSource.MethodTableAuxiliaryDataPtr _
+        | NativeIntSource.PerInstInfoPtr _
+        | NativeIntSource.PerInstDictPtr _
         | NativeIntSource.GcHandlePtr _
         | NativeIntSource.EventPipeProviderPtr _
         | NativeIntSource.EventPipeEventPtr _
@@ -286,6 +308,8 @@ module NativeIntSource =
         | NativeIntSource.TypeHandlePtr _
         | NativeIntSource.MethodTablePtr _
         | NativeIntSource.MethodTableAuxiliaryDataPtr _
+        | NativeIntSource.PerInstInfoPtr _
+        | NativeIntSource.PerInstDictPtr _
         | NativeIntSource.GcHandlePtr _
         | NativeIntSource.EventPipeProviderPtr _
         | NativeIntSource.EventPipeEventPtr _
@@ -325,6 +349,12 @@ type CliRuntimePointer =
     | MethodRegistryHandle of int64
     | MethodTablePtr of ConcreteTypeHandle
     | MethodTableAuxiliaryDataPtr of RuntimeTypeHandleTarget
+    /// See `NativeIntSource.PerInstInfoPtr`. The eval-stack-flattened
+    /// counterpart is `NativeIntSource.PerInstInfoPtr`.
+    | PerInstInfoPtr of ConcreteTypeHandle
+    /// See `NativeIntSource.PerInstDictPtr`. The eval-stack-flattened
+    /// counterpart is `NativeIntSource.PerInstDictPtr`.
+    | PerInstDictPtr of ConcreteTypeHandle
     | Managed of ManagedPointerSource
     /// A GC handle stored in a typed-pointer slot (e.g. `void*`, `T*`). Arithmetic
     /// and comparison operations on this case must go through eval-stack

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -756,10 +756,13 @@ module NullaryIlOp =
                     $"Ldind %O{targetType} on PerInstInfoPtr %O{handle} is not modelled; only LdindI walks the synthetic PerInstInfo chain"
         | EvalStackValue.NativeInt (NativeIntSource.PerInstDictPtr handle) ->
             // Second deref of the `MethodTable*** PerInstInfo` chain: the
-            // first slot of the first per-instance dictionary holds the
-            // type's first generic argument's MethodTable*. PawPrint only
-            // models that slot — the rest of the dictionary layout is not
-            // walked.
+            // first slot of a `System.Nullable\`1` instantiation's
+            // single per-instance dictionary holds T's MethodTable*. The
+            // projection that minted this synthetic value already gates to
+            // Nullable; we re-check here as a defense-in-depth invariant
+            // because `Generics.[0]` is only the correct slot when the type
+            // has exactly one dictionary (the inherited-dictionary layout
+            // for derived generics would put the base's dictionary first).
             match targetType with
             | LdindI ->
                 let concreteType =
@@ -768,9 +771,18 @@ module NullaryIlOp =
                     | None ->
                         failwith $"Ldind on PerInstDictPtr: handle %O{handle} was not registered in AllConcreteTypes"
 
+                let isNullable =
+                    concreteType.Namespace = "System"
+                    && concreteType.Name = "Nullable`1"
+                    && concreteType.Assembly.FullName = corelib.Corelib.Name.FullName
+
+                if not isNullable then
+                    failwith
+                        $"Ldind on PerInstDictPtr %O{handle}: PawPrint only models the synthetic PerInstInfo dictionary chain for System.Nullable`1 today; broader support requires explicit dictionary-index modelling"
+
                 if concreteType.Generics.IsEmpty then
                     failwith
-                        $"Ldind on PerInstDictPtr %O{handle}: target is non-generic; PerInstInfo chain is meaningful only for generic instantiations"
+                        $"Ldind on PerInstDictPtr %O{handle}: System.Nullable`1 instantiation unexpectedly has no generic arguments"
 
                 let firstArg = concreteType.Generics.[0]
 

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -151,6 +151,8 @@ module NullaryIlOp =
             | EvalStackValue.NativeInt (NativeIntSource.TypeHandlePtr _)
             | EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr _)
             | EvalStackValue.NativeInt (NativeIntSource.MethodTableAuxiliaryDataPtr _)
+            | EvalStackValue.NativeInt (NativeIntSource.PerInstInfoPtr _)
+            | EvalStackValue.NativeInt (NativeIntSource.PerInstDictPtr _)
             | EvalStackValue.NativeInt (NativeIntSource.FieldHandlePtr _)
             | EvalStackValue.NativeInt (NativeIntSource.MethodHandlePtr _)
             | EvalStackValue.NativeInt (NativeIntSource.GcHandlePtr _)
@@ -296,6 +298,10 @@ module NullaryIlOp =
                 failwith $"Neg: refusing to negate MethodTable pointer %O{typeHandle}"
             | NativeIntSource.MethodTableAuxiliaryDataPtr typeHandle ->
                 failwith $"Neg: refusing to negate MethodTableAuxiliaryData pointer %O{typeHandle}"
+            | NativeIntSource.PerInstInfoPtr handle ->
+                failwith $"Neg: refusing to negate PerInstInfo pointer %O{handle}"
+            | NativeIntSource.PerInstDictPtr handle ->
+                failwith $"Neg: refusing to negate PerInstDict pointer %O{handle}"
             | NativeIntSource.MethodHandlePtr handle ->
                 failwith $"Neg: refusing to negate RuntimeMethodHandle pointer %d{handle}"
             | NativeIntSource.FieldHandlePtr handle ->
@@ -650,6 +656,10 @@ module NullaryIlOp =
             | NativeIntSource.MethodTableAuxiliaryDataPtr typeHandle ->
                 failwith
                     $"Conv_ovf_u: refusing to convert MethodTableAuxiliaryData pointer %O{typeHandle} to unsigned native int"
+            | NativeIntSource.PerInstInfoPtr handle ->
+                failwith $"Conv_ovf_u: refusing to convert PerInstInfo pointer %O{handle} to unsigned native int"
+            | NativeIntSource.PerInstDictPtr handle ->
+                failwith $"Conv_ovf_u: refusing to convert PerInstDict pointer %O{handle} to unsigned native int"
             | NativeIntSource.GcHandlePtr handle ->
                 failwith $"Conv_ovf_u: refusing to convert GC handle pointer %O{handle} to unsigned native int"
             | NativeIntSource.EventPipeProviderPtr id ->
@@ -726,6 +736,55 @@ module NullaryIlOp =
                 currentThread
                 state
             |> ExecutionResult.stepped
+        | EvalStackValue.NativeInt (NativeIntSource.PerInstInfoPtr handle) ->
+            // First deref of the `MethodTable*** PerInstInfo` chain: step
+            // from MethodTable*** to MethodTable** (the per-instance
+            // dictionary pointer). The chain is walked only via `ldind.i`;
+            // narrowing widths would betray the synthetic provenance.
+            match targetType with
+            | LdindI ->
+                let state =
+                    state
+                    |> IlMachineState.pushToEvalStack
+                        (CliType.RuntimePointer (CliRuntimePointer.PerInstDictPtr handle))
+                        currentThread
+                    |> IlMachineState.advanceProgramCounter currentThread
+
+                (state, WhatWeDid.Executed) |> ExecutionResult.stepped
+            | _ ->
+                failwith
+                    $"Ldind %O{targetType} on PerInstInfoPtr %O{handle} is not modelled; only LdindI walks the synthetic PerInstInfo chain"
+        | EvalStackValue.NativeInt (NativeIntSource.PerInstDictPtr handle) ->
+            // Second deref of the `MethodTable*** PerInstInfo` chain: the
+            // first slot of the first per-instance dictionary holds the
+            // type's first generic argument's MethodTable*. PawPrint only
+            // models that slot — the rest of the dictionary layout is not
+            // walked.
+            match targetType with
+            | LdindI ->
+                let concreteType =
+                    match AllConcreteTypes.lookup handle state.ConcreteTypes with
+                    | Some c -> c
+                    | None ->
+                        failwith $"Ldind on PerInstDictPtr: handle %O{handle} was not registered in AllConcreteTypes"
+
+                if concreteType.Generics.IsEmpty then
+                    failwith
+                        $"Ldind on PerInstDictPtr %O{handle}: target is non-generic; PerInstInfo chain is meaningful only for generic instantiations"
+
+                let firstArg = concreteType.Generics.[0]
+
+                let state =
+                    state
+                    |> IlMachineState.pushToEvalStack
+                        (CliType.RuntimePointer (CliRuntimePointer.MethodTablePtr firstArg))
+                        currentThread
+                    |> IlMachineState.advanceProgramCounter currentThread
+
+                (state, WhatWeDid.Executed) |> ExecutionResult.stepped
+            | _ ->
+                failwith
+                    $"Ldind %O{targetType} on PerInstDictPtr %O{handle} is not modelled; only LdindI walks the synthetic PerInstInfo chain"
         | _ ->
 
         let targetCliType = getTargetLdindCliType targetType
@@ -830,6 +889,8 @@ module NullaryIlOp =
                 | NativeIntSource.TypeHandlePtr _
                 | NativeIntSource.MethodTablePtr _
                 | NativeIntSource.MethodTableAuxiliaryDataPtr _
+                | NativeIntSource.PerInstInfoPtr _
+                | NativeIntSource.PerInstDictPtr _
                 | NativeIntSource.GcHandlePtr _
                 | NativeIntSource.AssemblyHandle _
                 | NativeIntSource.ModuleHandle _
@@ -886,6 +947,8 @@ module NullaryIlOp =
                 | NativeIntSource.TypeHandlePtr _
                 | NativeIntSource.MethodTablePtr _
                 | NativeIntSource.MethodTableAuxiliaryDataPtr _
+                | NativeIntSource.PerInstInfoPtr _
+                | NativeIntSource.PerInstDictPtr _
                 | NativeIntSource.GcHandlePtr _
                 | NativeIntSource.AssemblyHandle _
                 | NativeIntSource.ModuleHandle _

--- a/WoofWare.PawPrint/PointerHashSynthesis.fs
+++ b/WoofWare.PawPrint/PointerHashSynthesis.fs
@@ -100,9 +100,11 @@ module PointerHashSynthesis =
         | NativeIntSource.Verbatim _
         | NativeIntSource.ManagedPointer _
         | NativeIntSource.SyntheticCrossArrayOffset _
-        | NativeIntSource.OpaqueHashBits _ ->
+        | NativeIntSource.OpaqueHashBits _
+        | NativeIntSource.PerInstInfoPtr _
+        | NativeIntSource.PerInstDictPtr _ ->
             failwith
-                $"PointerHashSynthesis.canonicalKey: %O{src} is not a canonicalisable pointer shape; verbatim / managed-pointer / cross-array / already-synthesised values must be handled before reaching this function"
+                $"PointerHashSynthesis.canonicalKey: %O{src} is not a canonicalisable pointer shape; verbatim / managed-pointer / cross-array / already-synthesised values / PerInstInfo chain intermediates must be handled before reaching this function"
 
     /// Low-bit pattern required for a canonical key. Mirrors
     /// `NullaryIlOp.typeHandleLowAddressBits`: MethodTable* is aligned


### PR DESCRIPTION
## Summary

- Model CoreCLR's `MethodTable*** PerInstInfo` as a two-step synthetic deref chain (`PerInstInfoPtr` → `PerInstDictPtr` → `MethodTablePtr`) driven by `ldind.i` against new synthetic pointer provenance variants.
- Project the `PerInstInfo` field on `MethodTable` at `Ldfld`, gated specifically to `System.Nullable\`1`. Broader closed generics have inherited dictionary layouts (slot 0 = base type's dictionary, last slot = own) that the slot-0 read here would silently mis-model; refuse them explicitly with a pointer toward proper dictionary-index modelling.
- Unblocks `CastHelpers.IsNullableForType`, which is the sole BCL caller. Removes `IsAssignableToBasic.cs` from the `unimplemented` set.

## Implementation notes

- New `NativeIntSource` / `CliRuntimePointer` variants: `PerInstInfoPtr of ConcreteTypeHandle` and `PerInstDictPtr of ConcreteTypeHandle`. All exhaustive matches (eval-stack ↔ CliType round-tripping, byte conversion, alias comparisons, canonical-hash synthesis) updated to refuse byte/int conversion but admit identity-based equality.
- `MethodTableProjection.tryProjectFieldForRuntimeTypeHandleTarget` adds a `PerInstInfo` arm: closed `Nullable\`1` produces the synthetic pointer; arrays/TypeDescs/open generics/generic parameters/non-Nullable closed generics all fail with messages that name the constraint they violate, per the AGENTS.md guideline that classifiers stay truthful for their callers.
- `NullaryIlOp.executeLdind` adds two `LdindI` arms that step the chain. The `PerInstDictPtr` arm re-checks `Nullable\`1` as defense-in-depth against any future projection caller.

## Test plan

- [x] 8 new MethodTableProjection tests: positive Nullable path, refusal of non-generic concrete types, refusal of non-Nullable closed generics (`List<int>`), refusal of arrays/open-generic definitions, and both legs of the `Ldind` chain.
- [x] `IsAssignableToBasic.cs` end-to-end test now passes (removed from `unimplemented`).
- [x] Full suite green (1162/1162) prior to rebase; relevant 9 tests re-verified green after rebase on `origin/main`.
- [x] `codex review --base main` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)