### PR TITLE
Surface SignalTerminated as a first-class RunOutcome

### DIFF
--- a/WoofWare.PawPrint.App/DebuggerServer.fs
+++ b/WoofWare.PawPrint.App/DebuggerServer.fs
@@ -251,6 +251,11 @@ module DebuggerServer =
             match message with
             | Some m -> writer.WriteString ("message", m)
             | None -> writer.WriteNull "message"
+        | RunOutcome.SignalTerminated (_state, signal) ->
+            writer.WriteString ("kind", "signalTerminated")
+            writer.WriteString ("signal", sprintf "%O" signal)
+            writer.WriteNumber ("signo", Signal.toLinuxSigno signal)
+            writer.WriteNumber ("exitCode", 128 + Signal.toLinuxSigno signal)
         | RunOutcome.GuestUnhandledException (_, thread, exn) ->
             writer.WriteString ("kind", "guestUnhandledException")
             writer.WriteNumber ("thread", threadIdValue thread)
@@ -279,6 +284,7 @@ module DebuggerServer =
         | SessionState.Finished (RunOutcome.NormalExit (state, _), _)
         | SessionState.Finished (RunOutcome.ProcessExit (state, _), _)
         | SessionState.Finished (RunOutcome.FailFast (state, _, _), _)
+        | SessionState.Finished (RunOutcome.SignalTerminated (state, _), _)
         | SessionState.Finished (RunOutcome.GuestUnhandledException (state, _, _), _) -> state
         | SessionState.Deadlocked (prepared, _, _) -> prepared.State
 
@@ -329,6 +335,7 @@ module DebuggerServer =
                 | RunOutcome.NormalExit _ -> "normal exit"
                 | RunOutcome.ProcessExit _ -> "process exit"
                 | RunOutcome.FailFast _ -> "fail fast"
+                | RunOutcome.SignalTerminated _ -> "signal terminated"
                 | RunOutcome.GuestUnhandledException _ -> "guest unhandled exception"
 
             {

--- a/WoofWare.PawPrint.App/Program.fs
+++ b/WoofWare.PawPrint.App/Program.fs
@@ -167,6 +167,25 @@ module AppProgram =
                     -2146232797
                 else
                     134
+            | RunOutcome.SignalTerminated (state, signal) ->
+                // pal_signal.c's Terminate branch restores the original
+                // sigaction and calls `kill(g_pid, signalCode)`, so the
+                // host shell observes the process as having exited with
+                // the POSIX-conventional code `128 + signo`. Mirror that
+                // here so guests that install a signal handler and
+                // forward to the default disposition observe the same
+                // shell-level exit code as a real .NET process.
+                drainStandardStreams state
+                let signo = Signal.toLinuxSigno signal
+
+                logger.LogInformation (
+                    "Guest terminated by POSIX signal {SignalName} (signo {Signo}); exiting with code {ExitCode}",
+                    sprintf "%O" signal,
+                    signo,
+                    128 + signo
+                )
+
+                128 + signo
             | RunOutcome.GuestUnhandledException (state, _thread, exn) ->
                 drainStandardStreams state
 

--- a/WoofWare.PawPrint.Performance/Program.fs
+++ b/WoofWare.PawPrint.Performance/Program.fs
@@ -177,6 +177,8 @@ type StackHeavyProgramBenchmarks () =
         | RunOutcome.FailFast (_, _, message) ->
             let m = message |> Option.defaultValue "<no message>"
             failwith $"PawPrint guest called Environment.FailFast: %s{m}"
+        | RunOutcome.SignalTerminated (_, signal) ->
+            failwith $"PawPrint guest was terminated by POSIX signal %O{signal} during benchmark"
         | RunOutcome.GuestUnhandledException (_, _, exn) ->
             failwith $"PawPrint threw an unhandled guest exception: %O{exn.ExceptionObject}"
 

--- a/WoofWare.PawPrint.Test/CrossAssemblyHarness.fs
+++ b/WoofWare.PawPrint.Test/CrossAssemblyHarness.fs
@@ -105,6 +105,7 @@ module CrossAssemblyHarness =
                 | RunOutcome.FailFast (_, _, message) ->
                     let m = message |> Option.defaultValue "<no message>"
                     failwith $"Guest called Environment.FailFast: %s{m}"
+                | RunOutcome.SignalTerminated (_, signal) -> failwith $"Guest was terminated by POSIX signal %O{signal}"
                 | RunOutcome.NormalExit (state, thread) -> state, thread
                 | RunOutcome.ProcessExit (state, thread) -> state, thread
 

--- a/WoofWare.PawPrint.Test/TestDebuggerState.fs
+++ b/WoofWare.PawPrint.Test/TestDebuggerState.fs
@@ -18,6 +18,8 @@ module TestDebuggerState =
             | RunOutcome.FailFast (_, _, message) ->
                 let m = message |> Option.defaultValue "<no message>"
                 failwith $"PawPrint guest called Environment.FailFast: %s{m}"
+            | RunOutcome.SignalTerminated (_, signal) ->
+                failwith $"PawPrint guest was terminated by POSIX signal %O{signal}"
             | RunOutcome.GuestUnhandledException (_, _, exn) ->
                 failwith $"PawPrint threw an unexpected guest exception: %O{exn.ExceptionObject}"
 

--- a/WoofWare.PawPrint.Test/TestHardwareIntrinsicsProfile.fs
+++ b/WoofWare.PawPrint.Test/TestHardwareIntrinsicsProfile.fs
@@ -18,6 +18,8 @@ module TestHardwareIntrinsicsProfile =
             | RunOutcome.FailFast (_, _, message) ->
                 let m = message |> Option.defaultValue "<no message>"
                 failwith $"PawPrint guest called Environment.FailFast: %s{m}"
+            | RunOutcome.SignalTerminated (_, signal) ->
+                failwith $"PawPrint guest was terminated by POSIX signal %O{signal}"
             | RunOutcome.GuestUnhandledException (_, _, exn) ->
                 failwith $"PawPrint threw an unexpected guest exception: %O{exn.ExceptionObject}"
 

--- a/WoofWare.PawPrint.Test/TestImpureCases.fs
+++ b/WoofWare.PawPrint.Test/TestImpureCases.fs
@@ -163,6 +163,7 @@ module TestImpureCases =
                 | RunOutcome.FailFast (_, _, message) ->
                     let m = message |> Option.defaultValue "<no message>"
                     failwith $"Guest called Environment.FailFast: %s{m}"
+                | RunOutcome.SignalTerminated (_, signal) -> failwith $"Guest was terminated by POSIX signal %O{signal}"
                 | RunOutcome.NormalExit (state, thread) -> state, thread
                 | RunOutcome.ProcessExit (state, thread) -> state, thread
 

--- a/WoofWare.PawPrint.Test/TestProgramDebugger.fs
+++ b/WoofWare.PawPrint.Test/TestProgramDebugger.fs
@@ -23,6 +23,7 @@ module TestProgramDebugger =
         | ExitCode of int
         | GuestUnhandledException
         | FailFast of message : string option
+        | SignalTerminated of Signal
 
     let private sourceForExitCode (exitCode : int) : string =
         $"""
@@ -79,6 +80,7 @@ class Program
             | EvalStackValue.Int32 i :: _ -> OutcomeSignature.ExitCode i
             | other -> failwith $"Expected int32 exit stack, got %O{other}"
         | RunOutcome.FailFast (_, _, message) -> OutcomeSignature.FailFast message
+        | RunOutcome.SignalTerminated (_, signal) -> OutcomeSignature.SignalTerminated signal
         | RunOutcome.GuestUnhandledException _ -> OutcomeSignature.GuestUnhandledException
 
     let private stepToCompletion

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -169,6 +169,9 @@ module TestPureCases =
                     let m = message |> Option.defaultValue "<no message>"
 
                     failwith $"PawPrint guest called Environment.FailFast for %s{case.FileName}: %s{m}"
+                | _, RunOutcome.SignalTerminated (_, signal) ->
+                    failwith
+                        $"PawPrint guest was terminated by POSIX signal %O{signal} for %s{case.FileName}; this test does not exercise signal-driven termination"
                 | _, RunOutcome.ProcessExit _ -> failwith "unreachable: normalised away above"
             )
 
@@ -250,6 +253,8 @@ class Program
                 | RunOutcome.FailFast (_, _, message) ->
                     let m = message |> Option.defaultValue "<no message>"
                     failwith $"expected normal exit, got Environment.FailFast: %s{m}"
+                | RunOutcome.SignalTerminated (_, signal) ->
+                    failwith $"expected normal exit, got POSIX signal termination: %O{signal}"
                 | RunOutcome.GuestUnhandledException (_, _, exn) ->
                     failwith $"guest threw unhandled exception: %O{exn.ExceptionObject}"
             )
@@ -312,6 +317,8 @@ class Program
                 | RunOutcome.FailFast (_, _, message) ->
                     let m = message |> Option.defaultValue "<no message>"
                     failwith $"expected normal exit, got Environment.FailFast: %s{m}"
+                | RunOutcome.SignalTerminated (_, signal) ->
+                    failwith $"expected normal exit, got POSIX signal termination: %O{signal}"
                 | RunOutcome.GuestUnhandledException (_, _, exn) ->
                     failwith $"guest threw unhandled exception: %O{exn.ExceptionObject}"
             )
@@ -368,6 +375,8 @@ class Program
                 | RunOutcome.FailFast (_, _, message) ->
                     let m = message |> Option.defaultValue "<no message>"
                     failwith $"expected normal exit, got Environment.FailFast: %s{m}"
+                | RunOutcome.SignalTerminated (_, signal) ->
+                    failwith $"expected normal exit, got POSIX signal termination: %O{signal}"
                 | RunOutcome.GuestUnhandledException (_, _, exn) ->
                     failwith $"guest threw unhandled exception: %O{exn.ExceptionObject}"
             )
@@ -413,6 +422,8 @@ class Program
                 | RunOutcome.FailFast (_, _, message) ->
                     let m = message |> Option.defaultValue "<no message>"
                     failwith $"expected normal exit, got Environment.FailFast: %s{m}"
+                | RunOutcome.SignalTerminated (_, signal) ->
+                    failwith $"expected normal exit, got POSIX signal termination: %O{signal}"
                 | RunOutcome.GuestUnhandledException (_, _, exn) ->
                     failwith $"guest threw unhandled exception: %O{exn.ExceptionObject}"
             )
@@ -450,6 +461,8 @@ class Program
                 | RunOutcome.FailFast (_, _, message) -> message |> shouldEqual (Some "boom")
                 | RunOutcome.NormalExit _ -> failwith "expected FailFast, got normal exit"
                 | RunOutcome.ProcessExit _ -> failwith "expected FailFast, got process exit"
+                | RunOutcome.SignalTerminated (_, signal) ->
+                    failwith $"expected FailFast, got POSIX signal termination: %O{signal}"
                 | RunOutcome.GuestUnhandledException (_, _, exn) ->
                     failwith $"expected FailFast, got guest unhandled exception: %O{exn.ExceptionObject}"
             )

--- a/WoofWare.PawPrint.Test/TestRaces.fs
+++ b/WoofWare.PawPrint.Test/TestRaces.fs
@@ -46,5 +46,7 @@ module TestRaces =
         | RunOutcome.FailFast (_, _, message) ->
             let m = message |> Option.defaultValue "<no message>"
             failwith $"PawPrint guest called Environment.FailFast: %s{m}"
+        | RunOutcome.SignalTerminated (_, signal) ->
+            failwith $"PawPrint guest was terminated by POSIX signal %O{signal}"
         | RunOutcome.GuestUnhandledException (_, _, exn) ->
             failwith $"guest threw unhandled exception: %O{exn.ExceptionObject}"

--- a/WoofWare.PawPrint.Test/TestSignalTermination.fs
+++ b/WoofWare.PawPrint.Test/TestSignalTermination.fs
@@ -1,0 +1,82 @@
+namespace WoofWare.PawPrint.Test
+
+open System.Collections.Immutable
+open System.IO
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.DotnetRuntimeLocator
+open WoofWare.PawPrint
+open WoofWare.PawPrint.ExternImplementations
+
+/// End-to-end coverage for the `SystemNative_HandleNonCanceledPosixSignal`
+/// `DefaultDisposition.Terminate` branch: a guest that DllImports the
+/// handler with a Linux signo whose kernel default is Terminate (e.g.
+/// SIGTERM) must surface as `RunOutcome.SignalTerminated` carrying the
+/// originating `Signal`, and the App-layer mapping must produce the
+/// POSIX-conventional exit code `128 + signo`.
+///
+/// `TestSignal` already verifies the disposition classifier in isolation;
+/// this fixture nails down that the arm's Terminate branch propagates the
+/// outcome all the way through `ExecutionResult` → `RunOutcome` → the App
+/// exit-code mapping without dropping or rewriting the `Signal` identity.
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestSignalTermination =
+    let private assy = typeof<RunResult>.Assembly
+
+    let private runImpureSource (sourceFileName : string) : RunOutcome =
+        let source = Assembly.getEmbeddedResourceAsString sourceFileName assy
+        let image = Roslyn.compile [ source ]
+
+        let messages, loggerFactory =
+            LoggerFactory.makeTestWithProperties [ "source_file", sourceFileName ]
+
+        use _loggerFactoryResource = loggerFactory
+
+        let dotnetRuntimes =
+            DotnetRuntime.SelectForDll assy.Location |> ImmutableArray.CreateRange
+
+        use peImage = new MemoryStream (image)
+
+        try
+            Program.run
+                loggerFactory
+                (Some sourceFileName)
+                peImage
+                dotnetRuntimes
+                (NativeImpls.PassThru ())
+                Map.empty
+                []
+        with _ ->
+            for message in messages () do
+                System.Console.Error.WriteLine $"{message}"
+
+            reraise ()
+
+    [<Test>]
+    let ``HandleNonCanceledPosixSignal Terminate branch surfaces SignalTerminated`` () : unit =
+        // The C# guest calls SystemNative_HandleNonCanceledPosixSignal(15)
+        // directly. 15 is SIGTERM in PawPrint's Linux-signo table, which
+        // classifies as DefaultDisposition.Terminate; the arm must
+        // therefore short-circuit the run with SignalTerminated carrying
+        // the originating Signal.SIGTERM. A regression that fell through
+        // to `Main`'s `return 99` would surface as `NormalExit` with
+        // exit code 99 — the negative case below catches that.
+        let outcome = runImpureSource "SystemNativeHandleNonCanceledPosixSignalTerminate.cs"
+
+        match outcome with
+        | RunOutcome.SignalTerminated (_, signal) -> signal |> shouldEqual Signal.SIGTERM
+        | other -> failwith $"expected RunOutcome.SignalTerminated (Signal.SIGTERM), got %O{other}"
+
+    [<Test>]
+    let ``SignalTerminated maps to POSIX-conventional exit code 128 + signo`` () : unit =
+        // Codifies the App-layer exit-code mapping (`App/Program.fs`'s
+        // `SignalTerminated` arm). The mapping itself is one expression,
+        // but it's the contract between the simulator and the host shell:
+        // a process killed by SIGTERM exits 143, by SIGINT 130, etc. If
+        // someone re-tunes the formula (e.g. to hardcode 134 like
+        // FailFast does) this test catches it.
+        128 + Signal.toLinuxSigno Signal.SIGTERM |> shouldEqual 143
+        128 + Signal.toLinuxSigno Signal.SIGINT |> shouldEqual 130
+        128 + Signal.toLinuxSigno Signal.SIGABRT |> shouldEqual 134
+        128 + Signal.toLinuxSigno Signal.SIGHUP |> shouldEqual 129

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -73,6 +73,7 @@
     <Compile Include="TestSignalHandler.fs" />
     <Compile Include="TestSignalDispatcherThread.fs" />
     <Compile Include="TestSignalDispatch.fs" />
+    <Compile Include="TestSignalTermination.fs" />
     <Compile Include="TestWaitHandle.fs" />
     <Compile Include="TestSyncBlockMonitor.fs" />
     <Compile Include="TestPureCases.fs" />

--- a/WoofWare.PawPrint.Test/sourcesImpure/SystemNativeHandleNonCanceledPosixSignalTerminate.cs
+++ b/WoofWare.PawPrint.Test/sourcesImpure/SystemNativeHandleNonCanceledPosixSignalTerminate.cs
@@ -1,0 +1,37 @@
+using System.Runtime.InteropServices;
+
+// Exercises the SystemNative_HandleNonCanceledPosixSignal PawPrint
+// handler directly via a P/Invoke stub, with a signo whose POSIX
+// default disposition is Terminate. Real .NET would only ever reach
+// this entry point from PosixSignalRegistration's worker thread after
+// all registered handlers ran without cancelling; PawPrint accepts the
+// direct call too, since the BCL contract for the import is the same
+// either way (signo previously cleared by GetPlatformSignalNumber).
+//
+// This is an *impure* test: PawPrint always uses the Linux signo table
+// for determinism across hosts (so 15 means SIGTERM unambiguously
+// here), whereas the real CLR uses the host's signo table — and even
+// if 15 happens to be SIGTERM on the host, running this through the
+// real CLR would actually terminate the NUnit test process with
+// SIGTERM, which is obviously not what we want. The PawPrint runner
+// surfaces signal termination as `RunOutcome.SignalTerminated` so the
+// test harness can assert on the originating signal without taking
+// down the host.
+//
+// `Main` returning is unreachable: the P/Invoke call surfaces as
+// `ExecutionResult.SignalTerminated` and never returns control to the
+// guest. The `return 99` is present only to satisfy the C# compiler;
+// a regression that *did* return here would surface as a `NormalExit`
+// with exit code 99 and the test would fail on the outcome shape.
+
+class Program
+{
+    [DllImport("libSystem.Native", EntryPoint = "SystemNative_HandleNonCanceledPosixSignal")]
+    static extern void HandleNonCanceledPosixSignal(int signalCode);
+
+    static int Main(string[] args)
+    {
+        HandleNonCanceledPosixSignal(15); // SIGTERM (Linux signo)
+        return 99;
+    }
+}

--- a/WoofWare.PawPrint/IlMachineStateModel.fs
+++ b/WoofWare.PawPrint/IlMachineStateModel.fs
@@ -246,6 +246,18 @@ type ExecutionResult =
     /// and so callers can surface the abort to the host (logs, non-zero exit) rather than
     /// reporting a clean exit.
     | FailFast of IlMachineState * abortingThread : ThreadId * message : string option
+    /// A non-cancelled signal handler reached the kernel-default
+    /// `Terminate` disposition, so the simulated process exits with the
+    /// signal's identity. Mirrors `pal_signal.c`'s
+    /// `SystemNative_HandleNonCanceledPosixSignal` Terminate branch,
+    /// where the native code restores the original `sigaction` and calls
+    /// `kill(g_pid, signalCode)` to let the kernel terminate the process
+    /// with the signal-default exit status (POSIX convention: exit code
+    /// `128 + signo`). Carries no `ThreadId` because POSIX
+    /// `kill(pid, sig)` is process-global; there is no single owning
+    /// thread for this termination. The App layer derives the exit code
+    /// from `Signal.toLinuxSigno`.
+    | SignalTerminated of IlMachineState * signal : Signal
     | Stepped of IlMachineState * WhatWeDid * StepEffect
     | UnhandledException of
         IlMachineState *
@@ -334,6 +346,16 @@ type RunOutcome =
     /// because FailFast is semantically an abort, not a clean exit — finalizers do not
     /// run on real CoreCLR, and the host typically reports a non-zero/abort exit.
     | FailFast of IlMachineState * abortingThread : ThreadId * message : string option
+    /// The simulation was terminated by a POSIX signal whose
+    /// registered handler(s) did not cancel the default disposition,
+    /// and whose kernel default is `Terminate`. Carries the originating
+    /// `Signal` so the host can compute the POSIX-conventional exit
+    /// code `128 + Signal.toLinuxSigno signal` and surface the cause
+    /// for diagnostics. No `ThreadId` because process-level signal
+    /// termination is not attributable to a single thread (the real
+    /// native code calls `kill(g_pid, signalCode)`, which tears down
+    /// the whole process).
+    | SignalTerminated of IlMachineState * signal : Signal
     | GuestUnhandledException of
         IlMachineState *
         terminatingThread : ThreadId *
@@ -439,8 +461,9 @@ module NativeHandlerResult =
     ///
     /// * `Stepped(state, WhatWeDid.Executed, effect)` — the handler ran a normal step;
     ///   routed to `Completed(state, effect)` so the dispatcher pops the native frame.
-    /// * `Terminated`, `ProcessExit`, `FailFast`, `UnhandledException` — terminating
-    ///   outcomes wrapped in `NativeHandlerResult.Terminating` so the dispatcher surfaces
+    /// * `Terminated`, `ProcessExit`, `FailFast`, `SignalTerminated`,
+    ///   `UnhandledException` — terminating outcomes wrapped in
+    ///   `NativeHandlerResult.Terminating` so the dispatcher surfaces
     ///   them verbatim to the run loop, bypassing frame management.
     ///
     /// Any `Stepped` value with a `WhatWeDid` other than `Executed` is rejected as a logic
@@ -458,4 +481,5 @@ module NativeHandlerResult =
         | ExecutionResult.Terminated _
         | ExecutionResult.ProcessExit _
         | ExecutionResult.FailFast _
+        | ExecutionResult.SignalTerminated _
         | ExecutionResult.UnhandledException _ -> NativeHandlerResult.Terminating executionResult

--- a/WoofWare.PawPrint/Native/NativeSystemNative.fs
+++ b/WoofWare.PawPrint/Native/NativeSystemNative.fs
@@ -704,8 +704,20 @@ module NativeSystemNative =
                     // is not relevant to PawPrint, which has no terminal).
                     NativeHandlerResult.completed state |> Some
                 | DefaultDisposition.Terminate ->
-                    failwith
-                        $"%s{operation}: signal-driven process termination is not yet modelled (signo %d{signo}, signal %O{signal}); a follow-up slice will surface this as a RunOutcome rather than silently no-op'ing."
+                    // Mirrors `pal_signal.c`'s Terminate branch, which
+                    // restores the original `sigaction` and calls
+                    // `kill(g_pid, signalCode)` to let the kernel
+                    // terminate the process with the signal-default
+                    // exit status. PawPrint surfaces this as a
+                    // dedicated `SignalTerminated` outcome so the App
+                    // layer can compute the POSIX-conventional exit
+                    // code (`128 + Signal.toLinuxSigno signal`) and
+                    // distinguish signal-driven termination from a
+                    // managed `Environment.Exit` call carrying the
+                    // same exit code.
+                    ExecutionResult.SignalTerminated (state, signal)
+                    |> NativeHandlerResult.ofExecutionResult
+                    |> Some
         | Some "SystemNative_DisablePosixSignalHandling",
           [ ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32 ],
           MethodReturnType.Void ->

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -204,6 +204,8 @@ module Program =
                 ProgramStepOutcome.Completed (RunOutcome.ProcessExit (state, exitingThread))
             | ExecutionResult.FailFast (state, abortingThread, message) ->
                 ProgramStepOutcome.Completed (RunOutcome.FailFast (state, abortingThread, message))
+            | ExecutionResult.SignalTerminated (state, signal) ->
+                ProgramStepOutcome.Completed (RunOutcome.SignalTerminated (state, signal))
             | ExecutionResult.UnhandledException (state, terminatingThread, exn) ->
                 ProgramStepOutcome.Completed (RunOutcome.GuestUnhandledException (state, terminatingThread, exn))
             | ExecutionResult.Stepped (state, whatWeDid, _) ->
@@ -493,6 +495,12 @@ module Program =
         | RunOutcome.FailFast _ as outcome ->
             // A worker started during cctor pumping called Environment.FailFast; the
             // process has aborted. Propagate rather than pressing on into Main.
+            ProgramStartResult.CompletedBeforeMain outcome
+        | RunOutcome.SignalTerminated _ as outcome ->
+            // A non-cancelled signal handler reached the kernel-default
+            // Terminate disposition during cctor pumping. Same shape as
+            // ProcessExit: the simulated process is gone, so propagate
+            // rather than pressing on into Main.
             ProgramStartResult.CompletedBeforeMain outcome
         | RunOutcome.NormalExit (state, _) ->
 


### PR DESCRIPTION
## Summary
- Replaces the `failwith` left in `SystemNative_HandleNonCanceledPosixSignal`'s `DefaultDisposition.Terminate` branch (introduced in #605) with a real termination outcome: `ExecutionResult.SignalTerminated` is lifted by the scheduler to a new `RunOutcome.SignalTerminated`, and the App layer maps it to the POSIX-conventional `128 + signo` exit code (SIGTERM→143, SIGINT→130, SIGABRT→134, SIGHUP→129).
- `RunOutcome.SignalTerminated` carries only the originating `Signal` — no `ThreadId`. POSIX `kill(g_pid, signo)` is process-global, so naming a managed thread would be inventing identity the runtime doesn't have.
- End-to-end coverage in `TestSignalTermination` exercises the wiring via a direct DllImport of SIGTERM (15) and pins the `128 + signo` formula.

## Test plan
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` (1248 passed, 0 failed)
- [x] `nix develop -c dotnet fantomas .` (clean)
- [x] `codex review --base main` (no actionable findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)