### PR TITLE
Accept parameterless Main alongside Main(string[])

### DIFF
--- a/WoofWare.PawPrint.Test/CrossAssemblyHarness.fs
+++ b/WoofWare.PawPrint.Test/CrossAssemblyHarness.fs
@@ -134,8 +134,14 @@ module CrossAssemblyHarness =
         try
             let entry : Reflection.Assembly = loadContext.LoadFromAssemblyPath entryPath
             let entryPoint : Reflection.MethodInfo = entry.EntryPoint
-            let mainArgs : string[] = [||]
-            let invokeArgs : obj[] = [| mainArgs :> obj |]
+
+            let invokeArgs : obj[] =
+                match entryPoint.GetParameters().Length with
+                | 0 -> [||]
+                | _ ->
+                    let mainArgs : string[] = [||]
+                    [| mainArgs :> obj |]
+
             let result : obj = entryPoint.Invoke ((null : obj), invokeArgs)
             unbox<int> result
         finally

--- a/WoofWare.PawPrint.Test/RealRuntime.fs
+++ b/WoofWare.PawPrint.Test/RealRuntime.fs
@@ -14,7 +14,12 @@ module RealRuntime =
         let assy = System.Reflection.Assembly.Load assemblyBytes
 
         try
-            let result = assy.EntryPoint.Invoke ((null : obj), [| args |]) |> unbox<int>
+            let invokeArgs : obj[] =
+                match assy.EntryPoint.GetParameters().Length with
+                | 0 -> [||]
+                | _ -> [| box args |]
+
+            let result = assy.EntryPoint.Invoke ((null : obj), invokeArgs) |> unbox<int>
             RealRuntimeResult.NormalExit result
         with :? System.Reflection.TargetInvocationException as tie ->
             RealRuntimeResult.UnhandledException (tie.InnerException |> Option.ofObj |> Option.defaultValue (tie :> _))

--- a/WoofWare.PawPrint.Test/sourcesPure/MainNoArgs.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/MainNoArgs.cs
@@ -1,0 +1,7 @@
+public class Program
+{
+    static int Main()
+    {
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -491,6 +491,18 @@ module Program =
         if mainMethodFromMetadata.Signature.GenericParameterCount > 0 then
             failwith "Refusing to execute generic main method"
 
+        let mainTakesStringArrayArg =
+            match mainMethodFromMetadata.Signature.ParameterTypes |> Seq.toList with
+            | [] -> false
+            | [ TypeDefn.OneDimensionalArrayLowerBoundZero (TypeDefn.PrimitiveType PrimitiveType.String) ] -> true
+            | _ ->
+                failwith
+                    "Main method must take no parameters or a single string[]; other signatures not yet implemented"
+
+        match mainMethodFromMetadata.Signature.ReturnType with
+        | MethodReturnType.Returns (TypeDefn.PrimitiveType PrimitiveType.Int32) -> ()
+        | _ -> failwith "Main method must return int32; other types not currently supported"
+
         let state =
             IlMachineState.initial loggerFactory dotnetRuntimeDirs dumped
             |> fun s -> s.MapKernel (EmulatedKernel.withEnvironment env)
@@ -610,7 +622,15 @@ module Program =
                         ImmutableArray.Empty
                         state
 
-                // Create the method state with the concretized method
+                // Create the method state with the concretized method.
+                // The body has been replaced with onlyRet, so these are placeholders whose
+                // length must match the method's parameter count.
+                let placeholderArgs =
+                    if mainTakesStringArrayArg then
+                        ImmutableArray.CreateRange [ CliType.ObjectRef None ]
+                    else
+                        ImmutableArray.Empty
+
                 match
                     MethodState.Empty
                         state.ConcreteTypes
@@ -619,7 +639,7 @@ module Program =
                         dumped
                         concretizedMainMethod
                         ImmutableArray.Empty
-                        (ImmutableArray.CreateRange [ CliType.ObjectRef None ])
+                        placeholderArgs
                         None
                 with
                 | Ok concretizedMeth -> IlMachineState.addThread concretizedMeth state, Some baseTypes
@@ -674,15 +694,12 @@ module Program =
 
         let state = loadInitialState state
 
-        let arrayAllocation, state =
-            match mainMethodFromMetadata.Signature.ParameterTypes |> Seq.toList with
-            | [ TypeDefn.OneDimensionalArrayLowerBoundZero (TypeDefn.PrimitiveType PrimitiveType.String) ] ->
-                allocateArgs loggerFactory argv baseClassTypes state
-            | _ -> failwith "Main method must take an array of strings; other signatures not yet implemented"
-
-        match mainMethodFromMetadata.Signature.ReturnType with
-        | MethodReturnType.Returns (TypeDefn.PrimitiveType PrimitiveType.Int32) -> ()
-        | _ -> failwith "Main method must return int32; other types not currently supported"
+        let mainArgs, state =
+            if mainTakesStringArrayArg then
+                let arrayAllocation, state = allocateArgs loggerFactory argv baseClassTypes state
+                ImmutableArray.Create (CliType.ofManagedObject arrayAllocation), state
+            else
+                ImmutableArray.Empty, state
 
         // We might be in the middle of class construction. Pump the static constructors to completion.
         // We haven't yet entered the main method!
@@ -725,7 +742,7 @@ module Program =
                     dumped
                     concretizedMainMethod
                     ImmutableArray.Empty
-                    (ImmutableArray.Create (CliType.ofManagedObject arrayAllocation))
+                    mainArgs
                     None
             with
             | Ok s -> s


### PR DESCRIPTION
## Summary
- Lift the entrypoint signature/return-type validation in `Program.prepare` up front, cache a `mainTakesStringArrayArg` flag, and drive both the cctor-bootstrap placeholder frame and the real Main invocation off that one decision. When Main is parameterless we skip the `string[]` allocation entirely and pass an empty argument list to `MethodState.Empty`.
- Teach `RealRuntime.executeWithRealRuntime` and `CrossAssemblyHarness.executeWithRealRuntime` to size their reflection-invoke `obj[]` to the entrypoint's parameter count, so the real-runtime oracle no longer throws `TargetParameterCountException` against a `static int Main()` source.
- Add `sourcesPure/MainNoArgs.cs` as a tiny regression test exercising the new zero-parameter branch end-to-end against the real runtime.

## Test plan
- [x] `nix develop -c dotnet build WoofWare.PawPrint.slnx` — 0 warnings, 0 errors
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 1273 / 1273 pass (including the new `MainNoArgs.cs`)
- [x] `nix develop -c dotnet fantomas .` — no files reformatted
- [x] `codex review --base main` — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)