### PR TITLE
Move SystemNativeClose end-to-end test to the impure (PawPrint-only) bucket

### DIFF
--- a/WoofWare.PawPrint.Test/TestImpureCases.fs
+++ b/WoofWare.PawPrint.Test/TestImpureCases.fs
@@ -109,6 +109,27 @@ module TestImpureCases =
                         |> shouldEqual 0
                     )
             }
+            {
+                // Exercises the SystemNative_Close / SystemNative_Dup handler
+                // pair end-to-end against the PawPrint FileDescriptorRegistry:
+                // close of an invalid fd, close of a freshly-duped fd, the
+                // double-close EBADF path, and the lowest-free gap-fill after
+                // a close. This used to live in sourcesPure for cross-runtime
+                // validation, but the real CLR's multi-threaded fd activity
+                // races our close + dup window in the NUnit test process, so
+                // it now runs as an impure (PawPrint-only) test where the
+                // interpreter's deterministic single-threaded fd table makes
+                // the assertions stable. The registry-level invariants are
+                // still independently covered by TestFileDescriptorRegistry's
+                // property tests; this test verifies the wiring from the
+                // P/Invoke handler through to the registry.
+                FileName = "SystemNativeClose.cs"
+                ExpectedReturnCode = 0
+                Environment = Map.empty
+                ExpectsUnhandledException = false
+                NativeImpls = NativeImpls.PassThru ()
+                AssertTerminalState = None
+            }
         ]
 
     let runTest (case : EndToEndTestCase) : unit =

--- a/WoofWare.PawPrint.Test/sourcesImpure/SystemNativeClose.cs
+++ b/WoofWare.PawPrint.Test/sourcesImpure/SystemNativeClose.cs
@@ -2,22 +2,32 @@ using System;
 using System.Runtime.InteropServices;
 
 // Exercises the SystemNative_Close PawPrint handler directly via a P/Invoke
-// stub, without depending on `SafeFileHandle` marshalling. The CLR runtime
-// dispatches this to the real libSystem.Native shim; PawPrint intercepts the
-// call and routes it through FileDescriptorRegistry.
+// stub, without depending on `SafeFileHandle` marshalling. PawPrint intercepts
+// the call and routes it through FileDescriptorRegistry.
 //
-// This test must pass on both the real runtime and PawPrint, so it asserts
-// only invariants that hold on every Unix kernel:
+// This is an *impure* test: it runs only inside PawPrint, never against the
+// real CLR. The assertions below — particularly the lowest-free gap-fill and
+// the double-close-returns-EBADF cases — only hold when the fd table is not
+// being mutated concurrently by anything else in the host process. The real
+// CLR test harness lives inside a multi-threaded NUnit process where parallel
+// tests and runtime background threads (GC, finalizer, ThreadPool I/O) can
+// open or close fds at arbitrary moments; on Linux CI this raced our close +
+// dup window and flaked the test, and worse could let our double-close
+// actually close another thread's fd if it had reused the freed slot.
+// PawPrint's interpreter is single-threaded and deterministic, so the exact
+// POSIX semantics are stable here.
+//
+// The assertions:
 //   * close of an invalid fd returns -1
 //   * close of a freshly-duped fd returns 0
 //   * a second close of the same fd returns -1 (the slot is gone)
-//   * after close-then-dup, the freed fd is the one POSIX allocates next
+//   * after close-then-dup, the freed fd is the one allocated next
 //     (lowest non-negative integer not in use)
 //
-// The test deliberately never closes fd 0/1/2 — on the real CLR that would
-// detach the test process from its stdin/stdout/stderr and corrupt the test
-// runner's output. The registry unit tests in TestFileDescriptorRegistry
-// cover close semantics over std-stream fds directly.
+// The test deliberately never closes fd 0/1/2 — on PawPrint that would remove
+// the stdin/stdout/stderr entries from the simulated fd table.
+// `TestFileDescriptorRegistry` covers close over std-stream fds directly,
+// alongside property tests for the lowest-free invariant.
 class Program
 {
     [DllImport("libSystem.Native", EntryPoint = "SystemNative_Close")]


### PR DESCRIPTION
## Summary

- `SystemNativeClose.cs` was a *pure* (cross-runtime) end-to-end test asserting POSIX `close(2)` / `dup(2)` semantics: invalid-fd EBADF, fresh dup + close, double-close EBADF, and lowest-free gap-fill.
- The gap-fill and double-close assertions are only stable when no concurrent fd activity exists in the process. The real CLR runs them inside a multi-threaded NUnit harness where parallel pure tests and runtime background threads (GC, finalizer, ThreadPool I/O) can open/close fds at any moment — flaking the gap-fill on Linux CI (returned 5), and worse, letting the double-close silently close another thread's fd if the slot had been reused.
- Moved the C# source to `sourcesImpure/` and registered it in `TestImpureCases.fs`. PawPrint's single-threaded deterministic fd table makes all four assertions stable. Registry-level invariants are independently covered by `TestFileDescriptorRegistry`'s property tests.

## Test plan

- [x] `nix develop -c dotnet test --filter "Name~SystemNativeClose"` passes locally
- [x] `nix develop -c dotnet test --filter "Name~SystemNative"` (all five SystemNative-related tests) passes
- [x] `codex review --base main` reports no regression
- [ ] CI is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)