### PR TITLE
Implement SystemNative_InitializeTerminalAndSignalHandling as no-op success

### DIFF
--- a/WoofWare.PawPrint.Test/TestImpureCases.fs
+++ b/WoofWare.PawPrint.Test/TestImpureCases.fs
@@ -18,12 +18,15 @@ module TestImpureCases =
     let unimplemented =
         [
             // `Console.WriteLine("Hello, world!")` triggers lazy initialisation of `Console.Out`,
-            // which descends Console::get_Out → ConsolePal::OpenStandardOutput → Interop+Sys::Dup.
-            // PawPrint now intercepts SystemNative_Dup via FileDescriptorRegistry and
-            // SystemNative_Write via the same handler family, so both the std-stream open path and
-            // the actual byte-emitting call are implemented; the WriteLine flow now blocks
-            // downstream on the unimplemented libSystem.Globalization.Native P/Invoke
-            // `GlobalizationNative_LoadICU` during CultureInfo initialisation.
+            // which descends Console::get_Out → ConsolePal::OpenStandardOutput → Interop+Sys::Dup,
+            // then ConsolePal::EnsureInitializedCore → Interop.Sys.InitializeTerminalAndSignalHandling.
+            // PawPrint now intercepts SystemNative_Dup via FileDescriptorRegistry, SystemNative_Write
+            // via the same handler family, and SystemNative_InitializeTerminalAndSignalHandling as a
+            // no-op success (matching the WASI variant — we model neither termios nor signals). The
+            // WriteLine flow now blocks downstream on the unimplemented libSystem.Native P/Invoke
+            // `SystemNative_IsATty`, called from `Console.IsOutputRedirected` to decide whether to
+            // open a SyncTextWriter around stdout or a plain StreamWriter; until it lands the guest
+            // cannot fall through to the byte-emitting `Write` call this test is meant to exercise.
             {
                 FileName = "WriteLine.cs"
                 ExpectedReturnCode = 1

--- a/WoofWare.PawPrint.Test/sourcesPure/SystemNativeInitializeTerminalAndSignalHandling.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/SystemNativeInitializeTerminalAndSignalHandling.cs
@@ -1,0 +1,36 @@
+using System.Runtime.InteropServices;
+
+// Exercises the SystemNative_InitializeTerminalAndSignalHandling PawPrint
+// handler directly via a P/Invoke stub, without depending on `Console`'s
+// initialisation chain. The CLR runtime would dispatch this to the real
+// libSystem.Native shim (which snapshots termios and installs the master
+// SIGINT/SIGQUIT/SIGCHLD/SIGWINCH handler under a mutex); PawPrint models
+// neither termios nor signals, so the handler returns success unconditionally
+// (matching the WASI variant of the same native function).
+//
+// This test must pass on both the real runtime and PawPrint, so it asserts
+// only the invariant that holds on every supported host: the call returns a
+// non-zero value (truthy, marshalled as `bool true` at the BCL boundary).
+// The specific contract — successive calls are idempotent — is documented
+// in the native source but not separately observable here, since the only
+// observable signal is the return value and it is success on the first call.
+class Program
+{
+    [DllImport("libSystem.Native", EntryPoint = "SystemNative_InitializeTerminalAndSignalHandling")]
+    static extern int SystemNative_InitializeTerminalAndSignalHandling();
+
+    static int Main(string[] args)
+    {
+        int first = SystemNative_InitializeTerminalAndSignalHandling();
+        if (first == 0) return 1;
+
+        // A second call must also succeed: the native implementation is
+        // documented as a one-shot mutex-guarded initialiser whose subsequent
+        // calls short-circuit through a cached `initialized` flag. Both
+        // branches surface as a non-zero return on every Unix host.
+        int second = SystemNative_InitializeTerminalAndSignalHandling();
+        if (second == 0) return 2;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/Native/NativeSystemNative.fs
+++ b/WoofWare.PawPrint/Native/NativeSystemNative.fs
@@ -88,6 +88,32 @@ module NativeSystemNative =
             // PawPrint does not model Unix file flags. Report that hidden flags
             // are unsupported so CoreLib follows the portable attribute path.
             pushInt32 0 ctx |> Some
+        | Some "SystemNative_InitializeTerminalAndSignalHandling",
+          [],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
+            // Real `SystemNative_InitializeTerminalAndSignalHandling` (in
+            // `pal_console.c`) is a one-shot mutex-guarded initialiser that
+            // snapshots termios via `tcgetattr` and installs the master
+            // SIGINT/SIGQUIT/SIGCHLD/SIGWINCH handler. PawPrint models neither
+            // termios (our std streams have no terminal state — see
+            // FileDescriptorRegistry) nor signals (see SystemNative_Close's
+            // comment for the project-wide stance). The WASI variant of the
+            // same native function returns `true` unconditionally for exactly
+            // the same reason: nothing to initialise.
+            //
+            // Per-signal handler registrations (RegisterForCtrlC,
+            // SetTerminalInvalidationHandler, PosixSignalRegistration.Register)
+            // are not implemented yet; when the first such arm lands, this
+            // function will flip a `SignalState.Initialized` bit that the
+            // registration arms assert. Until then there is no consumer for
+            // such state, so we do not grow the kernel speculatively.
+            //
+            // The BCL P/Invoke uses `SetLastError = true` and reads
+            // `Marshal.GetLastSystemError()` only on the failure path
+            // (`ConsolePal.Unix.cs:884` throws `Win32Exception` iff this
+            // returns false), so `LastSystemError` does not need to be
+            // touched on the success path.
+            pushInt32 1 ctx |> Some
         | Some "SystemNative_GetErrNo",
           [],
           MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->


### PR DESCRIPTION
## Summary

- Adds a `libSystem.Native` handler arm for `SystemNative_InitializeTerminalAndSignalHandling` that returns truthy without mutating kernel state, matching the WASI variant in `pal_console_wasi.c`. PawPrint models neither termios nor signals, so the only correct behaviour for this entry point is to claim success and let the BCL proceed past `ConsolePal.EnsureInitializedCore`.
- The handler arm carries a comment that names the future pivot: when the first per-signal registration arm lands (`RegisterForCtrlC`, `SetTerminalInvalidationHandler`, `PosixSignalRegistration.Register`, …), it will introduce `EmulatedKernel.SignalState` and flip an `Initialized` bit that the registration arms assert. Until then the kernel is not grown speculatively.
- Adds `sourcesPure/SystemNativeInitializeTerminalAndSignalHandling.cs`: a focused `DllImport` test that exercises the entry point directly. Asserts only the invariant that holds on every supported host — a non-zero return on the first and second call — so it passes on both PawPrint and the real runtime.
- Refreshes the `WriteLine.cs` entry in `TestImpureCases.unimplemented`: the chain now reaches `SystemNative_IsATty` (called from `Console.IsOutputRedirected`), which is the freshly observed next blocker. The previous comment named `GlobalizationNative_LoadICU`/CultureInfo; that path is now bypassed since invariant culture is set unconditionally.

## Test plan

- [x] `nix develop -c dotnet fantomas .` — clean
- [x] `nix develop -c dotnet test --filter "Name~SystemNativeInitializeTerminal"` — new test passes on PawPrint and the real runtime
- [x] Regression set: `SystemNativeWrite`, `SystemNativeClose`, `SystemNativeDup`, `SystemNativeWriteSuccess` — all pass
- [x] Full `TestImpureCases` module — all pass; `WriteLine.cs` correctly remains `[<Explicit>]` via the `unimplemented` slot
- [x] `codex review --base main` — approved, no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)