### PR TITLE
Support multiple handlers per signal in SignalState

### DIFF
--- a/WoofWare.PawPrint.Test/TestSignalState.fs
+++ b/WoofWare.PawPrint.Test/TestSignalState.fs
@@ -61,7 +61,7 @@ module TestSignalState =
     let ``empty has nothing registered, nothing blocked, nothing pending`` () : unit =
         let s = SignalState.empty
         SignalState.isInitialized s |> shouldEqual false
-        SignalState.tryGetHandler Signal.SIGINT s |> shouldEqual None
+        SignalState.handlers Signal.SIGINT s |> shouldEqual []
         SignalState.isBlocked t0 Signal.SIGINT s |> shouldEqual false
         SignalState.blockedFor t0 s |> shouldEqual Set.empty
         SignalState.pending s |> Seq.toList |> shouldEqual []
@@ -80,30 +80,83 @@ module TestSignalState =
     [<Test>]
     let ``register installs handler`` () : unit =
         let s = SignalState.empty |> SignalState.register Signal.SIGINT (callback 1)
-        SignalState.tryGetHandler Signal.SIGINT s |> shouldEqual (Some (callback 1))
+        SignalState.handlers Signal.SIGINT s |> shouldEqual [ callback 1 ]
 
     [<Test>]
-    let ``register replaces an existing handler`` () : unit =
+    let ``register appends new handlers in registration order`` () : unit =
+        // .NET semantics: a second `PosixSignalRegistration.Create` for the
+        // same signal installs a sibling handler, it does not replace the
+        // first. Both fire at dispatch time (in reverse registration order
+        // with `Cancel` short-circuit semantics, which is the dispatcher's
+        // job — `SignalState` just stores the list).
         let s =
             SignalState.empty
             |> SignalState.register Signal.SIGINT (callback 1)
             |> SignalState.register Signal.SIGINT (callback 2)
 
-        SignalState.tryGetHandler Signal.SIGINT s |> shouldEqual (Some (callback 2))
+        SignalState.handlers Signal.SIGINT s |> shouldEqual [ callback 1 ; callback 2 ]
+
+    [<Test>]
+    let ``register preserves duplicates as distinct entries`` () : unit =
+        // Even with the same `SignalHandler` value, each call is a separate
+        // registration — mirrors that each .NET `PosixSignalRegistration`
+        // is its own `Token` regardless of delegate target identity.
+        let s =
+            SignalState.empty
+            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.register Signal.SIGINT (callback 1)
+
+        SignalState.handlers Signal.SIGINT s |> shouldEqual [ callback 1 ; callback 1 ]
 
     [<Test>]
     let ``unregister removes an installed handler`` () : unit =
         let s =
             SignalState.empty
             |> SignalState.register Signal.SIGINT (callback 1)
-            |> SignalState.unregister Signal.SIGINT
+            |> SignalState.unregister Signal.SIGINT (callback 1)
 
-        SignalState.tryGetHandler Signal.SIGINT s |> shouldEqual None
+        SignalState.handlers Signal.SIGINT s |> shouldEqual []
 
     [<Test>]
     let ``unregister of an absent handler is a no-op`` () : unit =
-        let s = SignalState.empty |> SignalState.unregister Signal.SIGINT
+        let s = SignalState.empty |> SignalState.unregister Signal.SIGINT (callback 1)
         s |> shouldEqual SignalState.empty
+
+    [<Test>]
+    let ``unregister of a non-matching handler with siblings is a no-op`` () : unit =
+        let before =
+            SignalState.empty
+            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.register Signal.SIGINT (callback 2)
+
+        let after = before |> SignalState.unregister Signal.SIGINT (callback 3)
+
+        after |> shouldEqual before
+
+    [<Test>]
+    let ``unregister removes only the first matching handler when duplicates exist`` () : unit =
+        let s =
+            SignalState.empty
+            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.register Signal.SIGINT (callback 2)
+            |> SignalState.unregister Signal.SIGINT (callback 1)
+
+        SignalState.handlers Signal.SIGINT s |> shouldEqual [ callback 1 ; callback 2 ]
+
+    [<Test>]
+    let ``unregister that empties the list drops the key`` () : unit =
+        // Critical structural-equality invariant: a state that registered
+        // and then fully unregistered must equal a state that never
+        // registered. Without dropping the empty-list key, the dedup hash
+        // used downstream would distinguish two semantically-equivalent
+        // states.
+        let registeredThenRemoved =
+            SignalState.empty
+            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.unregister Signal.SIGINT (callback 1)
+
+        registeredThenRemoved |> shouldEqual SignalState.empty
 
     [<Test>]
     let ``unregister leaves pending entries queued, just non-deliverable`` () : unit =
@@ -120,7 +173,7 @@ module TestSignalState =
             SignalState.empty
             |> SignalState.register Signal.SIGINT (callback 1)
             |> SignalState.enqueue entry
-            |> SignalState.unregister Signal.SIGINT
+            |> SignalState.unregister Signal.SIGINT (callback 1)
 
         SignalState.pending s |> Seq.toList |> shouldEqual [ entry ]
         SignalState.tryDeliverable (liveThreads [ t0 ]) s |> shouldEqual None
@@ -139,12 +192,35 @@ module TestSignalState =
             |> SignalState.register Signal.SIGINT (callback 1)
 
         match SignalState.tryDeliverable (liveThreads [ t0 ]) s with
-        | Some (e, tid, h, s') ->
+        | Some (e, tid, hs, s') ->
             e |> shouldEqual entry
             tid |> shouldEqual t0
-            h |> shouldEqual (callback 1)
+            hs |> shouldEqual [ callback 1 ]
             SignalState.pending s' |> Seq.toList |> shouldEqual []
         | None -> failwith "expected deliverable entry once handler was registered"
+
+    [<Test>]
+    let ``tryDeliverable returns every handler in registration order`` () : unit =
+        // .NET dispatches in reverse registration order; the SignalState
+        // layer exposes the registration-order list and leaves the
+        // reversal to the dispatcher. Pinning the order here so a future
+        // refactor can't silently flip it.
+        let entry =
+            {
+                Signal = Signal.SIGINT
+                Target = ValueNone
+            }
+
+        let s =
+            SignalState.empty
+            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.register Signal.SIGINT (callback 2)
+            |> SignalState.register Signal.SIGINT (callback 3)
+            |> SignalState.enqueue entry
+
+        match SignalState.tryDeliverable (liveThreads [ t0 ]) s with
+        | Some (_, _, hs, _) -> hs |> shouldEqual [ callback 1 ; callback 2 ; callback 3 ]
+        | None -> failwith "expected deliverable entry"
 
     [<Test>]
     let ``block then isBlocked`` () : unit =
@@ -322,10 +398,10 @@ module TestSignalState =
         // Live-thread order is deliberately scrambled to confirm the
         // implementation sorts internally rather than trusting input order.
         match SignalState.tryDeliverable (liveThreads [ t2 ; t0 ; t1 ]) s with
-        | Some (e, tid, h, s') ->
+        | Some (e, tid, hs, s') ->
             e |> shouldEqual entry
             tid |> shouldEqual t0
-            h |> shouldEqual (callback 1)
+            hs |> shouldEqual [ callback 1 ]
             SignalState.pending s' |> Seq.toList |> shouldEqual []
         | None -> failwith "expected deliverable entry"
 
@@ -435,7 +511,7 @@ module TestSignalState =
     type private Op =
         | MarkInitialized
         | Register of signal : Signal * handler : SignalHandler
-        | Unregister of signal : Signal
+        | Unregister of signal : Signal * handler : SignalHandler
         | Block of thread : ThreadId * signal : Signal
         | Unblock of thread : ThreadId * signal : Signal
         | Enqueue of entry : PendingSignal
@@ -443,10 +519,13 @@ module TestSignalState =
 
     /// Reference implementation: simple lists / maps, completely
     /// independent of the production module's internal representation.
+    /// Invariant: `Registrations` never contains an empty list as a value
+    /// — when the last handler for a signal is removed, the key is dropped
+    /// from the map, so absent/empty states are structurally identical.
     type private ReferenceState =
         {
             Initialized : bool
-            Registrations : Map<Signal, SignalHandler>
+            Registrations : Map<Signal, SignalHandler list>
             Blocked : Map<ThreadId, Set<Signal>>
             Pending : PendingSignal list
         }
@@ -465,7 +544,7 @@ module TestSignalState =
     let private referenceTryDeliverable
         (live : ThreadId list)
         (r : ReferenceState)
-        : (PendingSignal * ThreadId * SignalHandler * ReferenceState) option
+        : (PendingSignal * ThreadId * SignalHandler list * ReferenceState) option
         =
         let liveSet : Set<ThreadId> = Set.ofList live
 
@@ -489,19 +568,19 @@ module TestSignalState =
         let entries : PendingSignal[] = r.Pending |> List.toArray
         let mutable foundIdx : int = -1
         let mutable foundReceiver : ThreadId option = None
-        let mutable foundHandler : SignalHandler option = None
+        let mutable foundHandlers : SignalHandler list option = None
         let mutable i : int = 0
 
         while foundIdx < 0 && i < entries.Length do
             let entry = entries.[i]
 
             match Map.tryFind entry.Signal r.Registrations with
-            | Some h ->
+            | Some hs ->
                 match pickReceiver entry with
                 | Some tid ->
                     foundIdx <- i
                     foundReceiver <- Some tid
-                    foundHandler <- Some h
+                    foundHandlers <- Some hs
                 | None -> ()
             | None -> ()
 
@@ -519,11 +598,53 @@ module TestSignalState =
             Some (
                 entries.[foundIdx],
                 foundReceiver.Value,
-                foundHandler.Value,
+                foundHandlers.Value,
                 { r with
                     Pending = remaining
                 }
             )
+
+    /// Append the handler to the per-signal list; drop the key when the
+    /// list would otherwise be empty (it never is on insert, but unify the
+    /// invariant by writing the helper symmetrically).
+    let private refRegister (signal : Signal) (handler : SignalHandler) (r : ReferenceState) : ReferenceState =
+        let existing =
+            match Map.tryFind signal r.Registrations with
+            | None -> []
+            | Some hs -> hs
+
+        { r with
+            Registrations = Map.add signal (existing @ [ handler ]) r.Registrations
+        }
+
+    /// Remove the first match of `handler` (by structural equality) from
+    /// `signal`'s list; drop the key when the resulting list is empty.
+    let private refUnregister (signal : Signal) (handler : SignalHandler) (r : ReferenceState) : ReferenceState =
+        match Map.tryFind signal r.Registrations with
+        | None -> r
+        | Some hs ->
+            let mutable removed = false
+
+            let hs' =
+                hs
+                |> List.filter (fun h ->
+                    if not removed && h = handler then
+                        removed <- true
+                        false
+                    else
+                        true
+                )
+
+            if not removed then
+                r
+            elif List.isEmpty hs' then
+                { r with
+                    Registrations = Map.remove signal r.Registrations
+                }
+            else
+                { r with
+                    Registrations = Map.add signal hs' r.Registrations
+                }
 
     /// Advance both implementations by one op, asserting agreement on
     /// `tryDeliverable`'s full return tuple (since the next step's
@@ -536,16 +657,8 @@ module TestSignalState =
             { r with
                 Initialized = true
             }
-        | Op.Register (sig0, h) ->
-            SignalState.register sig0 h s,
-            { r with
-                Registrations = Map.add sig0 h r.Registrations
-            }
-        | Op.Unregister sig0 ->
-            SignalState.unregister sig0 s,
-            { r with
-                Registrations = Map.remove sig0 r.Registrations
-            }
+        | Op.Register (sig0, h) -> SignalState.register sig0 h s, refRegister sig0 h r
+        | Op.Unregister (sig0, h) -> SignalState.unregister sig0 h s, refUnregister sig0 h r
         | Op.Block (tid, sig0) ->
             let existing : Set<Signal> =
                 match Map.tryFind tid r.Blocked with
@@ -588,10 +701,10 @@ module TestSignalState =
 
             match actual, expected with
             | None, None -> s, r
-            | Some (e1, tid1, h1, s'), Some (e2, tid2, h2, r') ->
+            | Some (e1, tid1, hs1, s'), Some (e2, tid2, hs2, r') ->
                 e1 |> shouldEqual e2
                 tid1 |> shouldEqual tid2
-                h1 |> shouldEqual h2
+                hs1 |> shouldEqual hs2
                 s', r'
             | a, b -> failwith $"tryDeliverable disagreed: actual=%A{a}, reference=%A{b}"
 
@@ -600,6 +713,16 @@ module TestSignalState =
         SignalState.isInitialized s |> shouldEqual r.Initialized
         SignalState.registrations s |> shouldEqual r.Registrations
         SignalState.pending s |> Seq.toList |> shouldEqual r.Pending
+
+        for sig0 in allSignals do
+            let actualHandlers = SignalState.handlers sig0 s
+
+            let expectedHandlers =
+                match Map.tryFind sig0 r.Registrations with
+                | None -> []
+                | Some hs -> hs
+
+            actualHandlers |> shouldEqual expectedHandlers
 
         for tid in allThreads do
             for sig0 in allSignals do
@@ -633,7 +756,10 @@ module TestSignalState =
         elif kind < 25 then
             Op.Register (pick allSignals, callback (rng.Next 4))
         elif kind < 32 then
-            Op.Unregister (pick allSignals)
+            // Mix targeted unregister (often a no-op) with the "remove an
+            // actual registered handler" path. Using the same callback
+            // pool as Register keeps real hits frequent.
+            Op.Unregister (pick allSignals, callback (rng.Next 4))
         elif kind < 47 then
             Op.Block (pick allThreads, pick allSignals)
         elif kind < 57 then
@@ -665,6 +791,9 @@ module TestSignalState =
         let mutable observedSkipThenDeliver = 0
         let mutable observedDrainOfEmpty = 0
         let mutable observedDrainNoneNonEmpty = 0
+        let mutable observedMultiHandlerDelivery = 0
+        let mutable observedUnregisterRealHit = 0
+        let mutable observedMultiHandlerState = 0
 
         let property (NonNegativeInt seed : NonNegativeInt) : unit =
             let rng = System.Random seed
@@ -682,15 +811,25 @@ module TestSignalState =
                 match op with
                 | Op.DrainOne live ->
                     match referenceTryDeliverable live r with
-                    | Some (entry, _, _, _) ->
+                    | Some (entry, _, hs, _) ->
                         observedDeliveries <- observedDeliveries + 1
+
+                        if List.length hs > 1 then
+                            observedMultiHandlerDelivery <- observedMultiHandlerDelivery + 1
 
                         match r.Pending with
                         | head :: _ when head <> entry -> observedSkipThenDeliver <- observedSkipThenDeliver + 1
                         | _ -> ()
                     | None when r.Pending.IsEmpty -> observedDrainOfEmpty <- observedDrainOfEmpty + 1
                     | None -> observedDrainNoneNonEmpty <- observedDrainNoneNonEmpty + 1
+                | Op.Unregister (sig0, h) ->
+                    match Map.tryFind sig0 r.Registrations with
+                    | Some hs when List.contains h hs -> observedUnregisterRealHit <- observedUnregisterRealHit + 1
+                    | _ -> ()
                 | _ -> ()
+
+                if r.Registrations |> Map.exists (fun _ hs -> List.length hs > 1) then
+                    observedMultiHandlerState <- observedMultiHandlerState + 1
 
                 let s', r' = stepBoth op s r
                 s <- s'
@@ -702,10 +841,13 @@ module TestSignalState =
         // Distribution checks: the random walk must hit each load-bearing
         // path frequently enough that a regression would actually surface.
         // The thresholds are deliberately conservative — expected counts
-        // are in the hundreds, so requiring a few dozen guards against
-        // pathological non-coverage without becoming flaky on the lower
-        // tail of the seed distribution.
+        // are in the hundreds or thousands, so requiring a few dozen
+        // guards against pathological non-coverage without becoming flaky
+        // on the lower tail of the seed distribution.
         observedDeliveries |> shouldBeGreaterThan 100
         observedSkipThenDeliver |> shouldBeGreaterThan 20
         observedDrainOfEmpty |> shouldBeGreaterThan 20
         observedDrainNoneNonEmpty |> shouldBeGreaterThan 20
+        observedMultiHandlerDelivery |> shouldBeGreaterThan 20
+        observedUnregisterRealHit |> shouldBeGreaterThan 20
+        observedMultiHandlerState |> shouldBeGreaterThan 50

--- a/WoofWare.PawPrint/SignalState.fs
+++ b/WoofWare.PawPrint/SignalState.fs
@@ -19,10 +19,16 @@ type PendingSignal =
 ///   * `Initialized` — has the BCL invoked
 ///     `SystemNative_InitializeTerminalAndSignalHandling` yet? Several
 ///     console paths gate work behind this flag.
-///   * `Registrations` — the per-signal dispatch target. A signal that is
-///     not in this map has no handler installed; pending entries for such
-///     signals stay queued (the consumer decides whether to drop or wait
-///     for a registration).
+///   * `Registrations` — the per-signal handler list, in registration
+///     order (first-registered at the head, most-recently-registered at
+///     the tail). A signal that is not in this map has no handler
+///     installed; pending entries for such signals stay queued (the
+///     consumer decides whether to drop or wait for a registration).
+///     Multiple handlers per signal are supported and preserved as
+///     distinct list entries, mirroring real .NET, where every
+///     `PosixSignalRegistration` is its own `Token` in the BCL's
+///     per-signo list and dispatched in reverse registration order
+///     (LIFO) with `Cancel`-based short-circuit semantics.
 ///   * `Blocked` — per-thread sigprocmask. A signal in a thread's set is
 ///     blocked for that thread and cannot be delivered to it.
 ///   * `Pending` — FIFO queue of generated signals waiting for dispatch.
@@ -37,7 +43,12 @@ type SignalState =
     private
         {
             Initialized : bool
-            Registrations : Map<Signal, SignalHandler>
+            /// Per-signal handler list in registration order. The empty
+            /// list is NOT a permitted value: when the last handler for a
+            /// signal is unregistered, the key is dropped, so two states
+            /// differing only in "key absent" vs "key present with empty
+            /// list" remain structurally equal.
+            Registrations : Map<Signal, SignalHandler list>
             Blocked : Map<ThreadId, Set<Signal>>
             /// Pending entries in FIFO order (head = next candidate for
             /// dispatch). A plain list rather than `ImmutableQueue<T>`
@@ -73,27 +84,63 @@ module SignalState =
                 Initialized = true
             }
 
-    let tryGetHandler (signal : Signal) (state : SignalState) : SignalHandler option =
-        Map.tryFind signal state.Registrations
+    /// All handlers registered for `signal`, in registration order
+    /// (first-registered at the head). Returns the empty list when no
+    /// handler is installed. Dispatch consumers should iterate in
+    /// reverse to match .NET's LIFO dispatch semantics.
+    let handlers (signal : Signal) (state : SignalState) : SignalHandler list =
+        match Map.tryFind signal state.Registrations with
+        | None -> []
+        | Some hs -> hs
 
-    let registrations (state : SignalState) : Map<Signal, SignalHandler> = state.Registrations
+    let registrations (state : SignalState) : Map<Signal, SignalHandler list> = state.Registrations
 
-    /// Install or replace the handler for `signal`. POSIX permits exactly
-    /// one disposition per signal at a time; a second `register` overwrites
-    /// the first.
+    /// Append `handler` to the registration list for `signal`. POSIX (and
+    /// the .NET `PosixSignalRegistration` surface) permits any number of
+    /// independent handlers per signal, dispatched in reverse registration
+    /// order. Two `register` calls with structurally identical
+    /// `SignalHandler` values are preserved as two distinct entries here,
+    /// because each `PosixSignalRegistration` in real .NET is an
+    /// independent `Token` even when its delegate has the same target.
     let register (signal : Signal) (handler : SignalHandler) (state : SignalState) : SignalState =
+        let existing : SignalHandler list =
+            match Map.tryFind signal state.Registrations with
+            | None -> []
+            | Some hs -> hs
+
         { state with
-            Registrations = Map.add signal handler state.Registrations
+            Registrations = Map.add signal (existing @ [ handler ]) state.Registrations
         }
 
-    /// Remove the handler for `signal`. After this, pending entries for the
-    /// signal remain queued (a future `register` will make them deliverable)
-    /// but `tryDeliverable` will not dispatch them in the meantime. No-op if
-    /// no handler was installed.
-    let unregister (signal : Signal) (state : SignalState) : SignalState =
-        { state with
-            Registrations = Map.remove signal state.Registrations
-        }
+    /// Remove the first occurrence of `handler` (by structural equality)
+    /// from `signal`'s registration list. No-op if no matching handler is
+    /// registered for that signal. When the resulting list is empty, the
+    /// key is dropped from the map so two states differing only in
+    /// "absent" vs "empty list" remain structurally equal.
+    ///
+    /// Mirrors `PosixSignalRegistration.Dispose`, which removes exactly
+    /// the registration's own `Token` from the BCL's per-signo list and
+    /// leaves any sibling registrations in place.
+    let unregister (signal : Signal) (handler : SignalHandler) (state : SignalState) : SignalState =
+        match Map.tryFind signal state.Registrations with
+        | None -> state
+        | Some hs ->
+            let rec removeFirst (acc : SignalHandler list) (rest : SignalHandler list) : SignalHandler list option =
+                match rest with
+                | [] -> None
+                | h :: tail when h = handler -> Some (List.rev acc @ tail)
+                | h :: tail -> removeFirst (h :: acc) tail
+
+            match removeFirst [] hs with
+            | None -> state
+            | Some [] ->
+                { state with
+                    Registrations = Map.remove signal state.Registrations
+                }
+            | Some hs' ->
+                { state with
+                    Registrations = Map.add signal hs' state.Registrations
+                }
 
     let isBlocked (thread : ThreadId) (signal : Signal) (state : SignalState) : bool =
         match Map.tryFind thread state.Blocked with
@@ -159,7 +206,7 @@ module SignalState =
 
     /// Walk the pending queue in FIFO order and return the first entry that
     /// can be delivered now. An entry is deliverable iff:
-    ///   * a handler is registered for its `Signal`;
+    ///   * at least one handler is registered for its `Signal`;
     ///   * either it is `pthread_kill`-directed at a thread that is live and
     ///     not blocking the signal, or
     ///   * it is process-directed (`Target = ValueNone`) and at least one
@@ -170,12 +217,17 @@ module SignalState =
     /// "lowest id" composes well with the existing thread-scheduling
     /// conventions.
     ///
+    /// The returned `SignalHandler list` is in registration order. The
+    /// dispatch consumer is expected to iterate it in reverse to match
+    /// .NET's LIFO dispatch semantics (and to honour any per-handler
+    /// `Cancel` short-circuit).
+    ///
     /// Skipped (non-deliverable) entries keep their relative order in the
     /// queue. Returns `None` if no entry is deliverable.
     let tryDeliverable
         (liveThreads : ImmutableArray<ThreadId>)
         (state : SignalState)
-        : (PendingSignal * ThreadId * SignalHandler * SignalState) option
+        : (PendingSignal * ThreadId * SignalHandler list * SignalState) option
         =
         let liveSet : Set<ThreadId> = liveThreads |> Seq.toList |> Set.ofList
 
@@ -197,7 +249,7 @@ module SignalState =
             | head :: tail ->
                 match Map.tryFind head.Signal state.Registrations with
                 | None -> scan (head :: skipped) tail
-                | Some handler ->
+                | Some hs ->
                     match pickReceiver head with
                     | None -> scan (head :: skipped) tail
                     | Some tid ->
@@ -206,7 +258,7 @@ module SignalState =
                         Some (
                             head,
                             tid,
-                            handler,
+                            hs,
                             { state with
                                 Pending = remaining
                             }


### PR DESCRIPTION
## Summary

- Refactor `SignalState.Registrations` from `Map<Signal, SignalHandler>` to `Map<Signal, SignalHandler list>` in registration order, so two `register` calls install sibling handlers instead of one silently replacing the other. The empty list is never a permitted value — when the last handler for a signal is unregistered, the key is dropped, so absent/empty states stay structurally equal (required for `EmulatedKernel` dedup).
- Mirrors real .NET: each `PosixSignalRegistration.Create` adds a `Token` to a per-signo list; dispatch iterates in reverse registration order with `Cancel`-based short-circuit. The dispatcher (a later slice) is responsible for the reversal; `SignalState` stores registration order.
- API change: `tryGetHandler` → `handlers` (returns the registration-order list, empty when none). `unregister` now takes the `SignalHandler` to remove and drops the first structural match only. `tryDeliverable` returns the full handler list.
- 5 new unit tests for the multi-handler edges (append order, duplicate preservation, no-op on non-match, first-match-only removal, empty-list key drop). The property test gains three distribution counters confirming the random walk actually reaches multi-handler states (rather than degenerating to the single-handler case).

## Test plan

- [x] `nix develop -c dotnet test --filter "FullyQualifiedName~TestSignalState"` — 31/31 pass (property test runs 500 random sequences).
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 1198/1198 pass.
- [x] `nix develop -c dotnet fantomas .` — clean.
- [x] `codex review --base main` — no actionable findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)