### PR TITLE
Allocate a Parked signal-dispatcher thread on first signal init

### DIFF
--- a/WoofWare.PawPrint.App/DebuggerServer.fs
+++ b/WoofWare.PawPrint.App/DebuggerServer.fs
@@ -150,15 +150,16 @@ module DebuggerServer =
         writer.WritePropertyName "status"
         writeThreadStatus writer threadState.Status
 
-        match threadState.Status with
-        | ThreadStatus.NotStarted ->
-            // A pre-`Start` Thread has no frames yet; the ActiveMethodState/MethodState
-            // accessors would crash. Surface the absence explicitly rather than
-            // skipping the keys, so consumers see a consistent shape.
+        if ThreadStatus.hasNoActiveFrame threadState.Status then
+            // A frameless thread (pre-`Start`, or a kernel-owned Parked
+            // dispatcher) has no live frame; the ActiveMethodState/MethodState
+            // accessors would crash on the sentinel `FrameId -1`. Surface the
+            // absence explicitly rather than skipping the keys, so consumers
+            // see a consistent shape.
             writer.WriteNull "activeAssembly"
             writer.WriteNull "activeFrame"
             writer.WriteNull "activeFrameSummary"
-        | _ ->
+        else
             writer.WriteString ("activeAssembly", threadState.ActiveAssembly.FullName)
             writer.WriteNumber ("activeFrame", frameIdValue threadState.ActiveMethodState)
             writer.WritePropertyName "activeFrameSummary"
@@ -464,11 +465,10 @@ module DebuggerServer =
             writer.WritePropertyName "status"
             writeThreadStatus writer threadState.Status
 
-            match threadState.Status with
-            | ThreadStatus.NotStarted ->
+            if ThreadStatus.hasNoActiveFrame threadState.Status then
                 writer.WriteNull "activeAssembly"
                 writer.WriteNull "activeFrame"
-            | _ ->
+            else
                 writer.WriteString ("activeAssembly", threadState.ActiveAssembly.FullName)
                 writer.WriteNumber ("activeFrame", frameIdValue threadState.ActiveMethodState)
 
@@ -546,13 +546,12 @@ module DebuggerServer =
             writer.WritePropertyName "status"
             writeThreadStatus writer threadState.Status
 
-            match threadState.Status with
-            | ThreadStatus.NotStarted ->
+            if ThreadStatus.hasNoActiveFrame threadState.Status then
                 writer.WriteNull "activeAssembly"
                 writer.WriteNull "activeFrame"
                 writer.WriteNumber ("frameCount", frames.Length)
                 writer.WriteNull "activeFrameSummary"
-            | _ ->
+            else
                 writer.WriteString ("activeAssembly", threadState.ActiveAssembly.FullName)
                 writer.WriteNumber ("activeFrame", frameIdValue threadState.ActiveMethodState)
                 writer.WriteNumber ("frameCount", frames.Length)
@@ -635,13 +634,14 @@ module DebuggerServer =
             writer.WriteStartObject ()
             writer.WriteString ("error", $"thread %d{threadIdValue threadId} does not exist")
             writer.WriteEndObject ()
-        | Some threadState when threadState.Status = ThreadStatus.NotStarted ->
-            // No frames have been pushed yet; there is no active method whose IL
-            // we could disassemble. Report this rather than dereferencing the
+        | Some threadState when ThreadStatus.hasNoActiveFrame threadState.Status ->
+            // No frame has been pushed yet (pre-`Start`, or a kernel-owned
+            // Parked dispatcher); there is no active method whose IL we
+            // could disassemble. Report this rather than dereferencing the
             // sentinel ActiveMethodState.
             writer.WriteStartObject ()
             writer.WriteNumber ("thread", threadIdValue threadId)
-            writer.WriteString ("error", $"thread %d{threadIdValue threadId} has not been started")
+            writer.WriteString ("error", $"thread %d{threadIdValue threadId} has no active frame")
             writer.WriteEndObject ()
         | Some threadState ->
             let frameId = threadState.ActiveMethodState

--- a/WoofWare.PawPrint.App/DebuggerServer.fs
+++ b/WoofWare.PawPrint.App/DebuggerServer.fs
@@ -111,6 +111,7 @@ module DebuggerServer =
             writer.WriteNumber ("handle", handle)
             writer.WriteEndObject ()
         | ThreadStatus.Terminated -> writer.WriteStringValue "terminated"
+        | ThreadStatus.Parked -> writer.WriteStringValue "parked"
 
     let private writeFrameProperties
         (writer : Utf8JsonWriter)

--- a/WoofWare.PawPrint.Test/TestSignalDispatcherThread.fs
+++ b/WoofWare.PawPrint.Test/TestSignalDispatcherThread.fs
@@ -1,0 +1,138 @@
+namespace WoofWare.PawPrint.Test
+
+open System.Collections.Immutable
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+/// Focused tests for the kernel-owned signal-dispatch thread that PawPrint
+/// spawns on the first call to
+/// `SystemNative_InitializeTerminalAndSignalHandling`. The dispatcher mirrors
+/// real CoreCLR's `SignalHandlerLoop` pthread: it exists permanently from
+/// init time, the scheduler never picks it (until a future slice wires
+/// up a wakeup edge), and it has no managed `Thread` heap mirror. These
+/// tests pin down the structural shape so the downstream slice that
+/// invokes handlers on this thread builds on a known-good foundation.
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestSignalDispatcherThread =
+
+    let private corelib : DumpedAssembly =
+        let corelibPath = typeof<obj>.Assembly.Location
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        Assembly.readFile loggerFactory corelibPath
+
+    let private baseState () : IlMachineState =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        IlMachineState.initial loggerFactory ImmutableArray.Empty corelib
+
+    /// Frameless `ThreadState` used to populate the scheduler-test states
+    /// below with `Runnable` threads we don't actually want to step. Mirrors
+    /// the pattern in `TestSyncBlockMonitor`.
+    let private stubThreadState (status : ThreadStatus) : ThreadState =
+        {
+            MethodStates = Map.empty
+            NextFrameId = 0
+            ActiveMethodState = FrameId -1
+            Status = status
+            IsBackground = false
+            Name = None
+        }
+
+    [<Test>]
+    let ``empty SignalState has no signal thread`` () : unit =
+        SignalState.empty |> SignalState.signalThread |> shouldEqual None
+
+    [<Test>]
+    let ``markInitialized records the dispatcher ThreadId`` () : unit =
+        let dispatcher = ThreadId 7
+
+        SignalState.empty
+        |> SignalState.markInitialized dispatcher
+        |> SignalState.signalThread
+        |> shouldEqual (Some dispatcher)
+
+    [<Test>]
+    let ``allocateParkedThread mints a Parked, frameless thread`` () : unit =
+        let state, thread = baseState () |> IlMachineState.allocateParkedThread
+
+        let ts =
+            state.ThreadState
+            |> Map.tryFind thread
+            |> Option.defaultWith (fun () -> failwith "expected parked thread to be present in ThreadState")
+
+        ts.Status |> shouldEqual ThreadStatus.Parked
+        // A frameless thread carries an empty MethodStates map and a sentinel
+        // ActiveMethodState that is not live in the map. Any code path that
+        // dereferences the active frame on a Parked thread must crash loudly
+        // rather than silently producing garbage. `MethodState` does not
+        // satisfy structural equality (its embedded `MethodInfo` carries
+        // reference-equality payloads), so we assert emptiness via `Count`.
+        ts.MethodStates.Count |> shouldEqual 0
+        ts.MethodStates.ContainsKey ts.ActiveMethodState |> shouldEqual false
+
+    [<Test>]
+    let ``allocateParkedThread does not register a managed Thread object`` () : unit =
+        // The dispatcher is kernel-owned, not constructed via the managed
+        // `new Thread(...)` path. There is no `Thread` heap object for guest
+        // code to observe, so `ManagedThreadObjects` must not be touched.
+        let initial = baseState ()
+        let state, thread = initial |> IlMachineState.allocateParkedThread
+
+        state.ManagedThreadObjects |> Map.containsKey thread |> shouldEqual false
+
+        // The pre-existing managed-thread mapping is preserved bit-for-bit
+        // (allocation should only add to ThreadState, not touch the managed
+        // mirror).
+        state.ManagedThreadObjects |> shouldEqual initial.ManagedThreadObjects
+
+    [<Test>]
+    let ``allocateParkedThread mints distinct ids on successive calls`` () : unit =
+        let state0 = baseState ()
+        let state1, t1 = state0 |> IlMachineState.allocateParkedThread
+        let state2, t2 = state1 |> IlMachineState.allocateParkedThread
+
+        t1 |> shouldNotEqual t2
+        state2.ThreadState |> Map.containsKey t1 |> shouldEqual true
+        state2.ThreadState |> Map.containsKey t2 |> shouldEqual true
+
+    [<Test>]
+    let ``scheduler skips Parked threads in favour of Runnable ones`` () : unit =
+        // Put a Runnable thread alongside a Parked one; the scheduler must
+        // ignore the Parked slot and return the Runnable id.
+        let runnable = ThreadId 0
+        let parked = ThreadId 1
+
+        let state =
+            { baseState () with
+                ThreadState =
+                    Map.ofList
+                        [
+                            runnable, stubThreadState ThreadStatus.Runnable
+                            parked, stubThreadState ThreadStatus.Parked
+                        ]
+            }
+
+        Scheduler.chooseNext (ThreadId -1) state |> shouldEqual (Some runnable)
+
+    [<Test>]
+    let ``scheduler returns None when only Parked threads exist`` () : unit =
+        // A program whose only live threads are Parked is genuinely making no
+        // progress; the scheduler must return None and let the driver decide
+        // (deadlock vs. NormalExit on entry-thread termination). Pin down the
+        // None outcome so a future scheduler change doesn't quietly start
+        // picking Parked.
+        let parkedA = ThreadId 0
+        let parkedB = ThreadId 1
+
+        let state =
+            { baseState () with
+                ThreadState =
+                    Map.ofList
+                        [
+                            parkedA, stubThreadState ThreadStatus.Parked
+                            parkedB, stubThreadState ThreadStatus.Parked
+                        ]
+            }
+
+        Scheduler.chooseNext (ThreadId -1) state |> shouldEqual None

--- a/WoofWare.PawPrint.Test/TestSignalHandler.fs
+++ b/WoofWare.PawPrint.Test/TestSignalHandler.fs
@@ -141,12 +141,12 @@ module TestSignalHandler =
 
         let stateA =
             SignalState.empty
-            |> SignalState.markInitialized
+            |> SignalState.markInitialized (ThreadId 42)
             |> SignalState.setHandler (SignalHandler.ofMethodInfo methodA)
 
         let stateB =
             SignalState.empty
-            |> SignalState.markInitialized
+            |> SignalState.markInitialized (ThreadId 42)
             |> SignalState.setHandler (SignalHandler.ofMethodInfo methodB)
 
         stateA |> shouldEqual stateB

--- a/WoofWare.PawPrint.Test/TestSignalState.fs
+++ b/WoofWare.PawPrint.Test/TestSignalState.fs
@@ -66,13 +66,19 @@ module TestSignalState =
 
     [<Test>]
     let ``markInitialized is idempotent and structurally stable`` () : unit =
-        let once = SignalState.empty |> SignalState.markInitialized
-        let twice = once |> SignalState.markInitialized
+        let dispatcher = ThreadId 42
+        let other = ThreadId 99
+        let once = SignalState.empty |> SignalState.markInitialized dispatcher
+        let twice = once |> SignalState.markInitialized other
         SignalState.isInitialized once |> shouldEqual true
+        SignalState.signalThread once |> shouldEqual (Some dispatcher)
         // A second mark must not mutate the state's identity; downstream code
         // that compares states for equality (e.g. dedup hashing in the
-        // debugger) relies on this.
+        // debugger) relies on this. The dispatcher recorded on first init must
+        // also survive — a re-init must not orphan the previously-allocated
+        // signal thread by overwriting its id.
         twice |> shouldEqual once
+        SignalState.signalThread twice |> shouldEqual (Some dispatcher)
 
     [<Test>]
     let ``enable flips a signal's bit on`` () : unit =
@@ -527,6 +533,16 @@ module TestSignalState =
                 }
             )
 
+    /// Fixed `ThreadId` standing in for the signal-dispatcher thread in
+    /// property runs. The property test does not model thread allocation,
+    /// so any stable id will do — the oracle compares against `Initialized`
+    /// (a `bool`) rather than the dispatcher id, and a second
+    /// `MarkInitialized` op in a run must not change the recorded id
+    /// (see `SignalState.markInitialized`'s idempotency contract). Using a
+    /// constant guarantees both branches stay aligned across the random
+    /// sequence.
+    let private propertyDispatcher : ThreadId = ThreadId 0
+
     /// Advance both implementations by one op, asserting agreement on
     /// `tryDeliverable`'s full return tuple (since the next step's
     /// observable state alone cannot always distinguish a divergence in
@@ -534,7 +550,7 @@ module TestSignalState =
     let private stepBoth (op : Op) (s : SignalState) (r : ReferenceState) : SignalState * ReferenceState =
         match op with
         | Op.MarkInitialized ->
-            SignalState.markInitialized s,
+            SignalState.markInitialized propertyDispatcher s,
             { r with
                 Initialized = true
             }

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -71,6 +71,7 @@
     <Compile Include="TestSignal.fs" />
     <Compile Include="TestSignalState.fs" />
     <Compile Include="TestSignalHandler.fs" />
+    <Compile Include="TestSignalDispatcherThread.fs" />
     <Compile Include="TestWaitHandle.fs" />
     <Compile Include="TestSyncBlockMonitor.fs" />
     <Compile Include="TestPureCases.fs" />

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -91,6 +91,8 @@ module IlMachineState =
 
     let allocateUnstartedThread = IlMachineThreadState.allocateUnstartedThread
 
+    let allocateParkedThread = IlMachineThreadState.allocateParkedThread
+
     let startUnstartedThread = IlMachineThreadState.startUnstartedThread
 
     let allocateArray = IlMachineThreadState.allocateArray

--- a/WoofWare.PawPrint/IlMachineThreadState.fs
+++ b/WoofWare.PawPrint/IlMachineThreadState.fs
@@ -388,6 +388,43 @@ module IlMachineThreadState =
 
         newState, thread
 
+    /// Allocate a fresh `ThreadId` for a PawPrint-internal auxiliary
+    /// thread (currently the signal dispatcher spawned by
+    /// `SystemNative_InitializeTerminalAndSignalHandling`). The thread
+    /// has no managed `Thread` heap mirror — it is not entered in
+    /// `ManagedThreadObjects` — and its `ThreadState` is frameless with
+    /// status `ThreadStatus.Parked`, so the scheduler never picks it.
+    /// `ActiveMethodState` points at a sentinel `FrameId` that is not
+    /// live in the empty `MethodStates` map, mirroring the
+    /// `allocateUnstartedThread` shape: any attempt to dereference it
+    /// crashes loudly rather than executing arbitrary IL on an
+    /// unprepared thread.
+    ///
+    /// A future slice that wires signal dispatch will introduce an
+    /// explicit transition out of `Parked` (driven by the signal
+    /// subsystem, not by guest IL); until then a thread allocated here
+    /// remains `Parked` for the lifetime of the run.
+    let allocateParkedThread (state : IlMachineState) : IlMachineState * ThreadId =
+        let thread = ThreadId state.NextThreadId
+
+        let parkedState : ThreadState =
+            {
+                MethodStates = Map.empty
+                NextFrameId = 0
+                ActiveMethodState = FrameId -1
+                Status = ThreadStatus.Parked
+                IsBackground = false
+                Name = None
+            }
+
+        let newState =
+            { state with
+                NextThreadId = state.NextThreadId + 1
+                ThreadState = state.ThreadState |> Map.add thread parkedState
+            }
+
+        newState, thread
+
     /// Populate the bottom frame of a `NotStarted` thread with the user's
     /// delegate target and flip its status to `Runnable`. The thread was
     /// previously allocated by `allocateUnstartedThread` at `Thread.Initialize`

--- a/WoofWare.PawPrint/Native/NativeSystemNative.fs
+++ b/WoofWare.PawPrint/Native/NativeSystemNative.fs
@@ -524,20 +524,31 @@ module NativeSystemNative =
           MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
             // The real native side configures the controlling terminal, sets
             // up a self-pipe, and installs a dedicated signal-dispatch worker
-            // thread. PawPrint has no terminal and dispatches signals
-            // deterministically out of `SignalState`; this entry point's only
-            // observable effect on the kernel is flipping `Signals.Initialized`,
-            // which the BCL uses as a "have we set up yet?" gate. Real native
-            // code returns 0 on setup failure (e.g. EBADF from tcgetattr on a
-            // headless process); PawPrint always reports success because there
-            // is no underlying syscall that could fail. The call is idempotent
-            // for the same reason `SignalState.markInitialized` is — the BCL
-            // may invoke this from several initializers across its surface.
-            state.MapKernel (fun kernel ->
-                { kernel with
-                    Signals = SignalState.markInitialized kernel.Signals
-                }
-            )
+            // thread (via `pthread_create(..., SignalHandlerLoop, ...)`).
+            // PawPrint has no terminal but mirrors the dedicated-thread shape:
+            // on first init we allocate a fresh `ThreadId` for the
+            // signal dispatcher and park it (status `ThreadStatus.Parked`),
+            // recording its id in `Signals.Init`. A future slice will wake
+            // that thread out of `Parked` to actually invoke handlers.
+            // The call is idempotent: a second invocation preserves the
+            // already-allocated dispatcher (BCL initializers may run more
+            // than once across the surface). Real native code returns 0 on
+            // setup failure (e.g. EBADF from tcgetattr on a headless
+            // process); PawPrint always reports success because there is no
+            // underlying syscall that could fail.
+            let state =
+                if SignalState.isInitialized state.Kernel.Signals then
+                    state
+                else
+                    let state, dispatcher = IlMachineState.allocateParkedThread state
+
+                    state.MapKernel (fun kernel ->
+                        { kernel with
+                            Signals = SignalState.markInitialized dispatcher kernel.Signals
+                        }
+                    )
+
+            state
             |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 1) ctx.Thread
             |> NativeHandlerResult.completed
             |> Some

--- a/WoofWare.PawPrint/SignalState.fs
+++ b/WoofWare.PawPrint/SignalState.fs
@@ -63,12 +63,43 @@ module SignalHandler =
     let methodInfo (handler : SignalHandler) : MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle> =
         handler.Method
 
+/// Initialisation state of the simulator's signal subsystem. Mirrors
+/// real CoreCLR's lazy setup: the C side spins up a dedicated
+/// `SignalHandlerLoop` pthread the first time
+/// `SystemNative_InitializeTerminalAndSignalHandling` runs. PawPrint
+/// follows that contract by allocating a single Parked dispatcher
+/// `ThreadId` at the same moment and stashing it here. Encoding the
+/// pair as a DU rather than `Initialized : bool + DispatcherThread :
+/// ThreadId option` makes the load-bearing invariant — "the dispatcher
+/// thread exists iff signal handling is initialised" — unrepresentable
+/// to violate. Idempotent re-initialisation is a transition this DU
+/// observes (the existing dispatcher is preserved); the QCall site
+/// must check `isInitialized` before allocating a thread, otherwise a
+/// second init call would mint a dead second dispatcher.
+[<RequireQualifiedAccess>]
+type SignalInitState =
+    /// Signal handling has not yet been set up; no dispatcher thread
+    /// exists. `SignalState.empty` starts here.
+    | NotInitialized
+    /// The BCL has invoked
+    /// `SystemNative_InitializeTerminalAndSignalHandling` at least
+    /// once; `dispatcher` is the `ThreadId` of the PawPrint-internal
+    /// signal-dispatch thread allocated at that moment. The thread
+    /// lives in `IlMachineState.ThreadState` with status
+    /// `ThreadStatus.Parked`; a future slice will introduce a wakeup
+    /// edge that transitions it to `Runnable` to actually invoke a
+    /// handler. Until then the dispatcher thread is a placeholder
+    /// that pins down the structural shape ahead of dispatch wiring.
+    | Initialized of dispatcher : ThreadId
+
 /// Pure, deterministic model of the simulator's signal-handling state.
 ///
 /// The shape is deliberately small:
-///   * `Initialized` — has the BCL invoked
-///     `SystemNative_InitializeTerminalAndSignalHandling` yet? Several
-///     console paths gate work behind this flag.
+///   * `Init` — has the BCL invoked
+///     `SystemNative_InitializeTerminalAndSignalHandling` yet, and
+///     which `ThreadId` is the dispatcher? Several console paths gate
+///     work behind initialisation; downstream signal-delivery slices
+///     read the dispatcher id off this field.
 ///   * `Enabled` — the set of signals the BCL has asked libSystem.Native to
 ///     deliver to managed code via `SystemNative_EnablePosixSignalHandling`.
 ///     This mirrors the enable bits that the real native side keeps; the
@@ -97,7 +128,7 @@ module SignalHandler =
 type SignalState =
     private
         {
-            Initialized : bool
+            Init : SignalInitState
             Enabled : Set<Signal>
             Blocked : Map<ThreadId, Set<Signal>>
             /// Pending entries in FIFO order (head = next candidate for
@@ -116,24 +147,44 @@ type SignalState =
 module SignalState =
     let empty : SignalState =
         {
-            Initialized = false
+            Init = SignalInitState.NotInitialized
             Enabled = Set.empty
             Blocked = Map.empty
             Pending = []
             Handler = None
         }
 
-    let isInitialized (state : SignalState) : bool = state.Initialized
+    let isInitialized (state : SignalState) : bool =
+        match state.Init with
+        | SignalInitState.NotInitialized -> false
+        | SignalInitState.Initialized _ -> true
 
-    /// Idempotent: a second call is a no-op. Mirrors the BCL behaviour where
-    /// `EnsureInitialized` may run more than once across the BCL surface but
-    /// the underlying signal apparatus is set up exactly once.
-    let markInitialized (state : SignalState) : SignalState =
-        if state.Initialized then
-            state
-        else
+    /// `Some dispatcher` once signal handling has been initialised, where
+    /// `dispatcher` is the `ThreadId` of the PawPrint-internal Parked
+    /// signal-dispatch thread spawned at that moment. `None` until the BCL
+    /// first calls `SystemNative_InitializeTerminalAndSignalHandling`.
+    /// Mirrors real CoreCLR's `SignalHandlerLoop` pthread, which is
+    /// created at the same point in startup.
+    let signalThread (state : SignalState) : ThreadId option =
+        match state.Init with
+        | SignalInitState.NotInitialized -> None
+        | SignalInitState.Initialized dispatcher -> Some dispatcher
+
+    /// Idempotent: a second call preserves the existing dispatcher
+    /// `ThreadId` and does *not* swap in the caller-supplied one. The
+    /// caller is expected to guard with `isInitialized` and skip thread
+    /// allocation entirely on the second call; the idempotency here is a
+    /// defence in depth so a defensive caller does not accidentally
+    /// orphan an already-allocated dispatcher thread. Mirrors the BCL
+    /// behaviour where `EnsureInitialized` may run more than once across
+    /// the BCL surface but the underlying signal apparatus is set up
+    /// exactly once.
+    let markInitialized (dispatcher : ThreadId) (state : SignalState) : SignalState =
+        match state.Init with
+        | SignalInitState.Initialized _ -> state
+        | SignalInitState.NotInitialized ->
             { state with
-                Initialized = true
+                Init = SignalInitState.Initialized dispatcher
             }
 
     /// The currently-installed dispatch callback, or `None` if the BCL

--- a/WoofWare.PawPrint/ThreadState.fs
+++ b/WoofWare.PawPrint/ThreadState.fs
@@ -73,6 +73,26 @@ type ThreadStatus =
     /// This thread has executed its final `ret`; it will never run again. Its state is kept
     /// only so other threads can observe termination (e.g. to satisfy Join).
     | Terminated
+    /// PawPrint-internal auxiliary thread: it exists for kernel-side
+    /// bookkeeping rather than to run guest IL, and the scheduler never
+    /// picks it. The dispatcher thread spawned by
+    /// `SystemNative_InitializeTerminalAndSignalHandling` is the current
+    /// (and only) inhabitant: mirrors real CoreCLR's `SignalHandlerLoop`
+    /// pthread, which the runtime owns and the guest never names.
+    ///
+    /// The semantic difference from `NotStarted` is that no managed
+    /// `Thread` heap object backs a `Parked` thread — there is no
+    /// `Thread.Start` call that will ever fire to flip it to `Runnable`.
+    /// A future slice that wires signal-dispatch will introduce an
+    /// explicit transition out of `Parked` (driven by the signal
+    /// subsystem, not by guest IL); for now `Parked` is permanent for
+    /// the run.
+    ///
+    /// Permanently-`Parked` threads do not cause spurious deadlock
+    /// detection because the driver short-circuits to `NormalExit` as
+    /// soon as the entry thread terminates; the scheduler is never
+    /// asked to find another `Runnable` thread after that point.
+    | Parked
 
 type ThreadState =
     {

--- a/WoofWare.PawPrint/ThreadState.fs
+++ b/WoofWare.PawPrint/ThreadState.fs
@@ -94,6 +94,39 @@ type ThreadStatus =
     /// asked to find another `Runnable` thread after that point.
     | Parked
 
+[<RequireQualifiedAccess>]
+module ThreadStatus =
+    /// True iff the thread's `ActiveMethodState` references no live frame
+    /// — i.e. the sentinel `FrameId -1` set up by `allocateUnstartedThread`
+    /// / `allocateParkedThread` is still in place. Callers reading
+    /// `threadState.MethodState` / `ActiveAssembly` / `ActiveMethodState`
+    /// must check this first to avoid dereferencing the sentinel and
+    /// crashing.
+    ///
+    /// `Terminated` is *not* frame-less: a terminating thread keeps its
+    /// final frames around so other threads can observe state for Join
+    /// (and so the debugger can show what was running when the thread
+    /// ended). The set is therefore exactly `NotStarted` and `Parked`,
+    /// the two states a thread enters before any IL has executed on it.
+    ///
+    /// Implemented as a fully-enumerated match (not `| _ -> false`) so a
+    /// new frameless `ThreadStatus` variant fires an exhaustiveness
+    /// error here instead of silently masking bugs in the dozens of
+    /// callers that read frame data behind this guard.
+    let hasNoActiveFrame (status : ThreadStatus) : bool =
+        match status with
+        | ThreadStatus.NotStarted -> true
+        | ThreadStatus.Parked -> true
+        | ThreadStatus.Runnable -> false
+        | ThreadStatus.Terminated -> false
+        | ThreadStatus.BlockedOnJoin _ -> false
+        | ThreadStatus.BlockedOnClassInit _ -> false
+        | ThreadStatus.BlockedOnMonitorAcquire _ -> false
+        | ThreadStatus.BlockedOnMonitorWait _ -> false
+        | ThreadStatus.BlockedOnSyncBlockAcquire _ -> false
+        | ThreadStatus.BlockedOnSyncBlockWait _ -> false
+        | ThreadStatus.BlockedOnWaitHandle _ -> false
+
 type ThreadState =
     {
         // TODO: thread-local storage, synchronisation state, exception handling context


### PR DESCRIPTION
## Summary

- Add a kernel-owned signal-dispatcher thread, mirroring real CoreCLR's `SignalHandlerLoop` pthread: minted lazily on first `SystemNative_InitializeTerminalAndSignalHandling`, stashed on `SignalState`, never picked by the scheduler. No managed `Thread` mirror, since the BCL never calls `new Thread(...)` for it. A future slice will add the wake edge that actually invokes the installed handler.
- Introduce `ThreadStatus.Parked` (scheduler-invisible) and refactor `SignalState.Initialized : bool` into a `SignalInitState` DU (`NotInitialized | Initialized of dispatcher : ThreadId`) so the invariant "dispatcher exists iff initialised" is unrepresentable to violate.
- Add `ThreadStatus.hasNoActiveFrame` (fully-enumerated, no `_ -> false`) and route the four frame-dereferencing sites in `DebuggerServer.fs` through it, so a debugger request issued after signal init does not crash on the Parked dispatcher's sentinel `FrameId -1`.

## Test plan

- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — full suite (1226 tests) passes
- [x] New `TestSignalDispatcherThread` fixture covers: empty `SignalState` has no signal thread; `markInitialized` records the dispatcher id; `allocateParkedThread` mints a Parked, frameless thread without touching `ManagedThreadObjects`; successive allocations mint distinct ids; scheduler skips Parked in favour of Runnable; scheduler returns `None` when only Parked threads exist
- [x] Existing `TestSignalState` / `TestSignalHandler` updated for the new `markInitialized : ThreadId -> SignalState -> SignalState` signature; idempotent re-init preserves the original dispatcher id

🤖 Generated with [Claude Code](https://claude.com/claude-code)