### PR TITLE
Wire SystemNative signal P/Invoke arms onto a kernel enable set

### DIFF
--- a/WoofWare.PawPrint.Test/TestSignal.fs
+++ b/WoofWare.PawPrint.Test/TestSignal.fs
@@ -1,0 +1,155 @@
+namespace WoofWare.PawPrint.Test
+
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+/// Unit tests for the `Signal` conversion helpers that the SystemNative
+/// signal-handling arms rely on. These functions are the only piece of
+/// "business logic" in the four arms (`Initialize`,
+/// `GetPlatformSignalNumber`, `Enable`/`DisablePosixSignalHandling`); the
+/// rest of each arm is plumbing into `SignalState`, which is exercised by
+/// `TestSignalState`. End-to-end coverage for the GetPlatformSignalNumber
+/// arm lives in `sourcesPure/SystemNativeGetPlatformSignalNumber.cs`; the
+/// Enable/Disable arms can't be safely tested via direct P/Invoke on the
+/// real CLR (they install host-process sigaction handlers), so the
+/// conversion math is exhaustively verified here instead.
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestSignal =
+
+    /// The 14 modelled signals paired with their Linux signo. Drives both
+    /// the round-trip and the per-case toLinuxSigno assertion.
+    let private modelledSignals : (Signal * int) list =
+        [
+            Signal.SIGHUP, 1
+            Signal.SIGINT, 2
+            Signal.SIGQUIT, 3
+            Signal.SIGABRT, 6
+            Signal.SIGUSR1, 10
+            Signal.SIGUSR2, 12
+            Signal.SIGPIPE, 13
+            Signal.SIGTERM, 15
+            Signal.SIGCHLD, 17
+            Signal.SIGCONT, 18
+            Signal.SIGTSTP, 20
+            Signal.SIGTTIN, 21
+            Signal.SIGTTOU, 22
+            Signal.SIGWINCH, 28
+        ]
+
+    /// PosixSignal cross-platform enum values (negative, defined by the
+    /// managed BCL) paired with their PawPrint Signal identity. The .NET
+    /// `PosixSignal` enum only assigns negative values to 10 of the 14
+    /// modelled signals; the remaining four (SIGPIPE, SIGABRT, SIGUSR1/2)
+    /// have no cross-platform enum member and must be supplied as positive
+    /// native signos directly.
+    let private namedPosixEnumValues : (int * Signal) list =
+        [
+            -1, Signal.SIGHUP
+            -2, Signal.SIGINT
+            -3, Signal.SIGQUIT
+            -4, Signal.SIGTERM
+            -5, Signal.SIGCHLD
+            -6, Signal.SIGCONT
+            -7, Signal.SIGWINCH
+            -8, Signal.SIGTTIN
+            -9, Signal.SIGTTOU
+            -10, Signal.SIGTSTP
+        ]
+
+    [<Test>]
+    let ``toLinuxSigno produces the documented signo for every named case`` () : unit =
+        for signal, signo in modelledSignals do
+            Signal.toLinuxSigno signal |> shouldEqual signo
+
+    [<Test>]
+    let ``toLinuxSigno on Other returns the raw value unchanged`` () : unit =
+        // The `Other` constructor carries raw identity so callers that
+        // produced a positive native signo can round-trip it through the
+        // Signal type without losing the value. Negative raws come from
+        // cross-platform PosixSignal enum values the simulator doesn't
+        // model — those are also preserved verbatim, even though there's
+        // no useful signo to send back across the seam.
+        Signal.toLinuxSigno (Signal.Other 42) |> shouldEqual 42
+        Signal.toLinuxSigno (Signal.Other 999) |> shouldEqual 999
+        Signal.toLinuxSigno (Signal.Other -77) |> shouldEqual -77
+        Signal.toLinuxSigno (Signal.Other 0) |> shouldEqual 0
+
+    [<Test>]
+    let ``ofLinuxSigno is the inverse of toLinuxSigno on every modelled signal`` () : unit =
+        for signal, signo in modelledSignals do
+            Signal.ofLinuxSigno signo |> shouldEqual (ValueSome signal)
+
+    [<Test>]
+    let ``ofLinuxSigno returns ValueNone for signos PawPrint does not model`` () : unit =
+        // Signos that sit between modelled values and signos beyond the
+        // SIGRTMAX-ish ceiling both fail to match — the enable/disable
+        // arms can therefore rely on a `ValueSome` to indicate a signal
+        // they can dispatch through `SignalState`.
+        Signal.ofLinuxSigno 0 |> shouldEqual ValueNone
+        Signal.ofLinuxSigno 4 |> shouldEqual ValueNone // SIGILL — not modelled
+        Signal.ofLinuxSigno 5 |> shouldEqual ValueNone // SIGTRAP — not modelled
+        Signal.ofLinuxSigno 7 |> shouldEqual ValueNone // SIGBUS — not modelled
+        Signal.ofLinuxSigno 11 |> shouldEqual ValueNone // SIGSEGV — not modelled
+        Signal.ofLinuxSigno 100 |> shouldEqual ValueNone
+        Signal.ofLinuxSigno -1 |> shouldEqual ValueNone // negatives never match
+
+    [<Test>]
+    let ``ofPosixSignalEnum maps every cross-platform negative to the right case`` () : unit =
+        for raw, signal in namedPosixEnumValues do
+            Signal.ofPosixSignalEnum raw |> shouldEqual (ValueSome signal)
+
+    [<Test>]
+    let ``ofPosixSignalEnum treats positives as Linux signos`` () : unit =
+        // The BCL allows guests to construct a `PosixSignal` from a raw
+        // native signo (`(PosixSignal)signo`). When that happens the value
+        // arrives at GetPlatformSignalNumber as a positive int; the
+        // real native code accepts it iff it's a recognised host signal,
+        // and PawPrint accepts it iff it's a modelled Linux signo.
+        Signal.ofPosixSignalEnum 1 |> shouldEqual (ValueSome Signal.SIGHUP)
+        Signal.ofPosixSignalEnum 6 |> shouldEqual (ValueSome Signal.SIGABRT)
+        Signal.ofPosixSignalEnum 13 |> shouldEqual (ValueSome Signal.SIGPIPE)
+        Signal.ofPosixSignalEnum 28 |> shouldEqual (ValueSome Signal.SIGWINCH)
+
+    [<Test>]
+    let ``ofPosixSignalEnum returns ValueNone for 0 and unrecognised values`` () : unit =
+        // The cross-platform negative range only covers -1..-10; values
+        // outside that range with no positive interpretation must produce
+        // ValueNone so the arm returns 0 and the BCL raises
+        // ArgumentOutOfRangeException.
+        Signal.ofPosixSignalEnum 0 |> shouldEqual ValueNone // PosixSignalInvalid sentinel
+        Signal.ofPosixSignalEnum -11 |> shouldEqual ValueNone
+        Signal.ofPosixSignalEnum -100 |> shouldEqual ValueNone
+        Signal.ofPosixSignalEnum System.Int32.MinValue |> shouldEqual ValueNone
+        // Positive signos PawPrint doesn't model also fail — same path as
+        // ofLinuxSigno's ValueNone branch.
+        Signal.ofPosixSignalEnum 100 |> shouldEqual ValueNone
+        Signal.ofPosixSignalEnum System.Int32.MaxValue |> shouldEqual ValueNone
+
+    [<Test>]
+    let ``ofPosixSignalEnum and toLinuxSigno round-trip through GetPlatformSignalNumber semantics`` () : unit =
+        // Simulates the full GetPlatformSignalNumber arm:
+        //   raw -> Signal.ofPosixSignalEnum -> toLinuxSigno -> signo
+        // for every cross-platform enum value and for every positive
+        // modelled signo. A non-zero result means "the BCL can call
+        // Enable/DisablePosixSignalHandling with this signo and PawPrint
+        // will accept it"; a zero result means the BCL will throw
+        // ArgumentOutOfRangeException at the Register call site.
+        let armBehaviour (raw : int) : int =
+            match Signal.ofPosixSignalEnum raw with
+            | ValueSome s -> Signal.toLinuxSigno s
+            | ValueNone -> 0
+
+        for raw, _signal in namedPosixEnumValues do
+            // Every negative cross-platform enum value must produce a non-zero
+            // signo — these are the values `PosixSignalRegistration.Register`
+            // is documented to accept.
+            armBehaviour raw |> shouldNotEqual 0
+
+        for _signal, signo in modelledSignals do
+            armBehaviour signo |> shouldEqual signo
+
+        armBehaviour 0 |> shouldEqual 0
+        armBehaviour -11 |> shouldEqual 0
+        armBehaviour 100 |> shouldEqual 0

--- a/WoofWare.PawPrint.Test/TestSignal.fs
+++ b/WoofWare.PawPrint.Test/TestSignal.fs
@@ -122,10 +122,44 @@ module TestSignal =
         Signal.ofPosixSignalEnum -11 |> shouldEqual ValueNone
         Signal.ofPosixSignalEnum -100 |> shouldEqual ValueNone
         Signal.ofPosixSignalEnum System.Int32.MinValue |> shouldEqual ValueNone
-        // Positive signos PawPrint doesn't model also fail — same path as
-        // ofLinuxSigno's ValueNone branch.
+        // Positive signos beyond `linuxSignalMax` (Linux's SIGRTMAX = 64) sit
+        // outside any kernel's table and fail the same way real native code
+        // does — the `if (signal > 0 && signal <= GetSignalMax()) return signal;`
+        // branch falls through to `return 0;`.
+        Signal.ofPosixSignalEnum 65 |> shouldEqual ValueNone
         Signal.ofPosixSignalEnum 100 |> shouldEqual ValueNone
         Signal.ofPosixSignalEnum System.Int32.MaxValue |> shouldEqual ValueNone
+
+    [<Test>]
+    let ``ofPosixSignalEnum preserves raw identity for valid unmodelled positives`` () : unit =
+        // Mirrors the real native semantics: when a guest casts an arbitrary
+        // native signo to `PosixSignal` (e.g. `(PosixSignal)4` for SIGILL or
+        // `(PosixSignal)11` for SIGSEGV), `SystemNative_GetPlatformSignalNumber`
+        // returns the raw value unchanged when it sits within `GetSignalMax()`.
+        // PawPrint preserves identity via `Signal.Other`, so the value round-
+        // trips back across the seam and `PosixSignalRegistration.Register`
+        // accepts the registration instead of throwing.
+        Signal.ofPosixSignalEnum 4 |> shouldEqual (ValueSome (Signal.Other 4)) // SIGILL
+        Signal.ofPosixSignalEnum 5 |> shouldEqual (ValueSome (Signal.Other 5)) // SIGTRAP
+        Signal.ofPosixSignalEnum 7 |> shouldEqual (ValueSome (Signal.Other 7)) // SIGBUS
+        Signal.ofPosixSignalEnum 11 |> shouldEqual (ValueSome (Signal.Other 11)) // SIGSEGV
+        // Boundary: `linuxSignalMax` (SIGRTMAX on Linux) is the highest accepted value.
+        Signal.ofPosixSignalEnum Signal.linuxSignalMax
+        |> shouldEqual (ValueSome (Signal.Other Signal.linuxSignalMax))
+
+    [<Test>]
+    let ``ofPlatformSigno agrees with ofPosixSignalEnum on positive inputs`` () : unit =
+        // `ofPlatformSigno` is the helper the enable/disable arms use to
+        // accept a signo arriving from `GetPlatformSignalNumber`. It must
+        // produce the same `Signal` identity that the enum-side helper would
+        // have constructed, otherwise the enable bit would key on a different
+        // case than the registration request.
+        for signo in 1 .. Signal.linuxSignalMax do
+            Signal.ofPlatformSigno signo |> shouldEqual (Signal.ofPosixSignalEnum signo)
+
+        Signal.ofPlatformSigno 0 |> shouldEqual ValueNone
+        Signal.ofPlatformSigno -1 |> shouldEqual ValueNone
+        Signal.ofPlatformSigno (Signal.linuxSignalMax + 1) |> shouldEqual ValueNone
 
     [<Test>]
     let ``ofPosixSignalEnum and toLinuxSigno round-trip through GetPlatformSignalNumber semantics`` () : unit =
@@ -150,6 +184,18 @@ module TestSignal =
         for _signal, signo in modelledSignals do
             armBehaviour signo |> shouldEqual signo
 
+        // Unmodelled-but-valid positive signos round-trip via `Signal.Other`:
+        // `armBehaviour 4` is the SIGILL case from the Codex finding — the
+        // guest casts `(PosixSignal)4`, the arm must return 4, and the BCL
+        // forwards 4 unchanged to `EnablePosixSignalHandling`.
+        armBehaviour 4 |> shouldEqual 4
+        armBehaviour 11 |> shouldEqual 11
+        armBehaviour Signal.linuxSignalMax |> shouldEqual Signal.linuxSignalMax
+
         armBehaviour 0 |> shouldEqual 0
         armBehaviour -11 |> shouldEqual 0
+        // Just past SIGRTMAX, the arm returns 0 — same path as the real native
+        // `if (signal > 0 && signal <= GetSignalMax()) return signal;` falling
+        // through to `return 0;`.
+        armBehaviour (Signal.linuxSignalMax + 1) |> shouldEqual 0
         armBehaviour 100 |> shouldEqual 0

--- a/WoofWare.PawPrint.Test/TestSignal.fs
+++ b/WoofWare.PawPrint.Test/TestSignal.fs
@@ -162,6 +162,28 @@ module TestSignal =
         Signal.ofPlatformSigno (Signal.linuxSignalMax + 1) |> shouldEqual ValueNone
 
     [<Test>]
+    let ``isUncatchable flags SIGKILL and SIGSTOP and nothing else`` () : unit =
+        // The POSIX standard names exactly two uncatchable signals: SIGKILL
+        // (Linux signo 9) and SIGSTOP (Linux signo 19). The kernel rejects
+        // `sigaction` for either with `EINVAL`. Neither is in PawPrint's
+        // modelled signal set, so they only ever arrive as `Signal.Other n`.
+        Signal.isUncatchable (Signal.Other 9) |> shouldEqual true // SIGKILL
+        Signal.isUncatchable (Signal.Other 19) |> shouldEqual true // SIGSTOP
+
+        // Every modelled signal can be caught — that's the whole point of
+        // installing a handler. Iterate to assert the negative case without
+        // hard-coding the modelled set twice.
+        for signal, _signo in modelledSignals do
+            Signal.isUncatchable signal |> shouldEqual false
+
+        // Other `Other` values (signos that just happen to fall outside the
+        // modelled set, but are still catchable) must not be flagged.
+        Signal.isUncatchable (Signal.Other 4) |> shouldEqual false // SIGILL
+        Signal.isUncatchable (Signal.Other 11) |> shouldEqual false // SIGSEGV
+        Signal.isUncatchable (Signal.Other 8) |> shouldEqual false // SIGFPE
+        Signal.isUncatchable (Signal.Other 64) |> shouldEqual false
+
+    [<Test>]
     let ``ofPosixSignalEnum and toLinuxSigno round-trip through GetPlatformSignalNumber semantics`` () : unit =
         // Simulates the full GetPlatformSignalNumber arm:
         //   raw -> Signal.ofPosixSignalEnum -> toLinuxSigno -> signo

--- a/WoofWare.PawPrint.Test/TestSignalState.fs
+++ b/WoofWare.PawPrint.Test/TestSignalState.fs
@@ -8,9 +8,10 @@ open NUnit.Framework
 open WoofWare.PawPrint
 
 /// Property-based and unit tests for the deterministic `SignalState` data
-/// model. `SignalState` has no consumer in the simulator yet — these tests
-/// pin down its behaviour in isolation so the downstream slices (dispatch,
-/// harness injection, native handler arms) can build on a known-good shape.
+/// model. `SignalState` has no full dispatcher in the simulator yet — these
+/// tests pin down its behaviour in isolation so the downstream slices
+/// (dispatch, harness injection, native handler arms) can build on a
+/// known-good shape.
 ///
 /// The property test runs a random sequence of operations through both the
 /// production module and a structurally-different reference oracle, then
@@ -49,23 +50,19 @@ module TestSignalState =
             Signal.Other 99
         ]
 
-    let private addr (n : int) : ManagedHeapAddress = ManagedHeapAddress n
-
-    let private callback (n : int) : SignalHandler = SignalHandler.PosixCallback (addr n)
-
     let private liveThreads (threads : ThreadId list) : ImmutableArray<ThreadId> = threads |> ImmutableArray.CreateRange
 
     // ------------------------- Unit tests ------------------------- //
 
     [<Test>]
-    let ``empty has nothing registered, nothing blocked, nothing pending`` () : unit =
+    let ``empty has nothing enabled, nothing blocked, nothing pending`` () : unit =
         let s = SignalState.empty
         SignalState.isInitialized s |> shouldEqual false
-        SignalState.tryGetHandler Signal.SIGINT s |> shouldEqual None
+        SignalState.isEnabled Signal.SIGINT s |> shouldEqual false
         SignalState.isBlocked t0 Signal.SIGINT s |> shouldEqual false
         SignalState.blockedFor t0 s |> shouldEqual Set.empty
         SignalState.pending s |> Seq.toList |> shouldEqual []
-        SignalState.registrations s |> shouldEqual Map.empty
+        SignalState.enabled s |> shouldEqual Set.empty
 
     [<Test>]
     let ``markInitialized is idempotent and structurally stable`` () : unit =
@@ -78,38 +75,50 @@ module TestSignalState =
         twice |> shouldEqual once
 
     [<Test>]
-    let ``register installs handler`` () : unit =
-        let s = SignalState.empty |> SignalState.register Signal.SIGINT (callback 1)
-        SignalState.tryGetHandler Signal.SIGINT s |> shouldEqual (Some (callback 1))
+    let ``enable flips a signal's bit on`` () : unit =
+        let s = SignalState.empty |> SignalState.enable Signal.SIGINT
+        SignalState.isEnabled Signal.SIGINT s |> shouldEqual true
+        SignalState.isEnabled Signal.SIGHUP s |> shouldEqual false
+        SignalState.enabled s |> shouldEqual (Set.singleton Signal.SIGINT)
 
     [<Test>]
-    let ``register replaces an existing handler`` () : unit =
+    let ``enable is idempotent`` () : unit =
+        let once = SignalState.empty |> SignalState.enable Signal.SIGINT
+        let twice = once |> SignalState.enable Signal.SIGINT
+        twice |> shouldEqual once
+
+    [<Test>]
+    let ``disable clears a previously enabled signal`` () : unit =
         let s =
             SignalState.empty
-            |> SignalState.register Signal.SIGINT (callback 1)
-            |> SignalState.register Signal.SIGINT (callback 2)
+            |> SignalState.enable Signal.SIGINT
+            |> SignalState.disable Signal.SIGINT
 
-        SignalState.tryGetHandler Signal.SIGINT s |> shouldEqual (Some (callback 2))
-
-    [<Test>]
-    let ``unregister removes an installed handler`` () : unit =
-        let s =
-            SignalState.empty
-            |> SignalState.register Signal.SIGINT (callback 1)
-            |> SignalState.unregister Signal.SIGINT
-
-        SignalState.tryGetHandler Signal.SIGINT s |> shouldEqual None
+        SignalState.isEnabled Signal.SIGINT s |> shouldEqual false
 
     [<Test>]
-    let ``unregister of an absent handler is a no-op`` () : unit =
-        let s = SignalState.empty |> SignalState.unregister Signal.SIGINT
+    let ``disable of an unenabled signal is a no-op`` () : unit =
+        let s = SignalState.empty |> SignalState.disable Signal.SIGINT
         s |> shouldEqual SignalState.empty
 
     [<Test>]
-    let ``unregister leaves pending entries queued, just non-deliverable`` () : unit =
+    let ``enable then disable collapses to the empty state`` () : unit =
+        // Mirrors the unblock/empty-mask collapse: an enable followed by a
+        // matching disable must be structurally identical to never having
+        // enabled. Without this, state dedup in the debugger would
+        // distinguish two semantically-equivalent states.
+        let enabledThenDisabled =
+            SignalState.empty
+            |> SignalState.enable Signal.SIGINT
+            |> SignalState.disable Signal.SIGINT
+
+        enabledThenDisabled |> shouldEqual SignalState.empty
+
+    [<Test>]
+    let ``disable leaves pending entries queued, just non-deliverable`` () : unit =
         // POSIX semantics: removing the disposition while a signal is
         // pending doesn't drop the signal — it remains queued and becomes
-        // deliverable again if a handler is re-installed.
+        // deliverable again if the signal is re-enabled.
         let entry =
             {
                 Signal = Signal.SIGINT
@@ -118,15 +127,15 @@ module TestSignalState =
 
         let s =
             SignalState.empty
-            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.enable Signal.SIGINT
             |> SignalState.enqueue entry
-            |> SignalState.unregister Signal.SIGINT
+            |> SignalState.disable Signal.SIGINT
 
         SignalState.pending s |> Seq.toList |> shouldEqual [ entry ]
         SignalState.tryDeliverable (liveThreads [ t0 ]) s |> shouldEqual None
 
     [<Test>]
-    let ``register after enqueue makes a queued signal deliverable`` () : unit =
+    let ``enable after enqueue makes a queued signal deliverable`` () : unit =
         let entry =
             {
                 Signal = Signal.SIGINT
@@ -136,15 +145,14 @@ module TestSignalState =
         let s =
             SignalState.empty
             |> SignalState.enqueue entry
-            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.enable Signal.SIGINT
 
         match SignalState.tryDeliverable (liveThreads [ t0 ]) s with
-        | Some (e, tid, h, s') ->
+        | Some (e, tid, s') ->
             e |> shouldEqual entry
             tid |> shouldEqual t0
-            h |> shouldEqual (callback 1)
             SignalState.pending s' |> Seq.toList |> shouldEqual []
-        | None -> failwith "expected deliverable entry once handler was registered"
+        | None -> failwith "expected deliverable entry once signal was enabled"
 
     [<Test>]
     let ``block then isBlocked`` () : unit =
@@ -242,14 +250,14 @@ module TestSignalState =
 
         let buildA () =
             SignalState.empty
-            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.enable Signal.SIGINT
             |> SignalState.block t0 Signal.SIGTERM
             |> SignalState.enqueue entryA
             |> SignalState.enqueue entryB
 
         let buildB () =
             SignalState.empty
-            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.enable Signal.SIGINT
             |> SignalState.block t0 Signal.SIGTERM
             |> SignalState.enqueue entryA
             |> SignalState.enqueue entryB
@@ -265,12 +273,12 @@ module TestSignalState =
         // split.
         let drainedFromA =
             match SignalState.tryDeliverable (liveThreads [ t0 ; t1 ]) a with
-            | Some (_, _, _, s') -> s'
+            | Some (_, _, s') -> s'
             | None -> failwith "expected deliverable entry from buildA"
 
         let drainedFromB =
             match SignalState.tryDeliverable (liveThreads [ t0 ; t1 ]) b with
-            | Some (_, _, _, s') -> s'
+            | Some (_, _, s') -> s'
             | None -> failwith "expected deliverable entry from buildB"
 
         drainedFromA |> shouldEqual drainedFromB
@@ -282,7 +290,7 @@ module TestSignalState =
         |> shouldEqual None
 
     [<Test>]
-    let ``tryDeliverable returns None when no handler is registered`` () : unit =
+    let ``tryDeliverable returns None when the signal is not enabled`` () : unit =
         let s =
             SignalState.empty
             |> SignalState.enqueue
@@ -297,7 +305,7 @@ module TestSignalState =
     let ``tryDeliverable returns None when there are no live threads`` () : unit =
         let s =
             SignalState.empty
-            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.enable Signal.SIGINT
             |> SignalState.enqueue
                 {
                     Signal = Signal.SIGINT
@@ -316,16 +324,15 @@ module TestSignalState =
 
         let s =
             SignalState.empty
-            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.enable Signal.SIGINT
             |> SignalState.enqueue entry
 
         // Live-thread order is deliberately scrambled to confirm the
         // implementation sorts internally rather than trusting input order.
         match SignalState.tryDeliverable (liveThreads [ t2 ; t0 ; t1 ]) s with
-        | Some (e, tid, h, s') ->
+        | Some (e, tid, s') ->
             e |> shouldEqual entry
             tid |> shouldEqual t0
-            h |> shouldEqual (callback 1)
             SignalState.pending s' |> Seq.toList |> shouldEqual []
         | None -> failwith "expected deliverable entry"
 
@@ -333,7 +340,7 @@ module TestSignalState =
     let ``tryDeliverable skips the lowest thread if it is blocking the signal`` () : unit =
         let s =
             SignalState.empty
-            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.enable Signal.SIGINT
             |> SignalState.block t0 Signal.SIGINT
             |> SignalState.enqueue
                 {
@@ -342,14 +349,14 @@ module TestSignalState =
                 }
 
         match SignalState.tryDeliverable (liveThreads [ t0 ; t1 ; t2 ]) s with
-        | Some (_, tid, _, _) -> tid |> shouldEqual t1
+        | Some (_, tid, _) -> tid |> shouldEqual t1
         | None -> failwith "expected deliverable entry"
 
     [<Test>]
     let ``tryDeliverable returns None when every live thread blocks the signal`` () : unit =
         let s =
             SignalState.empty
-            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.enable Signal.SIGINT
             |> SignalState.block t0 Signal.SIGINT
             |> SignalState.block t1 Signal.SIGINT
             |> SignalState.enqueue
@@ -366,7 +373,7 @@ module TestSignalState =
         // targeted at t0 must stay queued, not get delivered to t1.
         let s =
             SignalState.empty
-            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.enable Signal.SIGINT
             |> SignalState.block t0 Signal.SIGINT
             |> SignalState.enqueue
                 {
@@ -380,7 +387,7 @@ module TestSignalState =
     let ``tryDeliverable for a targeted dead thread is held`` () : unit =
         let s =
             SignalState.empty
-            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.enable Signal.SIGINT
             |> SignalState.enqueue
                 {
                     Signal = Signal.SIGINT
@@ -391,7 +398,7 @@ module TestSignalState =
 
     [<Test>]
     let ``tryDeliverable preserves the FIFO order of skipped entries`` () : unit =
-        // Three entries: (1) no handler installed, (2) targeted at a thread
+        // Three entries: (1) signal not enabled, (2) targeted at a thread
         // blocking it, (3) process-directed and deliverable to t1. The
         // returned state must contain entries (1) and (2) in their original
         // order; only entry (3) is removed.
@@ -415,14 +422,14 @@ module TestSignalState =
 
         let s =
             SignalState.empty
-            |> SignalState.register Signal.SIGINT (callback 1)
+            |> SignalState.enable Signal.SIGINT
             |> SignalState.block t0 Signal.SIGINT
             |> SignalState.enqueue head
             |> SignalState.enqueue middle
             |> SignalState.enqueue tail
 
         match SignalState.tryDeliverable (liveThreads [ t0 ; t1 ]) s with
-        | Some (e, tid, _, s') ->
+        | Some (e, tid, s') ->
             e |> shouldEqual tail
             tid |> shouldEqual t1
             SignalState.pending s' |> Seq.toList |> shouldEqual [ head ; middle ]
@@ -434,19 +441,19 @@ module TestSignalState =
     /// maps to exactly one public method on the API.
     type private Op =
         | MarkInitialized
-        | Register of signal : Signal * handler : SignalHandler
-        | Unregister of signal : Signal
+        | Enable of signal : Signal
+        | Disable of signal : Signal
         | Block of thread : ThreadId * signal : Signal
         | Unblock of thread : ThreadId * signal : Signal
         | Enqueue of entry : PendingSignal
         | DrainOne of live : ThreadId list
 
-    /// Reference implementation: simple lists / maps, completely
+    /// Reference implementation: simple lists / sets / maps, completely
     /// independent of the production module's internal representation.
     type private ReferenceState =
         {
             Initialized : bool
-            Registrations : Map<Signal, SignalHandler>
+            Enabled : Set<Signal>
             Blocked : Map<ThreadId, Set<Signal>>
             Pending : PendingSignal list
         }
@@ -454,7 +461,7 @@ module TestSignalState =
     let private referenceEmpty : ReferenceState =
         {
             Initialized = false
-            Registrations = Map.empty
+            Enabled = Set.empty
             Blocked = Map.empty
             Pending = []
         }
@@ -465,7 +472,7 @@ module TestSignalState =
     let private referenceTryDeliverable
         (live : ThreadId list)
         (r : ReferenceState)
-        : (PendingSignal * ThreadId * SignalHandler * ReferenceState) option
+        : (PendingSignal * ThreadId * ReferenceState) option
         =
         let liveSet : Set<ThreadId> = Set.ofList live
 
@@ -489,21 +496,17 @@ module TestSignalState =
         let entries : PendingSignal[] = r.Pending |> List.toArray
         let mutable foundIdx : int = -1
         let mutable foundReceiver : ThreadId option = None
-        let mutable foundHandler : SignalHandler option = None
         let mutable i : int = 0
 
         while foundIdx < 0 && i < entries.Length do
             let entry = entries.[i]
 
-            match Map.tryFind entry.Signal r.Registrations with
-            | Some h ->
+            if Set.contains entry.Signal r.Enabled then
                 match pickReceiver entry with
                 | Some tid ->
                     foundIdx <- i
                     foundReceiver <- Some tid
-                    foundHandler <- Some h
                 | None -> ()
-            | None -> ()
 
             i <- i + 1
 
@@ -519,7 +522,6 @@ module TestSignalState =
             Some (
                 entries.[foundIdx],
                 foundReceiver.Value,
-                foundHandler.Value,
                 { r with
                     Pending = remaining
                 }
@@ -536,15 +538,15 @@ module TestSignalState =
             { r with
                 Initialized = true
             }
-        | Op.Register (sig0, h) ->
-            SignalState.register sig0 h s,
+        | Op.Enable sig0 ->
+            SignalState.enable sig0 s,
             { r with
-                Registrations = Map.add sig0 h r.Registrations
+                Enabled = Set.add sig0 r.Enabled
             }
-        | Op.Unregister sig0 ->
-            SignalState.unregister sig0 s,
+        | Op.Disable sig0 ->
+            SignalState.disable sig0 s,
             { r with
-                Registrations = Map.remove sig0 r.Registrations
+                Enabled = Set.remove sig0 r.Enabled
             }
         | Op.Block (tid, sig0) ->
             let existing : Set<Signal> =
@@ -588,18 +590,20 @@ module TestSignalState =
 
             match actual, expected with
             | None, None -> s, r
-            | Some (e1, tid1, h1, s'), Some (e2, tid2, h2, r') ->
+            | Some (e1, tid1, s'), Some (e2, tid2, r') ->
                 e1 |> shouldEqual e2
                 tid1 |> shouldEqual tid2
-                h1 |> shouldEqual h2
                 s', r'
             | a, b -> failwith $"tryDeliverable disagreed: actual=%A{a}, reference=%A{b}"
 
     /// Compare every observable accessor; the accessors are the contract.
     let private assertEquivalent (s : SignalState) (r : ReferenceState) : unit =
         SignalState.isInitialized s |> shouldEqual r.Initialized
-        SignalState.registrations s |> shouldEqual r.Registrations
+        SignalState.enabled s |> shouldEqual r.Enabled
         SignalState.pending s |> Seq.toList |> shouldEqual r.Pending
+
+        for sig0 in allSignals do
+            SignalState.isEnabled sig0 s |> shouldEqual (Set.contains sig0 r.Enabled)
 
         for tid in allThreads do
             for sig0 in allSignals do
@@ -631,9 +635,9 @@ module TestSignalState =
         if kind < 5 then
             Op.MarkInitialized
         elif kind < 25 then
-            Op.Register (pick allSignals, callback (rng.Next 4))
+            Op.Enable (pick allSignals)
         elif kind < 32 then
-            Op.Unregister (pick allSignals)
+            Op.Disable (pick allSignals)
         elif kind < 47 then
             Op.Block (pick allThreads, pick allSignals)
         elif kind < 57 then
@@ -682,7 +686,7 @@ module TestSignalState =
                 match op with
                 | Op.DrainOne live ->
                     match referenceTryDeliverable live r with
-                    | Some (entry, _, _, _) ->
+                    | Some (entry, _, _) ->
                         observedDeliveries <- observedDeliveries + 1
 
                         match r.Pending with

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -68,6 +68,7 @@
     <Compile Include="TestDebuggerServer.fs" />
     <Compile Include="TestBclIntrinsicStaticFields.fs" />
     <Compile Include="TestLowLevelMonitor.fs" />
+    <Compile Include="TestSignal.fs" />
     <Compile Include="TestSignalState.fs" />
     <Compile Include="TestWaitHandle.fs" />
     <Compile Include="TestSyncBlockMonitor.fs" />

--- a/WoofWare.PawPrint.Test/sourcesPure/SystemNativeGetPlatformSignalNumber.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/SystemNativeGetPlatformSignalNumber.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Runtime.InteropServices;
+
+// Exercises the SystemNative_GetPlatformSignalNumber PawPrint handler directly
+// via a P/Invoke stub. The function is pure (no global state, no host signal
+// handler installation), so calling it from a unit test is safe on both the
+// real CLR and PawPrint — unlike Enable/DisablePosixSignalHandling, which
+// install sigaction handlers in the host process.
+//
+// The test asserts only signal numbers where Linux and macOS agree, because
+// PawPrint always reports Linux signos for determinism while the real CLR
+// reports whichever native value the host header file defines. Disagreement
+// would surface as a failure on one platform but not the other; the cases
+// below all match on both.
+//
+// PosixSignal enum values (negative for cross-platform identities) from the
+// managed BCL:
+//   SIGHUP   = -1
+//   SIGINT   = -2
+//   SIGQUIT  = -3
+//   SIGTERM  = -4
+//   SIGCHLD  = -5  (signo differs: Linux 17, macOS 20 — NOT tested)
+//   SIGCONT  = -6  (signo differs: Linux 18, macOS 19 — NOT tested)
+//   SIGWINCH = -7  (signo agrees: 28)
+//   SIGTTIN  = -8  (signo agrees: 21)
+//   SIGTTOU  = -9  (signo agrees: 22)
+//   SIGTSTP  = -10 (signo differs: Linux 20, macOS 18 — NOT tested)
+class Program
+{
+    [DllImport("libSystem.Native", EntryPoint = "SystemNative_GetPlatformSignalNumber")]
+    static extern int GetPlatformSignalNumber(int posixSignal);
+
+    static int Main(string[] args)
+    {
+        // Cross-platform cases where Linux and macOS agree.
+        if (GetPlatformSignalNumber(-1) != 1) return 1;  // SIGHUP
+        if (GetPlatformSignalNumber(-2) != 2) return 2;  // SIGINT
+        if (GetPlatformSignalNumber(-3) != 3) return 3;  // SIGQUIT
+        if (GetPlatformSignalNumber(-4) != 15) return 4; // SIGTERM
+        if (GetPlatformSignalNumber(-7) != 28) return 5; // SIGWINCH
+        if (GetPlatformSignalNumber(-8) != 21) return 6; // SIGTTIN
+        if (GetPlatformSignalNumber(-9) != 22) return 7; // SIGTTOU
+
+        // Passing a positive signo that the runtime recognises must round-trip
+        // back unchanged. SIGINT (2) is universally signo 2 on every modern
+        // Unix, so this is safe on every supported host.
+        if (GetPlatformSignalNumber(2) != 2) return 8;
+
+        // Zero is the "unknown signal" sentinel: GetPlatformSignalNumber
+        // returns 0 for any input it doesn't recognise, which the BCL then
+        // promotes to ArgumentOutOfRangeException.
+        if (GetPlatformSignalNumber(0) != 0) return 9;
+
+        // A negative value outside the cross-platform enum range is unknown
+        // and must produce 0. -100 is comfortably past the lowest defined
+        // value (-10) and not a valid platform signo.
+        if (GetPlatformSignalNumber(-100) != 0) return 10;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/SystemNativeGetPlatformSignalNumber.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/SystemNativeGetPlatformSignalNumber.cs
@@ -46,6 +46,16 @@ class Program
         // Unix, so this is safe on every supported host.
         if (GetPlatformSignalNumber(2) != 2) return 8;
 
+        // Unmodelled-but-valid native signos must also round-trip — this is
+        // what guests rely on when they cast a raw signo to PosixSignal and
+        // hand it to PosixSignalRegistration.Create. SIGILL (4) and SIGSEGV
+        // (11) agree on both Linux and macOS; neither is in PawPrint's
+        // modelled set, but both sit well within GetSignalMax(), so the real
+        // native code returns them unchanged and PawPrint must too (via
+        // Signal.Other).
+        if (GetPlatformSignalNumber(4) != 4) return 11;  // SIGILL
+        if (GetPlatformSignalNumber(11) != 11) return 12; // SIGSEGV
+
         // Zero is the "unknown signal" sentinel: GetPlatformSignalNumber
         // returns 0 for any input it doesn't recognise, which the BCL then
         // promotes to ArgumentOutOfRangeException.

--- a/WoofWare.PawPrint/Errno.fs
+++ b/WoofWare.PawPrint/Errno.fs
@@ -30,6 +30,15 @@ module Errno =
     /// real runtime.
     let EFAULT : int = 14
 
+    /// `EINVAL` — Invalid argument. Returned by `sigaction(2)` when the
+    /// caller asks to install a handler for an uncatchable signal
+    /// (`SIGKILL` or `SIGSTOP`). PawPrint surfaces this through
+    /// `SystemNative_EnablePosixSignalHandling`, which the BCL's
+    /// `PosixSignalRegistration.Create` reads via
+    /// `Marshal.GetLastSystemError` to throw a meaningful error to the
+    /// guest. Value matches Linux and Darwin (both define it as 22).
+    let EINVAL : int = 22
+
     /// `ERANGE` — Result too large / out of range. Used by PawPrint's
     /// `SystemNative_Write` / `SystemNative_Read` shims when the caller
     /// supplies a negative `bufferSize`, matching the behaviour of

--- a/WoofWare.PawPrint/Native/NativeSystemNative.fs
+++ b/WoofWare.PawPrint/Native/NativeSystemNative.fs
@@ -498,4 +498,101 @@ module NativeSystemNative =
                         $"SystemNative_Free: expected null or native-heap pointer, got %O{other} (only pointers from SystemNative_Malloc/Calloc may be freed here)"
 
             NativeHandlerResult.completed state |> Some
+        | Some "SystemNative_InitializeTerminalAndSignalHandling",
+          [],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
+            // The real native side configures the controlling terminal, sets
+            // up a self-pipe, and installs a dedicated signal-dispatch worker
+            // thread. PawPrint has no terminal and dispatches signals
+            // deterministically out of `SignalState`; this entry point's only
+            // observable effect on the kernel is flipping `Signals.Initialized`,
+            // which the BCL uses as a "have we set up yet?" gate. Real native
+            // code returns 0 on setup failure (e.g. EBADF from tcgetattr on a
+            // headless process); PawPrint always reports success because there
+            // is no underlying syscall that could fail. The call is idempotent
+            // for the same reason `SignalState.markInitialized` is — the BCL
+            // may invoke this from several initializers across its surface.
+            state.MapKernel (fun kernel ->
+                { kernel with
+                    Signals = SignalState.markInitialized kernel.Signals
+                }
+            )
+            |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 1) ctx.Thread
+            |> NativeHandlerResult.completed
+            |> Some
+        | Some "SystemNative_GetPlatformSignalNumber",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32 ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
+            // Real native code keys off the host's <signal.h>; PawPrint always
+            // uses the Linux signo table (see `Signal.toLinuxSigno`) so a
+            // simulation trace is byte-for-byte identical across host OSes.
+            // PosixSignal values the simulator doesn't model — both unrecognised
+            // cross-platform negatives and positive signos outside the modelled
+            // set — map to 0, which `PosixSignalRegistration.Register` promotes
+            // to an `ArgumentOutOfRangeException`, matching the real native
+            // semantics where unknown signals fall through to the trailing
+            // `return 0;` in `SystemNative_GetPlatformSignalNumber`.
+            let raw =
+                NativeCall.int32Argument "SystemNative_GetPlatformSignalNumber" instruction.Arguments.[0]
+
+            let signo =
+                match Signal.ofPosixSignalEnum raw with
+                | ValueSome signal -> Signal.toLinuxSigno signal
+                | ValueNone -> 0
+
+            pushInt32 signo ctx |> Some
+        | Some "SystemNative_EnablePosixSignalHandling",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32 ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
+            // Flips the per-signo "managed code wants this" bit. The handler
+            // dictionary itself lives on the simulated managed heap (maintained
+            // by `PosixSignalRegistration`'s `s_registrations`); this arm only
+            // touches the kernel-side enable set. By contract, the BCL only
+            // calls this with signos that `SystemNative_GetPlatformSignalNumber`
+            // returned non-zero for, so a signo arriving here must round-trip
+            // through `Signal.ofLinuxSigno` — anything else indicates a guest
+            // bypassing the standard registration path with a hand-rolled
+            // P/Invoke, and we fail loudly rather than silently dropping the
+            // request. Real native code asserts `signalCode > 0 && <= GetSignalMax()`.
+            let operation = "SystemNative_EnablePosixSignalHandling"
+            let signo = NativeCall.int32Argument operation instruction.Arguments.[0]
+
+            match Signal.ofLinuxSigno signo with
+            | ValueNone ->
+                failwith
+                    $"%s{operation}: refusing to enable unmodelled signo %d{signo} (signos arriving here should have round-tripped through SystemNative_GetPlatformSignalNumber, which only returns signos PawPrint models)"
+            | ValueSome signal ->
+                state.MapKernel (fun kernel ->
+                    { kernel with
+                        Signals = SignalState.enable signal kernel.Signals
+                    }
+                )
+                |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 1) ctx.Thread
+                |> NativeHandlerResult.completed
+                |> Some
+        | Some "SystemNative_DisablePosixSignalHandling",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32 ],
+          MethodReturnType.Void ->
+            // Mirror image of `SystemNative_EnablePosixSignalHandling`: clear
+            // the per-signo enable bit. Real native code also conditionally
+            // restores the prior `sigaction` disposition; PawPrint has no
+            // installed disposition to restore, so the only kernel-visible
+            // effect is the cleared bit. Same round-trip contract as enable:
+            // an unmodelled signo arriving here is a guest bypassing
+            // `GetPlatformSignalNumber`, and we surface the divergence.
+            let operation = "SystemNative_DisablePosixSignalHandling"
+            let signo = NativeCall.int32Argument operation instruction.Arguments.[0]
+
+            match Signal.ofLinuxSigno signo with
+            | ValueNone ->
+                failwith
+                    $"%s{operation}: refusing to disable unmodelled signo %d{signo} (signos arriving here should have round-tripped through SystemNative_GetPlatformSignalNumber, which only returns signos PawPrint models)"
+            | ValueSome signal ->
+                state.MapKernel (fun kernel ->
+                    { kernel with
+                        Signals = SignalState.disable signal kernel.Signals
+                    }
+                )
+                |> NativeHandlerResult.completed
+                |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeSystemNative.fs
+++ b/WoofWare.PawPrint/Native/NativeSystemNative.fs
@@ -14,6 +14,27 @@ module NativeSystemNative =
         |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 value) ctx.Thread
         |> NativeHandlerResult.completed
 
+    /// Matches the parameter type that `Interop.Sys.GetPlatformSignalNumber`
+    /// declares. The BCL's LibraryImport source generator preserves the
+    /// `PosixSignal` enum in the P/Invoke stub signature (the enum is
+    /// blittable, so no conversion thunk is emitted), so PawPrint sees the
+    /// enum-typed parameter — not a plain `Int32`. The C-side stub
+    /// `static partial extern int __PInvoke(PosixSignal signal)` is what
+    /// PawPrint dispatches on. Other guests may take the same entry point
+    /// via a hand-rolled `[DllImport]` declaring `int` directly (e.g. the
+    /// unit-test stub in `sourcesPure/SystemNativeGetPlatformSignalNumber.cs`),
+    /// so we accept either shape — the underlying `int32Argument` decode
+    /// peels enum boxing via `unwrapPrimitiveLikeDeep` and produces the same
+    /// raw value either way.
+    let private (|PosixSignalParam|_|) (concreteTypes : AllConcreteTypes) (handle : ConcreteTypeHandle) : unit option =
+        match handle with
+        | ConcretePrimitive concreteTypes PrimitiveType.Int32 -> Some ()
+        | ConcreteType concreteTypes ("System.Private.CoreLib",
+                                      "System.Runtime.InteropServices",
+                                      "PosixSignal",
+                                      generics) when generics.IsEmpty -> Some ()
+        | _ -> None
+
     /// Decode an `nint`-shaped Unix file-descriptor argument. CoreLib passes
     /// fds across the SystemNative boundary as plain `IntPtr` values (the low
     /// 32 bits of `SafeFileHandle.handle`); PawPrint represents these as
@@ -521,17 +542,21 @@ module NativeSystemNative =
             |> NativeHandlerResult.completed
             |> Some
         | Some "SystemNative_GetPlatformSignalNumber",
-          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32 ],
+          [ PosixSignalParam state.ConcreteTypes ],
           MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
             // Real native code keys off the host's <signal.h>; PawPrint always
             // uses the Linux signo table (see `Signal.toLinuxSigno`) so a
             // simulation trace is byte-for-byte identical across host OSes.
-            // PosixSignal values the simulator doesn't model — both unrecognised
-            // cross-platform negatives and positive signos outside the modelled
-            // set — map to 0, which `PosixSignalRegistration.Register` promotes
-            // to an `ArgumentOutOfRangeException`, matching the real native
-            // semantics where unknown signals fall through to the trailing
-            // `return 0;` in `SystemNative_GetPlatformSignalNumber`.
+            // Unmodelled cross-platform negatives and out-of-range positives
+            // (outside `(0, Signal.linuxSignalMax]`) both map to 0 — which
+            // `PosixSignalRegistration.Register` promotes to an
+            // `ArgumentOutOfRangeException`, matching the real native semantics
+            // where unknown signals fall through to the trailing `return 0;`
+            // in `SystemNative_GetPlatformSignalNumber`. Positive signos within
+            // range that PawPrint doesn't name still round-trip via
+            // `Signal.Other`, so a guest that casts `(PosixSignal)4` for SIGILL
+            // gets `4` back, matching the C-side check
+            // `if (signal > 0 && signal <= GetSignalMax()) return signal;`.
             let raw =
                 NativeCall.int32Argument "SystemNative_GetPlatformSignalNumber" instruction.Arguments.[0]
 
@@ -549,18 +574,20 @@ module NativeSystemNative =
             // by `PosixSignalRegistration`'s `s_registrations`); this arm only
             // touches the kernel-side enable set. By contract, the BCL only
             // calls this with signos that `SystemNative_GetPlatformSignalNumber`
-            // returned non-zero for, so a signo arriving here must round-trip
-            // through `Signal.ofLinuxSigno` — anything else indicates a guest
-            // bypassing the standard registration path with a hand-rolled
+            // returned non-zero for, so a signo arriving here must lie within
+            // `(0, Signal.linuxSignalMax]` (modelled signals get a named case;
+            // unmodelled-but-valid signos round-trip via `Signal.Other` so the
+            // kernel still tracks the enable bit) — anything else indicates a
+            // guest bypassing the standard registration path with a hand-rolled
             // P/Invoke, and we fail loudly rather than silently dropping the
             // request. Real native code asserts `signalCode > 0 && <= GetSignalMax()`.
             let operation = "SystemNative_EnablePosixSignalHandling"
             let signo = NativeCall.int32Argument operation instruction.Arguments.[0]
 
-            match Signal.ofLinuxSigno signo with
+            match Signal.ofPlatformSigno signo with
             | ValueNone ->
                 failwith
-                    $"%s{operation}: refusing to enable unmodelled signo %d{signo} (signos arriving here should have round-tripped through SystemNative_GetPlatformSignalNumber, which only returns signos PawPrint models)"
+                    $"%s{operation}: refusing to enable out-of-range signo %d{signo} (signos arriving here must lie within (0, Signal.linuxSignalMax]; this looks like a guest bypassing SystemNative_GetPlatformSignalNumber)"
             | ValueSome signal ->
                 state.MapKernel (fun kernel ->
                     { kernel with
@@ -578,15 +605,16 @@ module NativeSystemNative =
             // restores the prior `sigaction` disposition; PawPrint has no
             // installed disposition to restore, so the only kernel-visible
             // effect is the cleared bit. Same round-trip contract as enable:
-            // an unmodelled signo arriving here is a guest bypassing
+            // an out-of-range signo arriving here (outside
+            // `(0, Signal.linuxSignalMax]`) is a guest bypassing
             // `GetPlatformSignalNumber`, and we surface the divergence.
             let operation = "SystemNative_DisablePosixSignalHandling"
             let signo = NativeCall.int32Argument operation instruction.Arguments.[0]
 
-            match Signal.ofLinuxSigno signo with
+            match Signal.ofPlatformSigno signo with
             | ValueNone ->
                 failwith
-                    $"%s{operation}: refusing to disable unmodelled signo %d{signo} (signos arriving here should have round-tripped through SystemNative_GetPlatformSignalNumber, which only returns signos PawPrint models)"
+                    $"%s{operation}: refusing to disable out-of-range signo %d{signo} (signos arriving here must lie within (0, Signal.linuxSignalMax]; this looks like a guest bypassing SystemNative_GetPlatformSignalNumber)"
             | ValueSome signal ->
                 state.MapKernel (fun kernel ->
                     { kernel with

--- a/WoofWare.PawPrint/Native/NativeSystemNative.fs
+++ b/WoofWare.PawPrint/Native/NativeSystemNative.fs
@@ -588,6 +588,25 @@ module NativeSystemNative =
             | ValueNone ->
                 failwith
                     $"%s{operation}: refusing to enable out-of-range signo %d{signo} (signos arriving here must lie within (0, Signal.linuxSignalMax]; this looks like a guest bypassing SystemNative_GetPlatformSignalNumber)"
+            | ValueSome signal when Signal.isUncatchable signal ->
+                // Real native code calls `sigaction(signo, ...)` which the
+                // kernel rejects with `EINVAL` for `SIGKILL` (9) and
+                // `SIGSTOP` (19). `InstallSignalHandler` returns false and
+                // `SystemNative_EnablePosixSignalHandling` propagates 0 with
+                // `errno = EINVAL`, which `PosixSignalRegistration.Create`
+                // then reads via `Marshal.GetLastSystemError` to throw. We
+                // mirror exactly that: leave the enable bit clear, set
+                // errno, push 0. Don't fail loud here — uncatchable signals
+                // are a documented BCL-observable failure mode, not a
+                // simulator bug.
+                state.MapKernel (fun kernel ->
+                    { kernel with
+                        LastSystemError = Errno.EINVAL
+                    }
+                )
+                |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread
+                |> NativeHandlerResult.completed
+                |> Some
             | ValueSome signal ->
                 state.MapKernel (fun kernel ->
                     { kernel with

--- a/WoofWare.PawPrint/Signal.fs
+++ b/WoofWare.PawPrint/Signal.fs
@@ -12,6 +12,9 @@ namespace WoofWare.PawPrint
 /// numbers, which are platform-specific. The native↔domain mapping lives at
 /// the P/Invoke seam and is platform-aware; the domain type is the
 /// platform-neutral identity that the rest of the simulator works with.
+/// PawPrint always uses the Linux signal-number table, regardless of host
+/// OS — see `Signal.toLinuxSigno`. This keeps the simulator deterministic
+/// across hosts.
 type Signal =
     | SIGHUP
     | SIGINT
@@ -33,14 +36,69 @@ type Signal =
     /// directly). Two `Other` values are equal iff their raw values match.
     | Other of rawSignal : int
 
-/// How a delivered signal should be dispatched inside the simulator. Today
-/// the only shape is "invoke a managed callback identified by an object
-/// reference"; the discriminated-union shape leaves headroom for future
-/// dispositions (ignore, default, terminate) without churning callers.
 [<RequireQualifiedAccess>]
-type SignalHandler =
-    /// Dispatch by invoking a managed callback wrapped behind the supplied
-    /// object reference. Concretely, this is the `PosixSignalRegistration`
-    /// (or analogous) object the guest installed via the runtime; the
-    /// signal-delivery glue will reach in and invoke its delegate.
-    | PosixCallback of objectRef : ManagedHeapAddress
+module Signal =
+    /// Map a domain `Signal` to its Linux native signo. PawPrint uses the
+    /// Linux table on every host, so simulation traces don't depend on the
+    /// host OS. Callers crossing the P/Invoke seam must use this — never the
+    /// host's own headers — for deterministic output.
+    let toLinuxSigno (signal : Signal) : int =
+        match signal with
+        | Signal.SIGHUP -> 1
+        | Signal.SIGINT -> 2
+        | Signal.SIGQUIT -> 3
+        | Signal.SIGABRT -> 6
+        | Signal.SIGUSR1 -> 10
+        | Signal.SIGUSR2 -> 12
+        | Signal.SIGPIPE -> 13
+        | Signal.SIGTERM -> 15
+        | Signal.SIGCHLD -> 17
+        | Signal.SIGCONT -> 18
+        | Signal.SIGTSTP -> 20
+        | Signal.SIGTTIN -> 21
+        | Signal.SIGTTOU -> 22
+        | Signal.SIGWINCH -> 28
+        | Signal.Other rawSignal -> rawSignal
+
+    /// Inverse of `toLinuxSigno` on the named cases. Returns `ValueNone` for
+    /// signos that don't correspond to a modelled signal — the caller can
+    /// then decide whether to fail loudly or wrap in `Other`.
+    let ofLinuxSigno (signo : int) : Signal voption =
+        match signo with
+        | 1 -> ValueSome Signal.SIGHUP
+        | 2 -> ValueSome Signal.SIGINT
+        | 3 -> ValueSome Signal.SIGQUIT
+        | 6 -> ValueSome Signal.SIGABRT
+        | 10 -> ValueSome Signal.SIGUSR1
+        | 12 -> ValueSome Signal.SIGUSR2
+        | 13 -> ValueSome Signal.SIGPIPE
+        | 15 -> ValueSome Signal.SIGTERM
+        | 17 -> ValueSome Signal.SIGCHLD
+        | 18 -> ValueSome Signal.SIGCONT
+        | 20 -> ValueSome Signal.SIGTSTP
+        | 21 -> ValueSome Signal.SIGTTIN
+        | 22 -> ValueSome Signal.SIGTTOU
+        | 28 -> ValueSome Signal.SIGWINCH
+        | _ -> ValueNone
+
+    /// Map a managed `PosixSignal` enum value (as the BCL passes it across
+    /// the seam) to a domain `Signal`. The managed enum uses negative
+    /// values for cross-platform identities and positive values when the
+    /// caller has supplied a raw native signo directly; this helper
+    /// translates either form. Returns `ValueNone` for values we don't
+    /// recognise — `SystemNative_GetPlatformSignalNumber` returns 0 in that
+    /// case, and `PosixSignalRegistration.Register` then throws.
+    let ofPosixSignalEnum (raw : int) : Signal voption =
+        match raw with
+        | -1 -> ValueSome Signal.SIGHUP
+        | -2 -> ValueSome Signal.SIGINT
+        | -3 -> ValueSome Signal.SIGQUIT
+        | -4 -> ValueSome Signal.SIGTERM
+        | -5 -> ValueSome Signal.SIGCHLD
+        | -6 -> ValueSome Signal.SIGCONT
+        | -7 -> ValueSome Signal.SIGWINCH
+        | -8 -> ValueSome Signal.SIGTTIN
+        | -9 -> ValueSome Signal.SIGTTOU
+        | -10 -> ValueSome Signal.SIGTSTP
+        | n when n > 0 -> ofLinuxSigno n
+        | _ -> ValueNone

--- a/WoofWare.PawPrint/Signal.fs
+++ b/WoofWare.PawPrint/Signal.fs
@@ -38,6 +38,16 @@ type Signal =
 
 [<RequireQualifiedAccess>]
 module Signal =
+    /// Highest signal number the simulator accepts at the P/Invoke seam.
+    /// Matches Linux's `SIGRTMAX` on every modern glibc build (the real
+    /// native side reads `GetSignalMax()` from `<signal.h>`, which expands
+    /// to `SIGRTMAX` whenever that macro is defined). Used as the ceiling
+    /// for the "is this a plausible native signo?" check: a guest can pass
+    /// a `(PosixSignal)42` and PawPrint will round-trip the raw value
+    /// through `Signal.Other`, but a `(PosixSignal)200` is firmly outside
+    /// any kernel's table and returns 0 like the real native function.
+    let linuxSignalMax : int = 64
+
     /// Map a domain `Signal` to its Linux native signo. PawPrint uses the
     /// Linux table on every host, so simulation traces don't depend on the
     /// host OS. Callers crossing the P/Invoke seam must use this — never the
@@ -81,6 +91,25 @@ module Signal =
         | 28 -> ValueSome Signal.SIGWINCH
         | _ -> ValueNone
 
+    /// Map a positive native signo to a domain `Signal`. Modelled signos
+    /// produce their named case; unmodelled-but-valid signos (positive and
+    /// `<= linuxSignalMax`) round-trip through `Signal.Other` so the seam
+    /// preserves identity — matching the real native semantics, where
+    /// `SystemNative_GetPlatformSignalNumber` returns the raw value when
+    /// `signal > 0 && signal <= GetSignalMax()` and `PosixSignalRegistration`
+    /// then forwards it to `Enable/DisablePosixSignalHandling` unchanged.
+    /// Values outside `(0, linuxSignalMax]` return `ValueNone`; callers
+    /// translate that to the "unknown signal" sentinel (0 for the BCL
+    /// boundary, `ArgumentOutOfRangeException` higher up).
+    let ofPlatformSigno (signo : int) : Signal voption =
+        match ofLinuxSigno signo with
+        | ValueSome signal -> ValueSome signal
+        | ValueNone ->
+            if signo > 0 && signo <= linuxSignalMax then
+                ValueSome (Signal.Other signo)
+            else
+                ValueNone
+
     /// Map a managed `PosixSignal` enum value (as the BCL passes it across
     /// the seam) to a domain `Signal`. The managed enum uses negative
     /// values for cross-platform identities and positive values when the
@@ -100,5 +129,4 @@ module Signal =
         | -8 -> ValueSome Signal.SIGTTIN
         | -9 -> ValueSome Signal.SIGTTOU
         | -10 -> ValueSome Signal.SIGTSTP
-        | n when n > 0 -> ofLinuxSigno n
-        | _ -> ValueNone
+        | n -> ofPlatformSigno n

--- a/WoofWare.PawPrint/Signal.fs
+++ b/WoofWare.PawPrint/Signal.fs
@@ -91,6 +91,20 @@ module Signal =
         | 28 -> ValueSome Signal.SIGWINCH
         | _ -> ValueNone
 
+    /// Signals that cannot be caught, blocked, or ignored on POSIX. The
+    /// kernel rejects `sigaction(SIGKILL, ...)` / `sigaction(SIGSTOP, ...)`
+    /// with `EINVAL`, so `SystemNative_EnablePosixSignalHandling` returns
+    /// `false` (install failed) and `PosixSignalRegistration.Create` throws
+    /// rather than recording an impossible handler. PawPrint mirrors this
+    /// at the seam; the simulator never delivers either signal, regardless
+    /// of what's in the pending queue, because no one can legally install
+    /// a handler for them.
+    let isUncatchable (signal : Signal) : bool =
+        match signal with
+        | Signal.Other 9 -> true // SIGKILL
+        | Signal.Other 19 -> true // SIGSTOP
+        | _ -> false
+
     /// Map a positive native signo to a domain `Signal`. Modelled signos
     /// produce their named case; unmodelled-but-valid signos (positive and
     /// `<= linuxSignalMax`) round-trip through `Signal.Other` so the seam

--- a/WoofWare.PawPrint/SignalState.fs
+++ b/WoofWare.PawPrint/SignalState.fs
@@ -19,25 +19,28 @@ type PendingSignal =
 ///   * `Initialized` — has the BCL invoked
 ///     `SystemNative_InitializeTerminalAndSignalHandling` yet? Several
 ///     console paths gate work behind this flag.
-///   * `Registrations` — the per-signal dispatch target. A signal that is
-///     not in this map has no handler installed; pending entries for such
-///     signals stay queued (the consumer decides whether to drop or wait
-///     for a registration).
+///   * `Enabled` — the set of signals the BCL has asked libSystem.Native to
+///     deliver to managed code via `SystemNative_EnablePosixSignalHandling`.
+///     This mirrors the enable bits that the real native side keeps; the
+///     mapping from signals to managed handlers lives in the simulated
+///     managed heap (the BCL maintains its own `static Dictionary<int, ...>`
+///     keyed by signo), and is none of this module's concern. A pending
+///     entry whose signal is not enabled stays queued; the consumer decides
+///     whether to drop or wait for an enable.
 ///   * `Blocked` — per-thread sigprocmask. A signal in a thread's set is
 ///     blocked for that thread and cannot be delivered to it.
 ///   * `Pending` — FIFO queue of generated signals waiting for dispatch.
 ///
 /// The `EmulatedKernel.Signals` field carries an instance of this type per
 /// simulated process, but no code dispatches signals out of it yet —
-/// downstream slices will plug in the harness-side injection point, the
-/// between-instruction delivery hook, and the native P/Invoke arms that
-/// register and block. The data shape itself is exercised end-to-end by
-/// property tests against a reference oracle.
+/// downstream slices will plug in the harness-side injection point and the
+/// between-instruction delivery hook. The data shape itself is exercised
+/// end-to-end by property tests against a reference oracle.
 type SignalState =
     private
         {
             Initialized : bool
-            Registrations : Map<Signal, SignalHandler>
+            Enabled : Set<Signal>
             Blocked : Map<ThreadId, Set<Signal>>
             /// Pending entries in FIFO order (head = next candidate for
             /// dispatch). A plain list rather than `ImmutableQueue<T>`
@@ -55,7 +58,7 @@ module SignalState =
     let empty : SignalState =
         {
             Initialized = false
-            Registrations = Map.empty
+            Enabled = Set.empty
             Blocked = Map.empty
             Pending = []
         }
@@ -73,27 +76,34 @@ module SignalState =
                 Initialized = true
             }
 
-    let tryGetHandler (signal : Signal) (state : SignalState) : SignalHandler option =
-        Map.tryFind signal state.Registrations
+    let isEnabled (signal : Signal) (state : SignalState) : bool = Set.contains signal state.Enabled
 
-    let registrations (state : SignalState) : Map<Signal, SignalHandler> = state.Registrations
+    let enabled (state : SignalState) : Set<Signal> = state.Enabled
 
-    /// Install or replace the handler for `signal`. POSIX permits exactly
-    /// one disposition per signal at a time; a second `register` overwrites
-    /// the first.
-    let register (signal : Signal) (handler : SignalHandler) (state : SignalState) : SignalState =
-        { state with
-            Registrations = Map.add signal handler state.Registrations
-        }
+    /// Mark `signal` as enabled for managed dispatch. Idempotent: a second
+    /// `enable` of an already-enabled signal is a no-op. Mirrors
+    /// `SystemNative_EnablePosixSignalHandling` on the C side, which flips
+    /// a per-signo enable bit; the actual handler dictionary lives on the
+    /// simulated managed heap.
+    let enable (signal : Signal) (state : SignalState) : SignalState =
+        if Set.contains signal state.Enabled then
+            state
+        else
+            { state with
+                Enabled = Set.add signal state.Enabled
+            }
 
-    /// Remove the handler for `signal`. After this, pending entries for the
-    /// signal remain queued (a future `register` will make them deliverable)
-    /// but `tryDeliverable` will not dispatch them in the meantime. No-op if
-    /// no handler was installed.
-    let unregister (signal : Signal) (state : SignalState) : SignalState =
-        { state with
-            Registrations = Map.remove signal state.Registrations
-        }
+    /// Clear the enable bit for `signal`. No-op if not enabled. Pending
+    /// entries for the signal remain queued (a future `enable` makes them
+    /// deliverable) but `tryDeliverable` will not dispatch them in the
+    /// meantime.
+    let disable (signal : Signal) (state : SignalState) : SignalState =
+        if Set.contains signal state.Enabled then
+            { state with
+                Enabled = Set.remove signal state.Enabled
+            }
+        else
+            state
 
     let isBlocked (thread : ThreadId) (signal : Signal) (state : SignalState) : bool =
         match Map.tryFind thread state.Blocked with
@@ -159,7 +169,7 @@ module SignalState =
 
     /// Walk the pending queue in FIFO order and return the first entry that
     /// can be delivered now. An entry is deliverable iff:
-    ///   * a handler is registered for its `Signal`;
+    ///   * its `Signal` is enabled (the BCL has asked for managed dispatch);
     ///   * either it is `pthread_kill`-directed at a thread that is live and
     ///     not blocking the signal, or
     ///   * it is process-directed (`Target = ValueNone`) and at least one
@@ -175,7 +185,7 @@ module SignalState =
     let tryDeliverable
         (liveThreads : ImmutableArray<ThreadId>)
         (state : SignalState)
-        : (PendingSignal * ThreadId * SignalHandler * SignalState) option
+        : (PendingSignal * ThreadId * SignalState) option
         =
         let liveSet : Set<ThreadId> = liveThreads |> Seq.toList |> Set.ofList
 
@@ -195,9 +205,9 @@ module SignalState =
             match rest with
             | [] -> None
             | head :: tail ->
-                match Map.tryFind head.Signal state.Registrations with
-                | None -> scan (head :: skipped) tail
-                | Some handler ->
+                if not (Set.contains head.Signal state.Enabled) then
+                    scan (head :: skipped) tail
+                else
                     match pickReceiver head with
                     | None -> scan (head :: skipped) tail
                     | Some tid ->
@@ -206,7 +216,6 @@ module SignalState =
                         Some (
                             head,
                             tid,
-                            handler,
                             { state with
                                 Pending = remaining
                             }


### PR DESCRIPTION
## Summary
- Refactors `SignalState` from `Registrations : Map<Signal, SignalHandler>` to `Enabled : Set<Signal>`, mirroring the C-side libSystem.Native enable-bit model. The BCL's per-signal handler dictionary lives on the simulated managed heap, so the kernel-side state has no honest seam through which to populate handler identities. Drops the unused `SignalHandler` DU.
- Adds four P/Invoke arms in `NativeSystemNative`:
  - `SystemNative_InitializeTerminalAndSignalHandling` — marks `Signals` initialized, returns 1.
  - `SystemNative_GetPlatformSignalNumber` — maps the managed `PosixSignal` enum to a deterministic Linux signo via `Signal.ofPosixSignalEnum` and `Signal.toLinuxSigno`; returns 0 for unmodelled signals, which the BCL promotes to `ArgumentOutOfRangeException`.
  - `SystemNative_EnablePosixSignalHandling` / `DisablePosixSignalHandling` — flip the per-signal enable bit in `SignalState` by signo round-tripped through `Signal.ofLinuxSigno`; an unmodelled signo arriving here means a guest bypassed `GetPlatformSignalNumber`, and the arm fails loudly.
- Signal number table is Linux-flavoured on every host so simulation traces are byte-for-byte identical regardless of platform.

## Test plan
- [x] `nix develop -c dotnet build WoofWare.PawPrint/WoofWare.PawPrint.fsproj` clean.
- [x] `nix develop -c dotnet build WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` clean.
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 1203 passed, 0 failed.
- [x] `TestSignal.fs` covers `Signal.toLinuxSigno`, `ofLinuxSigno`, and `ofPosixSignalEnum` exhaustively (round-trips, every modelled signal, every cross-platform `PosixSignal` enum value, unknown / out-of-range inputs).
- [x] `TestSignalState.fs` property test (500 iterations) updated to use the new `enable`/`disable` API; the reference oracle now stores `Enabled : Set` and still agrees on every observable.
- [x] `sourcesPure/SystemNativeGetPlatformSignalNumber.cs` exercises the `GetPlatformSignalNumber` arm end-to-end on both the real CLR and PawPrint, asserting only signo values where Linux and macOS agree. `Init`/`Enable`/`Disable` arms cannot be exercised the same way because they install host-process `sigaction` handlers; their argument-decoding logic is covered by `TestSignal.fs` and the kernel mutation they perform is covered by `TestSignalState.fs`.
- [ ] `codex review --base main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)