### PR TITLE
Project ParentMethodTable for OpenGenericTypeDefinition targets

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -19,8 +19,8 @@ module TestPureCases =
         [
             "AdvancedStructLayout.cs" // past MarshalNative_SizeOfHelper for ByValTStr and SystemNative_Malloc / SystemNative_Free / Marshal.AllocHGlobal / FreeHGlobal; now blocked downstream at the unimplemented MarshalNative_TryGetStructMarshalStub QCall (CoreLib's Marshal.StructureToPtr path)
             "Threads.cs" // past ThreadNative_InformThreadNameChange (Thread.Name setter); now blocked on unimplemented PAL call libSystem.Native!SystemNative_GetLowResolutionTimestamp (.Sys::GetLowResolutionTimestamp, used by the Task/ThreadPool scheduler)
-            "GetFieldOnOpenGenericTypeDefinition.cs" // FieldHandle declaring-type canonicalisation is fixed; now blocked on the BCL's RuntimeType.GetFieldCandidates walk reaching MethodTable::ParentMethodTable for the OpenGenericTypeDefinition target — the projection only handles Closed today.
-            "LdtokenField.cs" // Test 5 hits typeof(GenericClass<>).GetField("GenericField"), which goes through the same MethodTable::ParentMethodTable projection on an OpenGenericTypeDefinition target as GetFieldOnOpenGenericTypeDefinition.cs.
+            "GetFieldOnOpenGenericTypeDefinition.cs" // FieldHandle declaring-type canonicalisation and MethodTable::ParentMethodTable for OpenGenericTypeDefinition targets are both fixed; now blocked downstream on the RuntimeTypeHandle_GetInterfaces QCall, whose interface walk is built on closed ConcreteTypeHandle and rejects OpenGenericTypeDefinition targets.
+            "LdtokenField.cs" // Test 5 hits typeof(GenericClass<>).GetField("GenericField"), which goes through the same RuntimeTypeHandle_GetInterfaces QCall on an OpenGenericTypeDefinition target as GetFieldOnOpenGenericTypeDefinition.cs.
         ]
         |> Set.ofList
 

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -373,6 +373,108 @@ module IlMachineRuntimeMetadata =
 
                     state, Some baseHandle
 
+    /// Detect whether a TypeDefn structurally references any
+    /// `GenericTypeParameter`. Used to distinguish a closed base type (e.g.
+    /// `class G<T> : object`) from a shared base type (e.g.
+    /// `class G<T> : Base<T>`) when walking from an open generic typedef to
+    /// its parent: only the former can be concretized with no generic args
+    /// and produce a `Closed` parent handle.
+    let rec private typeDefnReferencesGenericTypeParameter (ty : TypeDefn) : bool =
+        match ty with
+        | TypeDefn.GenericTypeParameter _ -> true
+        | TypeDefn.PrimitiveType _
+        | TypeDefn.Void
+        | TypeDefn.FromDefinition _
+        | TypeDefn.FromReference _
+        | TypeDefn.GenericMethodParameter _ -> false
+        | TypeDefn.Array (elt, _)
+        | TypeDefn.Pinned elt
+        | TypeDefn.Pointer elt
+        | TypeDefn.Byref elt
+        | TypeDefn.OneDimensionalArrayLowerBoundZero elt -> typeDefnReferencesGenericTypeParameter elt
+        | TypeDefn.Modified (_, afterMod, _) -> typeDefnReferencesGenericTypeParameter afterMod
+        | TypeDefn.GenericInstantiation (generic, args) ->
+            typeDefnReferencesGenericTypeParameter generic
+            || args |> Seq.exists typeDefnReferencesGenericTypeParameter
+        | TypeDefn.FunctionPointer signature ->
+            let returnReferences =
+                match signature.ReturnType with
+                | MethodReturnType.Void -> false
+                | MethodReturnType.Returns ret -> typeDefnReferencesGenericTypeParameter ret
+
+            returnReferences
+            || signature.ParameterTypes |> List.exists typeDefnReferencesGenericTypeParameter
+
+    /// Given a `RuntimeTypeHandleTarget`, resolve and return its parent's
+    /// `RuntimeTypeHandleTarget`. Returns `None` only at `System.Object`.
+    ///
+    /// `Closed` defers to `resolveBaseConcreteType` and rewraps as `Closed`.
+    ///
+    /// `OpenGenericTypeDefinition` represents CoreCLR's canonical MethodTable
+    /// for a generic typedef (i.e. `G<__Canon>`). Its parent MT is the parent
+    /// type after substituting `__Canon` for each of `G`'s parameters. The
+    /// case where the base type doesn't mention `G`'s parameters at all (e.g.
+    /// `class G<T> : object`, `class G<T> : Base<int>`) is fully closed and
+    /// concretizes with no generics. The shared-base case (e.g.
+    /// `class G<T> : Base<T>` → parent is `Base<__Canon>` →
+    /// `OpenGenericTypeDefinition Base`) is not yet implemented and surfaces
+    /// loudly; the immediate callers (`MethodTable::ParentMethodTable` lookups
+    /// driven by reflection on open typedefs) only exercise the closed-parent
+    /// case today.
+    ///
+    /// `GenericParameter` and `MethodGenericParameter` are TypeDescs in
+    /// CoreCLR and carry no MethodTable; asking for their parent is a bug.
+    let resolveBaseRuntimeTypeHandleTarget
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (target : RuntimeTypeHandleTarget)
+        : IlMachineState * RuntimeTypeHandleTarget option
+        =
+        match target with
+        | RuntimeTypeHandleTarget.Closed handle ->
+            let state, parent =
+                resolveBaseConcreteType loggerFactory baseClassTypes state handle
+
+            state, parent |> Option.map RuntimeTypeHandleTarget.Closed
+        | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
+            let assy =
+                match state.LoadedAssembly identity.Assembly with
+                | Some assembly -> assembly
+                | None ->
+                    failwith
+                        $"resolveBaseRuntimeTypeHandleTarget: assembly %s{identity.AssemblyFullName} not loaded for open generic typedef %O{identity.TypeDefinition.Get}"
+
+            let typeInfo = assy.TypeDefs.[identity.TypeDefinition.Get]
+
+            match typeInfo.BaseType with
+            | None -> state, None
+            | Some baseTypeInfo ->
+                let state, baseAssy, baseTypeDefn =
+                    resolveBaseTypeInfo loggerFactory baseClassTypes state assy baseTypeInfo
+
+                if typeDefnReferencesGenericTypeParameter baseTypeDefn then
+                    failwith
+                        $"TODO: resolveBaseRuntimeTypeHandleTarget for open generic typedef %O{identity.TypeDefinition.Get} in %s{identity.AssemblyFullName}: base type %O{baseTypeDefn} references the typedef's own generic parameters (shared/canonical parent); only closed parents are supported today"
+                else
+                    let state, baseHandle =
+                        IlMachineTypeResolution.concretizeType
+                            loggerFactory
+                            baseClassTypes
+                            state
+                            baseAssy.Name
+                            ImmutableArray.Empty
+                            ImmutableArray.Empty
+                            baseTypeDefn
+
+                    state, Some (RuntimeTypeHandleTarget.Closed baseHandle)
+        | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
+            failwith
+                $"resolveBaseRuntimeTypeHandleTarget: refused for generic parameter #%i{position} of %O{declaringType.TypeDefinition.Get}: TypeDescs have no MethodTable in CoreCLR"
+        | RuntimeTypeHandleTarget.MethodGenericParameter (declaringType, declaringMethod, position) ->
+            failwith
+                $"resolveBaseRuntimeTypeHandleTarget: refused for method generic parameter #%i{position} of method %O{declaringMethod.Get} on %O{declaringType.TypeDefinition.Get}: TypeDescs have no MethodTable in CoreCLR"
+
     /// Collect ALL instance fields from the entire type hierarchy for a given ConcreteTypeHandle,
     /// walking from base to derived (base class fields appear first in the returned list).
     let rec collectAllInstanceFields

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -373,37 +373,38 @@ module IlMachineRuntimeMetadata =
 
                     state, Some baseHandle
 
-    /// Detect whether a TypeDefn structurally references any
-    /// `GenericTypeParameter`. Used to distinguish a closed base type (e.g.
-    /// `class G<T> : object`) from a shared base type (e.g.
-    /// `class G<T> : Base<T>`) when walking from an open generic typedef to
-    /// its parent: only the former can be concretized with no generic args
-    /// and produce a `Closed` parent handle.
-    let rec private typeDefnReferencesGenericTypeParameter (ty : TypeDefn) : bool =
+    /// True iff `ty` references any `GenericTypeParameter` / `GenericMethodParameter`. The
+    /// open-generic source cast walk uses this to decide whether a base/interface edge can be
+    /// materialised to a closed `ConcreteTypeHandle` (when false) or only stripped to its
+    /// definition identity for continued identity-walking (when true). A method generic
+    /// parameter has no legitimate appearance in a type definition's base or interfaces,
+    /// but treating it as unbound is the safe default.
+    let rec private containsAnyGenericParameter (ty : TypeDefn) : bool =
         match ty with
-        | TypeDefn.GenericTypeParameter _ -> true
-        | TypeDefn.PrimitiveType _
-        | TypeDefn.Void
-        | TypeDefn.FromDefinition _
-        | TypeDefn.FromReference _
-        | TypeDefn.GenericMethodParameter _ -> false
-        | TypeDefn.Array (elt, _)
-        | TypeDefn.Pinned elt
-        | TypeDefn.Pointer elt
-        | TypeDefn.Byref elt
-        | TypeDefn.OneDimensionalArrayLowerBoundZero elt -> typeDefnReferencesGenericTypeParameter elt
-        | TypeDefn.Modified (_, afterMod, _) -> typeDefnReferencesGenericTypeParameter afterMod
+        | TypeDefn.GenericTypeParameter _
+        | TypeDefn.GenericMethodParameter _ -> true
+        | TypeDefn.Array (element, _)
+        | TypeDefn.Pinned element
+        | TypeDefn.Pointer element
+        | TypeDefn.Byref element
+        | TypeDefn.OneDimensionalArrayLowerBoundZero element -> containsAnyGenericParameter element
+        | TypeDefn.Modified (original, modifier, _) ->
+            containsAnyGenericParameter original || containsAnyGenericParameter modifier
         | TypeDefn.GenericInstantiation (generic, args) ->
-            typeDefnReferencesGenericTypeParameter generic
-            || args |> Seq.exists typeDefnReferencesGenericTypeParameter
+            containsAnyGenericParameter generic
+            || (args |> Seq.exists containsAnyGenericParameter)
         | TypeDefn.FunctionPointer signature ->
-            let returnReferences =
+            let returnContains =
                 match signature.ReturnType with
                 | MethodReturnType.Void -> false
-                | MethodReturnType.Returns ret -> typeDefnReferencesGenericTypeParameter ret
+                | MethodReturnType.Returns ret -> containsAnyGenericParameter ret
 
-            returnReferences
-            || signature.ParameterTypes |> List.exists typeDefnReferencesGenericTypeParameter
+            returnContains
+            || (signature.ParameterTypes |> List.exists containsAnyGenericParameter)
+        | TypeDefn.PrimitiveType _
+        | TypeDefn.FromReference _
+        | TypeDefn.FromDefinition _
+        | TypeDefn.Void -> false
 
     /// Given a `RuntimeTypeHandleTarget`, resolve and return its parent's
     /// `RuntimeTypeHandleTarget`. Returns `None` only at `System.Object`.
@@ -453,9 +454,9 @@ module IlMachineRuntimeMetadata =
                 let state, baseAssy, baseTypeDefn =
                     resolveBaseTypeInfo loggerFactory baseClassTypes state assy baseTypeInfo
 
-                if typeDefnReferencesGenericTypeParameter baseTypeDefn then
+                if containsAnyGenericParameter baseTypeDefn then
                     failwith
-                        $"TODO: resolveBaseRuntimeTypeHandleTarget for open generic typedef %O{identity.TypeDefinition.Get} in %s{identity.AssemblyFullName}: base type %O{baseTypeDefn} references the typedef's own generic parameters (shared/canonical parent); only closed parents are supported today"
+                        $"TODO: resolveBaseRuntimeTypeHandleTarget for open generic typedef %O{identity.TypeDefinition.Get} in %s{identity.AssemblyFullName}: base type %O{baseTypeDefn} references generic parameters (shared/canonical parent); only closed parents are supported today"
                 else
                     let state, baseHandle =
                         IlMachineTypeResolution.concretizeType
@@ -1698,39 +1699,6 @@ module IlMachineRuntimeMetadata =
         | ConcreteTypeHandle.Byref _
         | ConcreteTypeHandle.Pointer _
         | ConcreteTypeHandle.FunctionPointer _ -> walk state objType
-
-    /// True iff `ty` references any `GenericTypeParameter` / `GenericMethodParameter`. The
-    /// open-generic source cast walk uses this to decide whether a base/interface edge can be
-    /// materialised to a closed `ConcreteTypeHandle` (when false) or only stripped to its
-    /// definition identity for continued identity-walking (when true). A method generic
-    /// parameter has no legitimate appearance in a type definition's base or interfaces,
-    /// but treating it as unbound is the safe default.
-    let rec private containsAnyGenericParameter (ty : TypeDefn) : bool =
-        match ty with
-        | TypeDefn.GenericTypeParameter _
-        | TypeDefn.GenericMethodParameter _ -> true
-        | TypeDefn.Array (element, _)
-        | TypeDefn.Pinned element
-        | TypeDefn.Pointer element
-        | TypeDefn.Byref element
-        | TypeDefn.OneDimensionalArrayLowerBoundZero element -> containsAnyGenericParameter element
-        | TypeDefn.Modified (original, modifier, _) ->
-            containsAnyGenericParameter original || containsAnyGenericParameter modifier
-        | TypeDefn.GenericInstantiation (generic, args) ->
-            containsAnyGenericParameter generic
-            || (args |> Seq.exists containsAnyGenericParameter)
-        | TypeDefn.FunctionPointer signature ->
-            let returnContains =
-                match signature.ReturnType with
-                | MethodReturnType.Void -> false
-                | MethodReturnType.Returns ret -> containsAnyGenericParameter ret
-
-            returnContains
-            || (signature.ParameterTypes |> List.exists containsAnyGenericParameter)
-        | TypeDefn.PrimitiveType _
-        | TypeDefn.FromReference _
-        | TypeDefn.FromDefinition _
-        | TypeDefn.Void -> false
 
     /// Apply a `TypeDefn` substitution to every `GenericTypeParameter` reference inside `ty`.
     /// This is purely syntactic; assembly identifiers and primitives pass through unchanged.

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -178,6 +178,9 @@ module IlMachineState =
 
     let resolveBaseConcreteType = IlMachineRuntimeMetadata.resolveBaseConcreteType
 
+    let resolveBaseRuntimeTypeHandleTarget =
+        IlMachineRuntimeMetadata.resolveBaseRuntimeTypeHandleTarget
+
     let collectAllInstanceFields = IlMachineRuntimeMetadata.collectAllInstanceFields
 
     let allocateManagedString = IlMachineRuntimeMetadata.allocateManagedString

--- a/WoofWare.PawPrint/MethodTableProjection.fs
+++ b/WoofWare.PawPrint/MethodTableProjection.fs
@@ -904,16 +904,18 @@ module internal MethodTableProjection =
                         $"MethodTable::AuxiliaryData projection refused for TypeDesc target %O{methodTableFor}: generic parameters have no MethodTable in CoreCLR"
             | "ParentMethodTable" ->
                 match methodTableFor with
-                | RuntimeTypeHandleTarget.Closed handle ->
+                | RuntimeTypeHandleTarget.Closed _
+                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
                     let state, parent =
-                        IlMachineState.resolveBaseConcreteType loggerFactory baseClassTypes state handle
+                        IlMachineState.resolveBaseRuntimeTypeHandleTarget
+                            loggerFactory
+                            baseClassTypes
+                            state
+                            methodTableFor
 
                     let result =
                         match parent with
-                        | Some parentHandle ->
-                            CliType.RuntimePointer (
-                                CliRuntimePointer.MethodTablePtr (RuntimeTypeHandleTarget.Closed parentHandle)
-                            )
+                        | Some parentTarget -> CliType.RuntimePointer (CliRuntimePointer.MethodTablePtr parentTarget)
                         | None ->
                             // CoreCLR sets ParentMethodTable to null at System.Object; the cast-walk
                             // loops in CastHelpers (e.g. IsInstanceOfClass, ChkCastClassSpecial) check
@@ -921,8 +923,6 @@ module internal MethodTableProjection =
                             CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim 0L))
 
                     Some (result, state)
-                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
-                    failwith $"TODO: MethodTable::ParentMethodTable projection for %O{methodTableFor}"
                 | RuntimeTypeHandleTarget.GenericParameter _
                 | RuntimeTypeHandleTarget.MethodGenericParameter _ ->
                     failwith


### PR DESCRIPTION
## Summary
- `MethodTable::ParentMethodTable` now resolves for `OpenGenericTypeDefinition` targets in addition to `Closed` ones. A new `resolveBaseRuntimeTypeHandleTarget` walks the canonical typedef's `BaseType`; a base that doesn't reference the typedef's own generic parameters (e.g. `class G<T> : object`, `class G<T> : Base<int>`) produces a `Closed` parent. The shared-base case (e.g. `class G<T> : Base<T>` → `Base<__Canon>`) surfaces a loud TODO.
- The `Closed` arm now flows through the same helper, so the projection is uniform: both shapes return a `RuntimeTypeHandleTarget`-shaped parent pointer (or `Verbatim 0` at `System.Object`).
- The two reflection-on-open-generic-typedef tests (`GetFieldOnOpenGenericTypeDefinition.cs`, `LdtokenField.cs`) progress past `ParentMethodTable` but now stop at the next OpenGenericTypeDefinition-unaware site, `RuntimeTypeHandle_GetInterfaces`. They stay in `unimplemented` with comments updated to point to the new blocker.

## Test plan
- [x] `nix develop -c dotnet test` — 1196 / 1196 pass
- [x] `nix develop -c dotnet fantomas .` clean
- [x] Verified both target tests now fault on `RuntimeTypeHandle_GetInterfaces` (not `ParentMethodTable`)