### PR TITLE
Add pure SignalState data model for deterministic signal handling

### DIFF
--- a/WoofWare.PawPrint.Test/TestSignalState.fs
+++ b/WoofWare.PawPrint.Test/TestSignalState.fs
@@ -1,0 +1,653 @@
+namespace WoofWare.PawPrint.Test
+
+open System.Collections.Immutable
+open FsCheck
+open FsCheck.FSharp
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+/// Property-based and unit tests for the deterministic `SignalState` data
+/// model. `SignalState` has no consumer in the simulator yet — these tests
+/// pin down its behaviour in isolation so the downstream slices (dispatch,
+/// harness injection, native handler arms) can build on a known-good shape.
+///
+/// The property test runs a random sequence of operations through both the
+/// production module and a structurally-different reference oracle, then
+/// asserts agreement on every observable accessor after each step. The
+/// oracle uses index-based scanning over an array; the production module
+/// uses a recursive accumulator-threaded walk. A regression in either side
+/// surfaces as a divergence the property catches.
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestSignalState =
+
+    let private propertyConfig : Config = Config.QuickThrowOnFailure.WithMaxTest 500
+
+    let private t0 : ThreadId = ThreadId 0
+    let private t1 : ThreadId = ThreadId 1
+    let private t2 : ThreadId = ThreadId 2
+
+    let private allThreads : ThreadId list = [ t0 ; t1 ; t2 ]
+
+    let private allSignals : Signal list =
+        [
+            Signal.SIGHUP
+            Signal.SIGINT
+            Signal.SIGQUIT
+            Signal.SIGTERM
+            Signal.SIGCHLD
+            Signal.SIGCONT
+            Signal.SIGWINCH
+            Signal.SIGTSTP
+            Signal.SIGTTIN
+            Signal.SIGTTOU
+            Signal.SIGPIPE
+            Signal.SIGUSR1
+            Signal.SIGUSR2
+            Signal.SIGABRT
+            Signal.Other 99
+        ]
+
+    let private addr (n : int) : ManagedHeapAddress = ManagedHeapAddress n
+
+    let private callback (n : int) : SignalHandler = SignalHandler.PosixCallback (addr n)
+
+    let private liveThreads (threads : ThreadId list) : ImmutableArray<ThreadId> = threads |> ImmutableArray.CreateRange
+
+    // ------------------------- Unit tests ------------------------- //
+
+    [<Test>]
+    let ``empty has nothing registered, nothing blocked, nothing pending`` () : unit =
+        let s = SignalState.empty
+        SignalState.isInitialized s |> shouldEqual false
+        SignalState.tryGetHandler Signal.SIGINT s |> shouldEqual None
+        SignalState.isBlocked t0 Signal.SIGINT s |> shouldEqual false
+        SignalState.blockedFor t0 s |> shouldEqual Set.empty
+        SignalState.pending s |> Seq.toList |> shouldEqual []
+        SignalState.registrations s |> shouldEqual Map.empty
+
+    [<Test>]
+    let ``markInitialized is idempotent and structurally stable`` () : unit =
+        let once = SignalState.empty |> SignalState.markInitialized
+        let twice = once |> SignalState.markInitialized
+        SignalState.isInitialized once |> shouldEqual true
+        // A second mark must not mutate the state's identity; downstream code
+        // that compares states for equality (e.g. dedup hashing in the
+        // debugger) relies on this.
+        twice |> shouldEqual once
+
+    [<Test>]
+    let ``register installs handler`` () : unit =
+        let s = SignalState.empty |> SignalState.register Signal.SIGINT (callback 1)
+        SignalState.tryGetHandler Signal.SIGINT s |> shouldEqual (Some (callback 1))
+
+    [<Test>]
+    let ``register replaces an existing handler`` () : unit =
+        let s =
+            SignalState.empty
+            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.register Signal.SIGINT (callback 2)
+
+        SignalState.tryGetHandler Signal.SIGINT s |> shouldEqual (Some (callback 2))
+
+    [<Test>]
+    let ``unregister removes an installed handler`` () : unit =
+        let s =
+            SignalState.empty
+            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.unregister Signal.SIGINT
+
+        SignalState.tryGetHandler Signal.SIGINT s |> shouldEqual None
+
+    [<Test>]
+    let ``unregister of an absent handler is a no-op`` () : unit =
+        let s = SignalState.empty |> SignalState.unregister Signal.SIGINT
+        s |> shouldEqual SignalState.empty
+
+    [<Test>]
+    let ``unregister leaves pending entries queued, just non-deliverable`` () : unit =
+        // POSIX semantics: removing the disposition while a signal is
+        // pending doesn't drop the signal — it remains queued and becomes
+        // deliverable again if a handler is re-installed.
+        let entry =
+            {
+                Signal = Signal.SIGINT
+                Target = ValueNone
+            }
+
+        let s =
+            SignalState.empty
+            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.enqueue entry
+            |> SignalState.unregister Signal.SIGINT
+
+        SignalState.pending s |> Seq.toList |> shouldEqual [ entry ]
+        SignalState.tryDeliverable (liveThreads [ t0 ]) s |> shouldEqual None
+
+    [<Test>]
+    let ``register after enqueue makes a queued signal deliverable`` () : unit =
+        let entry =
+            {
+                Signal = Signal.SIGINT
+                Target = ValueNone
+            }
+
+        let s =
+            SignalState.empty
+            |> SignalState.enqueue entry
+            |> SignalState.register Signal.SIGINT (callback 1)
+
+        match SignalState.tryDeliverable (liveThreads [ t0 ]) s with
+        | Some (e, tid, h, s') ->
+            e |> shouldEqual entry
+            tid |> shouldEqual t0
+            h |> shouldEqual (callback 1)
+            SignalState.pending s' |> Seq.toList |> shouldEqual []
+        | None -> failwith "expected deliverable entry once handler was registered"
+
+    [<Test>]
+    let ``block then isBlocked`` () : unit =
+        let s = SignalState.empty |> SignalState.block t0 Signal.SIGINT
+        SignalState.isBlocked t0 Signal.SIGINT s |> shouldEqual true
+        SignalState.isBlocked t0 Signal.SIGHUP s |> shouldEqual false
+        SignalState.isBlocked t1 Signal.SIGINT s |> shouldEqual false
+
+    [<Test>]
+    let ``block is idempotent`` () : unit =
+        let once = SignalState.empty |> SignalState.block t0 Signal.SIGINT
+        let twice = once |> SignalState.block t0 Signal.SIGINT
+        twice |> shouldEqual once
+
+    [<Test>]
+    let ``unblock removes a blocked signal`` () : unit =
+        let s =
+            SignalState.empty
+            |> SignalState.block t0 Signal.SIGINT
+            |> SignalState.unblock t0 Signal.SIGINT
+
+        SignalState.isBlocked t0 Signal.SIGINT s |> shouldEqual false
+        SignalState.blockedFor t0 s |> shouldEqual Set.empty
+
+    [<Test>]
+    let ``unblock collapses empty mask back to the empty state`` () : unit =
+        // Critical: a state that had a signal blocked and then unblocked must
+        // be structurally identical to a state that never blocked it. Without
+        // collapsing the empty mask, equality would distinguish two
+        // semantically-equivalent states and the property-test oracle would
+        // diverge from the implementation after every full unblock.
+        let blockedThenUnblocked =
+            SignalState.empty
+            |> SignalState.block t0 Signal.SIGINT
+            |> SignalState.unblock t0 Signal.SIGINT
+
+        blockedThenUnblocked |> shouldEqual SignalState.empty
+
+    [<Test>]
+    let ``unblock of an unblocked signal is a no-op`` () : unit =
+        let s = SignalState.empty |> SignalState.unblock t0 Signal.SIGINT
+        s |> shouldEqual SignalState.empty
+
+    [<Test>]
+    let ``enqueue appends to the back of the pending queue`` () : unit =
+        let a =
+            {
+                Signal = Signal.SIGINT
+                Target = ValueNone
+            }
+
+        let b =
+            {
+                Signal = Signal.SIGHUP
+                Target = ValueNone
+            }
+
+        let s = SignalState.empty |> SignalState.enqueue a |> SignalState.enqueue b
+
+        SignalState.pending s |> Seq.toList |> shouldEqual [ a ; b ]
+
+    [<Test>]
+    let ``enqueue does not coalesce duplicates`` () : unit =
+        let e =
+            {
+                Signal = Signal.SIGINT
+                Target = ValueNone
+            }
+
+        let s = SignalState.empty |> SignalState.enqueue e |> SignalState.enqueue e
+
+        SignalState.pending s |> Seq.toList |> shouldEqual [ e ; e ]
+
+    [<Test>]
+    let ``tryDeliverable returns None when nothing is pending`` () : unit =
+        SignalState.tryDeliverable (liveThreads [ t0 ]) SignalState.empty
+        |> shouldEqual None
+
+    [<Test>]
+    let ``tryDeliverable returns None when no handler is registered`` () : unit =
+        let s =
+            SignalState.empty
+            |> SignalState.enqueue
+                {
+                    Signal = Signal.SIGINT
+                    Target = ValueNone
+                }
+
+        SignalState.tryDeliverable (liveThreads [ t0 ]) s |> shouldEqual None
+
+    [<Test>]
+    let ``tryDeliverable returns None when there are no live threads`` () : unit =
+        let s =
+            SignalState.empty
+            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.enqueue
+                {
+                    Signal = Signal.SIGINT
+                    Target = ValueNone
+                }
+
+        SignalState.tryDeliverable (liveThreads []) s |> shouldEqual None
+
+    [<Test>]
+    let ``tryDeliverable picks the lowest live thread for a process-directed signal`` () : unit =
+        let entry =
+            {
+                Signal = Signal.SIGINT
+                Target = ValueNone
+            }
+
+        let s =
+            SignalState.empty
+            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.enqueue entry
+
+        // Live-thread order is deliberately scrambled to confirm the
+        // implementation sorts internally rather than trusting input order.
+        match SignalState.tryDeliverable (liveThreads [ t2 ; t0 ; t1 ]) s with
+        | Some (e, tid, h, s') ->
+            e |> shouldEqual entry
+            tid |> shouldEqual t0
+            h |> shouldEqual (callback 1)
+            SignalState.pending s' |> Seq.toList |> shouldEqual []
+        | None -> failwith "expected deliverable entry"
+
+    [<Test>]
+    let ``tryDeliverable skips the lowest thread if it is blocking the signal`` () : unit =
+        let s =
+            SignalState.empty
+            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.block t0 Signal.SIGINT
+            |> SignalState.enqueue
+                {
+                    Signal = Signal.SIGINT
+                    Target = ValueNone
+                }
+
+        match SignalState.tryDeliverable (liveThreads [ t0 ; t1 ; t2 ]) s with
+        | Some (_, tid, _, _) -> tid |> shouldEqual t1
+        | None -> failwith "expected deliverable entry"
+
+    [<Test>]
+    let ``tryDeliverable returns None when every live thread blocks the signal`` () : unit =
+        let s =
+            SignalState.empty
+            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.block t0 Signal.SIGINT
+            |> SignalState.block t1 Signal.SIGINT
+            |> SignalState.enqueue
+                {
+                    Signal = Signal.SIGINT
+                    Target = ValueNone
+                }
+
+        SignalState.tryDeliverable (liveThreads [ t0 ; t1 ]) s |> shouldEqual None
+
+    [<Test>]
+    let ``tryDeliverable for a targeted signal does not redirect to another thread`` () : unit =
+        // pthread_kill is pinned: even though t1 is unblocked, a signal
+        // targeted at t0 must stay queued, not get delivered to t1.
+        let s =
+            SignalState.empty
+            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.block t0 Signal.SIGINT
+            |> SignalState.enqueue
+                {
+                    Signal = Signal.SIGINT
+                    Target = ValueSome t0
+                }
+
+        SignalState.tryDeliverable (liveThreads [ t0 ; t1 ]) s |> shouldEqual None
+
+    [<Test>]
+    let ``tryDeliverable for a targeted dead thread is held`` () : unit =
+        let s =
+            SignalState.empty
+            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.enqueue
+                {
+                    Signal = Signal.SIGINT
+                    Target = ValueSome t2
+                }
+
+        SignalState.tryDeliverable (liveThreads [ t0 ; t1 ]) s |> shouldEqual None
+
+    [<Test>]
+    let ``tryDeliverable preserves the FIFO order of skipped entries`` () : unit =
+        // Three entries: (1) no handler installed, (2) targeted at a thread
+        // blocking it, (3) process-directed and deliverable to t1. The
+        // returned state must contain entries (1) and (2) in their original
+        // order; only entry (3) is removed.
+        let head =
+            {
+                Signal = Signal.SIGHUP
+                Target = ValueNone
+            }
+
+        let middle =
+            {
+                Signal = Signal.SIGINT
+                Target = ValueSome t0
+            }
+
+        let tail =
+            {
+                Signal = Signal.SIGINT
+                Target = ValueNone
+            }
+
+        let s =
+            SignalState.empty
+            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.block t0 Signal.SIGINT
+            |> SignalState.enqueue head
+            |> SignalState.enqueue middle
+            |> SignalState.enqueue tail
+
+        match SignalState.tryDeliverable (liveThreads [ t0 ; t1 ]) s with
+        | Some (e, tid, _, s') ->
+            e |> shouldEqual tail
+            tid |> shouldEqual t1
+            SignalState.pending s' |> Seq.toList |> shouldEqual [ head ; middle ]
+        | None -> failwith "expected deliverable entry"
+
+    // ----------------------- Property tests ----------------------- //
+
+    /// Operation language for the random property test. Each constructor
+    /// maps to exactly one public method on the API.
+    type private Op =
+        | MarkInitialized
+        | Register of signal : Signal * handler : SignalHandler
+        | Unregister of signal : Signal
+        | Block of thread : ThreadId * signal : Signal
+        | Unblock of thread : ThreadId * signal : Signal
+        | Enqueue of entry : PendingSignal
+        | DrainOne of live : ThreadId list
+
+    /// Reference implementation: simple lists / maps, completely
+    /// independent of the production module's internal representation.
+    type private ReferenceState =
+        {
+            Initialized : bool
+            Registrations : Map<Signal, SignalHandler>
+            Blocked : Map<ThreadId, Set<Signal>>
+            Pending : PendingSignal list
+        }
+
+    let private referenceEmpty : ReferenceState =
+        {
+            Initialized = false
+            Registrations = Map.empty
+            Blocked = Map.empty
+            Pending = []
+        }
+
+    /// Index-based two-pass scan: distinct algorithm from the production
+    /// module's recursive accumulator walk, so a regression in either side
+    /// surfaces as a divergence.
+    let private referenceTryDeliverable
+        (live : ThreadId list)
+        (r : ReferenceState)
+        : (PendingSignal * ThreadId * SignalHandler * ReferenceState) option
+        =
+        let liveSet : Set<ThreadId> = Set.ofList live
+
+        let sortedLive : ThreadId list =
+            live |> List.sortBy (fun (ThreadId.ThreadId i) -> i)
+
+        let isBlocked (tid : ThreadId) (s : Signal) : bool =
+            match Map.tryFind tid r.Blocked with
+            | None -> false
+            | Some set -> Set.contains s set
+
+        let pickReceiver (e : PendingSignal) : ThreadId option =
+            match e.Target with
+            | ValueSome tid ->
+                if Set.contains tid liveSet && not (isBlocked tid e.Signal) then
+                    Some tid
+                else
+                    None
+            | ValueNone -> sortedLive |> List.tryFind (fun tid -> not (isBlocked tid e.Signal))
+
+        let entries : PendingSignal[] = r.Pending |> List.toArray
+        let mutable foundIdx : int = -1
+        let mutable foundReceiver : ThreadId option = None
+        let mutable foundHandler : SignalHandler option = None
+        let mutable i : int = 0
+
+        while foundIdx < 0 && i < entries.Length do
+            let entry = entries.[i]
+
+            match Map.tryFind entry.Signal r.Registrations with
+            | Some h ->
+                match pickReceiver entry with
+                | Some tid ->
+                    foundIdx <- i
+                    foundReceiver <- Some tid
+                    foundHandler <- Some h
+                | None -> ()
+            | None -> ()
+
+            i <- i + 1
+
+        if foundIdx < 0 then
+            None
+        else
+            let remaining : PendingSignal list =
+                Array.append
+                    (Array.sub entries 0 foundIdx)
+                    (Array.sub entries (foundIdx + 1) (entries.Length - foundIdx - 1))
+                |> Array.toList
+
+            Some (
+                entries.[foundIdx],
+                foundReceiver.Value,
+                foundHandler.Value,
+                { r with
+                    Pending = remaining
+                }
+            )
+
+    /// Advance both implementations by one op, asserting agreement on
+    /// `tryDeliverable`'s full return tuple (since the next step's
+    /// observable state alone cannot always distinguish a divergence in
+    /// which entry was dequeued).
+    let private stepBoth (op : Op) (s : SignalState) (r : ReferenceState) : SignalState * ReferenceState =
+        match op with
+        | Op.MarkInitialized ->
+            SignalState.markInitialized s,
+            { r with
+                Initialized = true
+            }
+        | Op.Register (sig0, h) ->
+            SignalState.register sig0 h s,
+            { r with
+                Registrations = Map.add sig0 h r.Registrations
+            }
+        | Op.Unregister sig0 ->
+            SignalState.unregister sig0 s,
+            { r with
+                Registrations = Map.remove sig0 r.Registrations
+            }
+        | Op.Block (tid, sig0) ->
+            let existing : Set<Signal> =
+                match Map.tryFind tid r.Blocked with
+                | None -> Set.empty
+                | Some set -> set
+
+            SignalState.block tid sig0 s,
+            { r with
+                Blocked = Map.add tid (Set.add sig0 existing) r.Blocked
+            }
+        | Op.Unblock (tid, sig0) ->
+            let r' : ReferenceState =
+                match Map.tryFind tid r.Blocked with
+                | None -> r
+                | Some set ->
+                    if not (Set.contains sig0 set) then
+                        r
+                    else
+                        let set' = Set.remove sig0 set
+
+                        let blocked =
+                            if Set.isEmpty set' then
+                                Map.remove tid r.Blocked
+                            else
+                                Map.add tid set' r.Blocked
+
+                        { r with
+                            Blocked = blocked
+                        }
+
+            SignalState.unblock tid sig0 s, r'
+        | Op.Enqueue e ->
+            SignalState.enqueue e s,
+            { r with
+                Pending = r.Pending @ [ e ]
+            }
+        | Op.DrainOne live ->
+            let actual = SignalState.tryDeliverable (liveThreads live) s
+            let expected = referenceTryDeliverable live r
+
+            match actual, expected with
+            | None, None -> s, r
+            | Some (e1, tid1, h1, s'), Some (e2, tid2, h2, r') ->
+                e1 |> shouldEqual e2
+                tid1 |> shouldEqual tid2
+                h1 |> shouldEqual h2
+                s', r'
+            | a, b -> failwith $"tryDeliverable disagreed: actual=%A{a}, reference=%A{b}"
+
+    /// Compare every observable accessor; the accessors are the contract.
+    let private assertEquivalent (s : SignalState) (r : ReferenceState) : unit =
+        SignalState.isInitialized s |> shouldEqual r.Initialized
+        SignalState.registrations s |> shouldEqual r.Registrations
+        SignalState.pending s |> Seq.toList |> shouldEqual r.Pending
+
+        for tid in allThreads do
+            for sig0 in allSignals do
+                let actualBlocked = SignalState.isBlocked tid sig0 s
+
+                let expectedBlocked =
+                    match Map.tryFind tid r.Blocked with
+                    | None -> false
+                    | Some set -> Set.contains sig0 set
+
+                if actualBlocked <> expectedBlocked then
+                    failwith
+                        $"isBlocked %O{tid} %O{sig0} disagreed: actual=%b{actualBlocked}, reference=%b{expectedBlocked}"
+
+        for tid in allThreads do
+            let actualMask = SignalState.blockedFor tid s
+
+            let expectedMask =
+                match Map.tryFind tid r.Blocked with
+                | None -> Set.empty
+                | Some set -> set
+
+            actualMask |> shouldEqual expectedMask
+
+    let private randomOp (rng : System.Random) : Op =
+        let pick (xs : 'a list) : 'a = xs.[rng.Next xs.Length]
+        let kind = rng.Next 100
+
+        if kind < 5 then
+            Op.MarkInitialized
+        elif kind < 25 then
+            Op.Register (pick allSignals, callback (rng.Next 4))
+        elif kind < 32 then
+            Op.Unregister (pick allSignals)
+        elif kind < 47 then
+            Op.Block (pick allThreads, pick allSignals)
+        elif kind < 57 then
+            Op.Unblock (pick allThreads, pick allSignals)
+        elif kind < 80 then
+            let target =
+                if rng.Next 2 = 0 then
+                    ValueNone
+                else
+                    ValueSome (pick allThreads)
+
+            Op.Enqueue
+                {
+                    Signal = pick allSignals
+                    Target = target
+                }
+        else
+            // Live-thread set varies independently of pending entries so
+            // the dispatcher sees a moving target.
+            let nThreads = rng.Next (allThreads.Length + 1)
+
+            let threads = allThreads |> List.sortBy (fun _ -> rng.Next ()) |> List.take nThreads
+
+            Op.DrainOne threads
+
+    [<Test>]
+    let ``random op sequences agree with the reference oracle on every observable`` () : unit =
+        let mutable observedDeliveries = 0
+        let mutable observedSkipThenDeliver = 0
+        let mutable observedDrainOfEmpty = 0
+        let mutable observedDrainNoneNonEmpty = 0
+
+        let property (NonNegativeInt seed : NonNegativeInt) : unit =
+            let rng = System.Random seed
+            let steps = rng.Next (10, 80)
+
+            let mutable s = SignalState.empty
+            let mutable r = referenceEmpty
+            assertEquivalent s r
+
+            for _ in 1..steps do
+                let op = randomOp rng
+
+                // Distribution telemetry collected before the step so we can
+                // see what shape the random walk drove the model into.
+                match op with
+                | Op.DrainOne live ->
+                    match referenceTryDeliverable live r with
+                    | Some (entry, _, _, _) ->
+                        observedDeliveries <- observedDeliveries + 1
+
+                        match r.Pending with
+                        | head :: _ when head <> entry -> observedSkipThenDeliver <- observedSkipThenDeliver + 1
+                        | _ -> ()
+                    | None when r.Pending.IsEmpty -> observedDrainOfEmpty <- observedDrainOfEmpty + 1
+                    | None -> observedDrainNoneNonEmpty <- observedDrainNoneNonEmpty + 1
+                | _ -> ()
+
+                let s', r' = stepBoth op s r
+                s <- s'
+                r <- r'
+                assertEquivalent s r
+
+        Check.One (propertyConfig, property)
+
+        // Distribution checks: the random walk must hit each load-bearing
+        // path frequently enough that a regression would actually surface.
+        // The thresholds are deliberately conservative — expected counts
+        // are in the hundreds, so requiring a few dozen guards against
+        // pathological non-coverage without becoming flaky on the lower
+        // tail of the seed distribution.
+        observedDeliveries |> shouldBeGreaterThan 100
+        observedSkipThenDeliver |> shouldBeGreaterThan 20
+        observedDrainOfEmpty |> shouldBeGreaterThan 20
+        observedDrainNoneNonEmpty |> shouldBeGreaterThan 20

--- a/WoofWare.PawPrint.Test/TestSignalState.fs
+++ b/WoofWare.PawPrint.Test/TestSignalState.fs
@@ -219,6 +219,64 @@ module TestSignalState =
         SignalState.pending s |> Seq.toList |> shouldEqual [ e ; e ]
 
     [<Test>]
+    let ``structural equality survives a non-empty pending queue`` () : unit =
+        // Regression guard for a previous representation that stored
+        // `Pending` as `ImmutableQueue<T>`: that container uses reference
+        // equality, so two independently-built states with identical
+        // contents would compare unequal once the queue was non-empty.
+        // `EmulatedKernel` (which embeds `SignalState`) is compared
+        // structurally for deterministic state dedup; this test pins
+        // down that the contract holds across every operation that
+        // touches the queue.
+        let entryA =
+            {
+                Signal = Signal.SIGINT
+                Target = ValueNone
+            }
+
+        let entryB =
+            {
+                Signal = Signal.SIGHUP
+                Target = ValueSome t1
+            }
+
+        let buildA () =
+            SignalState.empty
+            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.block t0 Signal.SIGTERM
+            |> SignalState.enqueue entryA
+            |> SignalState.enqueue entryB
+
+        let buildB () =
+            SignalState.empty
+            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.block t0 Signal.SIGTERM
+            |> SignalState.enqueue entryA
+            |> SignalState.enqueue entryB
+
+        let a = buildA ()
+        let b = buildB ()
+        a |> shouldEqual b
+        hash a |> shouldEqual (hash b)
+
+        // The state after delivery must also compare equal to an
+        // independently-rebuilt equivalent — exercises the path where
+        // tryDeliverable rebuilds the pending list from a skipped/tail
+        // split.
+        let drainedFromA =
+            match SignalState.tryDeliverable (liveThreads [ t0 ; t1 ]) a with
+            | Some (_, _, _, s') -> s'
+            | None -> failwith "expected deliverable entry from buildA"
+
+        let drainedFromB =
+            match SignalState.tryDeliverable (liveThreads [ t0 ; t1 ]) b with
+            | Some (_, _, _, s') -> s'
+            | None -> failwith "expected deliverable entry from buildB"
+
+        drainedFromA |> shouldEqual drainedFromB
+        hash drainedFromA |> shouldEqual (hash drainedFromB)
+
+    [<Test>]
     let ``tryDeliverable returns None when nothing is pending`` () : unit =
         SignalState.tryDeliverable (liveThreads [ t0 ]) SignalState.empty
         |> shouldEqual None

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -68,6 +68,7 @@
     <Compile Include="TestDebuggerServer.fs" />
     <Compile Include="TestBclIntrinsicStaticFields.fs" />
     <Compile Include="TestLowLevelMonitor.fs" />
+    <Compile Include="TestSignalState.fs" />
     <Compile Include="TestWaitHandle.fs" />
     <Compile Include="TestSyncBlockMonitor.fs" />
     <Compile Include="TestPureCases.fs" />

--- a/WoofWare.PawPrint/EmulatedKernel.fs
+++ b/WoofWare.PawPrint/EmulatedKernel.fs
@@ -388,6 +388,14 @@ type EmulatedKernel =
         /// of this default at startup, and tests can pass their own overlay
         /// via `Program.run`.
         Environment : Map<string, string>
+        /// Pure data model of the simulated process's signal disposition,
+        /// per-thread sigprocmasks, and pending-signal queue. Populated by
+        /// future slices: nothing in the simulator dispatches signals yet,
+        /// so the field stays at `SignalState.empty` across every run today.
+        /// Held on `EmulatedKernel` (rather than per-thread) because POSIX
+        /// signal disposition is process-wide; the per-thread piece lives
+        /// inside `SignalState.Blocked`.
+        Signals : SignalState
     }
 
 /// Deterministic non-cryptographic PRNG that backs
@@ -478,6 +486,7 @@ module EmulatedKernel =
             NonCryptoRandomState = NonCryptoRandom.initialState
             OutputLog = ImmutableArray<OutputLogEntry>.Empty
             Environment = defaultEnvironment
+            Signals = SignalState.empty
         }
 
     /// Overlay the supplied environment variables on top of the kernel's

--- a/WoofWare.PawPrint/Signal.fs
+++ b/WoofWare.PawPrint/Signal.fs
@@ -1,0 +1,46 @@
+namespace WoofWare.PawPrint
+
+/// A POSIX signal recognised by the simulator. The named cases cover the
+/// signals the .NET BCL surfaces via the `PosixSignal` managed enum plus the
+/// common ones the runtime emits at process-startup (SIGPIPE, SIGABRT,
+/// SIGUSR1/2). Anything we don't have a case for is carried as `Other` along
+/// with the raw managed `PosixSignal` value so callers retain identity
+/// information across PawPrint even when we don't model the signal's
+/// semantics.
+///
+/// Note: this type intentionally does NOT mention native (POSIX) signal
+/// numbers, which are platform-specific. The native↔domain mapping lives at
+/// the P/Invoke seam and is platform-aware; the domain type is the
+/// platform-neutral identity that the rest of the simulator works with.
+type Signal =
+    | SIGHUP
+    | SIGINT
+    | SIGQUIT
+    | SIGTERM
+    | SIGCHLD
+    | SIGCONT
+    | SIGWINCH
+    | SIGTSTP
+    | SIGTTIN
+    | SIGTTOU
+    | SIGPIPE
+    | SIGUSR1
+    | SIGUSR2
+    | SIGABRT
+    /// Catch-all for signals the simulator doesn't model semantically yet.
+    /// Carries the raw managed `PosixSignal` enum value (negative for
+    /// cross-platform signals, positive when callers supply a native signo
+    /// directly). Two `Other` values are equal iff their raw values match.
+    | Other of rawSignal : int
+
+/// How a delivered signal should be dispatched inside the simulator. Today
+/// the only shape is "invoke a managed callback identified by an object
+/// reference"; the discriminated-union shape leaves headroom for future
+/// dispositions (ignore, default, terminate) without churning callers.
+[<RequireQualifiedAccess>]
+type SignalHandler =
+    /// Dispatch by invoking a managed callback wrapped behind the supplied
+    /// object reference. Concretely, this is the `PosixSignalRegistration`
+    /// (or analogous) object the guest installed via the runtime; the
+    /// signal-delivery glue will reach in and invoke its delegate.
+    | PosixCallback of objectRef : ManagedHeapAddress

--- a/WoofWare.PawPrint/SignalState.fs
+++ b/WoofWare.PawPrint/SignalState.fs
@@ -39,7 +39,15 @@ type SignalState =
             Initialized : bool
             Registrations : Map<Signal, SignalHandler>
             Blocked : Map<ThreadId, Set<Signal>>
-            Pending : ImmutableQueue<PendingSignal>
+            /// Pending entries in FIFO order (head = next candidate for
+            /// dispatch). A plain list rather than `ImmutableQueue<T>`
+            /// because the queue type uses reference equality, which would
+            /// break the structural equality `EmulatedKernel` relies on for
+            /// deterministic state comparison. Enqueue is O(n) on append,
+            /// which is fine: signal queues are tiny in practice (typically
+            /// 0–3 entries) and PawPrint trades performance for determinism
+            /// throughout.
+            Pending : PendingSignal list
         }
 
 [<RequireQualifiedAccess>]
@@ -49,7 +57,7 @@ module SignalState =
             Initialized = false
             Registrations = Map.empty
             Blocked = Map.empty
-            Pending = ImmutableQueue.Empty
+            Pending = []
         }
 
     let isInitialized (state : SignalState) : bool = state.Initialized
@@ -143,11 +151,11 @@ module SignalState =
     /// elsewhere if they want it.
     let enqueue (entry : PendingSignal) (state : SignalState) : SignalState =
         { state with
-            Pending = state.Pending.Enqueue entry
+            Pending = state.Pending @ [ entry ]
         }
 
-    /// Snapshot of the pending queue, in FIFO order.
-    let pending (state : SignalState) : ImmutableQueue<PendingSignal> = state.Pending
+    /// Snapshot of the pending queue, in FIFO order (head = next candidate).
+    let pending (state : SignalState) : PendingSignal list = state.Pending
 
     /// Walk the pending queue in FIFO order and return the first entry that
     /// can be delivered now. An entry is deliverable iff:
@@ -183,8 +191,6 @@ module SignalState =
                     None
             | ValueNone -> sortedLive |> List.tryFind (fun tid -> not (isBlocked tid entry.Signal state))
 
-        let entries : PendingSignal list = state.Pending |> Seq.toList
-
         let rec scan (skipped : PendingSignal list) (rest : PendingSignal list) =
             match rest with
             | [] -> None
@@ -197,16 +203,13 @@ module SignalState =
                     | Some tid ->
                         let remaining : PendingSignal list = List.rev skipped @ tail
 
-                        let pending' : ImmutableQueue<PendingSignal> =
-                            (ImmutableQueue.Empty, remaining) ||> List.fold (fun q e -> q.Enqueue e)
-
                         Some (
                             head,
                             tid,
                             handler,
                             { state with
-                                Pending = pending'
+                                Pending = remaining
                             }
                         )
 
-        scan [] entries
+        scan [] state.Pending

--- a/WoofWare.PawPrint/SignalState.fs
+++ b/WoofWare.PawPrint/SignalState.fs
@@ -1,0 +1,212 @@
+namespace WoofWare.PawPrint
+
+open System.Collections.Immutable
+
+/// A signal sitting in the simulator's pending queue, waiting to be
+/// dispatched. `Target = ValueNone` is the POSIX "kill the process" case
+/// (any live thread that isn't blocking the signal may receive it);
+/// `ValueSome` is `pthread_kill`-style directed delivery, where only the
+/// named thread is eligible.
+type PendingSignal =
+    {
+        Signal : Signal
+        Target : ThreadId voption
+    }
+
+/// Pure, deterministic model of the simulator's signal-handling state.
+///
+/// The shape is deliberately small:
+///   * `Initialized` — has the BCL invoked
+///     `SystemNative_InitializeTerminalAndSignalHandling` yet? Several
+///     console paths gate work behind this flag.
+///   * `Registrations` — the per-signal dispatch target. A signal that is
+///     not in this map has no handler installed; pending entries for such
+///     signals stay queued (the consumer decides whether to drop or wait
+///     for a registration).
+///   * `Blocked` — per-thread sigprocmask. A signal in a thread's set is
+///     blocked for that thread and cannot be delivered to it.
+///   * `Pending` — FIFO queue of generated signals waiting for dispatch.
+///
+/// The `EmulatedKernel.Signals` field carries an instance of this type per
+/// simulated process, but no code dispatches signals out of it yet —
+/// downstream slices will plug in the harness-side injection point, the
+/// between-instruction delivery hook, and the native P/Invoke arms that
+/// register and block. The data shape itself is exercised end-to-end by
+/// property tests against a reference oracle.
+type SignalState =
+    private
+        {
+            Initialized : bool
+            Registrations : Map<Signal, SignalHandler>
+            Blocked : Map<ThreadId, Set<Signal>>
+            Pending : ImmutableQueue<PendingSignal>
+        }
+
+[<RequireQualifiedAccess>]
+module SignalState =
+    let empty : SignalState =
+        {
+            Initialized = false
+            Registrations = Map.empty
+            Blocked = Map.empty
+            Pending = ImmutableQueue.Empty
+        }
+
+    let isInitialized (state : SignalState) : bool = state.Initialized
+
+    /// Idempotent: a second call is a no-op. Mirrors the BCL behaviour where
+    /// `EnsureInitialized` may run more than once across the BCL surface but
+    /// the underlying signal apparatus is set up exactly once.
+    let markInitialized (state : SignalState) : SignalState =
+        if state.Initialized then
+            state
+        else
+            { state with
+                Initialized = true
+            }
+
+    let tryGetHandler (signal : Signal) (state : SignalState) : SignalHandler option =
+        Map.tryFind signal state.Registrations
+
+    let registrations (state : SignalState) : Map<Signal, SignalHandler> = state.Registrations
+
+    /// Install or replace the handler for `signal`. POSIX permits exactly
+    /// one disposition per signal at a time; a second `register` overwrites
+    /// the first.
+    let register (signal : Signal) (handler : SignalHandler) (state : SignalState) : SignalState =
+        { state with
+            Registrations = Map.add signal handler state.Registrations
+        }
+
+    /// Remove the handler for `signal`. After this, pending entries for the
+    /// signal remain queued (a future `register` will make them deliverable)
+    /// but `tryDeliverable` will not dispatch them in the meantime. No-op if
+    /// no handler was installed.
+    let unregister (signal : Signal) (state : SignalState) : SignalState =
+        { state with
+            Registrations = Map.remove signal state.Registrations
+        }
+
+    let isBlocked (thread : ThreadId) (signal : Signal) (state : SignalState) : bool =
+        match Map.tryFind thread state.Blocked with
+        | None -> false
+        | Some set -> Set.contains signal set
+
+    let blockedFor (thread : ThreadId) (state : SignalState) : Set<Signal> =
+        match Map.tryFind thread state.Blocked with
+        | None -> Set.empty
+        | Some set -> set
+
+    /// Add `signal` to `thread`'s sigprocmask. Idempotent: a second `block`
+    /// of an already-blocked signal is a no-op. The thread does not need to
+    /// be live; masks for non-live threads are harmless because dispatch
+    /// already filters to the live set.
+    let block (thread : ThreadId) (signal : Signal) (state : SignalState) : SignalState =
+        let existing =
+            match Map.tryFind thread state.Blocked with
+            | None -> Set.empty
+            | Some set -> set
+
+        if Set.contains signal existing then
+            state
+        else
+            { state with
+                Blocked = Map.add thread (Set.add signal existing) state.Blocked
+            }
+
+    /// Remove `signal` from `thread`'s sigprocmask. No-op if the signal
+    /// wasn't blocked. When the resulting mask is empty, the thread's entry
+    /// is dropped from the map so two states are structurally equal if they
+    /// differ only in "absent" vs "empty" masks.
+    let unblock (thread : ThreadId) (signal : Signal) (state : SignalState) : SignalState =
+        match Map.tryFind thread state.Blocked with
+        | None -> state
+        | Some set ->
+            if not (Set.contains signal set) then
+                state
+            else
+                let set' = Set.remove signal set
+
+                let blocked =
+                    if Set.isEmpty set' then
+                        Map.remove thread state.Blocked
+                    else
+                        Map.add thread set' state.Blocked
+
+                { state with
+                    Blocked = blocked
+                }
+
+    /// Append a signal to the back of the pending queue. Two enqueues of the
+    /// same signal are not coalesced; POSIX allows duplicates for real-time
+    /// signals and we preserve identity here so callers can detect collapse
+    /// elsewhere if they want it.
+    let enqueue (entry : PendingSignal) (state : SignalState) : SignalState =
+        { state with
+            Pending = state.Pending.Enqueue entry
+        }
+
+    /// Snapshot of the pending queue, in FIFO order.
+    let pending (state : SignalState) : ImmutableQueue<PendingSignal> = state.Pending
+
+    /// Walk the pending queue in FIFO order and return the first entry that
+    /// can be delivered now. An entry is deliverable iff:
+    ///   * a handler is registered for its `Signal`;
+    ///   * either it is `pthread_kill`-directed at a thread that is live and
+    ///     not blocking the signal, or
+    ///   * it is process-directed (`Target = ValueNone`) and at least one
+    ///     live thread is not blocking the signal.
+    ///
+    /// For process-directed delivery, the lowest-id eligible thread receives
+    /// the signal — the choice is arbitrary but must be deterministic, and
+    /// "lowest id" composes well with the existing thread-scheduling
+    /// conventions.
+    ///
+    /// Skipped (non-deliverable) entries keep their relative order in the
+    /// queue. Returns `None` if no entry is deliverable.
+    let tryDeliverable
+        (liveThreads : ImmutableArray<ThreadId>)
+        (state : SignalState)
+        : (PendingSignal * ThreadId * SignalHandler * SignalState) option
+        =
+        let liveSet : Set<ThreadId> = liveThreads |> Seq.toList |> Set.ofList
+
+        let sortedLive : ThreadId list =
+            liveThreads |> Seq.toList |> List.sortBy (fun (ThreadId.ThreadId tid) -> tid)
+
+        let pickReceiver (entry : PendingSignal) : ThreadId option =
+            match entry.Target with
+            | ValueSome tid ->
+                if Set.contains tid liveSet && not (isBlocked tid entry.Signal state) then
+                    Some tid
+                else
+                    None
+            | ValueNone -> sortedLive |> List.tryFind (fun tid -> not (isBlocked tid entry.Signal state))
+
+        let entries : PendingSignal list = state.Pending |> Seq.toList
+
+        let rec scan (skipped : PendingSignal list) (rest : PendingSignal list) =
+            match rest with
+            | [] -> None
+            | head :: tail ->
+                match Map.tryFind head.Signal state.Registrations with
+                | None -> scan (head :: skipped) tail
+                | Some handler ->
+                    match pickReceiver head with
+                    | None -> scan (head :: skipped) tail
+                    | Some tid ->
+                        let remaining : PendingSignal list = List.rev skipped @ tail
+
+                        let pending' : ImmutableQueue<PendingSignal> =
+                            (ImmutableQueue.Empty, remaining) ||> List.fold (fun q e -> q.Enqueue e)
+
+                        Some (
+                            head,
+                            tid,
+                            handler,
+                            { state with
+                                Pending = pending'
+                            }
+                        )
+
+        scan [] entries

--- a/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
+++ b/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
@@ -36,6 +36,8 @@
     <Compile Include="TypeResolution.fs" />
     <Compile Include="HardwareIntrinsicsProfile.fs" />
     <Compile Include="DebuggerState.fs" />
+    <Compile Include="Signal.fs" />
+    <Compile Include="SignalState.fs" />
     <Compile Include="EmulatedKernel.fs" />
     <Compile Include="IlMachineStateModel.fs" />
     <Compile Include="IlMachineTypeResolution.fs" />


### PR DESCRIPTION
## Summary

First slice of the signal-handling pivot ([#585](https://github.com/Smaug123/WoofWare.PawPrint/pull/585) closed in favour of building the model properly rather than stubbing).

- `Signal` and `SignalHandler` types covering POSIX dispositions the .NET BCL exposes via `PosixSignal`, plus the runtime-emitted ones (`SIGPIPE`, `SIGUSR1/2`, `SIGABRT`) and an `Other` catch-all.
- `SignalState` module: pure, immutable state machine for the process-wide signal disposition, per-thread sigprocmasks, and a FIFO pending-signal queue, with `tryDeliverable` returning the first deliverable entry (deterministically picking the lowest-id eligible thread for process-directed signals).
- `EmulatedKernel.Signals` defaulted to `SignalState.empty` — no consumers yet; downstream slices wire in dispatch, harness injection, and the native P/Invoke arms.
- 25 tests, including a property test that runs random op sequences against a structurally-different reference oracle (index-based two-pass scan vs. the production module's recursive accumulator walk). Distribution checks guard the load-bearing paths (skip-then-deliver, drain-of-empty, drain-with-no-deliverable).

## Test plan

- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — all 1190 tests pass.
- [x] `nix develop -c dotnet test --filter "Name~SignalState"` — 25/25 pass; property test runs 500 random op sequences.
- [x] `nix develop -c dotnet fantomas .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)