### PR TITLE
Implement MarshalNative_TryGetStructMarshalStub for strictly-numeric structs

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -17,7 +17,7 @@ module TestPureCases =
 
     let unimplemented =
         [
-            "AdvancedStructLayout.cs" // past MarshalNative_SizeOfHelper for ByValTStr and SystemNative_Malloc / SystemNative_Free / Marshal.AllocHGlobal / FreeHGlobal; now blocked downstream at the unimplemented MarshalNative_TryGetStructMarshalStub QCall (CoreLib's Marshal.StructureToPtr path)
+            "AdvancedStructLayout.cs" // past MarshalNative_TryGetStructMarshalStub for the strictly-numeric blittable struct (Marshal.StructureToPtr now hits the SpanHelpers.Memmove fast path); now blocked downstream in Unsafe.ByteOffset, which doesn't yet support a `Pointer(...)` ManagedPointerSource (one of the byrefs comes from `&*(byte*)ptr` over an AllocHGlobal IntPtr)
             "LdtokenField.cs" // past Buffer's reflection-cache copy (cell-aware path); now blocked on the next reflection-cache step at unimplemented InternalCall RuntimeFieldHandle::GetApproxDeclaringMethodTable
             "InterfaceDispatch.cs" // expected: 0; was: 1024
             "Threads.cs" // past ThreadNative_InformThreadNameChange (Thread.Name setter); now blocked on unimplemented PAL call libSystem.Native!SystemNative_GetLowResolutionTimestamp (.Sys::GetLowResolutionTimestamp, used by the Task/ThreadPool scheduler)

--- a/WoofWare.PawPrint/Native/NativeMarshal.fs
+++ b/WoofWare.PawPrint/Native/NativeMarshal.fs
@@ -132,4 +132,91 @@ module NativeMarshal =
                     IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 size.Size)) ctx.Thread state
 
                 NativeHandlerResult.completed state |> Some
+        | "MarshalNative_TryGetStructMarshalStub",
+          "System.Private.CoreLib",
+          "System.Runtime.InteropServices",
+          "Marshal",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr
+            ConcretePointer (ConcreteFunctionPointer _)
+            ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.UIntPtr) ],
+          // The CoreLib declaration is `[return: MarshalAs(UnmanagedType.Bool)] bool`, which
+          // the QCall PInvoke stub presents to us as an Int32 return (Win32 BOOL is 4 bytes).
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
+            let operation = "MarshalNative_TryGetStructMarshalStub"
+
+            let methodTableArg = instruction.Arguments.[0] |> EvalStackValue.ofCliType
+            let typeHandle = NativeCall.methodTableOfEvalStackValue operation methodTableArg
+
+            let stubOutPtr =
+                NativeCall.managedPointerOfPointerArgument operation "structMarshalStub" instruction.Arguments.[1]
+
+            let sizeOutPtr =
+                NativeCall.managedPointerOfPointerArgument operation "size" instruction.Arguments.[2]
+
+            let zero, state =
+                IlMachineState.cliTypeZeroOfHandle state ctx.BaseClassTypes typeHandle
+
+            // CoreCLR's `MarshalNative_TryGetStructMarshalStub` (marshalnative.cpp:99-145)
+            // has three branches: blittable (memmove fast path, *stub = NULL, *size = native
+            // size, return TRUE), has-layout-non-blittable (synthesised IL stub, return TRUE),
+            // and no-layout (return FALSE so managed Marshal throws ArgumentException).
+            // This implementation handles only the first arm, and only for the strict subset
+            // we are confident matches CoreCLR exactly: structs whose fields are recursively
+            // plain numeric (Int8..Float64). Anything else — IntPtr/UIntPtr fields, enums,
+            // [MarshalAs] descriptors, Bool/Char/ObjectRef fields, AutoLayout types, classes,
+            // etc. — surfaces a host TODO. Each future widening (FALSE for no-layout types,
+            // stub-synthesis exceptions for has-layout-non-blittable types, IntPtr fields
+            // with verified provenance, [MarshalAs] descriptor handling, ...) wants its own
+            // motivating PawPrint test before being added to the classifier.
+            let rec isStrictlyNumericBlittable (t : CliType) : bool =
+                match t with
+                // NativeInt (IntPtr/UIntPtr) values carry provenance in PawPrint that the byte
+                // model rejects; CoreCLR happily memmoves the integer-width bits regardless.
+                // Excluded from the allowlist until we have explicit byte-copyability gating.
+                | CliType.Numeric (CliNumericType.NativeInt _) -> false
+                | CliType.Numeric _ -> true
+                | CliType.Bool _
+                | CliType.Char _
+                | CliType.ObjectRef _
+                | CliType.RuntimePointer _ -> false
+                | CliType.ValueType vt ->
+                    match vt._Storage with
+                    // RawBytes-backed value types are not the typical struct-with-fields
+                    // shape; conservatively reject so we don't quietly accept primitive
+                    // wrappers whose CoreCLR marshal size diverges from the byte image.
+                    | CliValueTypeStorage.RawBytes _ -> false
+                    | CliValueTypeStorage.Fields storage ->
+                        storage.Fields
+                        |> List.forall (fun field -> isStrictlyNumericBlittable field.Contents)
+
+            if isStrictlyNumericBlittable zero then
+                // The eventual `*structMarshalStub` we write here is null: the blittable path
+                // tells CoreLib to take the `SpanHelpers.Memmove` fast path
+                // (marshalnative.cpp:99-145).
+                let zeroNativeInt =
+                    CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim 0L))
+
+                // For the strictly-numeric subset, CoreCLR's marshal size and PawPrint's
+                // managed CLI size coincide: each field's managed width equals its native
+                // width, sequential layout uses natural alignment, and no `[MarshalAs]`
+                // resizing is in play.
+                let size = CliType.SizeOf zero
+
+                let state =
+                    IlMachineState.writeManagedByrefWithBase ctx.BaseClassTypes state stubOutPtr zeroNativeInt
+
+                let state =
+                    IlMachineState.writeManagedByrefWithBase
+                        ctx.BaseClassTypes
+                        state
+                        sizeOutPtr
+                        (CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim (int64 size.Size))))
+
+                let state =
+                    IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 1)) ctx.Thread state
+
+                NativeHandlerResult.completed state |> Some
+            else
+                failwith
+                    $"TODO %s{operation}: only strictly-numeric blittable structs are supported by this QCall today; type %O{typeHandle} has fields outside that allowlist (see comment for the deferred cases)"
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -13,6 +13,8 @@ module NativeQCall =
             "QCall_GetGCHandleForTypeHandle", NativeGcHandle.tryExecuteQCall "QCall_GetGCHandleForTypeHandle"
             "QCall_FreeGCHandleForTypeHandle", NativeGcHandle.tryExecuteQCall "QCall_FreeGCHandleForTypeHandle"
             "MarshalNative_SizeOfHelper", NativeMarshal.tryExecuteQCall "MarshalNative_SizeOfHelper"
+            "MarshalNative_TryGetStructMarshalStub",
+            NativeMarshal.tryExecuteQCall "MarshalNative_TryGetStructMarshalStub"
             "Buffer_MemMove", NativeBuffer.tryExecuteQCall "Buffer_MemMove"
             "ExceptionNative_GetMessageFromNativeResources",
             NativeException.tryExecuteQCall "ExceptionNative_GetMessageFromNativeResources"


### PR DESCRIPTION
## Summary
- Implements the `MarshalNative_TryGetStructMarshalStub` QCall, but only for the narrow strictly-numeric-blittable subset (recursive structs whose leaves are `Int8`..`Float64`, excluding `NativeInt`).
- For that subset, writes a null stub + the managed CLI size and returns TRUE so `Marshal.StructureToPtr` / `Marshal.PtrToStructure` can take the `SpanHelpers.Memmove` fast path.
- Anything else (IntPtr/UIntPtr fields, enums, `[MarshalAs]` descriptors, Bool/Char/ObjectRef fields, AutoLayout types, classes) surfaces a host TODO. Each future widening is left to its own focused PR with a motivating PawPrint test.

## Why minimal
A previous attempt grew into a full reimplementation of CoreCLR's `IsFieldBlittable` plus stub-synthesis exception modelling plus byte-copyability gating plus empty-struct size bump plus CharSet handling plus primitive-like unwrap. Each codex round found new gaps in that classifier because each gap is a separate piece of CoreCLR behaviour. Shrinking back to the strictly-numeric allowlist keeps the surface honest: we say TRUE exactly when we're confident, and TODO everywhere else.

The fuller attempt is preserved on `marshal-try-get-struct-stub-full-attempt` for reference, but is not the intended trajectory.

## Effect
`AdvancedStructLayout.cs` advances past this QCall (its only `Marshal.StructureToPtr` call uses a strictly-numeric `BlittableStruct`). It stays in `unimplemented` because `Unsafe.ByteOffset` does not yet support the `Pointer(...)` `ManagedPointerSource` produced when `Marshal.StructureToPtr` forms `&*(byte*)ptr` over an `AllocHGlobal` pointer.

## Follow-ups (separate PRs / issues)
- Return FALSE for no-layout types (`new object()` etc.) so `Marshal` can throw `ArgumentException`.
- Stub-synthesis-style TypeLoadException/MarshalDirectiveException for has-layout-non-blittable types.
- IntPtr/UIntPtr field handling, with byte-copyability provenance gating.
- Enum / primitive-like value-type fields.
- `[MarshalAs]` descriptor handling (ByValTStr, ByValArray, scalar width matching, Struct).
- Bool/Char fields, with declaring-type CharSet.
- Empty-struct native-size bump to 1 byte.
- Decimal-as-field rejection (Decimal's own MethodTable is blittable but it forces stub synthesis as a field).

## Test plan
- [x] `dotnet build` clean
- [x] Full `dotnet test` suite passes (1162 passed, 0 failed)
- [x] `dotnet fantomas` reports no formatting changes
- [x] `AdvancedStructLayout.cs` test remains in `unimplemented` with a refreshed reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)