### PR TITLE
Thread declaring RuntimeTypeHandleTarget through getOrAllocateField

### DIFF
--- a/WoofWare.PawPrint.Test/TestFieldHandleRegistry.fs
+++ b/WoofWare.PawPrint.Test/TestFieldHandleRegistry.fs
@@ -38,6 +38,12 @@ public class DerivedWithField : BaseWithField
 {
     public int DerivedData = 4;
 }
+
+public class GenericHolder<T>
+{
+    public T Value;
+    public static int StaticCount;
+}
 """
 
     type private FieldHandleFixture =
@@ -313,6 +319,60 @@ public class DerivedWithField : BaseWithField
 
         originalResolved.GetFieldDefinitionHandle().Get
         |> shouldEqual fixture.Field.Handle
+
+    [<Test>]
+    let ``Field handle on generic declaring type canonicalises to OpenGenericTypeDefinition`` () : unit =
+        // Regression: getOrAllocateField used to map the typedef's generic parameters onto
+        // TypeDefn.GenericTypeParameter placeholders and then concretise with empty typeGenerics,
+        // raising IndexOutOfRangeException. The fix mirrors CoreCLR's per-canonical FieldDesc
+        // semantics: the FieldHandle's declaring type is OpenGenericTypeDefinition for any
+        // generic declaring type, regardless of which closed instantiation the caller observed.
+        let fixture = makeFieldHandleFixture ()
+
+        let genericField =
+            fixture.Assembly.Fields.Values
+            |> Seq.find (fun field -> field.DeclaringType.Name = "GenericHolder`1" && field.Name = "Value")
+
+        let _, state = getOrAllocateField fixture genericField fixture.State
+
+        let registeredHandle =
+            state.FieldHandles
+            |> FieldHandleRegistry.resolveFieldFromId 1L
+            |> Option.defaultWith (fun () -> failwith "Expected a freshly allocated FieldHandle at id 1")
+
+        registeredHandle.GetFieldDefinitionHandle().Get
+        |> shouldEqual genericField.Handle
+
+        match registeredHandle.GetDeclaringTypeHandle () with
+        | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
+            identity |> shouldEqual genericField.DeclaringType.Identity
+        | other ->
+            failwithf
+                "Expected OpenGenericTypeDefinition for a generic declaring type, got %A. CoreCLR's per-canonical FieldDesc model requires one FieldDesc per generic typedef, shared across closed instantiations."
+                other
+
+    [<Test>]
+    let ``Field handle on generic declaring type is reused across allocations`` () : unit =
+        // Canonical sharing: calling getOrAllocateField twice for the same field on a generic
+        // declaring type must return the same FieldHandle id (and the same RuntimeFieldInfoStub
+        // address). This is what makes `typeof(Foo<>).GetField(...).FieldHandle` and
+        // `typeof(Foo<int>).GetField(...).FieldHandle` agree under the canonical model.
+        let fixture = makeFieldHandleFixture ()
+
+        let genericField =
+            fixture.Assembly.Fields.Values
+            |> Seq.find (fun field -> field.DeclaringType.Name = "GenericHolder`1" && field.Name = "StaticCount")
+
+        let firstHandle, state = getOrAllocateField fixture genericField fixture.State
+        let secondHandle, state = getOrAllocateField fixture genericField state
+
+        let firstAddr = runtimeFieldInfoStubAddress firstHandle
+        let secondAddr = runtimeFieldInfoStubAddress secondHandle
+
+        secondAddr |> shouldEqual firstAddr
+
+        fieldHandleIdAtAddress secondAddr state
+        |> shouldEqual (fieldHandleIdAtAddress firstAddr state)
 
     let private requiredTopLevelType
         (assembly : DumpedAssembly)

--- a/WoofWare.PawPrint.Test/TestFieldHandleRegistry.fs
+++ b/WoofWare.PawPrint.Test/TestFieldHandleRegistry.fs
@@ -136,10 +136,38 @@ public class GenericHolder<T>
         (state : IlMachineState)
         : CliType * IlMachineState
         =
+        // Derive the declaring target the same way callers in the runtime do: closed
+        // instantiation for a non-generic declaring type, open generic definition when the
+        // declaring type still has unbound parameters. Tests that need a specific target —
+        // e.g. asserting OpenGenericTypeDefinition on a closed `G<int>` instantiation — should
+        // call `IlMachineState.getOrAllocateField` directly.
+        let declaringTarget, state =
+            if field.DeclaringType.Generics.IsEmpty then
+                let ctx : TypeConcretization.ConcretizationContext<_> =
+                    {
+                        ConcreteTypes = state.ConcreteTypes
+                        LoadedAssemblies = state._LoadedAssemblies
+                        BaseTypes = fixture.BaseClassTypes
+                    }
+
+                let handle, ctx =
+                    TypeConcretization.concretizeTypeDefinition ctx field.DeclaringType.Identity
+
+                let state =
+                    { state with
+                        ConcreteTypes = ctx.ConcreteTypes
+                        _LoadedAssemblies = ctx.LoadedAssemblies
+                    }
+
+                RuntimeTypeHandleTarget.Closed handle, state
+            else
+                RuntimeTypeHandleTarget.OpenGenericTypeDefinition field.DeclaringType.Identity, state
+
         IlMachineState.getOrAllocateField
             fixture.LoggerFactory
             fixture.BaseClassTypes
             fixture.Assembly.Name
+            declaringTarget
             field.Handle
             state
 
@@ -321,12 +349,12 @@ public class GenericHolder<T>
         |> shouldEqual fixture.Field.Handle
 
     [<Test>]
-    let ``Field handle on generic declaring type canonicalises to OpenGenericTypeDefinition`` () : unit =
+    let ``Field handle on open generic declaring type records OpenGenericTypeDefinition`` () : unit =
         // Regression: getOrAllocateField used to map the typedef's generic parameters onto
         // TypeDefn.GenericTypeParameter placeholders and then concretise with empty typeGenerics,
-        // raising IndexOutOfRangeException. The fix mirrors CoreCLR's per-canonical FieldDesc
-        // semantics: the FieldHandle's declaring type is OpenGenericTypeDefinition for any
-        // generic declaring type, regardless of which closed instantiation the caller observed.
+        // raising IndexOutOfRangeException. After the fix the caller threads the declaring target
+        // through; the test helper supplies OpenGenericTypeDefinition for a still-open declaring
+        // type, mirroring `typeof(Foo<>).GetField(...).FieldHandle` in CoreCLR.
         let fixture = makeFieldHandleFixture ()
 
         let genericField =
@@ -348,15 +376,104 @@ public class GenericHolder<T>
             identity |> shouldEqual genericField.DeclaringType.Identity
         | other ->
             failwithf
-                "Expected OpenGenericTypeDefinition for a generic declaring type, got %A. CoreCLR's per-canonical FieldDesc model requires one FieldDesc per generic typedef, shared across closed instantiations."
+                "Expected OpenGenericTypeDefinition for the open generic declaring type, got %A. The helper passes OpenGenericTypeDefinition for callers that observe the field via `typeof(Foo<>).GetField(...)`."
                 other
 
     [<Test>]
-    let ``Field handle on generic declaring type is reused across allocations`` () : unit =
-        // Canonical sharing: calling getOrAllocateField twice for the same field on a generic
-        // declaring type must return the same FieldHandle id (and the same RuntimeFieldInfoStub
-        // address). This is what makes `typeof(Foo<>).GetField(...).FieldHandle` and
-        // `typeof(Foo<int>).GetField(...).FieldHandle` agree under the canonical model.
+    let ``Closed and open declaring targets for the same field allocate distinct handles`` () : unit =
+        // CoreCLR distinguishes `typeof(Foo<int>).GetField(...).FieldHandle` from
+        // `typeof(Foo<>).GetField(...).FieldHandle`: `FieldInfo.GetFieldFromHandle` rejects a
+        // mismatched declaring `RuntimeTypeHandle` between the two. Mirror that here: feeding
+        // the same FieldDefinitionHandle with two distinct `RuntimeTypeHandleTarget` values must
+        // allocate two distinct `FieldHandle` ids.
+        let fixture = makeFieldHandleFixture ()
+
+        let genericField =
+            fixture.Assembly.Fields.Values
+            |> Seq.find (fun field -> field.DeclaringType.Name = "GenericHolder`1" && field.Name = "Value")
+
+        let openTarget =
+            RuntimeTypeHandleTarget.OpenGenericTypeDefinition genericField.DeclaringType.Identity
+
+        let openFieldHandle, state =
+            IlMachineState.getOrAllocateField
+                fixture.LoggerFactory
+                fixture.BaseClassTypes
+                fixture.Assembly.Name
+                openTarget
+                genericField.Handle
+                fixture.State
+
+        // Build `GenericHolder<int>` as a closed instantiation, mirroring what
+        // `typeof(GenericHolder<int>)` would yield in the guest.
+        let int32Defn =
+            DumpedAssembly.typeInfoToTypeDefn'
+                fixture.BaseClassTypes
+                state._LoadedAssemblies
+                fixture.BaseClassTypes.Int32
+
+        let openHolderDefn =
+            TypeDefn.FromDefinition (
+                genericField.DeclaringType.Identity,
+                System.Reflection.Metadata.SignatureTypeKind.Class
+            )
+
+        let closedHolderDefn =
+            TypeDefn.GenericInstantiation (openHolderDefn, ImmutableArray.Create int32Defn)
+
+        let state, closedHolderHandle =
+            IlMachineState.concretizeType
+                fixture.LoggerFactory
+                fixture.BaseClassTypes
+                state
+                fixture.Assembly.Name
+                ImmutableArray.Empty
+                ImmutableArray.Empty
+                closedHolderDefn
+
+        let closedTarget = RuntimeTypeHandleTarget.Closed closedHolderHandle
+
+        let closedFieldHandle, state =
+            IlMachineState.getOrAllocateField
+                fixture.LoggerFactory
+                fixture.BaseClassTypes
+                fixture.Assembly.Name
+                closedTarget
+                genericField.Handle
+                state
+
+        let openAddr = runtimeFieldInfoStubAddress openFieldHandle
+        let closedAddr = runtimeFieldInfoStubAddress closedFieldHandle
+
+        closedAddr |> shouldNotEqual openAddr
+
+        let openId = fieldHandleIdAtAddress openAddr state
+        let closedId = fieldHandleIdAtAddress closedAddr state
+        closedId |> shouldNotEqual openId
+
+        let resolveOpen =
+            FieldHandleRegistry.resolveFieldFromId openId state.FieldHandles
+            |> Option.defaultWith (fun () -> failwith $"Could not resolve open field handle id %d{openId}")
+
+        let resolveClosed =
+            FieldHandleRegistry.resolveFieldFromId closedId state.FieldHandles
+            |> Option.defaultWith (fun () -> failwith $"Could not resolve closed field handle id %d{closedId}")
+
+        match resolveOpen.GetDeclaringTypeHandle () with
+        | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
+            identity |> shouldEqual genericField.DeclaringType.Identity
+        | other -> failwithf "Expected OpenGenericTypeDefinition, got %A" other
+
+        match resolveClosed.GetDeclaringTypeHandle () with
+        | RuntimeTypeHandleTarget.Closed handle -> handle |> shouldEqual closedHolderHandle
+        | other -> failwithf "Expected Closed concrete handle, got %A" other
+
+    [<Test>]
+    let ``Field handle on open generic declaring type is stable across allocations`` () : unit =
+        // Calling getOrAllocateField twice with the same declaring target must return the same
+        // FieldHandle id (and the same RuntimeFieldInfoStub address). This guarantees that
+        // repeated `typeof(Foo<>).GetField(...).FieldHandle` lookups in the guest are equal, and
+        // that separate calls into the same QCall path share allocations.
         let fixture = makeFieldHandleFixture ()
 
         let genericField =

--- a/WoofWare.PawPrint.Test/TestNativeSignature.fs
+++ b/WoofWare.PawPrint.Test/TestNativeSignature.fs
@@ -178,7 +178,7 @@ public sealed class GenericFieldHost<T>
                 state
                 (fun fields state -> IlMachineState.allocateManagedObject runtimeFieldInfoStubHandle fields state)
                 fixture.Assembly.Name
-                closedHostHandle
+                (RuntimeTypeHandleTarget.Closed closedHostHandle)
                 fixture.Field.Handle
                 state.FieldHandles
 

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -18,9 +18,9 @@ module TestPureCases =
     let unimplemented =
         [
             "AdvancedStructLayout.cs" // past MarshalNative_SizeOfHelper for ByValTStr and SystemNative_Malloc / SystemNative_Free / Marshal.AllocHGlobal / FreeHGlobal; now blocked downstream at the unimplemented MarshalNative_TryGetStructMarshalStub QCall (CoreLib's Marshal.StructureToPtr path)
-            "GetFieldOnOpenGenericTypeDefinition.cs" // RuntimeTypeHandle.GetFields now dispatches the OpenGenericTypeDefinition arm correctly, but getOrAllocateField (IlMachineRuntimeMetadata.fs:107) maps the field's declaring generics to TypeDefn.GenericTypeParameter placeholders and then concretizes with empty typeGenerics, throwing IndexOutOfRangeException; the same latent bug affects closed generic declaring types too (see UnaryMetadataTokenOps.fs:230 TODO)
-            "LdtokenField.cs" // QCall wiring for RuntimeTypeHandle.GetFields on open generic type definitions is now in place, but exercising it (Test 5: typeof(GenericClass<>).GetField) hits the same getOrAllocateField IndexOutOfRangeException as GetFieldOnOpenGenericTypeDefinition.cs above
             "Threads.cs" // past ThreadNative_InformThreadNameChange (Thread.Name setter); now blocked on unimplemented PAL call libSystem.Native!SystemNative_GetLowResolutionTimestamp (.Sys::GetLowResolutionTimestamp, used by the Task/ThreadPool scheduler)
+            "GetFieldOnOpenGenericTypeDefinition.cs" // FieldHandle declaring-type canonicalisation is fixed; now blocked on the BCL's RuntimeType.GetFieldCandidates walk reaching MethodTable::ParentMethodTable for the OpenGenericTypeDefinition target — the projection only handles Closed today.
+            "LdtokenField.cs" // Test 5 hits typeof(GenericClass<>).GetField("GenericField"), which goes through the same MethodTable::ParentMethodTable projection on an OpenGenericTypeDefinition target as GetFieldOnOpenGenericTypeDefinition.cs.
         ]
         |> Set.ofList
 

--- a/WoofWare.PawPrint/FieldHandleRegistry.fs
+++ b/WoofWare.PawPrint/FieldHandleRegistry.fs
@@ -8,12 +8,21 @@ type FieldHandle =
     private
         {
             AssemblyFullName : string
-            DeclaringType : ConcreteTypeHandle
+            /// CoreCLR's FieldDesc is per-canonical: one FieldDesc per generic type
+            /// definition, shared across all closed instantiations. We mirror that
+            /// by canonicalising the declaring type before allocation — a non-generic
+            /// declaring type becomes `Closed`, and a generic declaring type collapses
+            /// to its `OpenGenericTypeDefinition` identity rather than a particular
+            /// instantiation. This keeps the registry's key set in 1:1 correspondence
+            /// with the metadata `FieldDefinitionHandle` × generic-typedef pair and
+            /// makes lookups by `(declaring typedef, field handle)` total even when
+            /// the caller only has the open form (e.g. `typeof(Foo&lt;&gt;).GetField`).
+            DeclaringType : RuntimeTypeHandleTarget
             FieldHandle : ComparableFieldDefinitionHandle
         }
 
     member this.GetAssemblyFullName () : string = this.AssemblyFullName
-    member this.GetDeclaringTypeHandle () : ConcreteTypeHandle = this.DeclaringType
+    member this.GetDeclaringTypeHandle () : RuntimeTypeHandleTarget = this.DeclaringType
     member this.GetFieldDefinitionHandle () : ComparableFieldDefinitionHandle = this.FieldHandle
 
 type FieldHandleRegistry =
@@ -61,17 +70,30 @@ module FieldHandleRegistry =
         | TypeDefn.Void -> false
 
     /// Returns a (struct) System.RuntimeFieldHandle, with its contents (reference type) freshly allocated if necessary.
+    /// `declaringType` must be canonicalised per CoreCLR's FieldDesc model: a non-generic
+    /// declaring type as `Closed`, a generic declaring type as `OpenGenericTypeDefinition`.
+    /// Passing a closed instantiation of a generic declaring type would defeat the canonical
+    /// sharing and is rejected.
     let getOrAllocate
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (allConcreteTypes : AllConcreteTypes)
         (allocState : 'allocState)
         (allocate : CliValueType -> 'allocState -> ManagedHeapAddress * 'allocState)
         (declaringAssy : AssemblyName)
-        (declaringType : ConcreteTypeHandle)
+        (declaringType : RuntimeTypeHandleTarget)
         (handle : FieldDefinitionHandle)
         (reg : FieldHandleRegistry)
         : CliType * FieldHandleRegistry * 'allocState
         =
+        match declaringType with
+        | RuntimeTypeHandleTarget.Closed _
+        | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ -> ()
+        | RuntimeTypeHandleTarget.GenericParameter _
+        | RuntimeTypeHandleTarget.MethodGenericParameter _ ->
+            // Generic-parameter declaring types cannot own a field: fields live on the
+            // type that mentions the parameter, not on the parameter itself.
+            failwith
+                $"FieldHandleRegistry.getOrAllocate: declaring type must be Closed or OpenGenericTypeDefinition, got %O{declaringType}"
 
         let runtimeFieldHandle (runtimeFieldInfoStub : ManagedHeapAddress) =
             // RuntimeFieldHandle is a struct; it contains one field, an IRuntimeFieldInfo

--- a/WoofWare.PawPrint/FieldHandleRegistry.fs
+++ b/WoofWare.PawPrint/FieldHandleRegistry.fs
@@ -8,15 +8,14 @@ type FieldHandle =
     private
         {
             AssemblyFullName : string
-            /// CoreCLR's FieldDesc is per-canonical: one FieldDesc per generic type
-            /// definition, shared across all closed instantiations. We mirror that
-            /// by canonicalising the declaring type before allocation — a non-generic
-            /// declaring type becomes `Closed`, and a generic declaring type collapses
-            /// to its `OpenGenericTypeDefinition` identity rather than a particular
-            /// instantiation. This keeps the registry's key set in 1:1 correspondence
-            /// with the metadata `FieldDefinitionHandle` × generic-typedef pair and
-            /// makes lookups by `(declaring typedef, field handle)` total even when
-            /// the caller only has the open form (e.g. `typeof(Foo&lt;&gt;).GetField`).
+            /// The declaring type observed at allocation time. CoreCLR's
+            /// `typeof(G&lt;int&gt;).GetField(...).FieldHandle` is observably *not*
+            /// interchangeable with `typeof(G&lt;&gt;).GetField(...).FieldHandle` —
+            /// each carries its own instantiation context and `FieldInfo.GetFieldFromHandle`
+            /// rejects a mismatched declaring `RuntimeTypeHandle`. Mirror that here by
+            /// keying on the full `RuntimeTypeHandleTarget` the caller supplied: a closed
+            /// instantiation gets `Closed`; the open generic definition gets
+            /// `OpenGenericTypeDefinition`; and the two yield distinct registry ids.
             DeclaringType : RuntimeTypeHandleTarget
             FieldHandle : ComparableFieldDefinitionHandle
         }
@@ -70,10 +69,11 @@ module FieldHandleRegistry =
         | TypeDefn.Void -> false
 
     /// Returns a (struct) System.RuntimeFieldHandle, with its contents (reference type) freshly allocated if necessary.
-    /// `declaringType` must be canonicalised per CoreCLR's FieldDesc model: a non-generic
-    /// declaring type as `Closed`, a generic declaring type as `OpenGenericTypeDefinition`.
-    /// Passing a closed instantiation of a generic declaring type would defeat the canonical
-    /// sharing and is rejected.
+    /// `declaringType` must be either `Closed` (a fully concrete declaring type — non-generic or
+    /// a particular closed instantiation) or `OpenGenericTypeDefinition` (the open generic typedef,
+    /// e.g. for `typeof(Foo&lt;&gt;).GetField`). Distinct targets allocate distinct registry ids,
+    /// matching CoreCLR's per-instantiation `RuntimeFieldHandle` identity. Type-parameter targets
+    /// cannot own a field and are rejected.
     let getOrAllocate
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (allConcreteTypes : AllConcreteTypes)

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -114,20 +114,39 @@ module IlMachineRuntimeMetadata =
         =
         let field = state.LoadedAssembly(declaringAssy).Value.Fields.[fieldHandle]
 
-        // For LdToken, we need to convert GenericParamFromMetadata to TypeDefn
-        // When we don't have generic context, we use the generic type parameters directly
-        let declaringTypeWithGenerics =
-            field.DeclaringType
-            |> ConcreteType.mapGeneric (fun _index (param, _metadata) ->
-                TypeDefn.GenericTypeParameter param.SequenceNumber
-            )
-
+        // Mirror CoreCLR's per-canonical FieldDesc model: one FieldHandle per
+        // (generic typedef, field) pair, not per closed instantiation. A non-generic
+        // declaring type is registered as `Closed` (which still requires
+        // concretization so the resulting handle can be used wherever the closed
+        // handle is needed, e.g. `MethodTablePtr`); a generic declaring type is
+        // registered as `OpenGenericTypeDefinition` without instantiating its
+        // parameters. This avoids the old IndexOutOfRangeException path where
+        // `concretizeFieldDeclaringType` substituted `GenericTypeParameter`
+        // placeholders into an empty `typeGenerics` array, and matches CoreCLR's
+        // sharing semantics so that
+        // `typeof(Foo<>).GetField(...).FieldHandle` and
+        // `typeof(Foo<int>).GetField(...).FieldHandle` agree.
         let declaringType, state =
-            IlMachineTypeResolution.concretizeFieldDeclaringType
-                loggerFactory
-                baseClassTypes
-                declaringTypeWithGenerics
-                state
+            if field.DeclaringType.Generics.IsEmpty then
+                let ctx : TypeConcretization.ConcretizationContext<_> =
+                    {
+                        ConcreteTypes = state.ConcreteTypes
+                        LoadedAssemblies = state._LoadedAssemblies
+                        BaseTypes = baseClassTypes
+                    }
+
+                let handle, ctx =
+                    TypeConcretization.concretizeTypeDefinition ctx field.DeclaringType.Identity
+
+                let state =
+                    { state with
+                        ConcreteTypes = ctx.ConcreteTypes
+                        _LoadedAssemblies = ctx.LoadedAssemblies
+                    }
+
+                RuntimeTypeHandleTarget.Closed handle, state
+            else
+                RuntimeTypeHandleTarget.OpenGenericTypeDefinition field.DeclaringType.Identity, state
 
         let state, runtimeFieldInfoStub =
             TypeDefn.FromDefinition (

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -103,51 +103,22 @@ module IlMachineRuntimeMetadata =
 
         result, state
 
-    /// Returns a System.RuntimeFieldHandle.
+    /// Returns a System.RuntimeFieldHandle for the given field, observed on
+    /// `declaringType`. The caller is responsible for supplying the correct
+    /// instantiation context: in CoreCLR, `typeof(G<int>).GetField(...).FieldHandle`
+    /// and `typeof(G<>).GetField(...).FieldHandle` are observably different — each
+    /// carries its own declaring `RuntimeTypeHandle` — so this helper preserves the
+    /// distinction by keying on the full target. Type-parameter targets are rejected
+    /// by the registry because they cannot own a field.
     let getOrAllocateField
         (loggerFactory : ILoggerFactory)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (declaringAssy : AssemblyName)
+        (declaringType : RuntimeTypeHandleTarget)
         (fieldHandle : FieldDefinitionHandle)
         (state : IlMachineState)
         : CliType * IlMachineState
         =
-        let field = state.LoadedAssembly(declaringAssy).Value.Fields.[fieldHandle]
-
-        // Mirror CoreCLR's per-canonical FieldDesc model: one FieldHandle per
-        // (generic typedef, field) pair, not per closed instantiation. A non-generic
-        // declaring type is registered as `Closed` (which still requires
-        // concretization so the resulting handle can be used wherever the closed
-        // handle is needed, e.g. `MethodTablePtr`); a generic declaring type is
-        // registered as `OpenGenericTypeDefinition` without instantiating its
-        // parameters. This avoids the old IndexOutOfRangeException path where
-        // `concretizeFieldDeclaringType` substituted `GenericTypeParameter`
-        // placeholders into an empty `typeGenerics` array, and matches CoreCLR's
-        // sharing semantics so that
-        // `typeof(Foo<>).GetField(...).FieldHandle` and
-        // `typeof(Foo<int>).GetField(...).FieldHandle` agree.
-        let declaringType, state =
-            if field.DeclaringType.Generics.IsEmpty then
-                let ctx : TypeConcretization.ConcretizationContext<_> =
-                    {
-                        ConcreteTypes = state.ConcreteTypes
-                        LoadedAssemblies = state._LoadedAssemblies
-                        BaseTypes = baseClassTypes
-                    }
-
-                let handle, ctx =
-                    TypeConcretization.concretizeTypeDefinition ctx field.DeclaringType.Identity
-
-                let state =
-                    { state with
-                        ConcreteTypes = ctx.ConcreteTypes
-                        _LoadedAssemblies = ctx.LoadedAssemblies
-                    }
-
-                RuntimeTypeHandleTarget.Closed handle, state
-            else
-                RuntimeTypeHandleTarget.OpenGenericTypeDefinition field.DeclaringType.Identity, state
-
         let state, runtimeFieldInfoStub =
             TypeDefn.FromDefinition (
                 ResolvedTypeIdentity.ofTypeDefinition

--- a/WoofWare.PawPrint/Native/NativeRuntimeFieldHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeFieldHandle.fs
@@ -48,14 +48,23 @@ module NativeRuntimeFieldHandle =
         =
         let assembly, fieldInfo = getFieldForFieldHandle operation fieldHandle state
 
-        let declaringTypeHandle = fieldHandle.GetDeclaringTypeHandle ()
-
+        // RVA fields live on non-generic declaring types — `[FieldOffset]`/RVA
+        // initialisers cannot reference a generic typedef parameter. With the
+        // canonical FieldHandle declaring type model, "non-generic" means
+        // `Closed` (a generic declaring type would be `OpenGenericTypeDefinition`,
+        // for which RVA layout is not even definable). Reject other shapes
+        // loudly rather than silently fabricating empty generics.
         let typeGenerics =
-            match AllConcreteTypes.lookup declaringTypeHandle state.ConcreteTypes with
-            | Some declaringType -> declaringType.Generics
-            | None ->
+            match fieldHandle.GetDeclaringTypeHandle () with
+            | RuntimeTypeHandleTarget.Closed declaringTypeHandle ->
+                match AllConcreteTypes.lookup declaringTypeHandle state.ConcreteTypes with
+                | Some declaringType -> declaringType.Generics
+                | None ->
+                    failwith
+                        $"%s{operation}: declaring type handle %O{declaringTypeHandle} was not concretized, so RVA field size cannot be computed"
+            | other ->
                 failwith
-                    $"%s{operation}: declaring type handle %O{declaringTypeHandle} was not concretized, so RVA field size cannot be computed"
+                    $"%s{operation}: RVA field's declaring type is %O{other}; expected a Closed concrete type. RVA fields cannot live on a generic typedef."
 
         IlMachineState.peByteRangeForFieldRva loggerFactory baseClassTypes assembly fieldInfo typeGenerics state
 
@@ -145,13 +154,14 @@ module NativeRuntimeFieldHandle =
             // (runtimehandles.cpp:2192) is an FCall returning
             // pField->GetApproxEnclosingMethodTable() — the canonical MethodTable for
             // the field's declaring type. Under shared-generic codegen the canonical
-            // form is the open instantiation; PawPrint does not share generic
-            // instantiations, so the FieldHandle's stored DeclaringType is already
-            // the closed concrete type and is at least as precise as CoreCLR's
-            // result. The managed wrapper RuntimeFieldHandle.GetApproxDeclaringType
-            // (RuntimeHandles.cs:1523) hands the pointer to
-            // RuntimeTypeHandle.GetRuntimeType, which our MethodTablePtr
-            // representation already feeds via the TypeHandle registry.
+            // form is the open instantiation. With PawPrint's per-canonical
+            // FieldHandle model, the stored DeclaringType is `Closed` for non-generic
+            // declaring types and `OpenGenericTypeDefinition` for generic ones.
+            // `MethodTablePtr` currently only carries a closed `ConcreteTypeHandle`;
+            // widening it to a `RuntimeTypeHandleTarget` (so the open case can be
+            // handed back) is a larger refactor, and the open case isn't yet
+            // exercised by any consumer. Fail loudly there rather than silently
+            // synthesising a closed instantiation.
             let operation = "RuntimeFieldHandle.GetApproxDeclaringMethodTable"
 
             let fieldHandle =
@@ -160,7 +170,12 @@ module NativeRuntimeFieldHandle =
                 fieldHandleOfRuntimeFieldHandleInternal operation state instruction.Arguments.[0]
                 |> Option.defaultWith (fun () -> failwith $"%s{operation}: null field handle")
 
-            let declaringTypeHandle = fieldHandle.GetDeclaringTypeHandle ()
+            let declaringTypeHandle =
+                match fieldHandle.GetDeclaringTypeHandle () with
+                | RuntimeTypeHandleTarget.Closed handle -> handle
+                | other ->
+                    failwith
+                        $"TODO: %s{operation} does not yet support a non-Closed declaring type %O{other}; widening NativeIntSource.MethodTablePtr to RuntimeTypeHandleTarget is required to surface the open-generic MethodTable"
 
             let state =
                 IlMachineState.pushToEvalStack'

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
@@ -135,22 +135,19 @@ module NativeRuntimeTypeHelpers =
     /// Enumerate the non-literal fields declared by a `(assembly, typeDef)` pair,
     /// materialising each as a field-handle registry id (the int64 the BCL writes
     /// into the buffer). Instance fields are listed before statics; literals are
-    /// excluded. The declaring-type instantiation is intentionally not threaded
-    /// through here: `getOrAllocateField` is responsible for normalising it to a
-    /// canonical form so the same id is produced regardless of whether the caller
-    /// has an open or closed view, matching CoreCLR's per-canonical-MT FieldDesc
-    /// semantics. Today `getOrAllocateField` does not yet handle generic
-    /// declaring types correctly — it remaps the field's generics to canonical
-    /// placeholders and then concretizes them with an empty type-generics
-    /// context, which throws `IndexOutOfRangeException`; the GetFields wiring
-    /// above is correct, but exercising it on a generic declaring type requires
-    /// fixing that follow-up.
+    /// excluded. `declaringTarget` is the `RuntimeTypeHandleTarget` to record on
+    /// each allocated `FieldHandle`: callers walking a closed type pass the
+    /// `Closed` handle of that instantiation; callers walking an open generic
+    /// typedef pass `OpenGenericTypeDefinition`. CoreCLR observably distinguishes
+    /// these (`typeof(G<int>).GetField(...).FieldHandle` is incompatible with
+    /// `typeof(G<>)`'s) so the two cases produce distinct registry ids.
     let walkFieldsOfTypeDefinition
         (loggerFactory : ILoggerFactory)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (operation : string)
         (declaringAssemblyName : AssemblyName)
         (declaringTypeDefinition : System.Reflection.Metadata.TypeDefinitionHandle)
+        (declaringTarget : RuntimeTypeHandleTarget)
         (state : IlMachineState)
         : IlMachineState * int64 list
         =
@@ -175,7 +172,13 @@ module NativeRuntimeTypeHelpers =
         ((state, []), fields)
         ||> List.fold (fun (state, ids) field ->
             let runtimeFieldHandle, state =
-                IlMachineState.getOrAllocateField loggerFactory baseClassTypes declaringAssemblyName field.Handle state
+                IlMachineState.getOrAllocateField
+                    loggerFactory
+                    baseClassTypes
+                    declaringAssemblyName
+                    declaringTarget
+                    field.Handle
+                    state
 
             let stubAddress = runtimeFieldInfoStubAddress operation state runtimeFieldHandle
 
@@ -223,6 +226,7 @@ module NativeRuntimeTypeHelpers =
                 operation
                 concreteType.Assembly
                 concreteType.Definition.Get
+                (RuntimeTypeHandleTarget.Closed typeHandle)
                 state
 
     let nominalCorElementType

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
@@ -1397,20 +1397,17 @@ module NativeRuntimeTypeQCall =
                 match typeHandleTarget with
                 | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
                     // CoreCLR's RuntimeTypeHandle::GetFields walks the canonical
-                    // (open-generic) MethodTable's FieldDescs, so a closed instantiation
-                    // and its open definition would both yield the same FieldDesc set.
-                    // PawPrint's getOrAllocateField is intended to normalise the declaring
-                    // type's generics to a canonical form so the registry ids match,
-                    // matching that contract; today it does not yet handle generic
-                    // declaring types end-to-end (see walkFieldsOfTypeDefinition's
-                    // doc-comment) so exercising this path on a generic class still
-                    // crashes deeper down.
+                    // (open-generic) MethodTable's FieldDescs. The resulting handles
+                    // carry `OpenGenericTypeDefinition` as the declaring target —
+                    // observably distinct from the closed-instantiation handles a
+                    // `typeof(G<int>)` walk would produce.
                     walkFieldsOfTypeDefinition
                         ctx.LoggerFactory
                         ctx.BaseClassTypes
                         operation
                         identity.Assembly
                         identity.TypeDefinition.Get
+                        (RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity)
                         state
                 | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
                     // The wrapper asserts !IsGenericVariable(type) before reaching us, so

--- a/WoofWare.PawPrint/Native/NativeSignature.fs
+++ b/WoofWare.PawPrint/Native/NativeSignature.fs
@@ -71,17 +71,29 @@ module NativeSignature =
         let assembly, fieldInfo =
             NativeRuntimeFieldHandle.getFieldForFieldHandle operation fieldHandle state
 
-        let declaringTypeHandle = fieldHandle.GetDeclaringTypeHandle ()
-
-        // FieldHandle is the metadata identity paired with the closed declaring type seen by the
-        // reflection caller; use that closed type for generic substitution rather than trusting the
-        // separate declaringType argument that CoreLib passes through unchanged.
+        // FieldHandle's declaring type is canonicalised per CoreCLR's per-canonical
+        // FieldDesc model: `Closed` for non-generic declaring types,
+        // `OpenGenericTypeDefinition` for generic ones. For closed declaring types
+        // we have a real generic-argument vector to substitute into the field
+        // signature; for the open form we don't, and a field whose signature
+        // depends on a type generic parameter cannot be concretised to a single
+        // `Closed` runtime type. The signature concretisation path therefore only
+        // succeeds when either the declaring type is `Closed` or the field's type
+        // does not reference its declaring type's generics. We pass empty
+        // generics in the open case and let `concretizeType` fault with its own
+        // diagnostic if the field signature actually needs them.
         let typeGenerics =
-            match AllConcreteTypes.lookup declaringTypeHandle state.ConcreteTypes with
-            | Some declaringType -> declaringType.Generics
-            | None ->
+            match fieldHandle.GetDeclaringTypeHandle () with
+            | RuntimeTypeHandleTarget.Closed declaringTypeHandle ->
+                match AllConcreteTypes.lookup declaringTypeHandle state.ConcreteTypes with
+                | Some declaringType -> declaringType.Generics
+                | None ->
+                    failwith
+                        $"%s{operation}: declaring type handle %O{declaringTypeHandle} was not concretized, so field signature cannot be resolved"
+            | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ -> ImmutableArray.Empty
+            | other ->
                 failwith
-                    $"%s{operation}: declaring type handle %O{declaringTypeHandle} was not concretized, so field signature cannot be resolved"
+                    $"%s{operation}: field declaring type %O{other} cannot host a field; expected Closed or OpenGenericTypeDefinition"
 
         let state, fieldType =
             IlMachineState.concretizeType

--- a/WoofWare.PawPrint/UnaryMetadataTokenOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataTokenOps.fs
@@ -227,9 +227,41 @@ module internal UnaryMetadataTokenOps =
         let state =
             match metadataToken with
             | MetadataToken.FieldDefinition h ->
-                // TODO: how do we know what concrete type this is a field on?
+                let field = activeAssy.Fields.[h]
+
+                if not field.DeclaringType.Generics.IsEmpty then
+                    // ldtoken FieldDef on a generic declaring type would need to substitute the
+                    // surrounding method's type generics into the field's declaring type to
+                    // produce a closed RuntimeFieldHandle (or an OpenGenericTypeDefinition handle
+                    // when the surrounding method itself is open). This mirrors the existing
+                    // MethodDef pattern, which fails loudly until that wiring is added.
+                    failwith
+                        $"TODO: ldtoken FieldDef on a generic declaring type requires substituting the surrounding method instantiation; got %O{field}"
+
+                let ctx : TypeConcretization.ConcretizationContext<_> =
+                    {
+                        ConcreteTypes = state.ConcreteTypes
+                        LoadedAssemblies = state._LoadedAssemblies
+                        BaseTypes = baseClassTypes
+                    }
+
+                let closedDeclaringHandle, ctx =
+                    TypeConcretization.concretizeTypeDefinition ctx field.DeclaringType.Identity
+
+                let state =
+                    { state with
+                        ConcreteTypes = ctx.ConcreteTypes
+                        _LoadedAssemblies = ctx.LoadedAssemblies
+                    }
+
                 let runtimeFieldHandle, state =
-                    IlMachineState.getOrAllocateField loggerFactory baseClassTypes activeAssy.Name h state
+                    IlMachineState.getOrAllocateField
+                        loggerFactory
+                        baseClassTypes
+                        activeAssy.Name
+                        (RuntimeTypeHandleTarget.Closed closedDeclaringHandle)
+                        h
+                        state
 
                 IlMachineState.pushToEvalStack runtimeFieldHandle thread state
             | MetadataToken.MethodDef h ->


### PR DESCRIPTION
## Summary

- `getOrAllocateField` no longer maps the field's declaring generics to placeholders and concretises with empty type generics (the previous `IndexOutOfRangeException` path). Instead, `FieldHandle.DeclaringType` is now a `RuntimeTypeHandleTarget` supplied by the caller, matching CoreCLR's observable distinction between `typeof(G<int>).GetField(...).FieldHandle` and `typeof(G<>).GetField(...).FieldHandle` (which CoreCLR's `FieldInfo.GetFieldFromHandle` actively rejects when crossed).
- Call sites pass the target they already have: `walkClosedTypeHandleFields` passes `Closed`, the `RuntimeTypeHandle_GetFields` QCall passes `OpenGenericTypeDefinition`, and `ldtoken FieldDef` concretises for non-generic declaring types (failing loudly for generic ones, mirroring the existing `MethodDef` pattern).
- The unrelated regression tests `LdtokenField.cs` and `GetFieldOnOpenGenericTypeDefinition.cs` remain in the `unimplemented` set: their next blocker is `ParentMethodTable` projection for `OpenGenericTypeDefinition`, called out in the comment that re-introduces them.

## Test plan

- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 1196 passing (3 new unit tests in `TestFieldHandleRegistry.fs`, including one that asserts open and closed declaring targets allocate distinct registry ids — the property `codex review` highlighted).
- [x] `nix develop -c dotnet fantomas .` — clean.
- [x] `codex review --base main` — reports no prioritised correctness issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)