### PR TITLE
Widen MethodTablePtr payload to RuntimeTypeHandleTarget

### DIFF
--- a/WoofWare.PawPrint.Test/TestCliTypeBytes.fs
+++ b/WoofWare.PawPrint.Test/TestCliTypeBytes.fs
@@ -256,7 +256,9 @@ module TestCliTypeBytes =
             [
                 cliField
                     "Ptr"
-                    (CliType.RuntimePointer (CliRuntimePointer.MethodTablePtr int32Handle))
+                    (CliType.RuntimePointer (
+                        CliRuntimePointer.MethodTablePtr (RuntimeTypeHandleTarget.Closed int32Handle)
+                    ))
                     (Some 0)
                     intPtrHandle
             ]
@@ -308,7 +310,9 @@ module TestCliTypeBytes =
                 cliField "Obj" (CliType.ObjectRef None) (Some 0) objectHandle
                 cliField
                     "Ptr"
-                    (CliType.RuntimePointer (CliRuntimePointer.MethodTablePtr int32Handle))
+                    (CliType.RuntimePointer (
+                        CliRuntimePointer.MethodTablePtr (RuntimeTypeHandleTarget.Closed int32Handle)
+                    ))
                     (Some 8)
                     intPtrHandle
             ]
@@ -334,7 +338,7 @@ module TestCliTypeBytes =
                 )
             )
             NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed int32Handle)
-            NativeIntSource.MethodTablePtr int32Handle
+            NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed int32Handle)
             NativeIntSource.MethodTableAuxiliaryDataPtr (RuntimeTypeHandleTarget.Closed int32Handle)
             NativeIntSource.MethodHandlePtr 1234L
             NativeIntSource.FieldHandlePtr 1234L
@@ -355,7 +359,11 @@ module TestCliTypeBytes =
                 Gen.constant (rawSizedValueType 8)
                 Gen.constant (fieldBackedBoolValueType ())
                 Gen.constant (CliType.ObjectRef None)
-                Gen.constant (CliType.RuntimePointer (CliRuntimePointer.MethodTablePtr int32Handle))
+                Gen.constant (
+                    CliType.RuntimePointer (
+                        CliRuntimePointer.MethodTablePtr (RuntimeTypeHandleTarget.Closed int32Handle)
+                    )
+                )
                 Gen.constant (objectReferenceValueType () |> CliType.ValueType)
                 Gen.constant (runtimePointerValueType () |> CliType.ValueType)
                 nonByteRenderableNativeIntSources ()
@@ -499,7 +507,9 @@ module TestCliTypeBytes =
         CliType.ByteAddressability (CliType.ObjectRef None)
         |> shouldEqual (CliByteAddressability.Rejected CliByteAddressabilityRejection.ObjectReference)
 
-        CliType.ByteAddressability (CliType.RuntimePointer (CliRuntimePointer.MethodTablePtr int32Handle))
+        CliType.ByteAddressability (
+            CliType.RuntimePointer (CliRuntimePointer.MethodTablePtr (RuntimeTypeHandleTarget.Closed int32Handle))
+        )
         |> shouldEqual (CliByteAddressability.Rejected CliByteAddressabilityRejection.RuntimePointer)
 
         let objectValueType = objectReferenceValueType ()
@@ -589,7 +599,8 @@ module TestCliTypeBytes =
         let cases =
             [
                 CliType.ObjectRef None, "object reference"
-                CliType.RuntimePointer (CliRuntimePointer.MethodTablePtr int32Handle), "runtime pointer"
+                CliType.RuntimePointer (CliRuntimePointer.MethodTablePtr (RuntimeTypeHandleTarget.Closed int32Handle)),
+                "runtime pointer"
                 objectReferenceValueType () |> CliType.ValueType, "value type containing object references"
                 runtimePointerValueType () |> CliType.ValueType, "value type containing runtime pointers"
             ]

--- a/WoofWare.PawPrint.Test/TestEvalStack.fs
+++ b/WoofWare.PawPrint.Test/TestEvalStack.fs
@@ -37,7 +37,7 @@ module TestEvalStack =
 
     [<Test>]
     let ``toCliTypeCoerced RuntimePointer target preserves method table pointer provenance`` () : unit =
-        let typeHandle = ConcreteTypeHandle.Concrete 42
+        let typeHandle = RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete 42)
 
         match
             EvalStackValue.toCliTypeCoerced
@@ -49,7 +49,7 @@ module TestEvalStack =
 
     [<Test>]
     let ``RuntimePointer carrying method table pointer flattens back to native int`` () : unit =
-        let typeHandle = ConcreteTypeHandle.Concrete 42
+        let typeHandle = RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete 42)
 
         match EvalStackValue.ofCliType (CliType.RuntimePointer (CliRuntimePointer.MethodTablePtr typeHandle)) with
         | EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr actual) when actual = typeHandle -> ()
@@ -106,13 +106,19 @@ module TestEvalStack =
     [<Test>]
     let ``ceq compares method table pointers by concrete type identity`` () : unit =
         let methodTable =
-            EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr (ConcreteTypeHandle.Concrete 42))
+            EvalStackValue.NativeInt (
+                NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete 42))
+            )
 
         let sameMethodTable =
-            EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr (ConcreteTypeHandle.Concrete 42))
+            EvalStackValue.NativeInt (
+                NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete 42))
+            )
 
         let otherMethodTable =
-            EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr (ConcreteTypeHandle.Concrete 43))
+            EvalStackValue.NativeInt (
+                NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete 43))
+            )
 
         let sameRuntimeTypeHandle =
             EvalStackValue.NativeInt (
@@ -139,7 +145,7 @@ module TestEvalStack =
             ConcreteTypeHandle.OneDimArrayZero (ConcreteTypeHandle.Concrete 42)
 
         let arrayMethodTable =
-            EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr arrayHandle)
+            EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed arrayHandle))
 
         let arrayRuntimeTypeHandle =
             EvalStackValue.NativeInt (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed arrayHandle))
@@ -149,7 +155,7 @@ module TestEvalStack =
         let pointerHandle = ConcreteTypeHandle.Pointer (ConcreteTypeHandle.Concrete 42)
 
         let pointerMethodTable =
-            EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr pointerHandle)
+            EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed pointerHandle))
 
         let pointerRuntimeTypeHandle =
             EvalStackValue.NativeInt (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed pointerHandle))
@@ -157,7 +163,7 @@ module TestEvalStack =
         let byrefHandle = ConcreteTypeHandle.Byref (ConcreteTypeHandle.Concrete 42)
 
         let byrefMethodTable =
-            EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr byrefHandle)
+            EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed byrefHandle))
 
         let byrefRuntimeTypeHandle =
             EvalStackValue.NativeInt (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed byrefHandle))
@@ -207,7 +213,10 @@ module TestEvalStack =
         // identity ops, so this case fails loudly until ceq is taught to look it up.
         let widened =
             EvalStackValue.Int64 (
-                Int64Source.WidenedNativeInt (NativeIntSource.MethodTablePtr (ConcreteTypeHandle.Concrete 42), true)
+                Int64Source.WidenedNativeInt (
+                    NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete 42)),
+                    true
+                )
             )
 
         let hashBits = EvalStackValue.Int64 (Int64Source.OpaqueHashBits 4L)

--- a/WoofWare.PawPrint.Test/TestFieldHandleRegistry.fs
+++ b/WoofWare.PawPrint.Test/TestFieldHandleRegistry.fs
@@ -706,7 +706,11 @@ public class GenericHolder<T>
         // as a NativeInt MethodTablePtr because the .NET 10 wrapper resolves the RuntimeType
         // to a MethodTable before invoking the QCall.
         let methodTableArg =
-            CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.MethodTablePtr declaringTypeHandle))
+            CliType.Numeric (
+                CliNumericType.NativeInt (
+                    NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed declaringTypeHandle)
+                )
+            )
 
         let methodArgs =
             ImmutableArray.CreateRange

--- a/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
+++ b/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
@@ -236,7 +236,8 @@ public interface IOpenInterface<T>
             {
                 Id = FieldId.named "Ptr"
                 Name = "Ptr"
-                Contents = CliType.RuntimePointer (CliRuntimePointer.MethodTablePtr intHandle)
+                Contents =
+                    CliType.RuntimePointer (CliRuntimePointer.MethodTablePtr (RuntimeTypeHandleTarget.Closed intHandle))
                 Offset = Some 0
                 Type = intPtrHandle
                 MarshallingDescriptor = None
@@ -902,7 +903,7 @@ public unsafe struct PointerWrapper
             )
             functionPointerSource ()
             NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed (handleFor bct.Int32))
-            NativeIntSource.MethodTablePtr (handleFor bct.Int32)
+            NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed (handleFor bct.Int32))
             NativeIntSource.MethodTableAuxiliaryDataPtr (RuntimeTypeHandleTarget.Closed (handleFor bct.Int32))
             NativeIntSource.MethodHandlePtr 1234L
             NativeIntSource.FieldHandlePtr 5678L
@@ -1043,7 +1044,9 @@ public unsafe struct PointerWrapper
         let state =
             state
             |> IlMachineState.pushToEvalStack'
-                (EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr intArrayHandle))
+                (EvalStackValue.NativeInt (
+                    NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed intArrayHandle)
+                ))
                 thread
 
         let state, whatWeDid =
@@ -1198,7 +1201,9 @@ public unsafe struct PointerWrapper
         let intHandle = handleFor bct.Int32
 
         project "ElementType" (ConcreteTypeHandle.OneDimArrayZero intHandle)
-        |> shouldEqual (CliType.RuntimePointer (CliRuntimePointer.MethodTablePtr intHandle))
+        |> shouldEqual (
+            CliType.RuntimePointer (CliRuntimePointer.MethodTablePtr (RuntimeTypeHandleTarget.Closed intHandle))
+        )
 
     [<Test>]
     let ``AuxiliaryData preserves MethodTable auxiliary-data pointer provenance`` () : unit =
@@ -1374,7 +1379,9 @@ public unsafe struct PointerWrapper
         let state =
             state
             |> IlMachineState.pushToEvalStack'
-                (EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr nullableIntHandle))
+                (EvalStackValue.NativeInt (
+                    NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed nullableIntHandle)
+                ))
                 thread
 
         let state, whatWeDid =
@@ -1441,7 +1448,9 @@ public unsafe struct PointerWrapper
             | other -> failwith $"Expected stepped execution, got %O{other}"
 
         IlMachineState.peekEvalStack thread state
-        |> shouldEqual (Some (EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr intHandle)))
+        |> shouldEqual (
+            Some (EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed intHandle)))
+        )
 
         state.ThreadState.[thread].MethodState.IlOpIndex
         |> shouldEqual (IlOp.NumberOfBytes op)

--- a/WoofWare.PawPrint.Test/TestPointerHashSynthesis.fs
+++ b/WoofWare.PawPrint.Test/TestPointerHashSynthesis.fs
@@ -18,7 +18,8 @@ module TestPointerHashSynthesis =
 
     [<Test>]
     let ``same source materialised twice returns same bits and bumps counter only once`` () : unit =
-        let src = NativeIntSource.MethodTablePtr (ConcreteTypeHandle.Concrete 42)
+        let src =
+            NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete 42))
 
         let bits1, counters1 = materialise src PointerHashCounters.empty
         counters1.NextCounter |> shouldEqual 1UL
@@ -31,8 +32,11 @@ module TestPointerHashSynthesis =
 
     [<Test>]
     let ``distinct sources get distinct bits`` () : unit =
-        let a = NativeIntSource.MethodTablePtr (ConcreteTypeHandle.Concrete 1)
-        let b = NativeIntSource.MethodTablePtr (ConcreteTypeHandle.Concrete 2)
+        let a =
+            NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete 1))
+
+        let b =
+            NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete 2))
 
         let bitsA, counters = materialise a PointerHashCounters.empty
         let bitsB, counters = materialise b counters
@@ -45,8 +49,8 @@ module TestPointerHashSynthesis =
     let ``order-stable assignment - same sequence on two fresh fixtures produces same bits`` () : unit =
         let sources : NativeIntSource list =
             [
-                NativeIntSource.MethodTablePtr (ConcreteTypeHandle.Concrete 7)
-                NativeIntSource.MethodTablePtr (ConcreteTypeHandle.Concrete 8)
+                NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete 7))
+                NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete 8))
                 NativeIntSource.TypeHandlePtr (
                     RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Pointer (ConcreteTypeHandle.Concrete 9))
                 )
@@ -69,8 +73,11 @@ module TestPointerHashSynthesis =
 
     [<Test>]
     let ``registration order assigns counters in order; first-registered gets smaller bits`` () : unit =
-        let a = NativeIntSource.MethodTablePtr (ConcreteTypeHandle.Concrete 11)
-        let b = NativeIntSource.MethodTablePtr (ConcreteTypeHandle.Concrete 12)
+        let a =
+            NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete 11))
+
+        let b =
+            NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete 12))
 
         // First registration in any sequence gets counter 0 → bits = ((0+1) <<< 2) | 0 = 4.
         let bitsAAlone, _ = materialise a PointerHashCounters.empty
@@ -99,7 +106,7 @@ module TestPointerHashSynthesis =
     [<Test>]
     let ``MethodTablePtr and TypeHandlePtr(Closed _) alias for Concrete shape`` () : unit =
         let handle = ConcreteTypeHandle.Concrete 99
-        let mtSrc = NativeIntSource.MethodTablePtr handle
+        let mtSrc = NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed handle)
         let thSrc = NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed handle)
 
         let bitsMt, counters = materialise mtSrc PointerHashCounters.empty
@@ -116,7 +123,9 @@ module TestPointerHashSynthesis =
         let handle = ConcreteTypeHandle.OneDimArrayZero (ConcreteTypeHandle.Concrete 5)
 
         let bitsMt, counters =
-            materialise (NativeIntSource.MethodTablePtr handle) PointerHashCounters.empty
+            materialise
+                (NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed handle))
+                PointerHashCounters.empty
 
         let bitsTh, counters =
             materialise (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed handle)) counters
@@ -129,7 +138,9 @@ module TestPointerHashSynthesis =
         let handle = ConcreteTypeHandle.Array (ConcreteTypeHandle.Concrete 3, 2)
 
         let bitsMt, counters =
-            materialise (NativeIntSource.MethodTablePtr handle) PointerHashCounters.empty
+            materialise
+                (NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed handle))
+                PointerHashCounters.empty
 
         let bitsTh, counters =
             materialise (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed handle)) counters
@@ -145,7 +156,9 @@ module TestPointerHashSynthesis =
         let pointerHandle = ConcreteTypeHandle.Pointer element
 
         let bitsMt, counters =
-            materialise (NativeIntSource.MethodTablePtr element) PointerHashCounters.empty
+            materialise
+                (NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed element))
+                PointerHashCounters.empty
 
         let bitsTh, counters =
             materialise (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed pointerHandle)) counters
@@ -156,7 +169,9 @@ module TestPointerHashSynthesis =
     [<Test>]
     let ``low bits are clear for MethodTablePtr`` () : unit =
         let bits, _ =
-            materialise (NativeIntSource.MethodTablePtr (ConcreteTypeHandle.Concrete 7)) PointerHashCounters.empty
+            materialise
+                (NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete 7)))
+                PointerHashCounters.empty
 
         bits &&& 3L |> shouldEqual 0L
 
@@ -165,7 +180,9 @@ module TestPointerHashSynthesis =
         let handle = ConcreteTypeHandle.OneDimArrayZero (ConcreteTypeHandle.Concrete 7)
 
         let bits, _ =
-            materialise (NativeIntSource.MethodTablePtr handle) PointerHashCounters.empty
+            materialise
+                (NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed handle))
+                PointerHashCounters.empty
 
         bits &&& 3L |> shouldEqual 0L
 
@@ -292,9 +309,14 @@ module TestPointerHashSynthesis =
         // AssemblyHandle, ModuleHandle, MetadataImportHandle.
         let sources : NativeIntSource list =
             [
-                for i in 0..9 -> NativeIntSource.MethodTablePtr (ConcreteTypeHandle.Concrete i)
                 for i in 0..9 ->
-                    NativeIntSource.MethodTablePtr (ConcreteTypeHandle.OneDimArrayZero (ConcreteTypeHandle.Concrete i))
+                    NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete i))
+                for i in 0..9 ->
+                    NativeIntSource.MethodTablePtr (
+                        RuntimeTypeHandleTarget.Closed (
+                            ConcreteTypeHandle.OneDimArrayZero (ConcreteTypeHandle.Concrete i)
+                        )
+                    )
                 for i in 0..9 ->
                     NativeIntSource.TypeHandlePtr (
                         RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Pointer (ConcreteTypeHandle.Concrete i))
@@ -334,7 +356,7 @@ module TestPointerHashSynthesis =
     [<Test>]
     let ``aliased encodings materialised separately do not double-bump the counter`` () : unit =
         let handle = ConcreteTypeHandle.Concrete 50
-        let mt = NativeIntSource.MethodTablePtr handle
+        let mt = NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed handle)
         let th = NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed handle)
 
         // Register the alias under one encoding, then via the other; total assigned should remain 1.
@@ -349,7 +371,7 @@ module TestPointerHashSynthesis =
     [<Test>]
     let ``MethodTableAuxiliaryDataPtr is canonicalised distinctly from MethodTablePtr`` () : unit =
         let handle = ConcreteTypeHandle.Concrete 77
-        let mt = NativeIntSource.MethodTablePtr handle
+        let mt = NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed handle)
 
         let aux =
             NativeIntSource.MethodTableAuxiliaryDataPtr (RuntimeTypeHandleTarget.Closed handle)

--- a/WoofWare.PawPrint/EvalStackValueComparisons.fs
+++ b/WoofWare.PawPrint/EvalStackValueComparisons.fs
@@ -519,16 +519,33 @@ module EvalStackValueComparisons =
             // equal when they reference the same concrete type. Only Concrete and array handles
             // have MethodTables in CoreCLR; Byref/Pointer/FunctionPointer are TypeDescs and never
             // alias a MethodTablePtr (otherwise e.g. `typeof(int*)` would compare equal to a
-            // MethodTablePtr synthesised for the same handle).
-            | NativeIntSource.MethodTablePtr h1, NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed h2)
-            | NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed h2), NativeIntSource.MethodTablePtr h1 ->
-                match h2 with
-                | ConcreteTypeHandle.Concrete _
-                | ConcreteTypeHandle.OneDimArrayZero _
-                | ConcreteTypeHandle.Array _ -> h1 = h2
-                | ConcreteTypeHandle.Byref _
-                | ConcreteTypeHandle.Pointer _
-                | ConcreteTypeHandle.FunctionPointer _ -> false
+            // MethodTablePtr synthesised for the same handle). The OpenGenericTypeDefinition
+            // case aliases the typedef's canonical MethodTable address with the same TypeHandle.
+            | NativeIntSource.MethodTablePtr t1, NativeIntSource.TypeHandlePtr t2
+            | NativeIntSource.TypeHandlePtr t2, NativeIntSource.MethodTablePtr t1 ->
+                match t1, t2 with
+                | RuntimeTypeHandleTarget.Closed h1, RuntimeTypeHandleTarget.Closed h2 ->
+                    match h2 with
+                    | ConcreteTypeHandle.Concrete _
+                    | ConcreteTypeHandle.OneDimArrayZero _
+                    | ConcreteTypeHandle.Array _ -> h1 = h2
+                    | ConcreteTypeHandle.Byref _
+                    | ConcreteTypeHandle.Pointer _
+                    | ConcreteTypeHandle.FunctionPointer _ -> false
+                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition i1,
+                  RuntimeTypeHandleTarget.OpenGenericTypeDefinition i2 -> i1 = i2
+                | RuntimeTypeHandleTarget.Closed _, RuntimeTypeHandleTarget.OpenGenericTypeDefinition _
+                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _, RuntimeTypeHandleTarget.Closed _ ->
+                    // The closed instantiation has its own MT distinct from the typedef's canonical MT.
+                    false
+                | RuntimeTypeHandleTarget.GenericParameter _, _
+                | RuntimeTypeHandleTarget.MethodGenericParameter _, _
+                | _, RuntimeTypeHandleTarget.GenericParameter _
+                | _, RuntimeTypeHandleTarget.MethodGenericParameter _ ->
+                    // A bare generic parameter has no MethodTable; this combination should
+                    // not arise from any legitimate construction.
+                    failwith
+                        $"CEQ: MethodTablePtr/TypeHandlePtr with generic-parameter target has no MethodTable identity: %O{t1} vs %O{t2}"
             | NativeIntSource.ManagedPointer f1, NativeIntSource.ManagedPointer f2 ->
                 // Match the `EvalStackValue.ManagedPointer` vs `ManagedPointer`
                 // arm below: trailing `ReinterpretAs` projections are address-

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -267,7 +267,7 @@ module Intrinsics =
 
             state
             |> IlMachineState.pushToEvalStack'
-                (EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr concreteType))
+                (EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed concreteType)))
                 currentThread
             |> IlMachineState.advanceProgramCounter currentThread
             |> Some

--- a/WoofWare.PawPrint/MethodTableProjection.fs
+++ b/WoofWare.PawPrint/MethodTableProjection.fs
@@ -878,7 +878,12 @@ module internal MethodTableProjection =
                 | RuntimeTypeHandleTarget.Closed handle ->
                     match tryArrayElement handle with
                     | Some (element, _) ->
-                        Some (CliType.RuntimePointer (CliRuntimePointer.MethodTablePtr element), state)
+                        Some (
+                            CliType.RuntimePointer (
+                                CliRuntimePointer.MethodTablePtr (RuntimeTypeHandleTarget.Closed element)
+                            ),
+                            state
+                        )
                     | None -> failwith $"TODO: MethodTable::ElementType projection for non-array type %O{handle}"
                 | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
                     failwith $"TODO: MethodTable::ElementType projection for %O{methodTableFor}"
@@ -905,7 +910,10 @@ module internal MethodTableProjection =
 
                     let result =
                         match parent with
-                        | Some parentHandle -> CliType.RuntimePointer (CliRuntimePointer.MethodTablePtr parentHandle)
+                        | Some parentHandle ->
+                            CliType.RuntimePointer (
+                                CliRuntimePointer.MethodTablePtr (RuntimeTypeHandleTarget.Closed parentHandle)
+                            )
                         | None ->
                             // CoreCLR sets ParentMethodTable to null at System.Object; the cast-walk
                             // loops in CastHelpers (e.g. IsInstanceOfClass, ChkCastClassSpecial) check

--- a/WoofWare.PawPrint/Native/NativeCall.fs
+++ b/WoofWare.PawPrint/Native/NativeCall.fs
@@ -443,9 +443,15 @@ module NativeCall =
     let methodTableOfEvalStackValue (operation : string) (arg : EvalStackValue) : ConcreteTypeHandle =
         match arg with
         | EvalStackValue.NativeInt (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed typeHandle))
-        | EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr typeHandle) -> typeHandle
-        | EvalStackValue.NativeInt (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity)) ->
+        | EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed typeHandle)) ->
+            typeHandle
+        | EvalStackValue.NativeInt (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity))
+        | EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity)) ->
             failwith $"%s{operation}: expected closed MethodTable pointer argument, got open generic %O{identity}"
+        | EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.GenericParameter _ as target))
+        | EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.MethodGenericParameter _ as target)) ->
+            failwith
+                $"%s{operation}: expected closed MethodTable pointer argument, got generic parameter %O{target} (TypeDescs have no MethodTable)"
         | other -> failwith $"%s{operation}: expected MethodTable pointer argument, got %O{other}"
 
     /// Decode a `void*`/`TypeHandle` argument to the underlying RuntimeTypeHandleTarget. Unlike
@@ -454,9 +460,8 @@ module NativeCall =
     /// `TypeHandle.GetCorElementType` QCall).
     let runtimeTypeHandleTargetOfEvalStackValue (operation : string) (arg : EvalStackValue) : RuntimeTypeHandleTarget =
         match arg with
-        | EvalStackValue.NativeInt (NativeIntSource.TypeHandlePtr target) -> target
-        | EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr typeHandle) ->
-            RuntimeTypeHandleTarget.Closed typeHandle
+        | EvalStackValue.NativeInt (NativeIntSource.TypeHandlePtr target)
+        | EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr target) -> target
         | other -> failwith $"%s{operation}: expected TypeHandle/MethodTable pointer argument, got %O{other}"
 
     let runtimeTypeHandleTargetOfRuntimeTypeRef

--- a/WoofWare.PawPrint/Native/NativeRuntimeFieldHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeFieldHandle.fs
@@ -157,11 +157,8 @@ module NativeRuntimeFieldHandle =
             // form is the open instantiation. With PawPrint's per-canonical
             // FieldHandle model, the stored DeclaringType is `Closed` for non-generic
             // declaring types and `OpenGenericTypeDefinition` for generic ones.
-            // `MethodTablePtr` currently only carries a closed `ConcreteTypeHandle`;
-            // widening it to a `RuntimeTypeHandleTarget` (so the open case can be
-            // handed back) is a larger refactor, and the open case isn't yet
-            // exercised by any consumer. Fail loudly there rather than silently
-            // synthesising a closed instantiation.
+            // `NativeIntSource.MethodTablePtr` carries the full `RuntimeTypeHandleTarget`,
+            // so the open-generic case surfaces directly.
             let operation = "RuntimeFieldHandle.GetApproxDeclaringMethodTable"
 
             let fieldHandle =
@@ -170,12 +167,7 @@ module NativeRuntimeFieldHandle =
                 fieldHandleOfRuntimeFieldHandleInternal operation state instruction.Arguments.[0]
                 |> Option.defaultWith (fun () -> failwith $"%s{operation}: null field handle")
 
-            let declaringTypeHandle =
-                match fieldHandle.GetDeclaringTypeHandle () with
-                | RuntimeTypeHandleTarget.Closed handle -> handle
-                | other ->
-                    failwith
-                        $"TODO: %s{operation} does not yet support a non-Closed declaring type %O{other}; widening NativeIntSource.MethodTablePtr to RuntimeTypeHandleTarget is required to surface the open-generic MethodTable"
+            let declaringTypeHandle = fieldHandle.GetDeclaringTypeHandle ()
 
             let state =
                 IlMachineState.pushToEvalStack'

--- a/WoofWare.PawPrint/NativeIntSource.fs
+++ b/WoofWare.PawPrint/NativeIntSource.fs
@@ -93,7 +93,15 @@ type NativeIntSource =
     | ManagedPointer of ManagedPointerSource
     | FunctionPointer of MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>
     | TypeHandlePtr of RuntimeTypeHandleTarget
-    | MethodTablePtr of ConcreteTypeHandle
+    /// `MethodTable*` for a runtime type. The payload widens to
+    /// `RuntimeTypeHandleTarget` so the open-generic typedef's canonical
+    /// MethodTable (`OpenGenericTypeDefinition`) can be expressed alongside
+    /// the closed instantiation MethodTable (`Closed`). TypeDesc cases
+    /// (`GenericParameter` / `MethodGenericParameter`) never own a real
+    /// MethodTable and must be rejected at producer sites; consumers that
+    /// require a closed `ConcreteTypeHandle` (e.g. fixed-instantiation
+    /// reflection paths) match `Closed` explicitly and fail loudly otherwise.
+    | MethodTablePtr of RuntimeTypeHandleTarget
     | MethodTableAuxiliaryDataPtr of RuntimeTypeHandleTarget
     /// Synthetic `MethodTable*** PerInstInfo` pointer for a generic instantiation.
     /// First `ldind` step yields `PerInstDictPtr` of the same handle (the
@@ -347,7 +355,9 @@ type CliRuntimePointer =
     | TypeHandlePtr of RuntimeTypeHandleTarget
     | FieldRegistryHandle of int64
     | MethodRegistryHandle of int64
-    | MethodTablePtr of ConcreteTypeHandle
+    /// See `NativeIntSource.MethodTablePtr` for the contract; the
+    /// eval-stack-flattened counterpart is `NativeIntSource.MethodTablePtr`.
+    | MethodTablePtr of RuntimeTypeHandleTarget
     | MethodTableAuxiliaryDataPtr of RuntimeTypeHandleTarget
     /// See `NativeIntSource.PerInstInfoPtr`. The eval-stack-flattened
     /// counterpart is `NativeIntSource.PerInstInfoPtr`.

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -789,7 +789,9 @@ module NullaryIlOp =
                 let state =
                     state
                     |> IlMachineState.pushToEvalStack
-                        (CliType.RuntimePointer (CliRuntimePointer.MethodTablePtr firstArg))
+                        (CliType.RuntimePointer (
+                            CliRuntimePointer.MethodTablePtr (RuntimeTypeHandleTarget.Closed firstArg)
+                        ))
                         currentThread
                     |> IlMachineState.advanceProgramCounter currentThread
 

--- a/WoofWare.PawPrint/PointerHashSynthesis.fs
+++ b/WoofWare.PawPrint/PointerHashSynthesis.fs
@@ -66,10 +66,19 @@ module PointerHashSynthesis =
     /// `TypeHandlePtr (Closed _)` collapses here, so the two encodings
     /// produce identical synthesised bits — that contract is required by
     /// the `ceq`/`cgtUn`/`cltUn` paths in `EvalStackValueComparisons` and
-    /// by the cast-cache hash pipeline.
+    /// by the cast-cache hash pipeline. The same aliasing rule applies for
+    /// `OpenGenericTypeDefinition`: the canonical MethodTable for the
+    /// typedef is the same address as the typedef's `TypeHandle`.
     let private canonicalKey (src : NativeIntSource) : CanonicalPointerKey =
         match src with
-        | NativeIntSource.MethodTablePtr h -> CanonicalPointerKey.MethodTable h
+        | NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed handle) ->
+            CanonicalPointerKey.MethodTable handle
+        | NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ as target) ->
+            CanonicalPointerKey.TypeHandle target
+        | NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.GenericParameter _ as target)
+        | NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.MethodGenericParameter _ as target) ->
+            failwith
+                $"PointerHashSynthesis.canonicalKey: MethodTablePtr(%O{target}) has no MethodTable identity (generic parameters are TypeDescs in CoreCLR)"
         | NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed handle as target) ->
             match handle with
             | ConcreteTypeHandle.Concrete _

--- a/WoofWare.PawPrint/UnaryMetadataFieldOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataFieldOps.fs
@@ -330,7 +330,14 @@ module internal UnaryMetadataFieldOps =
                     failwith
                         $"TODO: ldfld {field.DeclaringType.Namespace}.{field.DeclaringType.Name}::{field.Name} through RuntimeTypeHandleTarget %O{methodTableFor}"
             | EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr methodTableFor) ->
-                match MethodTableProjection.tryProjectField loggerFactory baseClassTypes field methodTableFor state with
+                match
+                    MethodTableProjection.tryProjectFieldForRuntimeTypeHandleTarget
+                        loggerFactory
+                        baseClassTypes
+                        field
+                        methodTableFor
+                        state
+                with
                 | Some (value, state) -> IlMachineState.pushToEvalStack value thread state
                 | None ->
                     failwith


### PR DESCRIPTION
## Summary

- Widen `NativeIntSource.MethodTablePtr` and `CliRuntimePointer.MethodTablePtr` from `ConcreteTypeHandle` to `RuntimeTypeHandleTarget`, mirroring `MethodTableAuxiliaryDataPtr`.
- TypeDesc cases (`GenericParameter` / `MethodGenericParameter`) never own a real MethodTable and are rejected at producer sites; consumers that require a closed `ConcreteTypeHandle` (e.g. `methodTableOfEvalStackValue`) match `Closed` explicitly.
- Cross-encoding alias (`MethodTablePtr` ↔ `TypeHandlePtr`) and `PointerHashSynthesis` canonical-key collapse extend naturally to `OpenGenericTypeDefinition` (the typedef's canonical MT is the same address as its `TypeHandle`).
- Removes the failwith TODO in `RuntimeFieldHandle::GetApproxDeclaringMethodTable` that this widening was scoped to unblock: the open-generic MT now surfaces directly. Downstream consumers (`MethodTable::ParentMethodTable` projection for `OpenGenericTypeDefinition`) remain TODO and will be implemented in the follow-up PR.

## Test plan

- [x] Full suite: `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --no-build --verbosity quiet` — 1196/1196 passing
- [x] `nix develop -c dotnet fantomas .`
- [x] `nix develop -c dotnet build WoofWare.PawPrint.slnx` — 0 warnings, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)