### PR TITLE
Bump zero-sized marshal layout to 1 byte

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/MarshalSizeOfEmptyStruct.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/MarshalSizeOfEmptyStruct.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Runtime.InteropServices;
+
+public class Program
+{
+    struct Empty
+    {
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct EmptySequential
+    {
+    }
+
+    public static int Main(string[] args)
+    {
+        // CoreCLR's `EEClassNativeLayoutInfo::CollectNativeLayoutFieldMetadataThrowing`
+        // (classlayoutinfo.cpp:984-988) bumps a computed zero-sized native layout to
+        // 1 byte so the type has a distinct address. `Marshal.SizeOf<T>()` of an
+        // empty struct therefore returns 1, not 0, even though the struct has no
+        // managed fields and a managed CLI size of 0.
+        if (Marshal.SizeOf(typeof(Empty)) != 1) return 1;
+        if (Marshal.SizeOf(typeof(EmptySequential)) != 1) return 2;
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/CliType.fs
+++ b/WoofWare.PawPrint/CliType.fs
@@ -1439,6 +1439,21 @@ and CliValueType =
                     size, if packing = 0 then DEFAULT_STRUCT_ALIGNMENT else packing
                 | Layout.Default -> 0, DEFAULT_STRUCT_ALIGNMENT
 
+            // CoreCLR's `EEClassNativeLayoutInfo::CollectNativeLayoutFieldMetadataThrowing`
+            // (classlayoutinfo.cpp:984-988) bumps a computed native layout size of 0 to 1
+            // so the type has a distinct native address. This is universal post-processing
+            // and applies whether the zero came from an empty field list, all fields
+            // eliding to nothing, or an explicit `Size = 0` on the `[StructLayout]`. Apply
+            // here so every concrete return path through the marshal-size walk respects
+            // the same invariant.
+            let bumpZeroSized (size : SizeofResult) : SizeofResult =
+                if size.Size = 0 then
+                    { size with
+                        Size = 1
+                    }
+                else
+                    size
+
             let computeFinal (currentEnd : int) (maxAlign : int) : SizeofResult =
                 let alignment = max maxAlign 1
                 let error = currentEnd % alignment
@@ -1449,21 +1464,24 @@ and CliValueType =
                     else
                         currentEnd + (alignment - error)
 
-                {
-                    Size = max totalSize minimumSize
-                    Alignment = alignment
-                }
+                bumpZeroSized
+                    {
+                        Size = max totalSize minimumSize
+                        Alignment = alignment
+                    }
 
             let seqFields, nonSeqFields =
                 storage.Fields |> List.partition (fun field -> field.ConfiguredOffset.IsNone)
 
             match seqFields, nonSeqFields with
             | [], [] ->
-                Result.Ok
-                    {
-                        Size = minimumSize
-                        Alignment = 1
-                    }
+                Result.Ok (
+                    bumpZeroSized
+                        {
+                            Size = minimumSize
+                            Alignment = 1
+                        }
+                )
             | _ :: _, [] ->
                 (Result.Ok (0, 0), seqFields)
                 ||> List.fold (fun acc field ->


### PR DESCRIPTION
## Summary

- Mirror CoreCLR's `EEClassNativeLayoutInfo::CollectNativeLayoutFieldMetadataThrowing` (`classlayoutinfo.cpp:984-988`) bump in `CliType.TryComputeMarshalSize`: a computed native layout size of 0 is bumped to 1 so the type has a distinct native address.
- Apply the bump on every concrete return path of the marshal-size walk (empty field list, all fields eliding, computed size of 0 via `[StructLayout(Size = 0)]`).
- Add `sourcesPure/MarshalSizeOfEmptyStruct.cs` as the motivating test: covers both the C# implicit case (compiler auto-emits `ClassLayout Size=1`) and the explicit `[StructLayout(LayoutKind.Sequential)]` case (no ClassLayout row, so `Layout.Default` with computed `Size = 0` reaches our post-processing).

This widens `MarshalNative_SizeOfHelper` only. The strict-numeric arm of `MarshalNative_TryGetStructMarshalStub` still uses managed `CliType.SizeOf` and has its own latent zero-bump concern, which deserves a dedicated motivating test in a follow-up.

Continues the work stream from #594, #597, #599, #601 — each PR widens `MarshalNative_TryGetStructMarshalStub` / `MarshalNative_SizeOfHelper` against a specific CoreCLR behaviour. Tracked in #595.

## Test plan

- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` (1273 / 1273 passing after rebase)
- [x] `nix develop -c dotnet fantomas .`
- [x] `codex review --base main` reported no actionable issues