### PR TITLE
Reject DateTime fields from strict-numeric blittable arm

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -20,6 +20,7 @@ module TestPureCases =
             "AdvancedStructLayout.cs" // past MarshalNative_SizeOfHelper for ByValTStr and SystemNative_Malloc / SystemNative_Free / Marshal.AllocHGlobal / FreeHGlobal; now blocked downstream at the unimplemented MarshalNative_TryGetStructMarshalStub QCall (CoreLib's Marshal.StructureToPtr path)
             "Threads.cs" // past ThreadNative_InformThreadNameChange (Thread.Name setter); now blocked on unimplemented PAL call libSystem.Native!SystemNative_GetLowResolutionTimestamp (.Sys::GetLowResolutionTimestamp, used by the Task/ThreadPool scheduler)
             "LdtokenField.cs" // Test 5's typeof(GenericClass<>).GetField path now passes; the test now reaches an unrelated downstream blocker, the InternalCall System.Signature::GetParameterOffsetInternal.
+            "MarshalStructureToPtrDateTimeField.cs" // MarshalNative_TryGetStructMarshalStub doesn't yet synthesise an IL stub for has-layout-non-blittable structs; CoreCLR writes an 8-byte OADate (`MARSHAL_TYPE_DATE`) for a `DateTime` field, but PawPrint currently rejects the struct loudly rather than memmove-ing the managed `_dateData` bytes. Real implementation needs the OADate-conversion stub.
         ]
         |> Set.ofList
 

--- a/WoofWare.PawPrint.Test/sourcesPure/MarshalStructureToPtrDateTimeField.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/MarshalStructureToPtrDateTimeField.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Runtime.InteropServices;
+
+public class Program
+{
+    [StructLayout(LayoutKind.Sequential)]
+    struct WithDateTime
+    {
+        public int Id;
+        public DateTime When;
+    }
+
+    public static int Main(string[] args)
+    {
+        // CoreCLR's `MarshalInfo::MarshalInfo` (mlinfo.cpp:1747) special-cases
+        // `System.DateTime` as `MARSHAL_TYPE_DATE` before the AutoLayout
+        // rejection: a sequential struct field typed `DateTime` marshals to
+        // native as an 8-byte OADate (a little-endian IEEE-754 double whose
+        // value is `dt.ToOADate()`), NOT as the managed `ulong _dateData`
+        // field's bytes. PawPrint's `MarshalNative_TryGetStructMarshalStub`
+        // `isStrictlyNumericBlittable` arm currently recurses into `DateTime`,
+        // sees its single `ulong _dateData` field, declares the parent struct
+        // blittable, and would take the memmove fast path — silently writing
+        // the managed `_dateData` bytes instead of OADate bytes. This test
+        // pins the expected behaviour and tracks the future OADate-conversion
+        // stub work.
+        var s = new WithDateTime { Id = 7, When = new DateTime(2020, 1, 2) };
+        int size = Marshal.SizeOf<WithDateTime>();
+        IntPtr ptr = Marshal.AllocHGlobal(size);
+        try
+        {
+            Marshal.StructureToPtr(s, ptr, false);
+            if (Marshal.ReadInt32(ptr, 0) != 7) return 1;
+            long bits = Marshal.ReadInt64(ptr, 8);
+            double actual = BitConverter.Int64BitsToDouble(bits);
+            double expected = s.When.ToOADate();
+            if (actual != expected) return 2;
+            // Belt-and-braces: ensure these aren't the managed `_dateData`
+            // bytes. `_dateData` for `new DateTime(2020,1,2)` is the tick
+            // count 637135200000000000 with the kind bits cleared.
+            if (bits == 637135200000000000L) return 3;
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(ptr);
+        }
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/CliType.fs
+++ b/WoofWare.PawPrint/CliType.fs
@@ -1199,8 +1199,11 @@ and CliValueType =
     /// a DateTime-typed field to `MARSHAL_TYPE_DATE` (8 bytes) at `mlinfo.cpp:1747`, BEFORE the
     /// AutoLayout rejection in the same classifier — so a sequential struct can embed DateTime
     /// even though `DateTime` itself is declared `[StructLayout(LayoutKind.Auto)]`. Callers use
-    /// this to honour the shortcut on the field walk and skip recursion into DateTime's storage.
-    static member private IsHostKnownDateTime
+    /// this both to honour the shortcut on the field-size walk and to reject DateTime fields
+    /// from the strict-numeric blittable arm of `MarshalNative_TryGetStructMarshalStub` (whose
+    /// memmove fast path would otherwise silently emit the managed `_dateData` bytes instead
+    /// of the OADate native form).
+    static member IsHostKnownDateTime
         (concreteTypes : AllConcreteTypes)
         (assemblies : ImmutableDictionary<string, DumpedAssembly>)
         (corelib : BaseClassTypes<DumpedAssembly>)

--- a/WoofWare.PawPrint/Native/NativeMarshal.fs
+++ b/WoofWare.PawPrint/Native/NativeMarshal.fs
@@ -201,14 +201,32 @@ module NativeMarshal =
                 | CliType.ObjectRef _
                 | CliType.RuntimePointer _ -> false
                 | CliType.ValueType vt ->
-                    match vt._Storage with
-                    // RawBytes-backed value types are not the typical struct-with-fields
-                    // shape; conservatively reject so we don't quietly accept primitive
-                    // wrappers whose CoreCLR marshal size diverges from the byte image.
-                    | CliValueTypeStorage.RawBytes _ -> false
-                    | CliValueTypeStorage.Fields storage ->
-                        storage.Fields
-                        |> List.forall (fun field -> isStrictlyNumericBlittable field.Contents)
+                    // DateTime is structurally a single `ulong _dateData` and would otherwise
+                    // qualify as strictly numeric, but CoreCLR's `MarshalInfo` (mlinfo.cpp:1747)
+                    // special-cases DateTime fields as `MARSHAL_TYPE_DATE`: 8 bytes of OADate
+                    // (`dt.ToOADate()` as a little-endian IEEE-754 double), NOT the managed
+                    // `_dateData` byte image. The memmove fast path would silently emit the
+                    // wrong bytes, so reject here and let the outer arm surface the existing
+                    // TODO failwith. Implementing the OADate conversion belongs in a future
+                    // PR that synthesises the has-layout-non-blittable IL stub.
+                    let isDateTime =
+                        CliValueType.IsHostKnownDateTime
+                            state.ConcreteTypes
+                            state._LoadedAssemblies
+                            ctx.BaseClassTypes
+                            vt
+
+                    if isDateTime then
+                        false
+                    else
+                        match vt._Storage with
+                        // RawBytes-backed value types are not the typical struct-with-fields
+                        // shape; conservatively reject so we don't quietly accept primitive
+                        // wrappers whose CoreCLR marshal size diverges from the byte image.
+                        | CliValueTypeStorage.RawBytes _ -> false
+                        | CliValueTypeStorage.Fields storage ->
+                            storage.Fields
+                            |> List.forall (fun field -> isStrictlyNumericBlittable field.Contents)
 
             if isStrictlyNumericBlittable zero then
                 // The eventual `*structMarshalStub` we write here is null: the blittable path


### PR DESCRIPTION
## Summary
- `MarshalNative_TryGetStructMarshalStub`'s `isStrictlyNumericBlittable` recursed into `DateTime`'s storage (a single `ulong _dateData`), declared the parent struct blittable, and took the memmove fast path — silently writing managed `_dateData` bytes where CoreCLR (`mlinfo.cpp:1747`) special-cases DateTime fields as `MARSHAL_TYPE_DATE` (8 bytes of OADate, i.e. `dt.ToOADate()` as a little-endian double).
- Reject DateTime in the classifier so the existing TODO `failwith` surfaces loudly. The actual OADate conversion stub is left for a separate PR.
- Adds a real-runtime motivating test (`sourcesPure/MarshalStructureToPtrDateTimeField.cs`) in `unimplemented` that pins the expected OADate behaviour while the stub is built out.

Tracking the same parent issue as #594 / #597 (issue #595).

## Test plan
- [x] `nix develop -c dotnet build WoofWare.PawPrint.slnx` (clean, warnings-as-errors)
- [x] `nix develop -c dotnet test --filter "Name~Marshal"` — all 9 Marshal tests pass; the new `MarshalStructureToPtrDateTimeField.cs` confirms real .NET's OADate behaviour
- [x] `nix develop -c dotnet test` — full suite 1211/1211 passing
- [x] `nix develop -c dotnet fantomas .` — no changes
- [x] `codex review --base main` — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)