### PR TITLE
Project RuntimeTypeHandle_GetInterfaces for OpenGenericTypeDefinition

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -19,8 +19,7 @@ module TestPureCases =
         [
             "AdvancedStructLayout.cs" // past MarshalNative_SizeOfHelper for ByValTStr and SystemNative_Malloc / SystemNative_Free / Marshal.AllocHGlobal / FreeHGlobal; now blocked downstream at the unimplemented MarshalNative_TryGetStructMarshalStub QCall (CoreLib's Marshal.StructureToPtr path)
             "Threads.cs" // past ThreadNative_InformThreadNameChange (Thread.Name setter); now blocked on unimplemented PAL call libSystem.Native!SystemNative_GetLowResolutionTimestamp (.Sys::GetLowResolutionTimestamp, used by the Task/ThreadPool scheduler)
-            "GetFieldOnOpenGenericTypeDefinition.cs" // FieldHandle declaring-type canonicalisation and MethodTable::ParentMethodTable for OpenGenericTypeDefinition targets are both fixed; now blocked downstream on the RuntimeTypeHandle_GetInterfaces QCall, whose interface walk is built on closed ConcreteTypeHandle and rejects OpenGenericTypeDefinition targets.
-            "LdtokenField.cs" // Test 5 hits typeof(GenericClass<>).GetField("GenericField"), which goes through the same RuntimeTypeHandle_GetInterfaces QCall on an OpenGenericTypeDefinition target as GetFieldOnOpenGenericTypeDefinition.cs.
+            "LdtokenField.cs" // Test 5's typeof(GenericClass<>).GetField path now passes; the test now reaches an unrelated downstream blocker, the InternalCall System.Signature::GetParameterOffsetInternal.
         ]
         |> Set.ofList
 

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -379,7 +379,7 @@ module IlMachineRuntimeMetadata =
     /// definition identity for continued identity-walking (when true). A method generic
     /// parameter has no legitimate appearance in a type definition's base or interfaces,
     /// but treating it as unbound is the safe default.
-    let rec private containsAnyGenericParameter (ty : TypeDefn) : bool =
+    let rec containsAnyGenericParameter (ty : TypeDefn) : bool =
         match ty with
         | TypeDefn.GenericTypeParameter _
         | TypeDefn.GenericMethodParameter _ -> true

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -214,3 +214,6 @@ module IlMachineState =
 
     let isRuntimeTypeHandleTargetAssignableTo =
         IlMachineRuntimeMetadata.isRuntimeTypeHandleTargetAssignableTo
+
+    let containsAnyGenericParameter =
+        IlMachineRuntimeMetadata.containsAnyGenericParameter

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
@@ -1480,30 +1480,24 @@ module NativeRuntimeTypeQCall =
             let retArray =
                 NativeCall.objectHandleOnStackTarget operation state "result" instruction.Arguments.[1]
 
-            let typeHandle =
-                match typeHandleTarget with
-                | RuntimeTypeHandleTarget.Closed handle -> handle
-                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
-                    failwith
-                        $"TODO: %s{operation} for open generic type definition %O{identity}; CoreCLR walks the canonical type's interface map, but PawPrint's interface concretization expects closed type generics"
-                | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
-                    failwith
-                        $"%s{operation}: generic parameter #%i{position} of %O{declaringType.TypeDefinition.Get} reached the QCall; the managed wrapper short-circuits IsTypeDesc to `[]` before this point"
-                | RuntimeTypeHandleTarget.MethodGenericParameter (declaringType, declaringMethod, position) ->
-                    failwith
-                        $"%s{operation}: method generic parameter #%i{position} of method %O{declaringMethod.Get} on %O{declaringType.TypeDefinition.Get} reached the QCall; the managed wrapper short-circuits IsTypeDesc to `[]` before this point"
-
-            match typeHandle with
-            | ConcreteTypeHandle.OneDimArrayZero _
-            | ConcreteTypeHandle.Array _ ->
+            match typeHandleTarget with
+            | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.OneDimArrayZero _ as handle)
+            | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Array _ as handle) ->
                 failwith
-                    $"TODO: %s{operation} for array type %O{typeHandle}; arrays expose runtime-provided interfaces (IList<T>, ICollection<T>, IEnumerable<T>, ...) that PawPrint does not yet synthesize"
-            | ConcreteTypeHandle.Byref _
-            | ConcreteTypeHandle.Pointer _
-            | ConcreteTypeHandle.FunctionPointer _ ->
+                    $"TODO: %s{operation} for array type %O{handle}; arrays expose runtime-provided interfaces (IList<T>, ICollection<T>, IEnumerable<T>, ...) that PawPrint does not yet synthesize"
+            | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Byref _ as handle)
+            | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Pointer _ as handle)
+            | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.FunctionPointer _ as handle) ->
                 failwith
-                    $"%s{operation}: byref/pointer/function-pointer handle %O{typeHandle} reached the QCall; the managed wrapper should have short-circuited IsTypeDesc to `[]`"
-            | ConcreteTypeHandle.Concrete _ ->
+                    $"%s{operation}: byref/pointer/function-pointer handle %O{handle} reached the QCall; the managed wrapper should have short-circuited IsTypeDesc to `[]`"
+            | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
+                failwith
+                    $"%s{operation}: generic parameter #%i{position} of %O{declaringType.TypeDefinition.Get} reached the QCall; the managed wrapper short-circuits IsTypeDesc to `[]` before this point"
+            | RuntimeTypeHandleTarget.MethodGenericParameter (declaringType, declaringMethod, position) ->
+                failwith
+                    $"%s{operation}: method generic parameter #%i{position} of method %O{declaringMethod.Get} on %O{declaringType.TypeDefinition.Get} reached the QCall; the managed wrapper short-circuits IsTypeDesc to `[]` before this point"
+            | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete _)
+            | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
 
             // CoreCLR's MethodTable interface map enumerates ALL implemented interfaces:
             // the type's direct ImplementedInterfaces rows, every interface those interfaces
@@ -1513,21 +1507,76 @@ module NativeRuntimeTypeQCall =
             // `IEnumerable<T>`, `IEnumerable`. Concretization always uses the *owning* type's
             // generics: when walking B<int>'s interfaces we resolve under `[int]`, regardless
             // of the derived class's own generic instantiation.
+            //
+            // For an `OpenGenericTypeDefinition` (CoreCLR's canonical MethodTable
+            // `G<__Canon>`), the interface map is also canonical: each row whose
+            // metadata references `G`'s generic parameters becomes a `bound shared`
+            // MT (e.g. `class G<T> : IList<T>` → slot `IList<__Canon>` →
+            // `OpenGenericTypeDefinition IList`). We do not yet have a representation
+            // for that shape, so the open-generic walker only handles rows that are
+            // fully closed in metadata (no generic parameter references at all);
+            // anything else fails loudly.
             let rec collectInterfaces
-                (state : IlMachineState, seen : Set<ConcreteTypeHandle>, ordered : ConcreteTypeHandle list)
-                (current : ConcreteTypeHandle)
-                : IlMachineState * Set<ConcreteTypeHandle> * ConcreteTypeHandle list
+                (state : IlMachineState, seen : Set<RuntimeTypeHandleTarget>, ordered : RuntimeTypeHandleTarget list)
+                (current : RuntimeTypeHandleTarget)
+                : IlMachineState * Set<RuntimeTypeHandleTarget> * RuntimeTypeHandleTarget list
                 =
                 let state, seen, ordered =
-                    match IlMachineState.tryGetConcreteTypeInfo state current with
-                    | None -> state, seen, ordered
-                    | Some (currentCt, currentTypeInfo) ->
+                    match current with
+                    | RuntimeTypeHandleTarget.Closed currentHandle ->
+                        match IlMachineState.tryGetConcreteTypeInfo state currentHandle with
+                        | None -> state, seen, ordered
+                        | Some (currentCt, currentTypeInfo) ->
+                            let currentAssy =
+                                state.LoadedAssembly' currentCt.Identity.AssemblyFullName
+                                |> Option.defaultWith (fun () ->
+                                    failwith
+                                        $"%s{operation}: owning assembly %s{currentCt.Identity.AssemblyFullName} not loaded"
+                                )
+
+                            ((state, seen, ordered), currentTypeInfo.ImplementedInterfaces)
+                            ||> Seq.fold (fun (state, seen, ordered) impl ->
+                                let implAssy =
+                                    state.LoadedAssembly impl.RelativeToAssembly |> Option.defaultValue currentAssy
+
+                                let state, implTypeDefn, implResolvedAssy =
+                                    IlMachineState.resolveTypeMetadataToken
+                                        ctx.LoggerFactory
+                                        ctx.BaseClassTypes
+                                        state
+                                        implAssy
+                                        currentCt.Generics
+                                        impl.InterfaceHandle
+
+                                let state, implHandle =
+                                    IlMachineState.concretizeType
+                                        ctx.LoggerFactory
+                                        ctx.BaseClassTypes
+                                        state
+                                        implResolvedAssy.Name
+                                        currentCt.Generics
+                                        ImmutableArray.Empty
+                                        implTypeDefn
+
+                                let implTarget = RuntimeTypeHandleTarget.Closed implHandle
+
+                                if Set.contains implTarget seen then
+                                    state, seen, ordered
+                                else
+                                    let seen = Set.add implTarget seen
+                                    let ordered = implTarget :: ordered
+                                    // Recurse into the interface's own transitive interface set.
+                                    collectInterfaces (state, seen, ordered) implTarget
+                            )
+                    | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
                         let currentAssy =
-                            state.LoadedAssembly' currentCt.Identity.AssemblyFullName
+                            state.LoadedAssembly identity.Assembly
                             |> Option.defaultWith (fun () ->
                                 failwith
-                                    $"%s{operation}: owning assembly %s{currentCt.Identity.AssemblyFullName} not loaded"
+                                    $"%s{operation}: assembly %s{identity.AssemblyFullName} not loaded for open generic typedef %O{identity.TypeDefinition.Get}"
                             )
+
+                        let currentTypeInfo = currentAssy.TypeDefs.[identity.TypeDefinition.Get]
 
                         ((state, seen, ordered), currentTypeInfo.ImplementedInterfaces)
                         ||> Seq.fold (fun (state, seen, ordered) impl ->
@@ -1540,42 +1589,55 @@ module NativeRuntimeTypeQCall =
                                     ctx.BaseClassTypes
                                     state
                                     implAssy
-                                    currentCt.Generics
+                                    ImmutableArray.Empty
                                     impl.InterfaceHandle
 
-                            let state, implHandle =
-                                IlMachineState.concretizeType
-                                    ctx.LoggerFactory
-                                    ctx.BaseClassTypes
-                                    state
-                                    implResolvedAssy.Name
-                                    currentCt.Generics
-                                    ImmutableArray.Empty
-                                    implTypeDefn
-
-                            if Set.contains implHandle seen then
-                                state, seen, ordered
+                            if IlMachineState.containsAnyGenericParameter implTypeDefn then
+                                failwith
+                                    $"TODO: %s{operation} for open generic typedef %O{identity.TypeDefinition.Get} in %s{identity.AssemblyFullName}: interface row resolves to %O{implTypeDefn}, which references generic parameters (bound-shared interface MT); only fully-closed interface rows are supported today"
                             else
-                                let seen = Set.add implHandle seen
-                                let ordered = implHandle :: ordered
-                                // Recurse into the interface's own transitive interface set.
-                                collectInterfaces (state, seen, ordered) implHandle
+                                let state, implHandle =
+                                    IlMachineState.concretizeType
+                                        ctx.LoggerFactory
+                                        ctx.BaseClassTypes
+                                        state
+                                        implResolvedAssy.Name
+                                        ImmutableArray.Empty
+                                        ImmutableArray.Empty
+                                        implTypeDefn
+
+                                let implTarget = RuntimeTypeHandleTarget.Closed implHandle
+
+                                if Set.contains implTarget seen then
+                                    state, seen, ordered
+                                else
+                                    let seen = Set.add implTarget seen
+                                    let ordered = implTarget :: ordered
+                                    collectInterfaces (state, seen, ordered) implTarget
                         )
+                    | RuntimeTypeHandleTarget.GenericParameter _
+                    | RuntimeTypeHandleTarget.MethodGenericParameter _ ->
+                        // The top-level dispatch above rejects these; the only way one
+                        // could reach the recursive walker is if a base-walk produced
+                        // a generic-parameter target, but `resolveBaseRuntimeTypeHandleTarget`
+                        // refuses for those shapes. Fail loudly if we ever get here.
+                        failwith
+                            $"%s{operation}: generic-parameter target %O{current} reached collectInterfaces; TypeDescs have no interface map"
 
                 // Walk up the base type chain.
-                let state, baseHandle =
-                    IlMachineState.resolveBaseConcreteType ctx.LoggerFactory ctx.BaseClassTypes state current
+                let state, baseTarget =
+                    IlMachineState.resolveBaseRuntimeTypeHandleTarget ctx.LoggerFactory ctx.BaseClassTypes state current
 
-                match baseHandle with
+                match baseTarget with
                 | None -> state, seen, ordered
-                | Some baseHandle -> collectInterfaces (state, seen, ordered) baseHandle
+                | Some baseTarget -> collectInterfaces (state, seen, ordered) baseTarget
 
-            let state, _, interfaceHandlesReversed =
-                collectInterfaces (state, Set.empty, []) typeHandle
+            let state, _, interfaceTargetsReversed =
+                collectInterfaces (state, Set.empty, []) typeHandleTarget
 
-            let interfaceHandles = List.rev interfaceHandlesReversed
+            let interfaceTargets = List.rev interfaceTargetsReversed
 
-            if List.isEmpty interfaceHandles then
+            if List.isEmpty interfaceTargets then
                 // Mirror CoreCLR: skip the allocation and leave the caller's `[]` local intact.
                 NativeHandlerResult.completed state |> Some
             else
@@ -1586,18 +1648,14 @@ module NativeRuntimeTypeQCall =
                     IlMachineState.allocateArray
                         (ConcreteTypeHandle.OneDimArrayZero runtimeTypeElementHandle)
                         (fun () -> CliType.ObjectRef None)
-                        (List.length interfaceHandles)
+                        (List.length interfaceTargets)
                         state
 
                 let state =
-                    ((state, 0), interfaceHandles)
-                    ||> List.fold (fun (state, index) ifaceHandle ->
+                    ((state, 0), interfaceTargets)
+                    ||> List.fold (fun (state, index) ifaceTarget ->
                         let runtimeTypeAddr, state =
-                            IlMachineState.getOrAllocateType
-                                ctx.LoggerFactory
-                                ctx.BaseClassTypes
-                                (RuntimeTypeHandleTarget.Closed ifaceHandle)
-                                state
+                            IlMachineState.getOrAllocateType ctx.LoggerFactory ctx.BaseClassTypes ifaceTarget state
 
                         let state =
                             IlMachineState.setArrayValue


### PR DESCRIPTION
## Summary
- Widen the `RuntimeTypeHandle_GetInterfaces` QCall's `collectInterfaces` walker to traverse `RuntimeTypeHandleTarget` instead of `ConcreteTypeHandle`, so an `OpenGenericTypeDefinition` (CoreCLR's `G<__Canon>` canonical MethodTable) can be walked uniformly with closed handles.
- For an `OpenGenericTypeDefinition`, look up the type def in its assembly, resolve each `ImplementedInterfaces` row under empty `typeGenerics`, accept rows whose resolved `TypeDefn` references no generic parameters (concretize as `Closed`), and fail loudly for rows that would need a "bound shared" interface MT (e.g. `class G<T> : IList<T>` → slot `IList<__Canon>`) since we do not yet have a representation for that shape.
- Base walks now go through `resolveBaseRuntimeTypeHandleTarget` (added in #593) so the recursion is total over the dispatched shape.

The change unblocks `GetFieldOnOpenGenericTypeDefinition.cs` (now passing — removed from `unimplemented`). `LdtokenField.cs` Test 5's `typeof(GenericClass<>).GetField` path now passes too, but the test as a whole still hits a separate downstream blocker (`System.Signature::GetParameterOffsetInternal`), so it stays in `unimplemented` with an updated comment.

`containsAnyGenericParameter` is promoted from `private` to public (with the matching re-export through `IlMachineState`) so the QCall can use the same predicate `resolveBaseRuntimeTypeHandleTarget` already uses for shared-vs-closed classification.

## Test plan
- [x] `dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 1196/1196 pass.
- [x] `Can evaluate C# files("GetFieldOnOpenGenericTypeDefinition.cs")` passes in the standard slot (previously only ran under `unimplemented`).
- [x] `LdtokenField.cs` still in `unimplemented` with comment updated to point at the new downstream blocker.
- [x] `dotnet fantomas .` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)