### PR TITLE
Implement RuntimeFieldHandle::GetApproxDeclaringMethodTable

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -18,7 +18,7 @@ module TestPureCases =
     let unimplemented =
         [
             "AdvancedStructLayout.cs" // past MarshalNative_SizeOfHelper for ByValTStr and SystemNative_Malloc / SystemNative_Free / Marshal.AllocHGlobal / FreeHGlobal; now blocked downstream at the unimplemented MarshalNative_TryGetStructMarshalStub QCall (CoreLib's Marshal.StructureToPtr path)
-            "LdtokenField.cs" // past Buffer's reflection-cache copy (cell-aware path); now blocked on the next reflection-cache step at unimplemented InternalCall RuntimeFieldHandle::GetApproxDeclaringMethodTable
+            "LdtokenField.cs" // past RuntimeFieldHandle::GetApproxDeclaringMethodTable; now blocked at RuntimeTypeHandle.GetFields for an open generic type definition (Test 5: typeof(GenericClass<>).GetField)
             "Threads.cs" // past ThreadNative_InformThreadNameChange (Thread.Name setter); now blocked on unimplemented PAL call libSystem.Native!SystemNative_GetLowResolutionTimestamp (.Sys::GetLowResolutionTimestamp, used by the Task/ThreadPool scheduler)
         ]
         |> Set.ofList

--- a/WoofWare.PawPrint.Test/sourcesPure/FieldInfoGetFieldFromHandle.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/FieldInfoGetFieldFromHandle.cs
@@ -1,0 +1,31 @@
+using System.Reflection;
+
+class Program
+{
+    public static int StaticIntField;
+    public string InstanceStringField;
+
+    static int Main(string[] args)
+    {
+        // FieldInfo.GetFieldFromHandle goes through
+        // RuntimeFieldHandle.GetApproxDeclaringType, which in turn calls the
+        // GetApproxDeclaringMethodTable InternalCall; round-tripping a field
+        // through its handle exercises that path on both a static and an
+        // instance field.
+        FieldInfo staticField = typeof(Program).GetField(nameof(StaticIntField));
+        if (staticField == null) return 1;
+
+        FieldInfo staticFromHandle = FieldInfo.GetFieldFromHandle(staticField.FieldHandle);
+        if (!ReferenceEquals(staticFromHandle, staticField)) return 2;
+        if (staticFromHandle.DeclaringType != typeof(Program)) return 3;
+
+        FieldInfo instanceField = typeof(Program).GetField(nameof(InstanceStringField));
+        if (instanceField == null) return 4;
+
+        FieldInfo instanceFromHandle = FieldInfo.GetFieldFromHandle(instanceField.FieldHandle);
+        if (!ReferenceEquals(instanceFromHandle, instanceField)) return 5;
+        if (instanceFromHandle.DeclaringType != typeof(Program)) return 6;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/Native/NativeRuntimeFieldHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeFieldHandle.fs
@@ -130,6 +130,45 @@ module NativeRuntimeFieldHandle =
                     state
 
             NativeHandlerResult.completed state |> Some
+        | "System.Private.CoreLib",
+          "System",
+          "RuntimeFieldHandle",
+          "GetApproxDeclaringMethodTable",
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib", "System", "RuntimeFieldHandleInternal", generics) ],
+          MethodReturnType.Returns (ConcretePointer (ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                                                                       "System.Runtime.CompilerServices",
+                                                                                       "MethodTable",
+                                                                                       methodTableGenerics))) when
+            generics.IsEmpty && methodTableGenerics.IsEmpty
+            ->
+            // CoreCLR's RuntimeFieldHandle::GetApproxDeclaringMethodTable
+            // (runtimehandles.cpp:2192) is an FCall returning
+            // pField->GetApproxEnclosingMethodTable() — the canonical MethodTable for
+            // the field's declaring type. Under shared-generic codegen the canonical
+            // form is the open instantiation; PawPrint does not share generic
+            // instantiations, so the FieldHandle's stored DeclaringType is already
+            // the closed concrete type and is at least as precise as CoreCLR's
+            // result. The managed wrapper RuntimeFieldHandle.GetApproxDeclaringType
+            // (RuntimeHandles.cs:1523) hands the pointer to
+            // RuntimeTypeHandle.GetRuntimeType, which our MethodTablePtr
+            // representation already feeds via the TypeHandle registry.
+            let operation = "RuntimeFieldHandle.GetApproxDeclaringMethodTable"
+
+            let fieldHandle =
+                // CoreCLR asserts !field.IsNullHandle() at the managed caller; fault
+                // loudly here, matching the sibling GetAttributes precedent above.
+                fieldHandleOfRuntimeFieldHandleInternal operation state instruction.Arguments.[0]
+                |> Option.defaultWith (fun () -> failwith $"%s{operation}: null field handle")
+
+            let declaringTypeHandle = fieldHandle.GetDeclaringTypeHandle ()
+
+            let state =
+                IlMachineState.pushToEvalStack'
+                    (EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr declaringTypeHandle))
+                    ctx.Thread
+                    state
+
+            NativeHandlerResult.completed state |> Some
         | _ -> None
 
     let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : NativeHandlerResult option =


### PR DESCRIPTION
## Summary

- Adds the `RuntimeFieldHandle::GetApproxDeclaringMethodTable` InternalCall handler in `NativeRuntimeFieldHandle.fs`. It resolves the field handle, reads its stored `DeclaringType : ConcreteTypeHandle`, and pushes a `MethodTablePtr` that the existing `TypeHandleRegistry` / `GetRuntimeTypeFromHandleSlow` path already consumes.
- PawPrint does not share generic instantiations, so the FieldHandle's stored DeclaringType is already the closed concrete type and is at least as precise as CoreCLR's canonical-form result.
- Adds focused regression test `sourcesPure/FieldInfoGetFieldFromHandle.cs` that round-trips static and instance fields through `FieldInfo.GetFieldFromHandle`; without the fix it fails on the InternalCall lookup.
- `LdtokenField.cs` has moved one blocker forward (now hits `RuntimeTypeHandle.GetFields` on an open generic type definition, `typeof(GenericClass<>).GetField`); its `unimplemented` comment is updated rather than removed.

## Test plan

- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — all 1166 tests pass
- [x] `nix develop -c dotnet test ... --filter "Name~FieldInfoGetFieldFromHandle"` passes with the fix; verified it fails without it (stashed the handler, re-ran, observed the InternalCall failure)
- [x] `nix develop -c dotnet fantomas` — no formatting changes
- [x] `codex review --base main` — no actionable correctness issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)