### PR TITLE
Project Signature metadata onto field PE bytes

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -19,7 +19,6 @@ module TestPureCases =
         [
             "AdvancedStructLayout.cs" // past MarshalNative_SizeOfHelper for ByValTStr and SystemNative_Malloc / SystemNative_Free / Marshal.AllocHGlobal / FreeHGlobal; now blocked downstream at the unimplemented MarshalNative_TryGetStructMarshalStub QCall (CoreLib's Marshal.StructureToPtr path)
             "Threads.cs" // past ThreadNative_InformThreadNameChange (Thread.Name setter); now blocked on unimplemented PAL call libSystem.Native!SystemNative_GetLowResolutionTimestamp (.Sys::GetLowResolutionTimestamp, used by the Task/ThreadPool scheduler)
-            "LdtokenField.cs" // Test 5's typeof(GenericClass<>).GetField path now passes; the test now reaches an unrelated downstream blocker, the InternalCall System.Signature::GetParameterOffsetInternal.
             "MarshalStructureToPtrDateTimeField.cs" // MarshalNative_TryGetStructMarshalStub doesn't yet synthesise an IL stub for has-layout-non-blittable structs; CoreCLR writes an 8-byte OADate (`MARSHAL_TYPE_DATE`) for a `DateTime` field, but PawPrint currently rejects the struct loudly rather than memmove-ing the managed `_dateData` bytes. Real implementation needs the OADate-conversion stub.
         ]
         |> Set.ofList

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -1,6 +1,7 @@
 namespace WoofWare.PawPrint
 
 open System
+open System.Reflection.Metadata
 
 [<RequireQualifiedAccess>]
 module IlMachineManagedByref =
@@ -626,12 +627,22 @@ module IlMachineManagedByref =
                 failwith $"PE byte-view read needs loaded assembly %s{peByteRange.AssemblyFullName}"
             )
 
-        let sectionData =
-            assembly.PeReader.GetSectionData peByteRange.RelativeVirtualAddress
+        let bytes =
+            match peByteRange.Source with
+            | PeByteRangePointerSource.FieldRva _
+            | PeByteRangePointerSource.ManagedResource _ ->
+                let sectionData =
+                    assembly.PeReader.GetSectionData peByteRange.RelativeVirtualAddress
 
-        let mutable reader = sectionData.GetReader ()
-        reader.Offset <- byteOffset
-        let bytes = reader.ReadBytes targetSize
+                let mutable reader = sectionData.GetReader ()
+                reader.Offset <- byteOffset
+                reader.ReadBytes targetSize
+            | PeByteRangePointerSource.FieldSignatureBlob field ->
+                let mdReader = assembly.PeReader.GetMetadataReader ()
+                let fieldDef = mdReader.GetFieldDefinition field.Get
+                let mutable blobReader = mdReader.GetBlobReader fieldDef.Signature
+                blobReader.Offset <- byteOffset
+                blobReader.ReadBytes targetSize
 
         CliType.ofBytesLike targetTemplate bytes
 

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -52,6 +52,9 @@ module IlMachineState =
     let peByteRangeForEmbeddedManifestResource =
         IlMachineTypeResolution.peByteRangeForEmbeddedManifestResource
 
+    let peByteRangeForFieldSignatureBlob =
+        IlMachineTypeResolution.peByteRangeForFieldSignatureBlob
+
     let peByteRangePointer = IlMachineTypeResolution.peByteRangePointer
 
     let getFrame = IlMachineThreadState.getFrame

--- a/WoofWare.PawPrint/IlMachineTypeResolution.fs
+++ b/WoofWare.PawPrint/IlMachineTypeResolution.fs
@@ -670,6 +670,29 @@ module IlMachineTypeResolution =
             Size = resource.PayloadLength
         }
 
+    /// PE byte range pointer over the COR signature blob bytes for a field
+    /// definition (ECMA II.23.2.4). The blob lives in the metadata stream's
+    /// #Blob heap rather than in a section, so `RelativeVirtualAddress` is
+    /// fixed at 0 for this variant; readers must dispatch on
+    /// `PeByteRangePointerSource.FieldSignatureBlob` and resolve the bytes via
+    /// the assembly's `MetadataReader.GetBlobReader` rather than through
+    /// `PeReader.GetSectionData`.
+    let peByteRangeForFieldSignatureBlob
+        (assembly : DumpedAssembly)
+        (fieldHandle : FieldDefinitionHandle)
+        : PeByteRangePointer
+        =
+        let mdReader = assembly.PeReader.GetMetadataReader ()
+        let fieldDef = mdReader.GetFieldDefinition fieldHandle
+        let blobReader = mdReader.GetBlobReader fieldDef.Signature
+
+        {
+            AssemblyFullName = assembly.Name.FullName
+            Source = PeByteRangePointerSource.FieldSignatureBlob (ComparableFieldDefinitionHandle.Make fieldHandle)
+            RelativeVirtualAddress = 0
+            Size = blobReader.Length
+        }
+
     let peByteRangePointer
         (loggerFactory : ILoggerFactory)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)

--- a/WoofWare.PawPrint/ManagedPointerSource.fs
+++ b/WoofWare.PawPrint/ManagedPointerSource.fs
@@ -12,6 +12,13 @@ type PeByteRangePointerSource =
     /// ECMA-335 4-byte length prefix; PeByteRangePointer.Size is the decoded
     /// payload length, not including that prefix.
     | ManagedResource of resourceName : string
+    /// The COR signature blob for a field definition (ECMA II.23.2.4),
+    /// stored in the metadata stream's #Blob heap rather than in a section.
+    /// `PeByteRangePointer.Size` is the blob's length; the RVA field has no
+    /// PE-section meaning for this variant and is set to 0. Bytes are read
+    /// via the assembly's `MetadataReader.GetBlobBytes` rather than through
+    /// `PeReader.GetSectionData`.
+    | FieldSignatureBlob of field : ComparableFieldDefinitionHandle
 
 type PeByteRangePointer =
     {
@@ -26,6 +33,7 @@ type PeByteRangePointer =
             match this.Source with
             | PeByteRangePointerSource.FieldRva field -> $"field %O{field.Get}"
             | PeByteRangePointerSource.ManagedResource resourceName -> $"managed resource %s{resourceName}"
+            | PeByteRangePointerSource.FieldSignatureBlob field -> $"field signature blob for %O{field.Get}"
 
         $"<PE data %s{this.AssemblyFullName} %s{source} at %d{this.RelativeVirtualAddress} size %d{this.Size}>"
 

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -64,6 +64,8 @@ module NativeQCall =
             "EventPipeInternal_WaitForSessionSignal",
             NativeEventPipe.tryExecuteQCall "EventPipeInternal_WaitForSessionSignal"
             "Signature_Init", NativeSignature.tryExecuteQCall "Signature_Init"
+            "Signature_GetCustomModifiersAtOffset",
+            NativeSignature.tryExecuteQCall "Signature_GetCustomModifiersAtOffset"
             "Array_CreateInstance", NativeArray.tryExecuteQCall "Array_CreateInstance"
             "Enum_GetValuesAndNames", NativeEnum.tryExecuteQCall "Enum_GetValuesAndNames"
             "AssemblyNative_GetResource", NativeRuntimeAssembly.tryExecuteQCall "AssemblyNative_GetResource"

--- a/WoofWare.PawPrint/Native/NativeSignature.fs
+++ b/WoofWare.PawPrint/Native/NativeSignature.fs
@@ -1,18 +1,58 @@
 namespace WoofWare.PawPrint
 
 open System.Collections.Immutable
+open System.Reflection.Metadata
 
 [<RequireQualifiedAccess>]
 module NativeSignature =
     /// ECMA II.23.2.4 calling-convention byte for a field signature blob.
     let private callingConventionField : int = 0x6
 
-    /// Deliberately bogus pointer value installed as the field-signature blob.
-    /// PawPrint does not yet serialise field signatures back to a COR-sig byte
-    /// stream. Anything that tries to read this pointer via the managed-pointer
-    /// boundary helpers will fail loudly through their catch-all rather than
-    /// silently treating it as null and producing an empty parse.
-    let private fieldSignatureBlobSentinel : int64 = 0xDEAD_BEEF_DEAD_BEEFL
+    /// ECMA II.23.2.3 low-nibble mask for the calling-convention byte; the
+    /// upper bits are the HASTHIS / EXPLICITTHIS / GENERIC / VARARG flags.
+    let private callingConventionMask : int = 0xF
+
+    /// Resolve a Signature `_sig` argument to the owning assembly plus the
+    /// COR signature `BlobHandle` it points at. PawPrint installs `_sig` as a
+    /// managed byref over a field's PE-metadata signature blob; this helper
+    /// unwraps that byref. Callers that only need the raw bytes can use
+    /// `resolveSignatureBlob`; callers that need to seek with a `BlobReader`
+    /// (e.g. token-aware parsers) acquire a fresh reader from the returned
+    /// handle.
+    let private resolveSignatureBlobHandle
+        (operation : string)
+        (state : IlMachineState)
+        (sigArg : CliType)
+        : DumpedAssembly * BlobHandle
+        =
+        let peByteRange =
+            match CliType.unwrapPrimitiveLikeDeep sigArg with
+            | CliType.RuntimePointer (CliRuntimePointer.Managed (ManagedPointerSource.Byref (ByrefRoot.PeByteRange peByteRange,
+                                                                                             _))) -> peByteRange
+            | other -> failwith $"%s{operation}: expected managed pointer over a PE byte range for sig, got %O{other}"
+
+        match peByteRange.Source with
+        | PeByteRangePointerSource.FieldSignatureBlob field ->
+            let assembly =
+                state.LoadedAssembly' peByteRange.AssemblyFullName
+                |> Option.defaultWith (fun () ->
+                    failwith
+                        $"%s{operation}: signature blob references unloaded assembly %s{peByteRange.AssemblyFullName}"
+                )
+
+            let mdReader = assembly.PeReader.GetMetadataReader ()
+            let fieldDef = mdReader.GetFieldDefinition field.Get
+            assembly, fieldDef.Signature
+        | other ->
+            failwith
+                $"%s{operation}: signature `_sig` byref points at non-signature PE byte range %O{other}; only FieldSignatureBlob is currently supported"
+
+    /// Resolve a Signature `_sig` argument to the COR signature blob bytes it
+    /// points at. Built on top of `resolveSignatureBlobHandle`.
+    let private resolveSignatureBlob (operation : string) (state : IlMachineState) (sigArg : CliType) : byte[] =
+        let assembly, blobHandle = resolveSignatureBlobHandle operation state sigArg
+        let mdReader = assembly.PeReader.GetMetadataReader ()
+        mdReader.GetBlobBytes blobHandle
 
     let private signatureObjectAddress (operation : string) (arg : CliType) : ManagedHeapAddress =
         match arg with
@@ -111,10 +151,13 @@ module NativeSignature =
             (RuntimeTypeHandleTarget.Closed fieldType)
             state
 
-    /// Populate the Signature object's `_returnTypeORfieldType`, `_sig`, and calling-convention
-    /// fields for the field-backed path. The constructor caller supplies `_declaringType`
-    /// directly, so this helper only needs to fill in the runtime-derived fields. Returns the
-    /// updated machine state.
+    /// Populate the Signature object's `_returnTypeORfieldType`, `_sig`, `_csig`,
+    /// and calling-convention fields for the field-backed path. The constructor
+    /// caller supplies `_declaringType` directly, so this helper only needs to
+    /// fill in the runtime-derived fields. `_sig` is set to a managed byref over
+    /// the field's COR signature blob bytes in the assembly metadata, and
+    /// `_csig` to the blob length, mirroring CoreCLR's
+    /// `pFieldDesc->GetSig(&_sig, &_csig)`. Returns the updated machine state.
     let private fillFieldSignature
         (ctx : NativeCallContext)
         (operation : string)
@@ -123,6 +166,7 @@ module NativeSignature =
         (returnTypeFieldName : string)
         (callingConventionFieldName : string)
         (sigFieldName : string)
+        (csigFieldName : string)
         (state : IlMachineState)
         : IlMachineState
         =
@@ -138,12 +182,28 @@ module NativeSignature =
                 callingConventionFieldName
                 (CliType.Numeric (CliNumericType.Int32 callingConventionField))
 
+        let assembly, _fieldInfo =
+            NativeRuntimeFieldHandle.getFieldForFieldHandle operation fieldHandle state
+
+        let peByteRange =
+            IlMachineState.peByteRangeForFieldSignatureBlob assembly (fieldHandle.GetFieldDefinitionHandle().Get)
+
+        let state, sigPointer =
+            IlMachineState.peByteRangePointer ctx.LoggerFactory ctx.BaseClassTypes peByteRange state
+
         let state =
             setSignatureField
                 state
                 signatureAddr
                 sigFieldName
-                (CliType.RuntimePointer (CliRuntimePointer.Verbatim fieldSignatureBlobSentinel))
+                (CliType.RuntimePointer (CliRuntimePointer.Managed sigPointer))
+
+        let state =
+            setSignatureField
+                state
+                signatureAddr
+                csigFieldName
+                (CliType.Numeric (CliNumericType.Int32 peByteRange.Size))
 
         state
 
@@ -231,7 +291,224 @@ module NativeSignature =
                     "_returnTypeORfieldType"
                     "_managedCallingConventionAndArgIteratorFlags"
                     "_sig"
+                    "_csig"
                     state
+
+            NativeHandlerResult.completed state |> Some
+        | "Signature_GetCustomModifiersAtOffset",
+          "System.Private.CoreLib",
+          "System",
+          "Signature",
+          "GetCustomModifiersAtOffset",
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "ObjectHandleOnStack",
+                                              sigObjGenerics)
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32
+            ConcreteType state.ConcreteTypes ("System.Private.CoreLib", "", "BOOL", boolGenerics)
+            ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "ObjectHandleOnStack",
+                                              resultGenerics) ],
+          MethodReturnType.Void when sigObjGenerics.IsEmpty && boolGenerics.IsEmpty && resultGenerics.IsEmpty ->
+            // CoreCLR's Signature_GetCustomModifiersAtOffset (runtimehandles.cpp:1461)
+            // walks the field/method signature blob from `offset`, collecting
+            // CMOD_REQD / CMOD_OPT prefixes whose `required` flag matches the caller's
+            // request, resolves each TypeDefOrRefOrSpec token under the Signature's
+            // type context, allocates a fresh `Type[]` of exactly cMods entries, and
+            // writes it back through the `result` ObjectHandleOnStack. The managed
+            // caller `Signature.GetCustomModifiersAtOffset` asserts the result is
+            // non-null even when cMods = 0, so we always allocate.
+            //
+            // Today PawPrint's `_sig` byref is only populated for field-shaped
+            // signatures (see `Signature_Init` / `GetSignature` above), so we use
+            // the declaring type's instantiation as the type context.
+            // CMOD_INTERNAL (0x21) carries a `void*` that points at a runtime-only
+            // TypeHandle; CoreCLR's own metadata writer never emits it from PE bytes,
+            // so we fail loudly if we encounter one.
+            let operation = "Signature.GetCustomModifiersAtOffset"
+
+            if instruction.Arguments.Length <> 4 then
+                failwith $"%s{operation}: expected four native arguments, got %d{instruction.Arguments.Length}"
+
+            let sigObjPtr =
+                NativeCall.objectHandleOnStackTarget operation state "sigObj" instruction.Arguments.[0]
+
+            let offset = NativeCall.int32Argument operation instruction.Arguments.[1]
+            let requiredFlag = NativeCall.int32Argument operation instruction.Arguments.[2]
+            let fRequired = requiredFlag <> 0
+
+            let resultPtr =
+                NativeCall.objectHandleOnStackTarget operation state "result" instruction.Arguments.[3]
+
+            let signatureValue =
+                IlMachineState.readManagedByref ctx.BaseClassTypes state sigObjPtr
+
+            let signatureAddr =
+                match signatureValue with
+                | CliType.ObjectRef (Some addr) -> addr
+                | CliType.ObjectRef None ->
+                    failwith $"%s{operation}: ObjectHandleOnStack pointed to a null Signature reference"
+                | other -> failwith $"%s{operation}: expected ObjectRef in ObjectHandleOnStack, got %O{other}"
+
+            let signatureObj = ManagedHeap.get signatureAddr state.ManagedHeap
+
+            let sigFieldId =
+                IlMachineState.requiredOwnInstanceFieldId state signatureObj.ConcreteType "_sig"
+
+            let sigCliValue =
+                AllocatedNonArrayObject.DereferenceFieldById sigFieldId signatureObj
+
+            let csigFieldId =
+                IlMachineState.requiredOwnInstanceFieldId state signatureObj.ConcreteType "_csig"
+
+            let csig =
+                match
+                    AllocatedNonArrayObject.DereferenceFieldById csigFieldId signatureObj
+                    |> CliType.unwrapPrimitiveLikeDeep
+                with
+                | CliType.Numeric (CliNumericType.Int32 v) -> v
+                | other -> failwith $"%s{operation}: expected Int32 in Signature._csig, got %O{other}"
+
+            let declaringTypeFieldId =
+                IlMachineState.requiredOwnInstanceFieldId state signatureObj.ConcreteType "_declaringType"
+
+            let declaringTypeAddr =
+                match AllocatedNonArrayObject.DereferenceFieldById declaringTypeFieldId signatureObj with
+                | CliType.ObjectRef (Some addr) -> addr
+                | CliType.ObjectRef None ->
+                    failwith
+                        $"%s{operation}: Signature._declaringType was null; the field-backed slice always carries a declaring RuntimeType"
+                | other ->
+                    failwith $"%s{operation}: expected RuntimeType ObjectRef in Signature._declaringType, got %O{other}"
+
+            let declaringTypeObj = ManagedHeap.get declaringTypeAddr state.ManagedHeap
+
+            let handleFieldId =
+                IlMachineState.requiredOwnInstanceFieldId state declaringTypeObj.ConcreteType "m_handle"
+
+            let declaringTarget =
+                match
+                    AllocatedNonArrayObject.DereferenceFieldById handleFieldId declaringTypeObj
+                    |> CliType.unwrapPrimitiveLike
+                with
+                | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.TypeHandlePtr target)) -> target
+                | other -> failwith $"%s{operation}: expected TypeHandlePtr in RuntimeType.m_handle, got %O{other}"
+
+            let typeGenerics =
+                match declaringTarget with
+                | RuntimeTypeHandleTarget.Closed handle ->
+                    match AllConcreteTypes.lookup handle state.ConcreteTypes with
+                    | Some ct -> ct.Generics
+                    | None ->
+                        failwith
+                            $"%s{operation}: declaring type handle %O{handle} was not concretized, so custom modifiers cannot be resolved"
+                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ -> ImmutableArray.Empty
+                | RuntimeTypeHandleTarget.GenericParameter _
+                | RuntimeTypeHandleTarget.MethodGenericParameter _ ->
+                    failwith
+                        $"%s{operation}: declaring type %O{declaringTarget} is a generic parameter; the field-backed slice expects a real declaring type"
+
+            let assembly, blobHandle = resolveSignatureBlobHandle operation state sigCliValue
+            let mdReader = assembly.PeReader.GetMetadataReader ()
+            let mutable blobReader = mdReader.GetBlobReader blobHandle
+
+            if blobReader.Length <> csig then
+                failwith
+                    $"%s{operation}: Signature._csig %d{csig} does not match the actual blob length %d{blobReader.Length}"
+
+            if offset < 0 || offset > csig then
+                failwith $"%s{operation}: offset %d{offset} is out of range for blob of length %d{csig}"
+
+            blobReader.Offset <- offset
+
+            // ECMA II.23.1.16 ELEMENT_TYPE_* constants for custom-modifier prefixes.
+            let CMOD_REQD : byte = 0x1Fuy
+            let CMOD_OPT : byte = 0x20uy
+            let CMOD_INTERNAL : byte = 0x21uy
+            let SENTINEL : byte = 0x41uy
+
+            let modifierHandles = ResizeArray<EntityHandle> ()
+            let mutable continueLoop = true
+
+            while continueLoop do
+                if blobReader.RemainingBytes <= 0 then
+                    failwith
+                        $"%s{operation}: signature blob ran out at offset %d{blobReader.Offset} while scanning for custom modifiers"
+
+                let data = blobReader.ReadByte ()
+
+                if data = CMOD_REQD || data = CMOD_OPT then
+                    let handle = blobReader.ReadTypeHandle ()
+                    let isRequired = (data = CMOD_REQD)
+
+                    if isRequired = fRequired then
+                        modifierHandles.Add handle
+                elif data = CMOD_INTERNAL then
+                    failwith
+                        $"TODO: %s{operation} encountered CMOD_INTERNAL (0x21) at offset %d{blobReader.Offset - 1}; not yet supported (only produced by runtime-only signatures)"
+                elif data <> SENTINEL then
+                    continueLoop <- false
+
+            let state, _, typeElementHandle =
+                NativeRuntimeTypeHelpers.concretizeNonGenericCorelibType
+                    ctx.LoggerFactory
+                    ctx.BaseClassTypes
+                    state
+                    "System"
+                    "Type"
+
+            let arrayAddr, state =
+                IlMachineState.allocateArray
+                    (ConcreteTypeHandle.OneDimArrayZero typeElementHandle)
+                    (fun () -> CliType.ObjectRef None)
+                    modifierHandles.Count
+                    state
+
+            let state =
+                ((state, 0), modifierHandles)
+                ||> Seq.fold (fun (state, index) eh ->
+                    let token = MetadataToken.ofEntityHandle eh
+
+                    let state, typeDefn, resolvedAssy =
+                        IlMachineState.resolveTypeMetadataToken
+                            ctx.LoggerFactory
+                            ctx.BaseClassTypes
+                            state
+                            assembly
+                            typeGenerics
+                            token
+
+                    let state, concreteHandle =
+                        IlMachineState.concretizeType
+                            ctx.LoggerFactory
+                            ctx.BaseClassTypes
+                            state
+                            resolvedAssy.Name
+                            typeGenerics
+                            ImmutableArray.Empty
+                            typeDefn
+
+                    let runtimeTypeAddr, state =
+                        IlMachineState.getOrAllocateType
+                            ctx.LoggerFactory
+                            ctx.BaseClassTypes
+                            (RuntimeTypeHandleTarget.Closed concreteHandle)
+                            state
+
+                    let state =
+                        IlMachineState.setArrayValue arrayAddr (CliType.ObjectRef (Some runtimeTypeAddr)) index state
+
+                    state, index + 1
+                )
+                |> fst
+
+            let state =
+                IlMachineState.writeManagedByrefWithBase
+                    ctx.BaseClassTypes
+                    state
+                    resultPtr
+                    (CliType.ObjectRef (Some arrayAddr))
 
             NativeHandlerResult.completed state |> Some
         | _ -> None
@@ -248,6 +525,52 @@ module NativeSignature =
             instruction.ExecutingMethod.Signature.ParameterTypes,
             instruction.ExecutingMethod.Signature.ReturnType
         with
+        | "System.Private.CoreLib",
+          "System",
+          "Signature",
+          "GetParameterOffsetInternal",
+          [ ConcretePointer (ConcreteVoid state.ConcreteTypes)
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32 ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
+            // Static InternalCall: `int GetParameterOffsetInternal(void* sig, int csig, int parameterIndex)`.
+            // Mirrors CoreCLR's `SignatureNative::GetParameterOffsetInternal`: for the
+            // FIELD calling convention (0x06) the only valid parameter index is 0 and
+            // the byte offset to the parameter type is exactly 1 (just past the
+            // single calling-conv byte). Method-shaped calling conventions are not
+            // yet covered.
+            let operation = "Signature.GetParameterOffsetInternal"
+
+            if instruction.Arguments.Length <> 3 then
+                failwith $"%s{operation}: expected three arguments, got %d{instruction.Arguments.Length}"
+
+            let csig = NativeCall.int32Argument operation instruction.Arguments.[1]
+            let parameterIndex = NativeCall.int32Argument operation instruction.Arguments.[2]
+
+            if csig <= 0 then
+                failwith $"%s{operation}: csig must be positive, got %d{csig}"
+
+            let bytes = resolveSignatureBlob operation state instruction.Arguments.[0]
+
+            if bytes.Length <> csig then
+                failwith $"%s{operation}: csig %d{csig} does not match the actual blob length %d{bytes.Length}"
+
+            let callConv = int bytes.[0] &&& callingConventionMask
+
+            let offset =
+                if callConv = callingConventionField then
+                    if parameterIndex <> 0 then
+                        failwith $"%s{operation}: FIELD signature only has parameterIndex 0, got %d{parameterIndex}"
+
+                    1
+                else
+                    failwith
+                        $"TODO: %s{operation} non-FIELD calling convention 0x%X{callConv} is not yet implemented (csig=%d{csig}, parameterIndex=%d{parameterIndex})"
+
+            let state =
+                IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 offset)) ctx.Thread state
+
+            NativeHandlerResult.completed state |> Some
         | "System.Private.CoreLib",
           "System",
           "Signature",
@@ -316,6 +639,7 @@ module NativeSignature =
                     "m_returnTypeORfieldType"
                     "m_managedCallingConventionAndArgIteratorFlags"
                     "m_sig"
+                    "m_csig"
                     state
 
             NativeHandlerResult.completed state |> Some

--- a/WoofWare.PawPrint/Native/NativeSignature.fs
+++ b/WoofWare.PawPrint/Native/NativeSignature.fs
@@ -465,8 +465,13 @@ module NativeSignature =
                     modifierHandles.Count
                     state
 
+            // CoreCLR fills the result array via `SetAt(--cMods, ...)`, counting
+            // down from `count - 1`, so the first matching modifier in scan order
+            // lands at the last index and the last at index 0. Mirror that
+            // ordering exactly: reflection callers comparing array contents
+            // against real .NET expect the modifiers in reverse-of-scan order.
             let state =
-                ((state, 0), modifierHandles)
+                ((state, modifierHandles.Count - 1), modifierHandles)
                 ||> Seq.fold (fun (state, index) eh ->
                     let token = MetadataToken.ofEntityHandle eh
 
@@ -499,7 +504,7 @@ module NativeSignature =
                     let state =
                         IlMachineState.setArrayValue arrayAddr (CliType.ObjectRef (Some runtimeTypeAddr)) index state
 
-                    state, index + 1
+                    state, index - 1
                 )
                 |> fst
 

--- a/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
+++ b/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
@@ -90,7 +90,6 @@
     <Compile Include="Native\NativeMetadataImport.fs" />
     <Compile Include="Native\NativeRuntimeFieldHandle.fs" />
     <Compile Include="Native\NativeRuntimeMethodHandle.fs" />
-    <Compile Include="Native\NativeSignature.fs" />
     <Compile Include="Native\NativeRuntimeHelpers.fs" />
     <Compile Include="Native\NativeMarshal.fs" />
     <Compile Include="Native\NativeGcHandle.fs" />
@@ -98,6 +97,7 @@
     <Compile Include="Native\NativeBuffer.fs" />
     <Compile Include="Native\NativeException.fs" />
     <Compile Include="Native\NativeRuntimeTypeHelpers.fs" />
+    <Compile Include="Native\NativeSignature.fs" />
     <Compile Include="Native\NativeRuntimeTypeQCall.fs" />
     <Compile Include="Native\NativeRuntimeTypeFCall.fs" />
     <Compile Include="Native\NativeRuntimeType.fs" />


### PR DESCRIPTION
## Summary
- Project the `Signature._sig` byref onto real PE field-signature blob bytes via a new `PeByteRangePointerSource.FieldSignatureBlob` variant, so `GetParameterOffsetInternal` returns a real byte offset consumable downstream.
- Implement the `Signature_GetCustomModifiersAtOffset` QCall, parsing CMOD_REQD / CMOD_OPT prefixes from the field signature blob and materialising a `Type[]` back through the result `ObjectHandleOnStack`. Reverse-order fill mirrors CoreCLR's `SetAt(--cMods, ...)`.
- Remove `LdtokenField.cs` from the `unimplemented` set in `TestPureCases.fs`; the previously-blocked Test 5 path now passes end-to-end.

## Test plan
- [x] `nix develop -c dotnet build WoofWare.PawPrint/WoofWare.PawPrint.fsproj` clean
- [x] `nix develop -c dotnet test ... --filter "Name~LdtokenField"` passes
- [x] Full suite (`nix develop -c dotnet test WoofWare.PawPrint.Test/...`) — 1210/1210 passing before rebase
- [x] `codex review --base main` returned clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)