### PR TITLE
Normalise pure tests to exit code 0 via self-validation

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -58,19 +58,7 @@ module TestPureCases =
 
     let expectsUnhandledException = [ "UnhandledException.cs" ] |> Set.ofList
 
-    let customExitCodes =
-        [
-            "NoOp.cs", 1
-            "BasicLock.cs", 1
-            "MonitorEnterRefBool.cs", 1
-            "ContendedMonitorEnter.cs", 99
-            "MonitorPulseWait.cs", 42
-            "MonitorWaitReentrant.cs", 7
-            "ExceptionWithNoOpFinally.cs", 3
-            "ExceptionWithNoOpCatch.cs", 10
-            "Threads.cs", 3
-        ]
-        |> Map.ofList
+    let customExitCodes = [ "ExceptionWithNoOpFinally.cs", 3 ] |> Map.ofList
 
     let allPure =
         assy.GetManifestResourceNames ()

--- a/WoofWare.PawPrint.Test/sourcesPure/BasicLock.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/BasicLock.cs
@@ -9,7 +9,7 @@ namespace HelloWorldApp
             object locker = new object();
             lock (locker)
             {
-                return 1;
+                return 0;
             }
         }
     }

--- a/WoofWare.PawPrint.Test/sourcesPure/ContendedMonitorEnter.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/ContendedMonitorEnter.cs
@@ -24,7 +24,7 @@ namespace HelloWorldApp
                 shared = 7;
             }
             t.Join();
-            return shared;
+            return shared == 99 ? 0 : 1;
         }
     }
 }

--- a/WoofWare.PawPrint.Test/sourcesPure/ExceptionWithNoOpCatch.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/ExceptionWithNoOpCatch.cs
@@ -13,7 +13,7 @@ namespace HelloWorldApp
         {
             try
             {
-                return ReallyMain(args);
+                return ReallyMain(args) == 10 ? 0 : 1;
             }
             catch
             {

--- a/WoofWare.PawPrint.Test/sourcesPure/MonitorEnterRefBool.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/MonitorEnterRefBool.cs
@@ -12,9 +12,8 @@ class MonitorEnterRefBool
         object lockObj = new object();
         bool taken = false;
         Monitor.Enter(lockObj, ref taken);
-        int result = taken ? 1 : 0;
         if (taken) Monitor.Exit(lockObj);
-        // taken should be true after Monitor.Enter, so result should be 1.
-        return result;
+        // taken should be true after Monitor.Enter.
+        return taken ? 0 : 1;
     }
 }

--- a/WoofWare.PawPrint.Test/sourcesPure/MonitorPulseWait.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/MonitorPulseWait.cs
@@ -28,7 +28,7 @@ namespace HelloWorldApp
                 }
             }
             t.Join();
-            return produced;
+            return produced == 42 ? 0 : 1;
         }
     }
 }

--- a/WoofWare.PawPrint.Test/sourcesPure/MonitorWaitReentrant.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/MonitorWaitReentrant.cs
@@ -35,7 +35,7 @@ namespace HelloWorldApp
                 }
             }
             t.Join();
-            return produced;
+            return produced == 7 ? 0 : 1;
         }
     }
 }

--- a/WoofWare.PawPrint.Test/sourcesPure/NoOp.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/NoOp.cs
@@ -6,7 +6,7 @@ namespace HelloWorldApp
     {
         static int Main(string[] args)
         {
-            return 1;
+            return 0;
         }
     }
 }

--- a/WoofWare.PawPrint.Test/sourcesPure/Threads.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/Threads.cs
@@ -7,7 +7,7 @@ namespace HelloWorldApp
         static async System.Threading.Tasks.Task<int> Main(string[] args)
         {
             var result = await Task.Run(() => 3);
-            return result;
+            return result == 3 ? 0 : 1;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Rewrite eight pure tests (`NoOp.cs`, `BasicLock.cs`, `MonitorEnterRefBool.cs`, `ContendedMonitorEnter.cs`, `MonitorPulseWait.cs`, `MonitorWaitReentrant.cs`, `ExceptionWithNoOpCatch.cs`, `Threads.cs`) so they assert their expected value internally and return 0 on success.
- Drop those entries from `customExitCodes` in `TestPureCases.fs`; they're now picked up by the autodiscovery `simpleCases` path.
- `ExceptionWithNoOpFinally.cs` stays in `customExitCodes` — its whole point is that `return x` inside a `try` captures `x` before the `finally` mutates it, and factoring that out into a helper would obscure the IL pattern under test. `Threads.cs` remains in `unimplemented`, but its real-runtime check now passes against the default expected exit code of 0.

## Test plan
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --filter "Name~NoOp.cs|Name~BasicLock.cs|Name~MonitorEnterRefBool.cs|Name~ContendedMonitorEnter.cs|Name~MonitorPulseWait.cs|Name~MonitorWaitReentrant.cs|Name~ExceptionWithNoOpCatch.cs|Name~Threads.cs"` — 8 passed
- [x] `nix develop -c dotnet test ... --filter "Name~ExceptionWithNoOpFinally"` — passed (still routed through `Custom exit code tests`)
- [x] `nix develop -c dotnet fantomas .`
- [x] `codex review --base main` — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)