### PR TITLE
Wire SystemNative_SetPosixSignalHandler onto a SignalState.Handler slot

### DIFF
--- a/WoofWare.PawPrint.Test/TestSignalHandler.fs
+++ b/WoofWare.PawPrint.Test/TestSignalHandler.fs
@@ -1,0 +1,188 @@
+namespace WoofWare.PawPrint.Test
+
+open System.Collections.Immutable
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+/// Focused tests for the `SignalHandler` wrapper that `SignalState.Handler`
+/// stores. The wrapper exists so a `MethodInfo` (whose naked structural
+/// equality is unstable — its `ImmutableArray` fields and `MethodBody` payloads
+/// compare by reference) can be embedded in a structurally-compared
+/// `EmulatedKernel` without breaking the deterministic state-dedup contract.
+/// These tests pin down:
+///   * `MethodInfo.NominallyEqual` correctly identifies the same underlying
+///     method even when the two `MethodInfo` records were constructed
+///     independently (so `SignalState.setHandler` is idempotent in practice).
+///   * Distinct methods compare unequal at both the `SignalHandler` and
+///     enclosing `SignalState` layers.
+///   * `GetHashCode` agrees with `Equals` for the equal-handler case.
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestSignalHandler =
+
+    let private corelib : DumpedAssembly =
+        let corelibPath = typeof<obj>.Assembly.Location
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        Assembly.readFile loggerFactory corelibPath
+
+    let private baseClassTypes : BaseClassTypes<DumpedAssembly> =
+        Corelib.getBaseTypes corelib
+
+    let private loadedAssemblies : ImmutableDictionary<string, DumpedAssembly> =
+        ImmutableDictionary<string, DumpedAssembly>.Empty.Add (corelib.Name.FullName, corelib)
+
+    let private concreteTypes : AllConcreteTypes =
+        Corelib.concretizeAll loadedAssemblies baseClassTypes AllConcreteTypes.Empty
+
+    let private baseState () : IlMachineState =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+
+        { IlMachineState.initial loggerFactory ImmutableArray.Empty corelib with
+            ConcreteTypes = concreteTypes
+        }
+
+    /// Look up a no-arg method by name on `System.Object` and concretize it.
+    /// `GetHashCode` / `ToString` / `GetType` are the safe choices: each is
+    /// uniquely named on `Object`, so the filter unambiguously picks one
+    /// `MethodInfo`, and the declaring type carries no generics so
+    /// concretization is a one-liner.
+    let private concretizeObjectMethod
+        (state : IlMachineState)
+        (methodName : string)
+        : IlMachineState * MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>
+        =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+
+        let objectType =
+            corelib.TryGetTopLevelTypeDef "System" "Object"
+            |> Option.defaultWith (fun () -> failwith "System.Object not found in corelib")
+
+        let rawMethod =
+            objectType.Methods
+            |> List.filter (fun m -> m.Name = methodName)
+            |> function
+                | [ method ] -> method
+                | [] -> failwith $"method %s{methodName} not found on System.Object"
+                | methods ->
+                    failwith $"method %s{methodName} on System.Object was ambiguous: %d{methods.Length} matches"
+
+        let state, method, _declaringType =
+            ExecutionConcretization.concretizeMethodWithTypeGenerics
+                loggerFactory
+                baseClassTypes
+                ImmutableArray.Empty
+                rawMethod
+                None
+                corelib.Name
+                ImmutableArray.Empty
+                state
+
+        state, method
+
+    [<Test>]
+    let ``empty SignalState has no handler installed`` () : unit =
+        SignalState.empty |> SignalState.handler |> shouldEqual None
+
+    [<Test>]
+    let ``setHandler then handler round-trips the installed handler`` () : unit =
+        let state, method = concretizeObjectMethod (baseState ()) "GetHashCode"
+        let handler = SignalHandler.ofMethodInfo method
+
+        let installed =
+            SignalState.empty |> SignalState.setHandler handler |> SignalState.handler
+
+        match installed with
+        | Some h -> h |> shouldEqual handler
+        | None -> failwith "expected setHandler to install the handler"
+
+    [<Test>]
+    let ``SignalHandler equality identifies independently-constructed wrappers around the same method`` () : unit =
+        // Two independent concretizations of `Object.GetHashCode` produce
+        // `MethodInfo` records whose `ImmutableArray` fields differ by
+        // reference but agree by nominal identity. The wrapper's
+        // `MethodInfo.NominallyEqual` contract must collapse them.
+        let state, methodA = concretizeObjectMethod (baseState ()) "GetHashCode"
+        let _, methodB = concretizeObjectMethod state "GetHashCode"
+
+        let handlerA = SignalHandler.ofMethodInfo methodA
+        let handlerB = SignalHandler.ofMethodInfo methodB
+
+        handlerA |> shouldEqual handlerB
+        hash handlerA |> shouldEqual (hash handlerB)
+
+    [<Test>]
+    let ``SignalHandler equality distinguishes different methods`` () : unit =
+        let state, getHashCode = concretizeObjectMethod (baseState ()) "GetHashCode"
+        let _, toString = concretizeObjectMethod state "ToString"
+
+        let handlerA = SignalHandler.ofMethodInfo getHashCode
+        let handlerB = SignalHandler.ofMethodInfo toString
+
+        handlerA |> shouldNotEqual handlerB
+
+    [<Test>]
+    let ``SignalHandler equals returns false against a non-SignalHandler value`` () : unit =
+        let _, method = concretizeObjectMethod (baseState ()) "GetHashCode"
+        let handler = SignalHandler.ofMethodInfo method
+
+        handler.Equals (box "not a handler") |> shouldEqual false
+        handler.Equals (box 42) |> shouldEqual false
+        handler.Equals (null : obj) |> shouldEqual false
+
+    [<Test>]
+    let ``SignalState structural equality survives an installed handler`` () : unit =
+        // Critical: `EmulatedKernel` (which embeds `SignalState`) is compared
+        // structurally for deterministic state dedup. Two states built
+        // independently with the same logical handler installed must compare
+        // equal — otherwise dedup would split semantically-equivalent states.
+        let state, methodA = concretizeObjectMethod (baseState ()) "GetHashCode"
+        let _, methodB = concretizeObjectMethod state "GetHashCode"
+
+        let stateA =
+            SignalState.empty
+            |> SignalState.markInitialized
+            |> SignalState.setHandler (SignalHandler.ofMethodInfo methodA)
+
+        let stateB =
+            SignalState.empty
+            |> SignalState.markInitialized
+            |> SignalState.setHandler (SignalHandler.ofMethodInfo methodB)
+
+        stateA |> shouldEqual stateB
+        hash stateA |> shouldEqual (hash stateB)
+
+    [<Test>]
+    let ``SignalState distinguishes states whose handlers differ`` () : unit =
+        let state, getHashCode = concretizeObjectMethod (baseState ()) "GetHashCode"
+        let _, toString = concretizeObjectMethod state "ToString"
+
+        let stateA =
+            SignalState.empty
+            |> SignalState.setHandler (SignalHandler.ofMethodInfo getHashCode)
+
+        let stateB =
+            SignalState.empty
+            |> SignalState.setHandler (SignalHandler.ofMethodInfo toString)
+
+        stateA |> shouldNotEqual stateB
+
+    [<Test>]
+    let ``setHandler is last-writer-wins`` () : unit =
+        // CoreLib's `PosixSignalRegistration.Initialize` only ever calls
+        // `SystemNative_SetPosixSignalHandler` once, but the underlying native
+        // contract is "overwrite g_posixSignalHandler". Pin down that the
+        // wrapper preserves that contract.
+        let state, getHashCode = concretizeObjectMethod (baseState ()) "GetHashCode"
+        let _, toString = concretizeObjectMethod state "ToString"
+
+        let handlerA = SignalHandler.ofMethodInfo getHashCode
+        let handlerB = SignalHandler.ofMethodInfo toString
+
+        let installed =
+            SignalState.empty
+            |> SignalState.setHandler handlerA
+            |> SignalState.setHandler handlerB
+            |> SignalState.handler
+
+        installed |> shouldEqual (Some handlerB)

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -70,6 +70,7 @@
     <Compile Include="TestLowLevelMonitor.fs" />
     <Compile Include="TestSignal.fs" />
     <Compile Include="TestSignalState.fs" />
+    <Compile Include="TestSignalHandler.fs" />
     <Compile Include="TestWaitHandle.fs" />
     <Compile Include="TestSyncBlockMonitor.fs" />
     <Compile Include="TestPureCases.fs" />

--- a/WoofWare.PawPrint/Native/NativeSystemNative.fs
+++ b/WoofWare.PawPrint/Native/NativeSystemNative.fs
@@ -616,6 +616,37 @@ module NativeSystemNative =
                 |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 1) ctx.Thread
                 |> NativeHandlerResult.completed
                 |> Some
+        | Some "SystemNative_SetPosixSignalHandler", [ ConcreteFunctionPointer _ ], MethodReturnType.Void ->
+            // The BCL calls this exactly once from
+            // `PosixSignalRegistration.Initialize` with `&OnPosixSignal`,
+            // a function-pointer-typed `delegate* unmanaged<int, PosixSignal, int>`.
+            // Real native code stashes the raw pointer into a global
+            // (`g_posixSignalHandler`) and the signal-handling thread later
+            // invokes it after a signal is queued. PawPrint just records the
+            // managed identity of the target method on `SignalState` — the
+            // forthcoming signal-delivery slice reads it back at dispatch
+            // time. We refuse anything other than a real
+            // `NativeIntSource.FunctionPointer`: any other tag means the
+            // value didn't come from `Ldftn` on a managed method, so we
+            // have no callable identity to record and silently dropping it
+            // would let the BCL register handlers that the simulator can
+            // never invoke.
+            let operation = "SystemNative_SetPosixSignalHandler"
+
+            let mi =
+                match CliType.unwrapPrimitiveLikeDeep instruction.Arguments.[0] with
+                | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.FunctionPointer mi)) -> mi
+                | other ->
+                    failwith
+                        $"%s{operation}: expected FunctionPointer argument (from Ldftn on the managed signal callback), got %O{other}"
+
+            state.MapKernel (fun kernel ->
+                { kernel with
+                    Signals = SignalState.setHandler (SignalHandler.ofMethodInfo mi) kernel.Signals
+                }
+            )
+            |> NativeHandlerResult.completed
+            |> Some
         | Some "SystemNative_DisablePosixSignalHandling",
           [ ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32 ],
           MethodReturnType.Void ->

--- a/WoofWare.PawPrint/SignalState.fs
+++ b/WoofWare.PawPrint/SignalState.fs
@@ -13,6 +13,56 @@ type PendingSignal =
         Target : ThreadId voption
     }
 
+/// Identity of the managed callback the BCL installed via
+/// `SystemNative_SetPosixSignalHandler(&OnPosixSignal)`. Wraps the
+/// `MethodInfo` of the target so a later signal-delivery slice has the
+/// call site pre-resolved — no need to round-trip through raw pointer
+/// bits.
+///
+/// The wrapper exists purely so `SignalState` keeps clean structural
+/// equality: `MethodInfo<_,_,_>` carries `ImmutableArray` fields and a
+/// `MethodBody` DU whose payloads use reference equality, so naked
+/// `MethodInfo` equality is unstable. `MethodInfo.NominallyEqual` is the
+/// stable identity contract (assembly + type identity + type generics +
+/// method handle + method generics) and is exactly what we need here:
+/// two `SignalHandler`s denote the same callback iff they would dispatch
+/// to the same managed method. Mirrors the same pattern used by
+/// `NativeIntSource.FunctionPointer`'s custom equality at the eval-stack
+/// layer.
+[<CustomEquality>]
+[<NoComparison>]
+type SignalHandler =
+    private
+        {
+            Method : MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>
+        }
+
+    member this.MethodInfo : MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle> =
+        this.Method
+
+    override this.Equals (other : obj) : bool =
+        match other with
+        | :? SignalHandler as other -> MethodInfo.NominallyEqual this.Method other.Method
+        | _ -> false
+
+    override this.GetHashCode () : int =
+        hash (
+            this.Method.DeclaringType.Identity,
+            this.Method.DeclaringType.Generics,
+            this.Method.Handle,
+            this.Method.Generics
+        )
+
+[<RequireQualifiedAccess>]
+module SignalHandler =
+    let ofMethodInfo (mi : MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>) : SignalHandler =
+        {
+            Method = mi
+        }
+
+    let methodInfo (handler : SignalHandler) : MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle> =
+        handler.Method
+
 /// Pure, deterministic model of the simulator's signal-handling state.
 ///
 /// The shape is deliberately small:
@@ -30,6 +80,14 @@ type PendingSignal =
 ///   * `Blocked` — per-thread sigprocmask. A signal in a thread's set is
 ///     blocked for that thread and cannot be delivered to it.
 ///   * `Pending` — FIFO queue of generated signals waiting for dispatch.
+///   * `Handler` — the BCL-supplied dispatch callback (the function
+///     pointer passed to `SystemNative_SetPosixSignalHandler`, in
+///     practice `PosixSignalRegistration.OnPosixSignal`). `None` until
+///     the BCL installs one; on a real Unix box the native side leaves
+///     `g_posixSignalHandler` NULL until the first
+///     `SetPosixSignalHandler` call and ignores delivered signals while
+///     it remains so. PawPrint will mirror that semantics once signal
+///     delivery is wired.
 ///
 /// The `EmulatedKernel.Signals` field carries an instance of this type per
 /// simulated process, but no code dispatches signals out of it yet —
@@ -51,6 +109,7 @@ type SignalState =
             /// 0–3 entries) and PawPrint trades performance for determinism
             /// throughout.
             Pending : PendingSignal list
+            Handler : SignalHandler option
         }
 
 [<RequireQualifiedAccess>]
@@ -61,6 +120,7 @@ module SignalState =
             Enabled = Set.empty
             Blocked = Map.empty
             Pending = []
+            Handler = None
         }
 
     let isInitialized (state : SignalState) : bool = state.Initialized
@@ -75,6 +135,26 @@ module SignalState =
             { state with
                 Initialized = true
             }
+
+    /// The currently-installed dispatch callback, or `None` if the BCL
+    /// has not yet called `SystemNative_SetPosixSignalHandler`. PawPrint
+    /// has no signal delivery wired yet, so this is purely a record of
+    /// what the BCL asked for; later slices will read it at the moment
+    /// of dispatch.
+    let handler (state : SignalState) : SignalHandler option = state.Handler
+
+    /// Install (or replace) the BCL-supplied signal-dispatch callback.
+    /// The real native side stores the pointer into `g_posixSignalHandler`
+    /// unconditionally, overwriting any prior value — which CoreLib only
+    /// ever does once from `PosixSignalRegistration.Initialize`, but the
+    /// underlying contract is "last writer wins". Two calls with the same
+    /// nominal handler are equality-equal via `SignalHandler.Equals` even
+    /// though the second one re-constructs the wrapper, so the state
+    /// transition is idempotent in practice.
+    let setHandler (handler : SignalHandler) (state : SignalState) : SignalState =
+        { state with
+            Handler = Some handler
+        }
 
     let isEnabled (signal : Signal) (state : SignalState) : bool = Set.contains signal state.Enabled
 


### PR DESCRIPTION
## Summary
- Implements the `SystemNative_SetPosixSignalHandler` P/Invoke arm, which CoreLib's `PosixSignalRegistration.Initialize` invokes from its static cctor with `&OnPosixSignal`.
- Adds a `Handler : SignalHandler option` field to `SignalState`. `SignalHandler` is a custom-equality wrapper around `MethodInfo` (using `MethodInfo.NominallyEqual`) so the kernel keeps clean structural equality — naked `MethodInfo` carries `ImmutableArray` fields and reference-equal `MethodBody` payloads.
- The arm refuses any argument that isn't a real `NativeIntSource.FunctionPointer` (i.e., didn't come from `Ldftn` on a managed method), so a guest can't smuggle in a value with no callable identity.

## Test plan
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 1217 passed, 0 failed.
- [x] `nix develop -c dotnet fantomas .` — clean.
- [x] `codex review --base main` — no findings.
- New `TestSignalHandler.fs` covers: empty-state default, set/get round-trip, independently-constructed wrappers around the same method compare equal (and hash equally), distinct methods don't, `Equals` rejects non-`SignalHandler` values, `SignalState` structural equality is preserved when handlers are installed, and `setHandler` is last-writer-wins.
- End-to-end sourcesPure coverage isn't viable: like the prior PR's Init/Enable/Disable arms, `SetPosixSignalHandler` is side-effectful on the host process (it overwrites the real CLR's `g_posixSignalHandler`), so a dual-execution sourcesPure test would clobber the test runner's own `PosixSignalRegistration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)