### PR TITLE
Handle Interlocked.MemoryBarrier as a no-op intrinsic

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/InterlockedMemoryBarrier.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/InterlockedMemoryBarrier.cs
@@ -1,0 +1,13 @@
+using System.Threading;
+
+class Program
+{
+    static int Main(string[] args)
+    {
+        int x = 41;
+        Interlocked.MemoryBarrier();
+        x++;
+        Interlocked.MemoryBarrier();
+        return x == 42 ? 0 : 1;
+    }
+}

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -693,12 +693,14 @@ module Intrinsics =
             | _ -> None
 
         | "System.Private.CoreLib", "Interlocked", "MemoryBarrier" ->
-            // [Intrinsic][MethodImpl(MethodImplOptions.InternalCall)]
-            // public static extern void MemoryBarrier();
-            // PawPrint single-steps a deterministic virtual CPU, so there is no
-            // host memory reordering for a fence to constrain. The no-op is
-            // correct here for the same reason as the `volatile.` IL prefix
-            // (NullaryIlOp.fs) and Volatile.{Read,Write}Barrier (below).
+            // [Intrinsic] public static void MemoryBarrier() => MemoryBarrier();
+            // Same shape as Volatile.{Read,Write}Barrier (below): the managed body is
+            // infinite self-recursion and the JIT replaces the call with the
+            // appropriate processor fence. PawPrint single-steps a deterministic
+            // virtual CPU, so there is no host memory reordering for a fence to
+            // constrain; the no-op is correct for the same reason as the `volatile.`
+            // IL prefix (NullaryIlOp.fs). Cannot live in safeIntrinsics because the
+            // IL would loop forever.
             // https://github.com/dotnet/runtime/blob/HEAD/src/libraries/System.Private.CoreLib/src/System/Threading/Interlocked.cs
             match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
             | [], MethodReturnType.Void -> ()

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -692,6 +692,20 @@ module Intrinsics =
                 executeInt64 methodToCall.Name state |> Some
             | _ -> None
 
+        | "System.Private.CoreLib", "Interlocked", "MemoryBarrier" ->
+            // [Intrinsic][MethodImpl(MethodImplOptions.InternalCall)]
+            // public static extern void MemoryBarrier();
+            // PawPrint single-steps a deterministic virtual CPU, so there is no
+            // host memory reordering for a fence to constrain. The no-op is
+            // correct here for the same reason as the `volatile.` IL prefix
+            // (NullaryIlOp.fs) and Volatile.{Read,Write}Barrier (below).
+            // https://github.com/dotnet/runtime/blob/HEAD/src/libraries/System.Private.CoreLib/src/System/Threading/Interlocked.cs
+            match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
+            | [], MethodReturnType.Void -> ()
+            | _ -> failwith $"Interlocked.MemoryBarrier: unexpected signature %A{methodToCall.Signature}"
+
+            state |> IlMachineState.advanceProgramCounter currentThread |> Some
+
         | "System.Private.CoreLib", "Interlocked", "CompareExchange" ->
             // The native-int-shaped overloads need their own path: the shipped IL wrappers do
             // `Unsafe.As<_, long>` and delegate to the Int64 overload, which would destroy our


### PR DESCRIPTION
## Summary

- Add an intrinsic-dispatch arm in `WoofWare.PawPrint/Intrinsics.fs` for `System.Threading.Interlocked.MemoryBarrier`: validate the `() -> void` signature, advance the PC, return.
- The managed IL body is `[Intrinsic] public static void MemoryBarrier() => MemoryBarrier();` (infinite self-recursion that the JIT rewrites into a processor fence), mirroring the existing `Volatile.{Read,Write}Barrier` shape. PawPrint single-steps a deterministic virtual CPU with no host reordering to fence against, so the no-op is correct — same rationale already documented for the `volatile.` IL prefix (`NullaryIlOp.fs`).
- Add `sourcesPure/InterlockedMemoryBarrier.cs` covering the call. Auto-discovered by `TestPureCases.fs`.

## Out of scope

- `Threads.cs` remains in the `unimplemented` set: it lists `Interlocked.MemoryBarrier` as the *next* blocker, not the only one. Per the repo's "incremental progress only" guidance, removing it from `unimplemented` is left for when it actually runs to completion.
- `Thread.MemoryBarrier` (a managed forwarder to `Interlocked.MemoryBarrier` — no separate handling needed) and `Interlocked.MemoryBarrierProcessWide` (different primitive — left until it actually shows up as a blocker).

## Test plan

- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --filter "Name~InterlockedMemoryBarrier"` — passes (1/1).
- [x] Full suite `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — passes (1250/1250).
- [x] `nix develop -c dotnet fantomas .` clean.
- [x] `codex review --base main` — no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)