### PR TITLE
Substitute method generics when initobj concretises its operand

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -18,7 +18,7 @@ module TestPureCases =
     let unimplemented =
         [
             "AdvancedStructLayout.cs" // past MarshalNative_SizeOfHelper for ByValTStr and SystemNative_Malloc / SystemNative_Free / Marshal.AllocHGlobal / FreeHGlobal; now blocked downstream at the unimplemented MarshalNative_TryGetStructMarshalStub QCall (CoreLib's Marshal.StructureToPtr path)
-            "Threads.cs" // past ClrConfig_GetConfigBoolValue now that AutoreleasePool's static-field init can read a "knob not set" answer; next blocker is the same TypeConcretization "Generic method parameter 0" failure that ResizeArray.cs hits (TypeConcretisation.fs:683, reached from an initobj at UnaryMetadataMemoryOps.fs:30)
+            "Threads.cs" // past the initobj generic-method-parameter bug; now blocks at IlMachineManagedByref.readReinterpretedByrefField (IlMachineManagedByref.fs:1204) when a TaskAwaiter ldfld of `m_task` tries to bytewise-reinterpret object-reference storage that PawPrint does not yet model
             "MarshalStructureToPtrDateTimeField.cs" // MarshalNative_TryGetStructMarshalStub doesn't yet synthesise an IL stub for has-layout-non-blittable structs; CoreCLR writes an 8-byte OADate (`MARSHAL_TYPE_DATE`) for a `DateTime` field, but PawPrint currently rejects the struct loudly rather than memmove-ing the managed `_dateData` bytes. Real implementation needs the OADate-conversion stub.
             "MarshalStructureToPtrIntPtrField.cs" // The TryGetStructMarshalStub QCall classifier still rejects IntPtr/UIntPtr fields outright. Byte-renderability of `NativeIntSource` is value-dependent (e.g. `TypeHandlePtr` from `obj.GetType().TypeHandle.Value` can't be serialised by `CliNumericType.ToBytes`), so a type-level "blittable" decision can't be honoured for every possible value. Parked here as the motivating end-to-end case for joint widening: once `ToBytes` handles every `NativeIntSource` variant, the classifier can widen too and this Verbatim-valued test should pass.
         ]
@@ -47,8 +47,9 @@ module TestPureCases =
         let empty = MockEnv.make ()
 
         [
-            // CurrentManagedThreadId now works; blocked downstream on TypeConcretization
-            // generic method parameter 0 from CollectionsMarshal.AsSpan initobj.
+            // Past the initobj generic-method-parameter bug; now blocks on the
+            // unimplemented JIT intrinsic System.Numerics.Vector`1.get_IsSupported(),
+            // reached from a LINQ/SIMD codepath in the BCL.
             "ResizeArray.cs",
             { empty with
                 System_Environment = System_Environment.passThru

--- a/WoofWare.PawPrint.Test/sourcesPure/InitobjGenericMethodParameter.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/InitobjGenericMethodParameter.cs
@@ -1,0 +1,16 @@
+class Program
+{
+    struct Point { public int X; public int Y; }
+
+    static T MakeDefault<T>() where T : struct
+    {
+        T value = default;
+        return value;
+    }
+
+    static int Main(string[] args)
+    {
+        Point p = MakeDefault<Point>();
+        return (p.X == 0 && p.Y == 0) ? 0 : 1;
+    }
+}

--- a/WoofWare.PawPrint/UnaryMetadataMemoryOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataMemoryOps.fs
@@ -34,7 +34,7 @@ module internal UnaryMetadataMemoryOps =
                 assy
                 targetType
                 declaringTypeGenerics
-                ImmutableArray.Empty
+                currentMethod.Generics
                 state
 
         let state =


### PR DESCRIPTION
## Summary
- `executeInitobj` was passing `ImmutableArray.Empty` as the method-generics array to `cliTypeZeroOf`, so `initobj !!T` (the IL C# emits for `T t = default;` inside a generic method) blew up at concretization with `IndexOutOfRangeException: Generic method parameter 0`. The sibling instructions in the same file (`stobj`, `ldobj`, `sizeof`) already thread `currentMethod.Generics` — this was an outlier, latent since the file was split out in #358 (and inherited verbatim from the pre-split source).
- Adds `InitobjGenericMethodParameter.cs` as a minimal regression test: `default(T)` inside `MakeDefault<T>() where T : struct`. Verified the test fails pre-fix with the exact stack and passes post-fix.
- Both `Threads.cs` and `ResizeArray.cs` were parked on this exact symptom. They now make progress past the concretization step and surface fresh downstream blockers, which the annotations are updated to record:
  - Threads.cs: byref reinterpret over object-reference storage in a TaskAwaiter `ldfld m_task` (`IlMachineManagedByref.fs:1204`).
  - ResizeArray.cs: unimplemented JIT intrinsic `System.Numerics.Vector\`1.get_IsSupported()`.

## Test plan
- [x] `nix develop -c dotnet fantomas .`
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 1254/1254 pass
- [x] Confirmed the new test fails on main (with the exact `IndexOutOfRangeException: Generic method parameter 0`) and passes on this branch
- [x] \`codex review --base main\` returns clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)