### PR TITLE
Wire RuntimeTypeHandle.GetFields for OpenGenericTypeDefinition

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -18,7 +18,8 @@ module TestPureCases =
     let unimplemented =
         [
             "AdvancedStructLayout.cs" // past MarshalNative_SizeOfHelper for ByValTStr and SystemNative_Malloc / SystemNative_Free / Marshal.AllocHGlobal / FreeHGlobal; now blocked downstream at the unimplemented MarshalNative_TryGetStructMarshalStub QCall (CoreLib's Marshal.StructureToPtr path)
-            "LdtokenField.cs" // past RuntimeFieldHandle::GetApproxDeclaringMethodTable; now blocked at RuntimeTypeHandle.GetFields for an open generic type definition (Test 5: typeof(GenericClass<>).GetField)
+            "GetFieldOnOpenGenericTypeDefinition.cs" // RuntimeTypeHandle.GetFields now dispatches the OpenGenericTypeDefinition arm correctly, but getOrAllocateField (IlMachineRuntimeMetadata.fs:107) maps the field's declaring generics to TypeDefn.GenericTypeParameter placeholders and then concretizes with empty typeGenerics, throwing IndexOutOfRangeException; the same latent bug affects closed generic declaring types too (see UnaryMetadataTokenOps.fs:230 TODO)
+            "LdtokenField.cs" // QCall wiring for RuntimeTypeHandle.GetFields on open generic type definitions is now in place, but exercising it (Test 5: typeof(GenericClass<>).GetField) hits the same getOrAllocateField IndexOutOfRangeException as GetFieldOnOpenGenericTypeDefinition.cs above
             "Threads.cs" // past ThreadNative_InformThreadNameChange (Thread.Name setter); now blocked on unimplemented PAL call libSystem.Native!SystemNative_GetLowResolutionTimestamp (.Sys::GetLowResolutionTimestamp, used by the Task/ThreadPool scheduler)
         ]
         |> Set.ofList

--- a/WoofWare.PawPrint.Test/sourcesPure/GetFieldOnOpenGenericTypeDefinition.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/GetFieldOnOpenGenericTypeDefinition.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+
+class Program
+{
+    public class GenericClass<T>
+    {
+        public T Value;
+        public static int StaticCount;
+    }
+
+    static int Main(string[] args)
+    {
+        // typeof(GenericClass<>).GetField goes through
+        // RuntimeType.GetFieldCandidates → RuntimeTypeHandle.GetFields, which
+        // dispatches the open generic type definition target down to the
+        // QCall RuntimeTypeHandle_GetFields. The Closed/Concrete arm of the
+        // walker is already exercised via FieldInfoGetFieldFromHandle.cs;
+        // this case exercises the OpenGenericTypeDefinition arm specifically.
+        System.Type openGeneric = typeof(GenericClass<>);
+
+        FieldInfo valueField = openGeneric.GetField("Value");
+        if (valueField == null) return 1;
+        if (valueField.Name != "Value") return 2;
+        if (valueField.IsStatic) return 3;
+
+        FieldInfo staticCountField = openGeneric.GetField("StaticCount");
+        if (staticCountField == null) return 4;
+        if (staticCountField.FieldType != typeof(int)) return 5;
+        if (!staticCountField.IsStatic) return 6;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
@@ -1,6 +1,7 @@
 namespace WoofWare.PawPrint
 
 open System.Collections.Immutable
+open System.Reflection
 open Microsoft.Extensions.Logging
 
 module NativeRuntimeTypeHelpers =
@@ -131,6 +132,64 @@ module NativeRuntimeTypeHelpers =
             | other -> failwith $"%s{operation}: expected RuntimeFieldHandle.m_ptr object ref, got %O{other}"
         | other -> failwith $"%s{operation}: expected RuntimeFieldHandle value type, got %O{other}"
 
+    /// Enumerate the non-literal fields declared by a `(assembly, typeDef)` pair,
+    /// materialising each as a field-handle registry id (the int64 the BCL writes
+    /// into the buffer). Instance fields are listed before statics; literals are
+    /// excluded. The declaring-type instantiation is intentionally not threaded
+    /// through here: `getOrAllocateField` is responsible for normalising it to a
+    /// canonical form so the same id is produced regardless of whether the caller
+    /// has an open or closed view, matching CoreCLR's per-canonical-MT FieldDesc
+    /// semantics. Today `getOrAllocateField` does not yet handle generic
+    /// declaring types correctly — it remaps the field's generics to canonical
+    /// placeholders and then concretizes them with an empty type-generics
+    /// context, which throws `IndexOutOfRangeException`; the GetFields wiring
+    /// above is correct, but exercising it on a generic declaring type requires
+    /// fixing that follow-up.
+    let walkFieldsOfTypeDefinition
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (operation : string)
+        (declaringAssemblyName : AssemblyName)
+        (declaringTypeDefinition : System.Reflection.Metadata.TypeDefinitionHandle)
+        (state : IlMachineState)
+        : IlMachineState * int64 list
+        =
+        let assembly =
+            state.LoadedAssembly declaringAssemblyName
+            |> Option.defaultWith (fun () ->
+                failwith
+                    $"%s{operation}: assembly for declaring type is not loaded: %s{declaringAssemblyName.FullName}"
+            )
+
+        let typeInfo = assembly.TypeDefs.[declaringTypeDefinition]
+
+        let fields =
+            typeInfo.Fields
+            |> List.filter (fun field -> not (field.Attributes.HasFlag System.Reflection.FieldAttributes.Literal))
+
+        let instanceFields, staticFields =
+            fields |> List.partition (fun field -> not field.IsStatic)
+
+        let fields = instanceFields @ staticFields
+
+        ((state, []), fields)
+        ||> List.fold (fun (state, ids) field ->
+            let runtimeFieldHandle, state =
+                IlMachineState.getOrAllocateField loggerFactory baseClassTypes declaringAssemblyName field.Handle state
+
+            let stubAddress = runtimeFieldInfoStubAddress operation state runtimeFieldHandle
+
+            let fieldHandleId =
+                FieldHandleRegistry.resolveFieldIdFromAddress stubAddress state.FieldHandles
+                |> Option.defaultWith (fun () ->
+                    failwith
+                        $"%s{operation}: RuntimeFieldInfoStub %O{stubAddress} was not present in the field handle registry"
+                )
+
+            state, fieldHandleId :: ids
+        )
+        |> fun (state, ids) -> state, List.rev ids
+
     /// Enumerate the non-literal fields of a closed runtime type handle, materialising
     /// each as a field-handle registry id (the int64 the BCL writes into the buffer).
     /// Mirrors CoreCLR's `RuntimeTypeHandle::GetFields` walk on a `MethodTable*`: instance
@@ -158,46 +217,13 @@ module NativeRuntimeTypeHelpers =
                     failwith $"%s{operation}: concrete type handle was not registered: %O{typeHandle}"
                 )
 
-            let assembly =
-                state.LoadedAssembly concreteType.Assembly
-                |> Option.defaultWith (fun () ->
-                    failwith
-                        $"%s{operation}: assembly for concrete type is not loaded: %s{concreteType.Assembly.FullName}"
-                )
-
-            let typeInfo = assembly.TypeDefs.[concreteType.Definition.Get]
-
-            let fields =
-                typeInfo.Fields
-                |> List.filter (fun field -> not (field.Attributes.HasFlag System.Reflection.FieldAttributes.Literal))
-
-            let instanceFields, staticFields =
-                fields |> List.partition (fun field -> not field.IsStatic)
-
-            let fields = instanceFields @ staticFields
-
-            ((state, []), fields)
-            ||> List.fold (fun (state, ids) field ->
-                let runtimeFieldHandle, state =
-                    IlMachineState.getOrAllocateField
-                        loggerFactory
-                        baseClassTypes
-                        concreteType.Assembly
-                        field.Handle
-                        state
-
-                let stubAddress = runtimeFieldInfoStubAddress operation state runtimeFieldHandle
-
-                let fieldHandleId =
-                    FieldHandleRegistry.resolveFieldIdFromAddress stubAddress state.FieldHandles
-                    |> Option.defaultWith (fun () ->
-                        failwith
-                            $"%s{operation}: RuntimeFieldInfoStub %O{stubAddress} was not present in the field handle registry"
-                    )
-
-                state, fieldHandleId :: ids
-            )
-            |> fun (state, ids) -> state, List.rev ids
+            walkFieldsOfTypeDefinition
+                loggerFactory
+                baseClassTypes
+                operation
+                concreteType.Assembly
+                concreteType.Definition.Get
+                state
 
     let nominalCorElementType
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
@@ -1396,8 +1396,22 @@ module NativeRuntimeTypeQCall =
             let state, fieldHandleIds =
                 match typeHandleTarget with
                 | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
-                    failwith
-                        $"TODO: %s{operation} for open generic type definition %O{identity}; expected behavior is to enumerate the canonical type's non-literal fields"
+                    // CoreCLR's RuntimeTypeHandle::GetFields walks the canonical
+                    // (open-generic) MethodTable's FieldDescs, so a closed instantiation
+                    // and its open definition would both yield the same FieldDesc set.
+                    // PawPrint's getOrAllocateField is intended to normalise the declaring
+                    // type's generics to a canonical form so the registry ids match,
+                    // matching that contract; today it does not yet handle generic
+                    // declaring types end-to-end (see walkFieldsOfTypeDefinition's
+                    // doc-comment) so exercising this path on a generic class still
+                    // crashes deeper down.
+                    walkFieldsOfTypeDefinition
+                        ctx.LoggerFactory
+                        ctx.BaseClassTypes
+                        operation
+                        identity.Assembly
+                        identity.TypeDefinition.Get
+                        state
                 | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
                     // The wrapper asserts !IsGenericVariable(type) before reaching us, so
                     // PawPrint should never see this case. Surface it loudly if it does.


### PR DESCRIPTION
## Summary

- Extract the (assembly, typeDef) → field-handle-id loop out of `walkClosedTypeHandleFields` into a new helper `walkFieldsOfTypeDefinition`. The existing `Closed.Concrete` arm now delegates to it.
- Wire the previously-`TODO` `OpenGenericTypeDefinition` arm of the `RuntimeTypeHandle_GetFields` QCall handler to call the new helper with `(identity.Assembly, identity.TypeDefinition.Get)`. CoreCLR shares a single FieldDesc set between an open generic definition and any of its closed instantiations; PawPrint's `getOrAllocateField` is intended to mirror that by normalising the declaring type's generics to a canonical form.

## Caveat

The wiring above is correct, but `getOrAllocateField` does **not** yet handle generic declaring types end-to-end. It remaps the field's generics to `TypeDefn.GenericTypeParameter` placeholders and then concretizes them with an empty type-generics context, throwing `IndexOutOfRangeException: Generic type parameter 0`. The same latent bug affects closed generic declaring types (e.g. `typeof(GenericClass<int>).GetFields()`), but no existing test exercised it before this PR.

The new `GetFieldOnOpenGenericTypeDefinition.cs` test is added to the `unimplemented` set with a note pointing at that follow-up. The `LdtokenField.cs` note is updated to reflect that its failure point has moved one frame deeper. The follow-up will fix `getOrAllocateField` (and the related `UnaryMetadataTokenOps.fs:230` TODO).

## Test plan

- [x] Full test suite passes (1167/1167)
- [x] New `GetFieldOnOpenGenericTypeDefinition.cs` lands in `unimplemented`; harness skips it
- [x] `nix develop -c dotnet fantomas .` leaves the tree clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)