### PR TITLE
TryGetStructMarshalStub: return FALSE for no-layout types

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/MarshalStructureToPtrNoLayoutThrows.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/MarshalStructureToPtrNoLayoutThrows.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Runtime.InteropServices;
+
+public class Program
+{
+    class PlainClass
+    {
+        public int X;
+    }
+
+    public static int Main(string[] args)
+    {
+        // CoreCLR's `MarshalNative_TryGetStructMarshalStub` (marshalnative.cpp:99) returns
+        // FALSE for any type whose `HasLayout()` is false — i.e. whose `TypeAttributes`
+        // carry `LayoutKind.Auto` (the default for reference types). The managed
+        // `Marshal.StructureToPtr` overload turns that FALSE into an `ArgumentException`
+        // (resource `Argument_MustHaveLayoutOrBeBlittable`). This test exercises two
+        // no-layout shapes: `System.Object` itself, and an ordinary class without
+        // `[StructLayout]`. Both reach the QCall via `RuntimeHelpers.GetMethodTable(structure)`
+        // and must surface the same `ArgumentException` rather than tripping any host TODO.
+        IntPtr ptr = Marshal.AllocHGlobal(8);
+        try
+        {
+            try
+            {
+                Marshal.StructureToPtr(new object(), ptr, false);
+                return 1;
+            }
+            catch (ArgumentException)
+            {
+                // Expected
+            }
+
+            try
+            {
+                Marshal.StructureToPtr(new PlainClass(), ptr, false);
+                return 2;
+            }
+            catch (ArgumentException)
+            {
+                // Expected
+            }
+
+            return 0;
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(ptr);
+        }
+    }
+}

--- a/WoofWare.PawPrint/CliType.fs
+++ b/WoofWare.PawPrint/CliType.fs
@@ -1228,23 +1228,25 @@ and CliValueType =
         | ConcreteTypeHandle.Pointer _
         | ConcreteTypeHandle.FunctionPointer _ -> false
 
-    /// True iff `vt`'s declared type carries `LayoutKind.Auto` in its `TypeAttributes.LayoutMask`.
-    /// CoreCLR rejects top-level `Marshal.SizeOf<T>()` when `T` is AutoLayout (`fieldmarshaler.cpp:309`
-    /// — `IsStructMarshalable` returns false because `HasLayout()` is false for AutoLayout types),
-    /// regardless of whether the struct happens to be blittable in practice. We mirror that rejection
-    /// at the top-level marshal-size entry; field-level use is gated separately so host-known
-    /// AutoLayout types (DateTime) can still appear as fields via their dedicated shortcut.
+    /// True iff `handle`'s declared type carries `LayoutKind.Auto` in its
+    /// `TypeAttributes.LayoutMask`. This is the CoreCLR `HasLayout() == false` predicate:
+    /// it covers reference types without `[StructLayout]` (whose default is AutoLayout) as
+    /// well as value types explicitly marked `[StructLayout(LayoutKind.Auto)]`.
+    /// CoreCLR rejects top-level `Marshal.SizeOf<T>()` and returns FALSE from
+    /// `MarshalNative_TryGetStructMarshalStub` for any such type (`fieldmarshaler.cpp:309`,
+    /// `marshalnative.cpp:99`).
     /// Returns `false` for synthetic handles (arrays, byrefs, pointers, function pointers) and for
-    /// handles whose backing TypeInfo can't be found — those don't have a CLR `LayoutKind` to honour.
-    static member private IsAutoLayout
+    /// handles whose backing TypeInfo can't be found — those don't have a CLR `LayoutKind` to honour
+    /// and callers must classify them through a different path.
+    static member IsAutoLayoutHandle
         (concreteTypes : AllConcreteTypes)
         (assemblies : ImmutableDictionary<string, DumpedAssembly>)
-        (vt : CliValueType)
+        (handle : ConcreteTypeHandle)
         : bool
         =
-        match vt._Declared with
+        match handle with
         | ConcreteTypeHandle.Concrete _ ->
-            match AllConcreteTypes.lookup vt._Declared concreteTypes with
+            match AllConcreteTypes.lookup handle concreteTypes with
             | None -> false
             | Some concreteType ->
                 match assemblies.TryGetValue concreteType.Assembly.FullName with
@@ -1261,6 +1263,18 @@ and CliValueType =
         | ConcreteTypeHandle.Byref _
         | ConcreteTypeHandle.Pointer _
         | ConcreteTypeHandle.FunctionPointer _ -> false
+
+    /// True iff `vt`'s declared type carries `LayoutKind.Auto`. Convenience wrapper around
+    /// `IsAutoLayoutHandle` for the field/struct marshal-size walk; field-level use is gated
+    /// separately so host-known AutoLayout types (DateTime) can still appear as fields via
+    /// their dedicated shortcut.
+    static member private IsAutoLayout
+        (concreteTypes : AllConcreteTypes)
+        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (vt : CliValueType)
+        : bool
+        =
+        CliValueType.IsAutoLayoutHandle concreteTypes assemblies vt._Declared
 
     /// Compute the unmanaged size of a single field, consulting `[MarshalAs(...)]` descriptors
     /// and the declaring type's `CharSet`. Without a descriptor, falls back to the managed

--- a/WoofWare.PawPrint/Native/NativeMarshal.fs
+++ b/WoofWare.PawPrint/Native/NativeMarshal.fs
@@ -153,21 +153,42 @@ module NativeMarshal =
             let sizeOutPtr =
                 NativeCall.managedPointerOfPointerArgument operation "size" instruction.Arguments.[2]
 
-            let zero, state =
-                IlMachineState.cliTypeZeroOfHandle state ctx.BaseClassTypes typeHandle
-
             // CoreCLR's `MarshalNative_TryGetStructMarshalStub` (marshalnative.cpp:99-145)
             // has three branches: blittable (memmove fast path, *stub = NULL, *size = native
             // size, return TRUE), has-layout-non-blittable (synthesised IL stub, return TRUE),
             // and no-layout (return FALSE so managed Marshal throws ArgumentException).
-            // This implementation handles only the first arm, and only for the strict subset
-            // we are confident matches CoreCLR exactly: structs whose fields are recursively
-            // plain numeric (Int8..Float64). Anything else — IntPtr/UIntPtr fields, enums,
-            // [MarshalAs] descriptors, Bool/Char/ObjectRef fields, AutoLayout types, classes,
-            // etc. — surfaces a host TODO. Each future widening (FALSE for no-layout types,
-            // stub-synthesis exceptions for has-layout-non-blittable types, IntPtr fields
-            // with verified provenance, [MarshalAs] descriptor handling, ...) wants its own
-            // motivating PawPrint test before being added to the classifier.
+            // This implementation handles the no-layout arm (AutoLayout types, which covers
+            // `System.Object` and ordinary classes without `[StructLayout]`, as well as value
+            // types explicitly marked `[StructLayout(LayoutKind.Auto)]`), and the first arm
+            // for the strict subset we are confident matches CoreCLR exactly: structs whose
+            // fields are recursively plain numeric (Int8..Float64). Anything else —
+            // IntPtr/UIntPtr fields, enums, [MarshalAs] descriptors, Bool/Char/ObjectRef
+            // fields, has-layout-non-blittable structs, etc. — surfaces a host TODO. Each
+            // future widening wants its own motivating PawPrint test before being added to
+            // the classifier.
+
+            if CliValueType.IsAutoLayoutHandle state.ConcreteTypes state._LoadedAssemblies typeHandle then
+                // No-layout branch: write *stub = NULL, *size = 0, return FALSE so the
+                // managed `Marshal.StructureToPtr` / `PtrToStructureHelper` / `DestroyStructure`
+                // wrappers throw `ArgumentException` (resource `Argument_MustHaveLayoutOrBeBlittable`).
+                let zeroNativeInt =
+                    CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim 0L))
+
+                let state =
+                    IlMachineState.writeManagedByrefWithBase ctx.BaseClassTypes state stubOutPtr zeroNativeInt
+
+                let state =
+                    IlMachineState.writeManagedByrefWithBase ctx.BaseClassTypes state sizeOutPtr zeroNativeInt
+
+                let state =
+                    IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 0)) ctx.Thread state
+
+                NativeHandlerResult.completed state |> Some
+            else
+
+            let zero, state =
+                IlMachineState.cliTypeZeroOfHandle state ctx.BaseClassTypes typeHandle
+
             let rec isStrictlyNumericBlittable (t : CliType) : bool =
                 match t with
                 // NativeInt (IntPtr/UIntPtr) values carry provenance in PawPrint that the byte


### PR DESCRIPTION
## Summary
- Implements the first bullet of #595: `MarshalNative_TryGetStructMarshalStub` now returns FALSE (writes null stub + zero size, pushes 0) when the type's `TypeAttributes.LayoutMask` is `AutoLayout` — i.e. CoreCLR's `HasLayout() == false` case. This covers `new object()` and ordinary classes without `[StructLayout]`, as well as value types explicitly marked `[StructLayout(LayoutKind.Auto)]`.
- The managed `Marshal.StructureToPtr` / `PtrToStructureHelper` / `DestroyStructure` wrappers turn that FALSE into the documented `ArgumentException` (`Argument_MustHaveLayoutOrBeBlittable`), so guest code matches CoreCLR's observable behaviour instead of tripping the host TODO.
- Extracts the existing private `CliValueType.IsAutoLayout` into a public `IsAutoLayoutHandle` taking a `ConcreteTypeHandle` (the previous wrapper now delegates), so the QCall classifier reuses the same predicate as the marshal-size walk.

## Why minimal
Per the parent issue, each remaining widening of the classifier wants its own focused PR + motivating test rather than another full reimplementation. This change is exactly the FALSE-for-no-layout-types arm and nothing else; the strictly-numeric blittable arm and the has-layout-non-blittable TODO are untouched.

## Test plan
- [x] New `MarshalStructureToPtrNoLayoutThrows.cs` covers `new object()` and a plain class without `[StructLayout]`; verified failing on `main` (TODO failwith) and passing after the fix.
- [x] `nix develop -c dotnet test ... --verbosity normal` — full suite green.
- [x] `nix develop -c dotnet fantomas .` — no formatting changes.
- [x] `codex review --base main` — no correctness issues found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)