### PR TITLE
Honour WaitHandle.WaitOne finite timeouts via virtual clock deadlines

### DIFF
--- a/WoofWare.PawPrint.App/DebuggerServer.fs
+++ b/WoofWare.PawPrint.App/DebuggerServer.fs
@@ -105,10 +105,15 @@ module DebuggerServer =
             writer.WriteString ("kind", "blockedOnSyncBlockWait")
             writer.WriteNumber ("lockObject", heapAddressValue lockObject)
             writer.WriteEndObject ()
-        | ThreadStatus.BlockedOnWaitHandle (WaitHandleId handle) ->
+        | ThreadStatus.BlockedOnWaitHandle (WaitHandleId handle, deadlineMs) ->
             writer.WriteStartObject ()
             writer.WriteString ("kind", "blockedOnWaitHandle")
             writer.WriteNumber ("handle", handle)
+
+            match deadlineMs with
+            | None -> ()
+            | Some ms -> writer.WriteNumber ("deadlineMs", ms)
+
             writer.WriteEndObject ()
         | ThreadStatus.Terminated -> writer.WriteStringValue "terminated"
         | ThreadStatus.Parked -> writer.WriteStringValue "parked"

--- a/WoofWare.PawPrint.Test/TestWaitHandle.fs
+++ b/WoofWare.PawPrint.Test/TestWaitHandle.fs
@@ -199,7 +199,7 @@ module TestWaitHandle =
         let state = baseState () |> withThreads [ t0 ]
         let id, state = WaitHandle.createSemaphore 2 5 state
 
-        let state = WaitHandle.waitOne t0 id state |> acquired
+        let state = WaitHandle.waitOne t0 id None state |> acquired
 
         let s = semaphoreOf id state
         s.Count |> shouldEqual 1
@@ -211,30 +211,30 @@ module TestWaitHandle =
         let state = baseState () |> withThreads [ t0 ; t1 ]
         let id, state = WaitHandle.createSemaphore 0 5 state
 
-        let state = WaitHandle.waitOne t0 id state |> blocked
-        let state = WaitHandle.waitOne t1 id state |> blocked
+        let state = WaitHandle.waitOne t0 id None state |> blocked
+        let state = WaitHandle.waitOne t1 id None state |> blocked
 
         let s = semaphoreOf id state
         s.Count |> shouldEqual 0
         s.WaitQueue |> shouldEqual [ t0 ; t1 ]
-        statusOf t0 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
-        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+        statusOf t0 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle (id, None))
+        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle (id, None))
 
     [<Test>]
     let ``waitOne fast path drives count to zero in sequence`` () : unit =
         let state = baseState () |> withThreads [ t0 ; t1 ; t2 ]
         let id, state = WaitHandle.createSemaphore 2 5 state
-        let state = WaitHandle.waitOne t0 id state |> acquired
-        let state = WaitHandle.waitOne t1 id state |> acquired
+        let state = WaitHandle.waitOne t0 id None state |> acquired
+        let state = WaitHandle.waitOne t1 id None state |> acquired
         // Count is now 0; t2 must block.
-        let state = WaitHandle.waitOne t2 id state |> blocked
+        let state = WaitHandle.waitOne t2 id None state |> blocked
 
         let s = semaphoreOf id state
         s.Count |> shouldEqual 0
         s.WaitQueue |> shouldEqual [ t2 ]
         statusOf t0 state |> shouldEqual ThreadStatus.Runnable
         statusOf t1 state |> shouldEqual ThreadStatus.Runnable
-        statusOf t2 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+        statusOf t2 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle (id, None))
 
     // -------------------------------------------------------------------
     // tryWaitOne — non-blocking probe used by zero-timeout WaitOne(0)
@@ -279,7 +279,7 @@ module TestWaitHandle =
         let state = baseState () |> withThreads [ t0 ]
         let id, state = WaitHandle.createSemaphore 2 5 state
 
-        let state = WaitHandle.waitOnePrioritized t0 id state |> acquired
+        let state = WaitHandle.waitOnePrioritized t0 id None state |> acquired
 
         let s = semaphoreOf id state
         s.Count |> shouldEqual 1
@@ -295,17 +295,17 @@ module TestWaitHandle =
         let state = baseState () |> withThreads [ t0 ; t1 ; t2 ]
         let id, state = WaitHandle.createSemaphore 0 5 state
 
-        let state = WaitHandle.waitOnePrioritized t0 id state |> blocked
-        let state = WaitHandle.waitOnePrioritized t1 id state |> blocked
-        let state = WaitHandle.waitOnePrioritized t2 id state |> blocked
+        let state = WaitHandle.waitOnePrioritized t0 id None state |> blocked
+        let state = WaitHandle.waitOnePrioritized t1 id None state |> blocked
+        let state = WaitHandle.waitOnePrioritized t2 id None state |> blocked
 
         let s = semaphoreOf id state
         s.Count |> shouldEqual 0
         // Latest-arrived prioritized waiter is at head; oldest is at tail.
         s.WaitQueue |> shouldEqual [ t2 ; t1 ; t0 ]
-        statusOf t0 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
-        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
-        statusOf t2 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+        statusOf t0 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle (id, None))
+        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle (id, None))
+        statusOf t2 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle (id, None))
 
     [<Test>]
     let ``releaseSemaphore wakes prioritized waiters in LIFO order`` () : unit =
@@ -315,20 +315,20 @@ module TestWaitHandle =
         let state = baseState () |> withThreads [ t0 ; t1 ; t2 ]
         let id, state = WaitHandle.createSemaphore 0 5 state
 
-        let state = WaitHandle.waitOnePrioritized t0 id state |> blocked
-        let state = WaitHandle.waitOnePrioritized t1 id state |> blocked
-        let state = WaitHandle.waitOnePrioritized t2 id state |> blocked
+        let state = WaitHandle.waitOnePrioritized t0 id None state |> blocked
+        let state = WaitHandle.waitOnePrioritized t1 id None state |> blocked
+        let state = WaitHandle.waitOnePrioritized t2 id None state |> blocked
 
         let _, state = WaitHandle.releaseSemaphore id 1 state
 
         statusOf t2 state |> shouldEqual ThreadStatus.Runnable
-        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
-        statusOf t0 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle (id, None))
+        statusOf t0 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle (id, None))
 
         let _, state = WaitHandle.releaseSemaphore id 1 state
 
         statusOf t1 state |> shouldEqual ThreadStatus.Runnable
-        statusOf t0 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+        statusOf t0 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle (id, None))
 
         let _, state = WaitHandle.releaseSemaphore id 1 state
 
@@ -343,9 +343,9 @@ module TestWaitHandle =
         let state = baseState () |> withThreads [ t0 ; t1 ; t2 ]
         let id, state = WaitHandle.createSemaphore 0 5 state
 
-        let state = WaitHandle.waitOne t0 id state |> blocked
-        let state = WaitHandle.waitOne t1 id state |> blocked
-        let state = WaitHandle.waitOnePrioritized t2 id state |> blocked
+        let state = WaitHandle.waitOne t0 id None state |> blocked
+        let state = WaitHandle.waitOne t1 id None state |> blocked
+        let state = WaitHandle.waitOnePrioritized t2 id None state |> blocked
 
         let s = semaphoreOf id state
         // t2 is at the head; t0 and t1 preserve their FIFO ordering behind.
@@ -354,8 +354,8 @@ module TestWaitHandle =
         let _, state = WaitHandle.releaseSemaphore id 1 state
 
         statusOf t2 state |> shouldEqual ThreadStatus.Runnable
-        statusOf t0 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
-        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+        statusOf t0 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle (id, None))
+        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle (id, None))
 
     [<Test>]
     let ``Property: releaseSemaphore wakes prioritized waiters in LIFO registration order`` () : unit =
@@ -367,7 +367,7 @@ module TestWaitHandle =
 
             let state =
                 threads
-                |> List.fold (fun s tid -> WaitHandle.waitOnePrioritized tid id s |> blocked) state
+                |> List.fold (fun s tid -> WaitHandle.waitOnePrioritized tid id None s |> blocked) state
 
             // LIFO over prioritized waiters: latest registration wakes first.
             let expectedWakeOrder = List.rev threads
@@ -418,8 +418,8 @@ module TestWaitHandle =
     let ``releaseSemaphore wakes a single FIFO-head waiter via direct handoff`` () : unit =
         let state = baseState () |> withThreads [ t0 ; t1 ]
         let id, state = WaitHandle.createSemaphore 0 5 state
-        let state = WaitHandle.waitOne t0 id state |> blocked
-        let state = WaitHandle.waitOne t1 id state |> blocked
+        let state = WaitHandle.waitOne t0 id None state |> blocked
+        let state = WaitHandle.waitOne t1 id None state |> blocked
 
         let result, state = WaitHandle.releaseSemaphore id 1 state
 
@@ -430,16 +430,16 @@ module TestWaitHandle =
         s.Count |> shouldEqual 0
         s.WaitQueue |> shouldEqual [ t1 ]
         statusOf t0 state |> shouldEqual ThreadStatus.Runnable
-        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle (id, None))
 
     [<Test>]
     let ``releaseSemaphore N wakes min(N, K) FIFO-head waiters and leaves N-K units accumulated`` () : unit =
         let state = baseState () |> withThreads [ t0 ; t1 ; t2 ; t3 ]
 
         let id, state = WaitHandle.createSemaphore 0 10 state
-        let state = WaitHandle.waitOne t0 id state |> blocked
-        let state = WaitHandle.waitOne t1 id state |> blocked
-        let state = WaitHandle.waitOne t2 id state |> blocked
+        let state = WaitHandle.waitOne t0 id None state |> blocked
+        let state = WaitHandle.waitOne t1 id None state |> blocked
+        let state = WaitHandle.waitOne t2 id None state |> blocked
         // Release 5 with 3 waiters: wakes all three; (5 - 3) = 2 units
         // accumulate in Count.
         let result, state = WaitHandle.releaseSemaphore id 5 state
@@ -457,11 +457,11 @@ module TestWaitHandle =
         let state = baseState () |> withThreads [ t0 ; t1 ; t2 ; t3 ; t4 ]
 
         let id, state = WaitHandle.createSemaphore 0 10 state
-        let state = WaitHandle.waitOne t0 id state |> blocked
-        let state = WaitHandle.waitOne t1 id state |> blocked
-        let state = WaitHandle.waitOne t2 id state |> blocked
-        let state = WaitHandle.waitOne t3 id state |> blocked
-        let state = WaitHandle.waitOne t4 id state |> blocked
+        let state = WaitHandle.waitOne t0 id None state |> blocked
+        let state = WaitHandle.waitOne t1 id None state |> blocked
+        let state = WaitHandle.waitOne t2 id None state |> blocked
+        let state = WaitHandle.waitOne t3 id None state |> blocked
+        let state = WaitHandle.waitOne t4 id None state |> blocked
 
         let result, state = WaitHandle.releaseSemaphore id 2 state
 
@@ -473,9 +473,9 @@ module TestWaitHandle =
         s.WaitQueue |> shouldEqual [ t2 ; t3 ; t4 ]
         statusOf t0 state |> shouldEqual ThreadStatus.Runnable
         statusOf t1 state |> shouldEqual ThreadStatus.Runnable
-        statusOf t2 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
-        statusOf t3 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
-        statusOf t4 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+        statusOf t2 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle (id, None))
+        statusOf t3 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle (id, None))
+        statusOf t4 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle (id, None))
 
     [<Test>]
     let ``releaseSemaphore rejects overflow and leaves state unchanged`` () : unit =
@@ -546,7 +546,7 @@ module TestWaitHandle =
                 threads
                 |> List.fold
                     (fun s tid ->
-                        let s = WaitHandle.waitOne tid id s |> acquired
+                        let s = WaitHandle.waitOne tid id None s |> acquired
                         let _, s = WaitHandle.releaseSemaphore id 1 s
                         s
                     )
@@ -575,7 +575,8 @@ module TestWaitHandle =
             let id, state = WaitHandle.createSemaphore 0 k state
 
             let state =
-                threads |> List.fold (fun s tid -> WaitHandle.waitOne tid id s |> blocked) state
+                threads
+                |> List.fold (fun s tid -> WaitHandle.waitOne tid id None s |> blocked) state
 
             // Snapshot the queue before any releases.
             let expectedWakeOrder = (semaphoreOf id state).WaitQueue
@@ -637,7 +638,7 @@ module TestWaitHandle =
     let ``close fails loud with parked waiters`` () : unit =
         let state = baseState () |> withThreads [ t0 ]
         let id, state = WaitHandle.createSemaphore 0 5 state
-        let state = WaitHandle.waitOne t0 id state |> blocked
+        let state = WaitHandle.waitOne t0 id None state |> blocked
 
         let exn =
             Assert.Throws<System.Exception> (fun () -> WaitHandle.close id state |> ignore)
@@ -662,7 +663,7 @@ module TestWaitHandle =
         let state = WaitHandle.close id state
 
         let exn =
-            Assert.Throws<System.Exception> (fun () -> WaitHandle.waitOne t0 id state |> ignore)
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.waitOne t0 id None state |> ignore)
 
         exn.Message |> shouldContainText "not registered"
 
@@ -715,7 +716,7 @@ module TestWaitHandle =
             match statusOf tid state with
             | ThreadStatus.BlockedOnWaitHandle _ -> state, waited, released
             | _ ->
-                let outcome = WaitHandle.waitOne tid id state
+                let outcome = WaitHandle.waitOne tid id None state
 
                 match outcome with
                 | WaitHandle.WaitOutcome.Acquired s -> s, waited + 1, released
@@ -829,7 +830,7 @@ module TestWaitHandle =
         let state = baseState () |> withThreads [ t0 ]
         let id, state = WaitHandle.createMutex false t0 state
 
-        let state = WaitHandle.waitOne t0 id state |> acquired
+        let state = WaitHandle.waitOne t0 id None state |> acquired
 
         let m = mutexOf id state
         m.Ownership |> shouldEqual (MutexOwnership.Held (t0, 1))
@@ -841,9 +842,9 @@ module TestWaitHandle =
         let state = baseState () |> withThreads [ t0 ]
         let id, state = WaitHandle.createMutex false t0 state
 
-        let state = WaitHandle.waitOne t0 id state |> acquired
-        let state = WaitHandle.waitOne t0 id state |> acquired
-        let state = WaitHandle.waitOne t0 id state |> acquired
+        let state = WaitHandle.waitOne t0 id None state |> acquired
+        let state = WaitHandle.waitOne t0 id None state |> acquired
+        let state = WaitHandle.waitOne t0 id None state |> acquired
 
         let m = mutexOf id state
         m.Ownership |> shouldEqual (MutexOwnership.Held (t0, 3))
@@ -854,15 +855,15 @@ module TestWaitHandle =
         let state = baseState () |> withThreads [ t0 ; t1 ; t2 ]
         let id, state = WaitHandle.createMutex true t0 state
 
-        let state = WaitHandle.waitOne t1 id state |> blocked
-        let state = WaitHandle.waitOne t2 id state |> blocked
+        let state = WaitHandle.waitOne t1 id None state |> blocked
+        let state = WaitHandle.waitOne t2 id None state |> blocked
 
         let m = mutexOf id state
         m.Ownership |> shouldEqual (MutexOwnership.Held (t0, 1))
         m.WaitQueue |> shouldEqual [ t1 ; t2 ]
         statusOf t0 state |> shouldEqual ThreadStatus.Runnable
-        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
-        statusOf t2 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle (id, None))
+        statusOf t2 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle (id, None))
 
     [<Test>]
     let ``releaseMutex by owner without waiters marks the mutex free`` () : unit =
@@ -880,8 +881,8 @@ module TestWaitHandle =
     let ``releaseMutex unwinds recursion before releasing`` () : unit =
         let state = baseState () |> withThreads [ t0 ]
         let id, state = WaitHandle.createMutex true t0 state
-        let state = WaitHandle.waitOne t0 id state |> acquired
-        let state = WaitHandle.waitOne t0 id state |> acquired
+        let state = WaitHandle.waitOne t0 id None state |> acquired
+        let state = WaitHandle.waitOne t0 id None state |> acquired
 
         let _, state = WaitHandle.releaseMutex t0 id state
         (mutexOf id state).Ownership |> shouldEqual (MutexOwnership.Held (t0, 2))
@@ -896,8 +897,8 @@ module TestWaitHandle =
     let ``releaseMutex with waiters hands ownership directly to the FIFO head`` () : unit =
         let state = baseState () |> withThreads [ t0 ; t1 ; t2 ]
         let id, state = WaitHandle.createMutex true t0 state
-        let state = WaitHandle.waitOne t1 id state |> blocked
-        let state = WaitHandle.waitOne t2 id state |> blocked
+        let state = WaitHandle.waitOne t1 id None state |> blocked
+        let state = WaitHandle.waitOne t2 id None state |> blocked
 
         let result, state = WaitHandle.releaseMutex t0 id state
 
@@ -909,7 +910,7 @@ module TestWaitHandle =
         m.WaitQueue |> shouldEqual [ t2 ]
         statusOf t0 state |> shouldEqual ThreadStatus.Runnable
         statusOf t1 state |> shouldEqual ThreadStatus.Runnable
-        statusOf t2 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+        statusOf t2 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle (id, None))
 
     [<Test>]
     let ``releaseMutex by a non-owner returns NotOwner and leaves state unchanged`` () : unit =
@@ -944,7 +945,7 @@ module TestWaitHandle =
 
             let state =
                 [ 1..depth ]
-                |> List.fold (fun s _ -> WaitHandle.waitOne t0 id s |> acquired) state
+                |> List.fold (fun s _ -> WaitHandle.waitOne t0 id None s |> acquired) state
 
             (mutexOf id state).Ownership = MutexOwnership.Held (t0, depth)
             && let state =
@@ -1026,7 +1027,7 @@ module TestWaitHandle =
         let id, state = WaitHandle.createMutex false t0 state
         let state = installAbandonedMutex id state
 
-        let state = WaitHandle.waitOne t0 id state |> acquiredAbandoned
+        let state = WaitHandle.waitOne t0 id None state |> acquiredAbandoned
 
         let m = mutexOf id state
         m.Ownership |> shouldEqual (MutexOwnership.Held (t0, 1))
@@ -1051,7 +1052,7 @@ module TestWaitHandle =
         let state = baseState () |> withThreads [ t0 ]
         let id, state = WaitHandle.createMutex false t0 state
         let state = installAbandonedMutex id state
-        let state = WaitHandle.waitOne t0 id state |> acquiredAbandoned
+        let state = WaitHandle.waitOne t0 id None state |> acquiredAbandoned
 
         let _, state = WaitHandle.releaseMutex t0 id state
 
@@ -1084,7 +1085,7 @@ module TestWaitHandle =
     let ``close fails loud on a mutex with parked waiters`` () : unit =
         let state = baseState () |> withThreads [ t0 ; t1 ]
         let id, state = WaitHandle.createMutex true t0 state
-        let state = WaitHandle.waitOne t1 id state |> blocked
+        let state = WaitHandle.waitOne t1 id None state |> blocked
 
         let exn =
             Assert.Throws<System.Exception> (fun () -> WaitHandle.close id state |> ignore)
@@ -1114,7 +1115,7 @@ module TestWaitHandle =
         let id, state = WaitHandle.createMutex false t0 state
 
         let exn =
-            Assert.Throws<System.Exception> (fun () -> WaitHandle.waitOnePrioritized t0 id state |> ignore)
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.waitOnePrioritized t0 id None state |> ignore)
 
         exn.Message |> shouldContainText "Mutex"
 
@@ -1139,7 +1140,7 @@ module TestWaitHandle =
         let state = WaitHandle.close id state
 
         let exn =
-            Assert.Throws<System.Exception> (fun () -> WaitHandle.waitOne t0 id state |> ignore)
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.waitOne t0 id None state |> ignore)
 
         exn.Message |> shouldContainText "not registered"
 
@@ -1234,7 +1235,7 @@ module TestWaitHandle =
         let state = baseState () |> withThreads [ t0 ]
         let id, state = WaitHandle.createEvent true EventResetMode.Manual state
 
-        let state = WaitHandle.waitOne t0 id state |> acquired
+        let state = WaitHandle.waitOne t0 id None state |> acquired
 
         let e = eventOf id state
         e.Signaled |> shouldEqual true
@@ -1246,7 +1247,7 @@ module TestWaitHandle =
         let state = baseState () |> withThreads [ t0 ]
         let id, state = WaitHandle.createEvent true EventResetMode.Auto state
 
-        let state = WaitHandle.waitOne t0 id state |> acquired
+        let state = WaitHandle.waitOne t0 id None state |> acquired
 
         let e = eventOf id state
         e.Signaled |> shouldEqual false
@@ -1258,24 +1259,24 @@ module TestWaitHandle =
         let state = baseState () |> withThreads [ t0 ; t1 ; t2 ]
         let id, state = WaitHandle.createEvent false EventResetMode.Manual state
 
-        let state = WaitHandle.waitOne t0 id state |> blocked
-        let state = WaitHandle.waitOne t1 id state |> blocked
-        let state = WaitHandle.waitOne t2 id state |> blocked
+        let state = WaitHandle.waitOne t0 id None state |> blocked
+        let state = WaitHandle.waitOne t1 id None state |> blocked
+        let state = WaitHandle.waitOne t2 id None state |> blocked
 
         let e = eventOf id state
         e.Signaled |> shouldEqual false
         e.WaitQueue |> shouldEqual [ t0 ; t1 ; t2 ]
-        statusOf t0 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
-        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
-        statusOf t2 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+        statusOf t0 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle (id, None))
+        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle (id, None))
+        statusOf t2 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle (id, None))
 
     [<Test>]
     let ``waitOne on an unsignalled Auto event parks the caller at the FIFO tail`` () : unit =
         let state = baseState () |> withThreads [ t0 ; t1 ; t2 ]
         let id, state = WaitHandle.createEvent false EventResetMode.Auto state
 
-        let state = WaitHandle.waitOne t0 id state |> blocked
-        let state = WaitHandle.waitOne t1 id state |> blocked
+        let state = WaitHandle.waitOne t0 id None state |> blocked
+        let state = WaitHandle.waitOne t1 id None state |> blocked
 
         let e = eventOf id state
         e.Signaled |> shouldEqual false
@@ -1298,9 +1299,9 @@ module TestWaitHandle =
     let ``setEvent on a Manual event wakes every parked waiter and latches Signaled=true`` () : unit =
         let state = baseState () |> withThreads [ t0 ; t1 ; t2 ]
         let id, state = WaitHandle.createEvent false EventResetMode.Manual state
-        let state = WaitHandle.waitOne t0 id state |> blocked
-        let state = WaitHandle.waitOne t1 id state |> blocked
-        let state = WaitHandle.waitOne t2 id state |> blocked
+        let state = WaitHandle.waitOne t0 id None state |> blocked
+        let state = WaitHandle.waitOne t1 id None state |> blocked
+        let state = WaitHandle.waitOne t2 id None state |> blocked
 
         let state = WaitHandle.setEvent id state
 
@@ -1326,9 +1327,9 @@ module TestWaitHandle =
     let ``setEvent on an Auto event with waiters wakes only the FIFO head, Signaled stays false`` () : unit =
         let state = baseState () |> withThreads [ t0 ; t1 ; t2 ]
         let id, state = WaitHandle.createEvent false EventResetMode.Auto state
-        let state = WaitHandle.waitOne t0 id state |> blocked
-        let state = WaitHandle.waitOne t1 id state |> blocked
-        let state = WaitHandle.waitOne t2 id state |> blocked
+        let state = WaitHandle.waitOne t0 id None state |> blocked
+        let state = WaitHandle.waitOne t1 id None state |> blocked
+        let state = WaitHandle.waitOne t2 id None state |> blocked
 
         let state = WaitHandle.setEvent id state
 
@@ -1336,17 +1337,17 @@ module TestWaitHandle =
         e.Signaled |> shouldEqual false
         e.WaitQueue |> shouldEqual [ t1 ; t2 ]
         statusOf t0 state |> shouldEqual ThreadStatus.Runnable
-        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
-        statusOf t2 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle (id, None))
+        statusOf t2 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle (id, None))
 
     [<Test>]
     let ``repeated setEvent on Auto with a queue drains FIFO one at a time`` () : unit =
         let state = baseState () |> withThreads [ t0 ; t1 ; t2 ; t3 ]
         let id, state = WaitHandle.createEvent false EventResetMode.Auto state
-        let state = WaitHandle.waitOne t0 id state |> blocked
-        let state = WaitHandle.waitOne t1 id state |> blocked
-        let state = WaitHandle.waitOne t2 id state |> blocked
-        let state = WaitHandle.waitOne t3 id state |> blocked
+        let state = WaitHandle.waitOne t0 id None state |> blocked
+        let state = WaitHandle.waitOne t1 id None state |> blocked
+        let state = WaitHandle.waitOne t2 id None state |> blocked
+        let state = WaitHandle.waitOne t3 id None state |> blocked
 
         let state = WaitHandle.setEvent id state
         (eventOf id state).WaitQueue |> shouldEqual [ t1 ; t2 ; t3 ]
@@ -1394,7 +1395,7 @@ module TestWaitHandle =
         let state = WaitHandle.setEvent id state
         (eventOf id state).Signaled |> shouldEqual true
 
-        let state = WaitHandle.waitOne t0 id state |> acquired
+        let state = WaitHandle.waitOne t0 id None state |> acquired
 
         let e = eventOf id state
         e.Signaled |> shouldEqual false
@@ -1434,16 +1435,16 @@ module TestWaitHandle =
     let ``resetEvent on an unsignalled Manual event with parked waiters does not touch the queue`` () : unit =
         let state = baseState () |> withThreads [ t0 ; t1 ]
         let id, state = WaitHandle.createEvent false EventResetMode.Manual state
-        let state = WaitHandle.waitOne t0 id state |> blocked
-        let state = WaitHandle.waitOne t1 id state |> blocked
+        let state = WaitHandle.waitOne t0 id None state |> blocked
+        let state = WaitHandle.waitOne t1 id None state |> blocked
 
         let state = WaitHandle.resetEvent id state
 
         let e = eventOf id state
         e.Signaled |> shouldEqual false
         e.WaitQueue |> shouldEqual [ t0 ; t1 ]
-        statusOf t0 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
-        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle id)
+        statusOf t0 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle (id, None))
+        statusOf t1 state |> shouldEqual (ThreadStatus.BlockedOnWaitHandle (id, None))
 
     // ---- tryWaitOne ----
 
@@ -1500,7 +1501,7 @@ module TestWaitHandle =
     let ``close fails loud on an event with parked waiters`` () : unit =
         let state = baseState () |> withThreads [ t0 ]
         let id, state = WaitHandle.createEvent false EventResetMode.Manual state
-        let state = WaitHandle.waitOne t0 id state |> blocked
+        let state = WaitHandle.waitOne t0 id None state |> blocked
 
         let exn =
             Assert.Throws<System.Exception> (fun () -> WaitHandle.close id state |> ignore)
@@ -1575,7 +1576,7 @@ module TestWaitHandle =
         let id, state = WaitHandle.createEvent false EventResetMode.Manual state
 
         let exn =
-            Assert.Throws<System.Exception> (fun () -> WaitHandle.waitOnePrioritized t0 id state |> ignore)
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.waitOnePrioritized t0 id None state |> ignore)
 
         exn.Message |> shouldContainText "Event"
 
@@ -1610,7 +1611,7 @@ module TestWaitHandle =
         let state = WaitHandle.close id state
 
         let exn =
-            Assert.Throws<System.Exception> (fun () -> WaitHandle.waitOne t0 id state |> ignore)
+            Assert.Throws<System.Exception> (fun () -> WaitHandle.waitOne t0 id None state |> ignore)
 
         exn.Message |> shouldContainText "not registered"
 
@@ -1641,7 +1642,7 @@ module TestWaitHandle =
             match statusOf tid state with
             | ThreadStatus.BlockedOnWaitHandle _ -> state
             | _ ->
-                match WaitHandle.waitOne tid id state with
+                match WaitHandle.waitOne tid id None state with
                 | WaitHandle.WaitOutcome.Acquired s
                 | WaitHandle.WaitOutcome.Blocked s -> s
                 | WaitHandle.WaitOutcome.AcquiredAbandoned _ ->

--- a/WoofWare.PawPrint.Test/sourcesPure/WaitHandleTimeoutSemaphore.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/WaitHandleTimeoutSemaphore.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Threading;
+
+namespace HelloWorldApp
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            // WaitHandle.WaitOne(int) with a non-zero finite timeout against an
+            // unsignalled handle must return false after the timeout elapses
+            // (rather than parking forever or returning true). This exercises
+            // the timed-wait codepath end-to-end: the semaphore starts with
+            // count 0 and nobody releases it, so the only way the guest can
+            // observe `false` is if the scheduler woke it from the wait queue
+            // with WAIT_TIMEOUT (the BCL converts that into WaitOne returning
+            // false).
+            //
+            // We use Semaphore because it's the simplest WaitHandle subclass
+            // that PawPrint supports through the CreateSemaphoreExW QCall and
+            // doesn't require additional plumbing (named events PNSE on Unix,
+            // mutex ownership has its own state machine). The 50 ms timeout
+            // is short enough that real .NET's wall clock walks past it in
+            // any test harness; PawPrint's virtual clock advances 1 ms per
+            // scheduler tick (and jumps to the next deadline when no thread
+            // is Runnable), so the timeout fires after ~50 ticks deterministically.
+            using (var sem = new Semaphore(0, 1))
+            {
+                if (sem.WaitOne(50))
+                {
+                    // count was zero and nobody released, so this must not
+                    // succeed; if it does we've masked the timeout firing.
+                    return 1;
+                }
+                return 0;
+            }
+        }
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/WaitHandleTimeoutSemaphoreSignalled.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/WaitHandleTimeoutSemaphoreSignalled.cs
@@ -1,0 +1,34 @@
+using System.Threading;
+
+namespace HelloWorldApp
+{
+    class Program
+    {
+        static Semaphore? sem;
+
+        static void Releaser()
+        {
+            // Releases the main thread's WaitOne(50) so it observes a signal
+            // (returning true) rather than the timeout firing (returning false).
+            sem!.Release();
+        }
+
+        static int Main(string[] args)
+        {
+            // Companion to WaitHandleTimeoutSemaphore.cs: exercises the
+            // *signal* path of WaitOne with a finite timeout. A worker thread
+            // releases the semaphore; the main thread is blocked in WaitOne(50)
+            // and must wake with the success result (WAIT_OBJECT_0 -> true)
+            // rather than waiting out the timeout. If the deadline-fire logic
+            // wrongly raced ahead of the signal-wake we'd return 1 here.
+            using (sem = new Semaphore(0, 1))
+            {
+                Thread t = new Thread(Releaser);
+                t.Start();
+                bool acquired = sem.WaitOne(50);
+                t.Join();
+                return acquired ? 0 : 1;
+            }
+        }
+    }
+}

--- a/WoofWare.PawPrint/Native/NativeWaitHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeWaitHandle.fs
@@ -261,13 +261,24 @@ module NativeWaitHandle =
         | other -> failwith $"%s{operation}: expected %s{argName} to be a pointer-shaped argument, got %O{other}"
 
     /// Drive the timeout dispatch shared by `WaitHandle_WaitOneCore`
-    /// and `WaitHandle_WaitOnePrioritized`: timeout = -1 (INFINITE)
-    /// blocks via `blockingWait`; timeout = 0 (the non-blocking probe
-    /// `WaitOne(0)` issues) takes the deterministic try-and-return path
-    /// via `tryWait`; any other finite timeout currently fails loud
-    /// (no virtual clock — same blocker as
-    /// `SystemNative_LowLevelMonitor_TimedWait`). Returns the new
-    /// `IlMachineState` and the Int32 return value the guest sees.
+    /// and `WaitHandle_WaitOnePrioritized`. Three cases:
+    ///
+    ///  - `timeout = -1` (INFINITE): pass `None` for the deadline, so a
+    ///    slow-path park records no deadline and the driver loop never
+    ///    fires a timeout.
+    ///  - `timeout = 0`: the non-blocking probe `WaitOne(0)` issues —
+    ///    routed through `tryWait`, which never parks and returns
+    ///    `WAIT_OBJECT_0` / `WAIT_ABANDONED` / `WAIT_TIMEOUT` inline.
+    ///  - `timeout > 0`: compute an absolute deadline as `VirtualClockMs
+    ///    + timeout` and thread it through `blockingWait`. The fast
+    ///    paths ignore the deadline; the slow path records it on the
+    ///    parked thread's `BlockedOnWaitHandle` status, and the driver
+    ///    loop's deadline-firing pass picks it up.
+    ///
+    /// Returns the new `IlMachineState` and the Int32 return value the
+    /// guest sees. Note that the `Blocked` outcome pushes `WAIT_OBJECT_0`
+    /// at park time even for a finite-timeout wait — the deadline-fire
+    /// path rewrites the slot to `WAIT_TIMEOUT` when it expires.
     ///
     /// `blockingWait` and `tryWait` are passed in separately rather
     /// than derived from a shared kind-generic primitive so that the
@@ -278,7 +289,7 @@ module NativeWaitHandle =
     let private dispatchWait
         (operation : string)
         (timeout : int)
-        (blockingWait : IlMachineState -> WaitHandle.WaitOutcome)
+        (blockingWait : int64 option -> IlMachineState -> WaitHandle.WaitOutcome)
         (tryWait : IlMachineState -> WaitHandle.TryWaitOutcome)
         (state : IlMachineState)
         : IlMachineState * int
@@ -291,7 +302,7 @@ module NativeWaitHandle =
             // `AcquiredAbandoned` returns `WAIT_ABANDONED`; `Blocked`
             // pushes `WAIT_OBJECT_0` at park time (see the
             // abandoned-mutex-propagation note in `WaitHandle.fs`).
-            match blockingWait state with
+            match blockingWait None state with
             | WaitHandle.WaitOutcome.Acquired state -> state, waitObjectZero
             | WaitHandle.WaitOutcome.AcquiredAbandoned state -> state, waitAbandoned
             | WaitHandle.WaitOutcome.Blocked state -> state, waitObjectZero
@@ -299,22 +310,38 @@ module NativeWaitHandle =
             // Zero-timeout: try the fast path, then return immediately.
             // CoreCLR returns `WAIT_OBJECT_0` / `WAIT_ABANDONED` if the
             // handle was signalled, else `WAIT_TIMEOUT`; the caller is
-            // never enqueued. Treating a zero-timeout as an
-            // unimplemented finite timeout would crash on a
-            // deterministic non-blocking probe (e.g. the `WaitOne(0)`
-            // poll pattern), which is the wrong envelope.
+            // never enqueued. Routing through `tryWait` rather than the
+            // finite-deadline path keeps the deterministic non-blocking
+            // probe entirely off the scheduler's deadline radar.
             match tryWait state with
             | WaitHandle.TryWaitOutcome.Acquired state -> state, waitObjectZero
             | WaitHandle.TryWaitOutcome.AcquiredAbandoned state -> state, waitAbandoned
             | WaitHandle.TryWaitOutcome.TimedOut state -> state, waitTimeout
-        else
-            // No virtual clock yet. Same envelope as `Monitor_Wait` /
-            // `SystemNative_LowLevelMonitor_TimedWait`: silently treating
-            // a finite timeout as Infinite would mask guest bugs that
-            // depend on timeout-based wakeups; treating it as immediate
-            // timeout would break the higher-level fairness contract.
+        elif timeout < 0 then
+            // The BCL's `WaitHandle.WaitOne(int)` wrapper validates that
+            // the only legal negative value is `-1 = INFINITE`; reaching
+            // the QCall with any other negative value means the wrapper
+            // was bypassed (guest bug). Fail loud rather than treating
+            // it as a 0 timeout (silent bug-masking) or as INFINITE
+            // (different deadlock surface).
             failwith
-                $"%s{operation}: finite timeout (%d{timeout} ms) is not yet implemented; PawPrint has no virtual clock. Guest code that depends on timed waits must be lifted onto a deterministic clock abstraction first."
+                $"%s{operation}: negative timeout %d{timeout} ms is not Infinite (-1); the BCL's WaitHandle.WaitOne(int) validates this argument before the QCall, so reaching here means the wrapper was bypassed."
+        else
+            // Finite positive timeout: compute an absolute deadline
+            // against the virtual clock. `VirtualClockMs` advances 1 ms
+            // per scheduler tick (per `Program.stepPrepared`), and the
+            // driver loop fires `WaitHandle.fireTimeout` when the clock
+            // reaches or passes a parked thread's deadline; if no other
+            // thread is Runnable, the driver also jumps the clock to
+            // the nearest pending deadline so the wait can resolve.
+            // `int64` keeps the addition safe even for
+            // `Int32.MaxValue` timeouts against a long-running clock.
+            let deadlineMs = state.Kernel.VirtualClockMs + int64 timeout
+
+            match blockingWait (Some deadlineMs) state with
+            | WaitHandle.WaitOutcome.Acquired state -> state, waitObjectZero
+            | WaitHandle.WaitOutcome.AcquiredAbandoned state -> state, waitAbandoned
+            | WaitHandle.WaitOutcome.Blocked state -> state, waitObjectZero
 
     /// Decode an optional `int*` out-pointer that may be `IntPtr.Zero`.
     /// `Some ptr` means we must write to `*ptr`; `None` means the

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -75,6 +75,78 @@ module Program =
         |> Seq.map (fun (ThreadId i, ts) -> $"thread {i} in state {ts.Status}")
         |> String.concat "; "
 
+    /// Project a thread status into its finite-timeout deadline against
+    /// the virtual clock, if any. Threads with no deadline (Runnable,
+    /// non-timed blocks, infinite waits) return `None`; threads parked
+    /// with a finite timeout return `Some absoluteVirtualClockMs`.
+    ///
+    /// Today only `BlockedOnWaitHandle` carries a deadline; the
+    /// extractor is structured so PR 2b/2c can add cases for
+    /// `BlockedOnMonitorWait` / `BlockedOnSyncBlockWait` without
+    /// rewiring the orchestrator below.
+    let private waitDeadline (status : ThreadStatus) : int64 option =
+        match status with
+        | ThreadStatus.BlockedOnWaitHandle (_, deadline) -> deadline
+        | ThreadStatus.Runnable
+        | ThreadStatus.NotStarted
+        | ThreadStatus.BlockedOnJoin _
+        | ThreadStatus.BlockedOnClassInit _
+        | ThreadStatus.BlockedOnMonitorAcquire _
+        | ThreadStatus.BlockedOnMonitorWait _
+        | ThreadStatus.BlockedOnSyncBlockAcquire _
+        | ThreadStatus.BlockedOnSyncBlockWait _
+        | ThreadStatus.Terminated
+        | ThreadStatus.Parked -> None
+
+    /// Fire a timeout wake for every blocked-with-deadline thread whose
+    /// deadline is `<= state.Kernel.VirtualClockMs`. Each fire removes
+    /// the thread from its handle's wait queue, rewrites the slow-path
+    /// `WAIT_OBJECT_0` slot on its eval stack to `WAIT_TIMEOUT`, and
+    /// flips it back to `Runnable`. Sorting by deadline isn't necessary
+    /// here — every fired wake produces an isolated state change against
+    /// a disjoint handle / thread, and a thread can only be in one
+    /// queue.
+    let private fireExpiredDeadlines (state : IlMachineState) : IlMachineState =
+        let now = state.Kernel.VirtualClockMs
+
+        let expired =
+            state.ThreadState
+            |> Map.toSeq
+            |> Seq.choose (fun (tid, ts) ->
+                match ts.Status with
+                | ThreadStatus.BlockedOnWaitHandle (handleId, Some deadline) when deadline <= now ->
+                    Some (tid, handleId)
+                | _ -> None
+            )
+            |> Seq.toList
+
+        expired
+        |> List.fold (fun s (tid, handleId) -> WaitHandle.fireTimeout tid handleId s) state
+
+    /// The minimum wait deadline among currently-blocked threads, or
+    /// `None` if no thread is parked with a finite timeout. Used by the
+    /// driver loop's jump-to-deadline fallback: if no thread is Runnable
+    /// but at least one has a finite-timeout wait outstanding, advance
+    /// `VirtualClockMs` to the nearest such deadline so the wait can
+    /// resolve on the next pass.
+    ///
+    /// The clock-jump must not bump `StepCounter` — the spurious-wakeup
+    /// schedules are keyed on `StepCounter`, and a jump-driven tick is
+    /// deliberately *not* a real scheduler tick. Keeping the two clocks
+    /// separate is exactly why `VirtualClockMs` is its own field rather
+    /// than derived from `StepCounter`.
+    let private nextDeadline (state : IlMachineState) : int64 option =
+        state.ThreadState
+        |> Map.toSeq
+        |> Seq.choose (fun (_, ts) -> waitDeadline ts.Status)
+        |> Seq.fold
+            (fun acc d ->
+                match acc with
+                | None -> Some d
+                | Some a -> Some (min a d)
+            )
+            None
+
     let private logStepOutcome
         (logger : ILogger)
         (state : IlMachineState)
@@ -159,6 +231,19 @@ module Program =
                     )
             }
 
+        // After advancing `VirtualClockMs`, fire any wait deadlines that
+        // are now in the past. This runs every tick (not just on
+        // deadlock) so a timeout against a thread holding a release lock
+        // can still expire while other threads make progress: e.g.
+        // thread A is parked with a 50 ms timeout on a semaphore, and
+        // thread B is busy computing something else — A's deadline still
+        // fires when the clock reaches it, even though B keeps the
+        // scheduler from ever stalling.
+        let prepared =
+            { prepared with
+                State = fireExpiredDeadlines prepared.State
+            }
+
         // Drive the signal-dispatcher state machine before the scheduler
         // picks its next thread. If a pending signal is deliverable and
         // the dispatcher is currently Parked, this flips it to Runnable
@@ -169,6 +254,36 @@ module Program =
             { prepared with
                 State = SignalDispatch.trySpawnHandler prepared.BaseClassTypes prepared.State
             }
+
+        // Jump-to-deadline fallback: if no thread is Runnable but at
+        // least one is parked with a finite-timeout wait outstanding,
+        // advance `VirtualClockMs` to the nearest pending deadline and
+        // fire it. This is what keeps a guest like `WaitOne(50)` against
+        // an unsignalled handle from deadlocking — without the jump, the
+        // clock would advance 1 ms per tick *only when there's something
+        // to step*, but there is nothing to step.
+        //
+        // Only `VirtualClockMs` is advanced (not `StepCounter`), so the
+        // spurious-wakeup schedule is untouched. A jump-driven wake is
+        // not a scheduler tick — it is the resolution of a timeout that
+        // would otherwise be invisible.
+        let prepared =
+            match Scheduler.chooseNext prepared.LastRan prepared.State with
+            | Some _ -> prepared
+            | None ->
+                match nextDeadline prepared.State with
+                | None -> prepared
+                | Some target ->
+                    let state =
+                        prepared.State.MapKernel (fun kernel ->
+                            { kernel with
+                                VirtualClockMs = max kernel.VirtualClockMs target
+                            }
+                        )
+
+                    { prepared with
+                        State = fireExpiredDeadlines state
+                    }
 
         match Scheduler.chooseNext prepared.LastRan prepared.State with
         | None ->

--- a/WoofWare.PawPrint/ThreadState.fs
+++ b/WoofWare.PawPrint/ThreadState.fs
@@ -69,7 +69,19 @@ type ThreadStatus =
     /// thread it resumes with `WAIT_OBJECT_0` already on the evaluation stack.
     /// Single-handle blocking only; multi-handle wait will need a separate
     /// variant carrying a list plus a wait-all/wait-any flag.
-    | BlockedOnWaitHandle of handle : WaitHandleId
+    ///
+    /// `deadlineMs = None` is an infinite wait (Win32 `INFINITE` / managed
+    /// `Timeout.Infinite`); `Some ms` is a finite timeout, expressed as the
+    /// absolute virtual-clock millisecond at which the wait expires. When
+    /// `VirtualClockMs` advances to that point and the thread is still
+    /// parked, the driver fires a timeout wake (`WaitHandle.fireTimeout`):
+    /// the thread is dequeued from the handle's `WaitQueue`, the
+    /// `WAIT_OBJECT_0` slot pushed at park time is rewritten to
+    /// `WAIT_TIMEOUT`, and the status flips back to `Runnable`. Storing the
+    /// deadline in the status itself (rather than alongside in a separate
+    /// map) makes the invariant "no deadline once Runnable again" structural
+    /// — a wake naturally forgets it.
+    | BlockedOnWaitHandle of handle : WaitHandleId * deadlineMs : int64 option
     /// This thread has executed its final `ret`; it will never run again. Its state is kept
     /// only so other threads can observe termination (e.g. to satisfy Join).
     | Terminated

--- a/WoofWare.PawPrint/WaitHandle.fs
+++ b/WoofWare.PawPrint/WaitHandle.fs
@@ -29,14 +29,18 @@ namespace WoofWare.PawPrint
 /// higher-level guest primitives (`LowLevelLifoSemaphore`,
 /// `PortableThreadPool`) depend on.
 ///
-/// Timeouts: non-zero finite timeouts on `WaitHandle_WaitOneCore` /
-/// `WaitHandle_WaitOnePrioritized` are not implemented today, for the
-/// same reason `LowLevelMonitor.TimedWait` is not — PawPrint has no
-/// virtual clock. Calls with a non-zero finite timeout fail loud in
-/// the native handler. The zero-timeout case is fully deterministic
-/// (`tryWaitOne`): it does not park, never touches the queue, and
-/// returns `WAIT_OBJECT_0` or `WAIT_TIMEOUT` depending on whether the
-/// fast path applied.
+/// Timeouts: finite timeouts on `WaitHandle_WaitOneCore` /
+/// `WaitHandle_WaitOnePrioritized` are supported through the
+/// virtual-clock plumbing in `EmulatedKernel.VirtualClockMs`. The
+/// native handler converts a millisecond timeout into an absolute
+/// deadline against `VirtualClockMs` and threads it through `waitOne` /
+/// `waitOnePrioritized`; if the slow path fires, the deadline is
+/// recorded on the parked thread's `BlockedOnWaitHandle` status. The
+/// driver loop fires `fireTimeout` for any thread whose deadline has
+/// elapsed, which dequeues the thread, rewrites the park-time
+/// `WAIT_OBJECT_0` slot on its eval stack to `WAIT_TIMEOUT`, and flips
+/// it back to `Runnable`. The zero-timeout case is still routed
+/// through `tryWaitOne` (fully deterministic, no park).
 ///
 /// Abandoned-mutex propagation: full support (rewriting the wake-time
 /// return value of already-blocked waiters when their owner thread
@@ -275,10 +279,15 @@ module WaitHandle =
 
     /// Internal: kind-private semaphore waitOne. Used by the kind
     /// dispatcher in `waitOne` and the property tests that exercise the
-    /// semaphore path directly.
+    /// semaphore path directly. `deadlineMs` is the absolute virtual-clock
+    /// millisecond at which the wait expires (or `None` for an infinite
+    /// wait); the value is recorded on the parked thread's `BlockedOn
+    /// WaitHandle` status when the slow path fires, so the driver loop's
+    /// deadline-firing pass knows when to time the wait out.
     let private waitOneSemaphore
         (thread : ThreadId)
         (id : WaitHandleId)
+        (deadlineMs : int64 option)
         (semaphore : SemaphoreState)
         (state : IlMachineState)
         : WaitOutcome
@@ -286,6 +295,9 @@ module WaitHandle =
         if semaphore.Count > 0 then
             // Fast path: consume one unit and stay Runnable. The new
             // count is in `[0, Maximum - 1]`, preserving the invariant.
+            // The deadline is irrelevant on the fast path; the wait
+            // never blocked, so there is no parked-thread record to
+            // attach it to.
             let semaphore =
                 { semaphore with
                     Count = semaphore.Count - 1
@@ -305,15 +317,18 @@ module WaitHandle =
 
             state
             |> writeHandle id (WaitHandleState.Semaphore semaphore)
-            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnWaitHandle id)
+            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnWaitHandle (id, deadlineMs))
             |> WaitOutcome.Blocked
 
     /// Internal: kind-private mutex waitOne. Re-entrant on owner; the
     /// `Free wasAbandoned=true` transition produces `AcquiredAbandoned`
-    /// and clears the flag.
+    /// and clears the flag. `deadlineMs` is recorded on the parked
+    /// thread's status when the slow path fires (held by another thread);
+    /// the fast paths do not consult it.
     let private waitOneMutex
         (thread : ThreadId)
         (id : WaitHandleId)
+        (deadlineMs : int64 option)
         (mutex : MutexState)
         (state : IlMachineState)
         : WaitOutcome
@@ -349,17 +364,18 @@ module WaitHandle =
 
             state
             |> writeHandle id (WaitHandleState.Mutex mutex)
-            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnWaitHandle id)
+            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnWaitHandle (id, deadlineMs))
             |> WaitOutcome.Blocked
 
     /// Internal: kind-private event waitOne. Acquiring a signalled `Auto`
     /// event consumes the signal (clears `Signaled`); acquiring a
     /// signalled `Manual` event leaves it signalled (every concurrent
     /// waiter passes through). On an unsignalled event the thread parks
-    /// at the FIFO tail.
+    /// at the FIFO tail with `deadlineMs` recorded on its status.
     let private waitOneEvent
         (thread : ThreadId)
         (id : WaitHandleId)
+        (deadlineMs : int64 option)
         (event : EventState)
         (state : IlMachineState)
         : WaitOutcome
@@ -386,7 +402,7 @@ module WaitHandle =
 
             state
             |> writeHandle id (WaitHandleState.Event event)
-            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnWaitHandle id)
+            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnWaitHandle (id, deadlineMs))
             |> WaitOutcome.Blocked
 
     /// Try to take ownership of `id` on behalf of `thread`. Dispatches
@@ -394,23 +410,39 @@ module WaitHandle =
     ///
     ///  - Semaphore: decrement the count if positive; otherwise park at
     ///    the FIFO tail of `WaitQueue` and flip the thread's status to
-    ///    `BlockedOnWaitHandle`.
+    ///    `BlockedOnWaitHandle (id, deadlineMs)`.
     ///  - Mutex: re-entrant fast path on the owning thread; take the
     ///    free mutex (producing `AcquiredAbandoned` iff the abandoned
     ///    flag was set, clearing it); otherwise park at the FIFO tail.
+    ///  - Event: signalled events fast-path (consuming the signal for
+    ///    `Auto`); unsignalled events park at the FIFO tail.
+    ///
+    /// `deadlineMs` is the absolute virtual-clock millisecond at which a
+    /// finite timeout expires, or `None` for an infinite wait. The fast
+    /// paths ignore it; only the slow paths thread it through to the
+    /// parked thread's status, where the driver loop's deadline-firing
+    /// pass picks it up.
     ///
     /// The IL `WaitOne` site advances in every case (the native handler
     /// returns `Stepped/Executed` for all three outcomes). When a parked
-    /// thread is later woken, its `WAIT_OBJECT_0` slot has already been
-    /// pushed onto its eval stack at park time — see the
-    /// abandoned-mutex-propagation note on the module docstring.
-    let waitOne (thread : ThreadId) (id : WaitHandleId) (state : IlMachineState) : WaitOutcome =
+    /// thread is later signal-woken, its `WAIT_OBJECT_0` slot has
+    /// already been pushed onto its eval stack at park time; if instead
+    /// its deadline fires first, `fireTimeout` rewrites that slot to
+    /// `WAIT_TIMEOUT` — see the abandoned-mutex-propagation note on the
+    /// module docstring for why signal-side rewrite isn't symmetric.
+    let waitOne
+        (thread : ThreadId)
+        (id : WaitHandleId)
+        (deadlineMs : int64 option)
+        (state : IlMachineState)
+        : WaitOutcome
+        =
         let handle = lookup id state
 
         match handle with
-        | WaitHandleState.Semaphore semaphore -> waitOneSemaphore thread id semaphore state
-        | WaitHandleState.Mutex mutex -> waitOneMutex thread id mutex state
-        | WaitHandleState.Event event -> waitOneEvent thread id event state
+        | WaitHandleState.Semaphore semaphore -> waitOneSemaphore thread id deadlineMs semaphore state
+        | WaitHandleState.Mutex mutex -> waitOneMutex thread id deadlineMs mutex state
+        | WaitHandleState.Event event -> waitOneEvent thread id deadlineMs event state
 
     /// Non-blocking probe used to model the zero-timeout `WaitOne(0)`
     /// path. CoreCLR's contract for a zero millisecond timeout: try the
@@ -514,8 +546,16 @@ module WaitHandle =
     /// fairness contract is LIFO over the kernel semaphore's FIFO base.
     ///
     /// The fast path is identical to `waitOne`: priority only matters
-    /// when the call has to block.
-    let waitOnePrioritized (thread : ThreadId) (id : WaitHandleId) (state : IlMachineState) : WaitOutcome =
+    /// when the call has to block. `deadlineMs` propagates to the parked
+    /// thread's status when the slow path fires, and is ignored on the
+    /// fast path for the same reason as `waitOne`.
+    let waitOnePrioritized
+        (thread : ThreadId)
+        (id : WaitHandleId)
+        (deadlineMs : int64 option)
+        (state : IlMachineState)
+        : WaitOutcome
+        =
         let handle = lookup id state
         let semaphore = expectSemaphore "WaitHandle.waitOnePrioritized" id handle
 
@@ -540,7 +580,7 @@ module WaitHandle =
 
             state
             |> writeHandle id (WaitHandleState.Semaphore semaphore)
-            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnWaitHandle id)
+            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnWaitHandle (id, deadlineMs))
             |> WaitOutcome.Blocked
 
     /// Increment the semaphore by `releaseCount`, waking up to that many
@@ -796,3 +836,89 @@ module WaitHandle =
                 WaitHandles = kernel.WaitHandles |> Map.remove id
             }
         )
+
+    /// Wake `thread` because its finite-timeout wait against handle `id`
+    /// has expired against the virtual clock. The thread must currently
+    /// be parked at this handle's wait queue (the driver only calls
+    /// this for threads observed in `BlockedOnWaitHandle (id, Some _)`,
+    /// so a mismatch here indicates a scheduler-side bug). Effects:
+    ///
+    ///  - Remove `thread` from whichever kind-specific `WaitQueue` it
+    ///    sits in. A semaphore's queue is FIFO; a prioritized waiter
+    ///    sits at the head. Either way the entry's position is opaque
+    ///    to the timeout — we filter by identity.
+    ///  - Rewrite the top of the thread's active frame's eval stack from
+    ///    the `WAIT_OBJECT_0` slot the slow-path push installed at park
+    ///    time to `WAIT_TIMEOUT (0x102)`. The IL `WaitOne` call site has
+    ///    already advanced past itself; the BCL's wrapper reads this
+    ///    value back from the QCall return and compares against
+    ///    `WaitHandle.WaitTimeout = 0x102` to return `false`.
+    ///  - Flip the thread's status back to `Runnable`. The deadline is
+    ///    implicitly forgotten — the new status carries no deadline
+    ///    field, which is exactly the invariant the variant encodes.
+    ///
+    /// Why pop-then-push rather than peek-and-mutate: the eval stack
+    /// surface only exposes push/pop primitives, and popping the
+    /// previously-pushed slot before pushing the timeout slot keeps the
+    /// stack depth invariant across the wake (no net change in depth,
+    /// just the top value).
+    let fireTimeout (thread : ThreadId) (id : WaitHandleId) (state : IlMachineState) : IlMachineState =
+        let handle = lookup id state
+
+        let state =
+            match handle with
+            | WaitHandleState.Semaphore semaphore ->
+                let newQueue = semaphore.WaitQueue |> List.filter (fun t -> t <> thread)
+
+                if List.length newQueue = List.length semaphore.WaitQueue then
+                    failwith
+                        $"WaitHandle.fireTimeout: thread %O{thread} is not in semaphore %O{id}'s wait queue; the scheduler observed a deadline on a thread the handle does not know about."
+
+                writeHandle
+                    id
+                    (WaitHandleState.Semaphore
+                        { semaphore with
+                            WaitQueue = newQueue
+                        })
+                    state
+            | WaitHandleState.Mutex mutex ->
+                let newQueue = mutex.WaitQueue |> List.filter (fun t -> t <> thread)
+
+                if List.length newQueue = List.length mutex.WaitQueue then
+                    failwith
+                        $"WaitHandle.fireTimeout: thread %O{thread} is not in mutex %O{id}'s wait queue; the scheduler observed a deadline on a thread the handle does not know about."
+
+                writeHandle
+                    id
+                    (WaitHandleState.Mutex
+                        { mutex with
+                            WaitQueue = newQueue
+                        })
+                    state
+            | WaitHandleState.Event event ->
+                let newQueue = event.WaitQueue |> List.filter (fun t -> t <> thread)
+
+                if List.length newQueue = List.length event.WaitQueue then
+                    failwith
+                        $"WaitHandle.fireTimeout: thread %O{thread} is not in event %O{id}'s wait queue; the scheduler observed a deadline on a thread the handle does not know about."
+
+                writeHandle
+                    id
+                    (WaitHandleState.Event
+                        { event with
+                            WaitQueue = newQueue
+                        })
+                    state
+
+        // Rewrite the park-time `WAIT_OBJECT_0 = 0` slot to `WAIT_TIMEOUT
+        // = 0x102`. The slow-path waitOne / waitOnePrioritized pushed
+        // `WAIT_OBJECT_0` because the slow path could not know in advance
+        // whether the wake would be a signal (keep the value) or a
+        // timeout (rewrite); choosing the optimistic value at park time
+        // makes signal-wake free.
+        let _, state = IlMachineState.popEvalStack thread state
+
+        let state =
+            IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0x102) thread state
+
+        Scheduler.setThreadStatus thread ThreadStatus.Runnable state


### PR DESCRIPTION
## Summary
- `WaitHandle.WaitOne(int)` and `WaitOne(TimeSpan)` with a finite positive timeout now record an absolute virtual-clock deadline on the `BlockedOnWaitHandle` thread status. The scheduler fires expired deadlines each tick (rewriting the parked `WAIT_OBJECT_0` push to `WAIT_TIMEOUT`) and, when no thread is currently runnable, jumps `VirtualClockMs` forward to the next pending deadline so a fully-timed-blocked system makes progress.
- Deadline storage is a per-variant `int64 option` payload, so PR 2b (`LowLevelMonitor.TimedWait`) and PR 2c (`Monitor.Wait`) plug in by adding match arms to the `waitDeadline` extractor rather than restructuring the scheduler.
- Zero-timeout and infinite-timeout paths are unchanged; negative non-Infinite timeouts now fail loud (the BCL wrapper validates the argument, so reaching the QCall means the wrapper was bypassed).
- Two new `sourcesPure` tests exercise the timeout-firing and signal-wake paths of `WaitOne(int)` end-to-end against `Semaphore`.

## Test plan
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 1251 passed, 0 failed
- [x] New tests pass: `WaitHandleTimeoutSemaphore` (deadline fires), `WaitHandleTimeoutSemaphoreSignalled` (Release wakes the waiter before the deadline)
- [x] `codex review --base main` — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)