### PR TITLE
Fold Vector<T>.IsSupported to false on the scalar-only profile

### DIFF
--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -40,22 +40,14 @@ module TestPureCases =
             { empty with
                 System_Environment = System_Environment.passThru
             }
-        ]
-        |> Map.ofList
-
-    let unimplementedMockTests : Map<string, NativeImpls> =
-        let empty = MockEnv.make ()
-
-        [
-            // Past the initobj generic-method-parameter bug; now blocks on the
-            // unimplemented JIT intrinsic System.Numerics.Vector`1.get_IsSupported(),
-            // reached from a LINQ/SIMD codepath in the BCL.
             "ResizeArray.cs",
             { empty with
                 System_Environment = System_Environment.passThru
             }
         ]
         |> Map.ofList
+
+    let unimplementedMockTests : Map<string, NativeImpls> = Map.empty
 
     let expectsUnhandledException = [ "UnhandledException.cs" ] |> Set.ofList
 

--- a/WoofWare.PawPrint.Test/sourcesPure/VectorIsSupported.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/VectorIsSupported.cs
@@ -1,0 +1,16 @@
+using System.Numerics;
+
+class Program
+{
+    static bool Check<T>() where T : struct => Vector<T>.IsSupported;
+
+    static int Main(string[] args)
+    {
+        // We don't assert a particular value; Check<int>() is `true` on real .NET
+        // (int is a primitive supported by Vector) and `false` on PawPrint's
+        // scalar-only virtual CPU. The test exists to make sure the call does
+        // not crash on PawPrint via the unimplemented-JIT-intrinsic path.
+        bool _ = Check<int>();
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/IntrinsicHelpers.fs
+++ b/WoofWare.PawPrint/IntrinsicHelpers.fs
@@ -435,17 +435,23 @@ module internal IntrinsicHelpers =
 
     // PawPrint emulates a deterministic scalar virtual CPU: every hardware-intrinsic
     // family reports IsSupported = false so the BCL falls through to its scalar/portable
-    // path. The IL body of these `[Intrinsic]` getters is a recursive `return IsSupported;`
-    // stub that the JIT replaces with a constant; without an explicit fold here it would
-    // recurse forever. New ISAs landing in CoreLib must be added to this set.
+    // path. Most of the IL bodies are a recursive `return IsSupported;` stub that the JIT
+    // replaces with a constant; without an explicit fold here it would recurse forever.
+    // A few entries (e.g. `System.Numerics.Vector\`1`) have honest terminating bodies that
+    // would return `true` for primitive `T` — we still fold them to `false` here because the
+    // scalar profile has no implementation of the SIMD ops a `true` answer would commit us to.
+    // New ISAs landing in CoreLib must be added to this set.
     //
     // Coverage source: src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics
-    // in the dotnet/runtime tree. Listing harmless-but-unmatched names is fine; the lookup
-    // is keyed off the fully qualified declaring type name, so types absent from the
-    // running CoreLib simply never trigger a match.
+    // (and System/Numerics for `Vector\`1`) in the dotnet/runtime tree. Listing
+    // harmless-but-unmatched names is fine; the lookup is keyed off the fully qualified
+    // declaring type name, so types absent from the running CoreLib simply never trigger a
+    // match.
     let scalarOnlyFalseIsSupportedIntrinsics =
         set
             [
+                // System.Numerics
+                "System.Numerics.Vector`1"
                 // System.Runtime.Intrinsics.Arm
                 "System.Runtime.Intrinsics.Arm.AdvSimd"
                 "System.Runtime.Intrinsics.Arm.AdvSimd.Arm64"


### PR DESCRIPTION
## Summary

- `System.Numerics.Vector<T>.get_IsSupported` was reaching the
  `TODO: implement JIT intrinsic` failwith from generic call sites in the BCL
  (e.g. `CollectionsMarshal.AsSpan<T>` reached via `ResizeArray.cs`). Unlike the
  recursive-stub `IsSupported` getters under `System.Runtime.Intrinsics.{Arm, Wasm,
  X86}.*`, its IL body is an honest `typeof(T) == typeof(primitive)` chain — but
  on PawPrint's deterministic scalar-only virtual CPU we still want it to report
  `false`, because returning `true` would commit us to implementing the rest of
  the `Vector<T>` SIMD chain with no scalar fallback.
- Adds `"System.Numerics.Vector\`1"` to `scalarOnlyFalseIsSupportedIntrinsics`
  (`WoofWare.PawPrint/IntrinsicHelpers.fs`) and refreshes the leading comment to
  note that the set now covers both recursive-stub bodies and honest bodies we
  deliberately fold. The matching arm at `Intrinsics.fs:80` picks up the new
  entry by set membership without further code changes.
- Promotes `ResizeArray.cs` from `unimplementedMockTests` to `requiresMocks` in
  `TestPureCases.fs` — it now runs end-to-end on PawPrint with the fix. Adds
  `sourcesPure/VectorIsSupported.cs` as a targeted regression test (the standalone
  `Vector<int>.IsSupported` call is dispatched correctly only when invoked
  via a method-generic context, which is what the test exercises).

## Test plan

- [x] `nix develop -c dotnet fantomas .`
- [x] New test fails without the fix: confirmed `TODO: implement JIT intrinsic ...System.Numerics.Vector\`1.get_IsSupported()`
- [x] New test passes with the fix.
- [x] `ResizeArray.cs` now passes via `Tests which require mocks`.
- [x] Full suite green: 1256 / 1256 passing.
- [x] `codex review --base main` — no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)