### PR TITLE
Intercept SystemNative_IsATty as always-not-a-tty

### DIFF
--- a/WoofWare.PawPrint.Test/TestImpureCases.fs
+++ b/WoofWare.PawPrint.Test/TestImpureCases.fs
@@ -130,6 +130,21 @@ module TestImpureCases =
                 NativeImpls = NativeImpls.PassThru ()
                 AssertTerminalState = None
             }
+            {
+                // Exercises the SystemNative_IsATty PawPrint handler against
+                // standard fds, a freshly-duped fd, and a closed fd. Lives in
+                // sourcesImpure because the real CLR's IsATty answer depends
+                // on whether the test process happens to have a TTY attached
+                // to its standard streams, which races with how a developer
+                // happens to run NUnit; PawPrint's headless-process model
+                // makes the answer stable by construction.
+                FileName = "SystemNativeIsATty.cs"
+                ExpectedReturnCode = 0
+                Environment = Map.empty
+                ExpectsUnhandledException = false
+                NativeImpls = NativeImpls.PassThru ()
+                AssertTerminalState = None
+            }
         ]
 
     let runTest (case : EndToEndTestCase) : unit =

--- a/WoofWare.PawPrint.Test/TestImpureCases.fs
+++ b/WoofWare.PawPrint.Test/TestImpureCases.fs
@@ -15,27 +15,39 @@ open WoofWare.PawPrint.Test
 module TestImpureCases =
     let assy = typeof<RunResult>.Assembly
 
-    let unimplemented =
+    let unimplemented : EndToEndTestCase list = []
+
+    let cases : EndToEndTestCase list =
         [
-            // `Console.WriteLine("Hello, world!")` triggers lazy initialisation of `Console.Out`,
-            // which descends Console::get_Out → ConsolePal::OpenStandardOutput → Interop+Sys::Dup.
-            // PawPrint now intercepts SystemNative_Dup via FileDescriptorRegistry and
-            // SystemNative_Write via the same handler family, so both the std-stream open path and
-            // the actual byte-emitting call are implemented; the WriteLine flow now blocks
-            // downstream on the unimplemented libSystem.Globalization.Native P/Invoke
-            // `GlobalizationNative_LoadICU` during CultureInfo initialisation.
             {
+                // `Console.WriteLine("Hello, world!")` exercises the full
+                // BCL stdio stack end-to-end: `Console::get_Out` descends
+                // `ConsolePal::OpenStandardOutput → Interop.Sys.Dup`, then
+                // the `StreamWriter` flush descends `Interop.Sys.Write`.
+                // Both shims are intercepted by PawPrint's
+                // FileDescriptorRegistry / EmulatedKernel. We assert on
+                // the bytes the guest actually appended to the stdout
+                // log, not just the exit code — a regression in the
+                // encoder, the StreamWriter buffer, or the SystemNative
+                // pointer decode would not change the exit code (the
+                // `return 1;` runs unconditionally) but would corrupt
+                // these bytes.
                 FileName = "WriteLine.cs"
                 ExpectedReturnCode = 1
                 NativeImpls = NativeImpls.PassThru ()
                 Environment = Map.empty
                 ExpectsUnhandledException = false
-                AssertTerminalState = None
-            }
-        ]
+                AssertTerminalState =
+                    Some (fun state ->
+                        OutputLogEntry.bytesFor FileDescriptorRole.StandardOutput state.Kernel.OutputLog
+                        |> Seq.toArray
+                        |> shouldEqual (System.Text.Encoding.UTF8.GetBytes "Hello, world!\n")
 
-    let cases : EndToEndTestCase list =
-        [
+                        OutputLogEntry.bytesFor FileDescriptorRole.StandardError state.Kernel.OutputLog
+                        |> Seq.length
+                        |> shouldEqual 0
+                    )
+            }
             {
                 FileName = "InstaQuit.cs"
                 ExpectedReturnCode = 1

--- a/WoofWare.PawPrint.Test/sourcesImpure/SystemNativeIsATty.cs
+++ b/WoofWare.PawPrint.Test/sourcesImpure/SystemNativeIsATty.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Runtime.InteropServices;
+
+// Exercises the SystemNative_IsATty PawPrint handler directly via a P/Invoke
+// stub, without depending on `SafeFileHandle` marshalling. PawPrint intercepts
+// the call and routes it through FileDescriptorRegistry.
+//
+// This is an *impure* test: it runs only inside PawPrint, never against the
+// real CLR. PawPrint models a headless simulated process where no fd ever
+// refers to a terminal, so every IsATty call returns 0. On a real CLR host
+// the answer depends on whether stdin/stdout/stderr happen to be attached to
+// a TTY at the moment the test runs — under NUnit on a developer's terminal
+// that would flake the std-stream assertions. PawPrint's behaviour is stable
+// by construction.
+//
+// The assertions:
+//   * IsATty(-1) returns 0 (bad fd, errno = EBADF in PawPrint)
+//   * IsATty(0)/(1)/(2) return 0 (live but never a tty in PawPrint)
+//   * IsATty(duped) returns 0 (a dup of stdin is not a tty either)
+//   * IsATty(closedFd) returns 0 (bad fd after close)
+class Program
+{
+    [DllImport("libSystem.Native", EntryPoint = "SystemNative_IsATty")]
+    static extern int SystemNative_IsATty(IntPtr fd);
+
+    [DllImport("libSystem.Native", EntryPoint = "SystemNative_Dup")]
+    static extern IntPtr SystemNative_Dup(IntPtr oldfd);
+
+    [DllImport("libSystem.Native", EntryPoint = "SystemNative_Close")]
+    static extern int SystemNative_Close(IntPtr fd);
+
+    static int Main(string[] args)
+    {
+        // -1 is never a live fd; IsATty returns 0.
+        if (SystemNative_IsATty((IntPtr)(-1)) != 0) return 1;
+
+        // Standard streams are live but PawPrint never treats them as a tty.
+        if (SystemNative_IsATty((IntPtr)0) != 0) return 2;
+        if (SystemNative_IsATty((IntPtr)1) != 0) return 3;
+        if (SystemNative_IsATty((IntPtr)2) != 0) return 4;
+
+        // dup stdin to a fresh fd; the duplicate is also not a tty.
+        IntPtr duped = SystemNative_Dup((IntPtr)0);
+        if ((long)duped < 3L) return 5;
+        if (SystemNative_IsATty(duped) != 0) return 6;
+
+        // After closing the duped fd, IsATty on the now-empty slot still
+        // returns 0 (PawPrint maps it to the EBADF path).
+        if (SystemNative_Close(duped) != 0) return 7;
+        if (SystemNative_IsATty(duped) != 0) return 8;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/Errno.fs
+++ b/WoofWare.PawPrint/Errno.fs
@@ -30,6 +30,13 @@ module Errno =
     /// real runtime.
     let EFAULT : int = 14
 
+    /// `ENOTTY` — Inappropriate ioctl for device. Returned by `isatty(3)`
+    /// when the supplied fd is open but does not refer to a terminal.
+    /// PawPrint surfaces this through `SystemNative_IsATty`, which always
+    /// reports "not a terminal" for live fds because the simulated process
+    /// is headless. Value matches Linux and Darwin (both define it as 25).
+    let ENOTTY : int = 25
+
     /// `EINVAL` — Invalid argument. Returned by `sigaction(2)` when the
     /// caller asks to install a handler for an uncatchable signal
     /// (`SIGKILL` or `SIGSTOP`). PawPrint surfaces this through

--- a/WoofWare.PawPrint/Native/NativeSystemNative.fs
+++ b/WoofWare.PawPrint/Native/NativeSystemNative.fs
@@ -254,6 +254,40 @@ module NativeSystemNative =
             |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 resultCode) ctx.Thread
             |> NativeHandlerResult.completed
             |> Some
+        | Some "SystemNative_IsATty",
+          [ ConcreteIntPtr state.ConcreteTypes ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
+            // `int32_t SystemNative_IsATty(intptr_t fd)` (pal_console.c:43)
+            // delegates to libc `isatty(3)`. PawPrint models a headless
+            // simulated process: no fd ever refers to a terminal, so we
+            // always return 0. CoreLib's only consumer is
+            // `ConsolePal.Unix.cs:IsHandleRedirected`, which therefore sees
+            // every standard stream as redirected — matching how this
+            // interpreter is run in practice (piped/captured output).
+            //
+            // errno mirrors libc: `ENOTTY` for live fds, `EBADF` for
+            // unknown fds. The BCL's `[LibraryImport]` wrapper for IsATty
+            // does not currently read this back, but a guest that calls
+            // the entry point directly may observe `LastSystemError` via
+            // `Marshal.GetLastSystemError`, so we set it honestly.
+            let fd = fdArgument "SystemNative_IsATty" instruction.Arguments.[0]
+
+            let errno =
+                match FileDescriptorRegistry.tryFind fd state.Kernel.FileDescriptors with
+                | Some _ -> Errno.ENOTTY
+                | None -> Errno.EBADF
+
+            let state =
+                state.MapKernel (fun kernel ->
+                    { kernel with
+                        LastSystemError = errno
+                    }
+                )
+
+            state
+            |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread
+            |> NativeHandlerResult.completed
+            |> Some
         | Some "SystemNative_Write",
           [ ConcreteIntPtr state.ConcreteTypes
             ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.Byte)


### PR DESCRIPTION
## Summary
- PawPrint models a headless simulated process: no fd is ever a terminal, so `SystemNative_IsATty` always returns 0. The BCL's `IsHandleRedirected` (`ConsolePal.Unix.cs`) therefore treats every standard stream as redirected, which matches how this interpreter is run in practice (piped/captured output).
- errno is set honestly: `ENOTTY` for live fds, `EBADF` for unknown ones. The `[LibraryImport]` wrapper for `IsATty` does not read it back, but a guest calling the entry point directly can observe it via `Marshal.GetLastSystemError`.
- Added `Errno.ENOTTY = 25` (value matches Linux and Darwin).

## Test plan
- [x] `nix develop -c dotnet build` — clean.
- [x] `nix develop -c dotnet test ... --filter "Name~SystemNativeIsATty"` — new impure test passes.
- [x] `nix develop -c dotnet test ... --filter "Name~SystemNative"` — 6/6 SystemNative end-to-end tests pass (no regression in Close/Dup/Write).
- [x] `nix develop -c dotnet test ... --filter "Name~FileDescriptor|Name~Errno"` — 7/7 registry tests pass.
- [x] `nix develop -c dotnet fantomas .` — formatted.
- [x] `codex review --base main` — "no actionable correctness issues in the diff."

The test is registered as impure because the real CLR's `isatty` answer depends on whether the test host happens to have a TTY attached to its standard streams, which flakes under NUnit; PawPrint's headless-process model makes the answer stable by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)