### PR TITLE
Implement Thread.Sleep against the virtual clock

### DIFF
--- a/WoofWare.PawPrint.App/DebuggerServer.fs
+++ b/WoofWare.PawPrint.App/DebuggerServer.fs
@@ -135,6 +135,15 @@ module DebuggerServer =
             | Some ms -> writer.WriteNumber ("deadlineMs", ms)
 
             writer.WriteEndObject ()
+        | ThreadStatus.BlockedOnSleep deadlineMs ->
+            writer.WriteStartObject ()
+            writer.WriteString ("kind", "blockedOnSleep")
+
+            match deadlineMs with
+            | None -> ()
+            | Some ms -> writer.WriteNumber ("deadlineMs", ms)
+
+            writer.WriteEndObject ()
         | ThreadStatus.Terminated -> writer.WriteStringValue "terminated"
         | ThreadStatus.Parked -> writer.WriteStringValue "parked"
 

--- a/WoofWare.PawPrint.Test/sourcesPure/ThreadSleep.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/ThreadSleep.cs
@@ -1,0 +1,28 @@
+using System.Threading;
+
+namespace HelloWorldApp
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            // Thread.Sleep(int) with a positive finite timeout must park the
+            // calling thread on `BlockedOnSleep (Some deadline)` until the
+            // virtual clock reaches the deadline, then resume past the call.
+            //
+            // No other thread is Runnable while Main sleeps, so the driver's
+            // jump-to-deadline fallback advances `VirtualClockMs` to the
+            // deadline and `Scheduler.fireSleepTimeout` flips Main back to
+            // Runnable. The IL resumes past the QCall site with no stack
+            // rewrite (Sleep returns void).
+            //
+            // CoreCLR's host-side `Thread.Sleep(50)` really suspends for ~50
+            // wall-clock ms, but the only observable effect to the oracle is
+            // that control returns past the call. PawPrint and the oracle
+            // therefore produce identical output.
+            Thread.Sleep(50);
+
+            return 0;
+        }
+    }
+}

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -45,6 +45,7 @@ module NativeQCall =
             "ThreadNative_GetIsBackground", NativeThreading.tryExecuteQCall "ThreadNative_GetIsBackground"
             "ThreadNative_InformThreadNameChange", NativeThreading.tryExecuteQCall "ThreadNative_InformThreadNameChange"
             "ThreadNative_YieldThread", NativeThreading.tryExecuteQCall "ThreadNative_YieldThread"
+            "ThreadNative_Sleep", NativeThreading.tryExecuteQCall "ThreadNative_Sleep"
             "Monitor_Wait", NativeMonitor.tryExecuteQCall "Monitor_Wait"
             "Monitor_Pulse", NativeMonitor.tryExecuteQCall "Monitor_Pulse"
             "Monitor_PulseAll", NativeMonitor.tryExecuteQCall "Monitor_PulseAll"

--- a/WoofWare.PawPrint/Native/NativeThreading.fs
+++ b/WoofWare.PawPrint/Native/NativeThreading.fs
@@ -606,6 +606,55 @@ module NativeThreading =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 0)) ctx.Thread state
 
             NativeHandlerResult.yielded state |> Some
+        | "ThreadNative_Sleep",
+          "System.Private.CoreLib",
+          "System.Threading",
+          "Thread",
+          "SleepInternal",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32 ],
+          MethodReturnType.Void ->
+            // .NET 10 CoreCLR routes `Thread.Sleep(int)` to `SleepInternal(int)`
+            // (a `[LibraryImport]` partial in `Thread.CoreCLR.cs`), which the
+            // runtime resolves as the `ThreadNative_Sleep` QCall
+            // (`comsynchronizable.cpp`). The BCL pre-validates the timeout
+            // (rejects values < -1 with `ArgumentOutOfRangeException`) and
+            // translates `Timeout.Infinite` (-1) and finite millisecond
+            // timeouts directly without any wide-string / handle marshalling.
+            // `Thread.Sleep(TimeSpan)` reaches the same partial via
+            // `WaitHandle.ToTimeoutMilliseconds`, so this single arm covers
+            // both overloads.
+            //
+            // PawPrint's deterministic scheduler advances `VirtualClockMs`
+            // one tick at a time; the actual wait is implemented by parking
+            // the thread in `BlockedOnSleep` with an absolute deadline
+            // (or `None` for `Timeout.Infinite`) and letting
+            // `Program.fireExpiredDeadlines` route through
+            // `Scheduler.fireSleepTimeout` once the virtual clock crosses
+            // the deadline. `Thread.Sleep(0)` is a no-op (BCL uses it as a
+            // yield hint; we have no preemption to invoke).
+            let operation = "ThreadNative_Sleep"
+
+            if instruction.Arguments.Length <> 1 then
+                failwith $"%s{operation}: expected one native argument, got %d{instruction.Arguments.Length}"
+
+            let millisecondsTimeout =
+                match instruction.Arguments.[0] |> CliType.unwrapPrimitiveLikeDeep with
+                | CliType.Numeric (CliNumericType.Int32 i) -> i
+                | other -> failwith $"%s{operation}: expected int32 millisecondsTimeout, got %O{other}"
+
+            let state =
+                if millisecondsTimeout = 0 then
+                    state
+                elif millisecondsTimeout = System.Threading.Timeout.Infinite then
+                    Scheduler.blockOnSleep ctx.Thread None state
+                elif millisecondsTimeout < 0 then
+                    failwith
+                        $"%s{operation}: negative timeout %d{millisecondsTimeout} ms is not Infinite (-1); the BCL Thread.Sleep call site is required to pre-validate this. Reaching here means the validation was bypassed (e.g. by a synthesised IL call) — bug in the caller."
+                else
+                    let deadline = state.Kernel.VirtualClockMs + int64 millisecondsTimeout
+                    Scheduler.blockOnSleep ctx.Thread (Some deadline) state
+
+            NativeHandlerResult.completed state |> Some
         | _ -> None
 
     let tryExecute (ctx : NativeCallContext) : NativeHandlerResult option =

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -99,6 +99,12 @@ module Program =
         /// pair, and `Scheduler.fireJoinTimeout` reads its state directly
         /// from the thread's status.
         | JoinTimeout
+        /// `Thread.Sleep(int)` with a positive finite timeout. Carries no
+        /// payload because sleep has no per-primitive wait queue and no
+        /// optimistic eval-stack push to rewrite (Sleep returns `void`).
+        /// `Scheduler.fireSleepTimeout` reads state directly from the
+        /// thread's status and flips it back to `Runnable`.
+        | SleepTimeout
 
     /// Project a thread status into its finite-timeout deadline against
     /// the virtual clock, if any. Threads with no deadline (Runnable,
@@ -116,11 +122,13 @@ module Program =
         | ThreadStatus.BlockedOnSyncBlockAcquire (lockObject, Some deadline) ->
             Some (FiredDeadline.SyncBlockAcquire lockObject, deadline)
         | ThreadStatus.BlockedOnJoin (_, Some deadline) -> Some (FiredDeadline.JoinTimeout, deadline)
+        | ThreadStatus.BlockedOnSleep (Some deadline) -> Some (FiredDeadline.SleepTimeout, deadline)
         | ThreadStatus.BlockedOnWaitHandle (_, None)
         | ThreadStatus.BlockedOnMonitorWait (_, None)
         | ThreadStatus.BlockedOnSyncBlockWait (_, None)
         | ThreadStatus.BlockedOnSyncBlockAcquire (_, None)
         | ThreadStatus.BlockedOnJoin (_, None)
+        | ThreadStatus.BlockedOnSleep None
         | ThreadStatus.Runnable
         | ThreadStatus.NotStarted
         | ThreadStatus.BlockedOnClassInit _
@@ -207,16 +215,17 @@ module Program =
         // Sort key: LowLevelMonitor entries first (group=0), then
         // SyncBlock wait entries (group=1), then SyncBlock acquire
         // entries (group=2), then WaitHandle entries (group=3), then
-        // Join entries (group=4). Within each subsystem-group, entries
-        // are keyed first by their primitive id (so distinct primitives
-        // are ordered deterministically but independently) and then by
-        // FIFO position in the primitive's queue (so the head of any
-        // contested primitive fires before its successors). For
-        // WaitHandle, queue order is unobservable for timeout fires, so
-        // ThreadId is used as a stable deterministic break. Join has no
+        // Join entries (group=4), then Sleep entries (group=5). Within
+        // each subsystem-group, entries are keyed first by their
+        // primitive id (so distinct primitives are ordered
+        // deterministically but independently) and then by FIFO position
+        // in the primitive's queue (so the head of any contested
+        // primitive fires before its successors). For WaitHandle, queue
+        // order is unobservable for timeout fires, so ThreadId is used
+        // as a stable deterministic break. Join and Sleep have no
         // per-primitive queue (the "primitive" is the target thread's
-        // status, with no joiner-side ordering), so ThreadId is the
-        // only deterministic break.
+        // status for Join, and the virtual clock itself for Sleep), so
+        // ThreadId is the only deterministic break.
         let sortKey ((tid, kind) : ThreadId * FiredDeadline) : int * int * int =
             match kind with
             | FiredDeadline.MonitorWait monitorId ->
@@ -235,6 +244,9 @@ module Program =
             | FiredDeadline.JoinTimeout ->
                 let (ThreadId t) = tid
                 4, t, 0
+            | FiredDeadline.SleepTimeout ->
+                let (ThreadId t) = tid
+                5, t, 0
 
         let expired = expired |> List.sortBy sortKey
 
@@ -247,6 +259,7 @@ module Program =
                 | FiredDeadline.SyncBlockWait addr -> SyncBlockMonitor.fireWaitTimeout tid addr s
                 | FiredDeadline.SyncBlockAcquire addr -> SyncBlockMonitor.fireAcquireTimeout tid addr s
                 | FiredDeadline.JoinTimeout -> Scheduler.fireJoinTimeout tid s
+                | FiredDeadline.SleepTimeout -> Scheduler.fireSleepTimeout tid s
             )
             state
 

--- a/WoofWare.PawPrint/Scheduler.fs
+++ b/WoofWare.PawPrint/Scheduler.fs
@@ -132,6 +132,61 @@ module Scheduler =
         let state = IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) thread state
         setThreadStatus thread ThreadStatus.Runnable state
 
+    /// Park `blocked` in `BlockedOnSleep`, transitioning out of `Runnable`.
+    /// Mirrors `blockOnJoin` but with no per-primitive wait queue: sleeping
+    /// is purely time-driven, the wake comes from `Scheduler.fireSleepTimeout`
+    /// when the virtual clock crosses the deadline. `deadlineMs = None` is
+    /// an infinite sleep (`Thread.Sleep(-1)` / `Timeout.Infinite`); `Some _`
+    /// is a finite timeout. No optimistic eval-stack push is performed
+    /// because `Thread.Sleep` returns `void`.
+    ///
+    /// Caller is responsible for advancing the program counter past the
+    /// `Sleep` call site before parking (so the wake resumes after the
+    /// call), matching the contract used by every other QCall handler that
+    /// blocks.
+    let blockOnSleep (blocked : ThreadId) (deadlineMs : int64 option) (state : IlMachineState) : IlMachineState =
+        { state with
+            ThreadState =
+                state.ThreadState
+                |> Map.change
+                    blocked
+                    (Option.map (fun s ->
+                        { s with
+                            Status = ThreadStatus.BlockedOnSleep deadlineMs
+                        }
+                    ))
+        }
+
+    /// Fire a `Thread.Sleep` timeout: the deadline-firing path has
+    /// observed that `thread` is parked in `BlockedOnSleep (Some _)` and
+    /// the virtual clock has advanced past its deadline. Flip the status
+    /// back to `Runnable` so the scheduler can resume the thread.
+    ///
+    /// Unlike `fireJoinTimeout` / `WaitHandle.fireTimeout` /
+    /// `LowLevelMonitor.fireTimeout` / `SyncBlockMonitor.fireWaitTimeout`,
+    /// there is no optimistic-push to rewrite: `Thread.Sleep(int)` returns
+    /// `void`, so the call site advanced past itself without leaving an
+    /// eval-stack slot behind. The wake therefore only needs to flip the
+    /// status.
+    ///
+    /// Fails loud if `thread` is not actually parked in `BlockedOnSleep`
+    /// with a finite deadline: the only caller is
+    /// `Program.fireExpiredDeadlines`, which enumerates the statuses
+    /// itself, so a miss would indicate the deadline-firing path was
+    /// reached for an infinite (or non-sleep) waiter — a structural bug
+    /// worth surfacing here.
+    let fireSleepTimeout (thread : ThreadId) (state : IlMachineState) : IlMachineState =
+        match state.ThreadState |> Map.tryFind thread with
+        | None -> failwith $"Scheduler.fireSleepTimeout: thread %O{thread} has no ThreadState."
+        | Some ts ->
+            match ts.Status with
+            | ThreadStatus.BlockedOnSleep (Some _) -> ()
+            | other ->
+                failwith
+                    $"Scheduler.fireSleepTimeout: thread %O{thread} is not parked in BlockedOnSleep with a finite deadline (status: %O{other}); the scheduler observed a sleep deadline against a thread the sleep machinery does not know about."
+
+        setThreadStatus thread ThreadStatus.Runnable state
+
     /// Record that `terminated` has finished executing its final `ret`.
     /// - Flips its own status to Terminated.
     /// - Wakes every thread that was BlockedOnJoin on it; they proceed past Join.

--- a/WoofWare.PawPrint/ThreadState.fs
+++ b/WoofWare.PawPrint/ThreadState.fs
@@ -146,6 +146,32 @@ type ThreadStatus =
     /// map) makes the invariant "no deadline once Runnable again" structural
     /// — a wake naturally forgets it.
     | BlockedOnWaitHandle of handle : WaitHandleId * deadlineMs : int64 option
+    /// This thread called `Thread.Sleep` (routed via the `ThreadNative_Sleep`
+    /// QCall) and is parked against the virtual clock with no associated
+    /// wait-queue or signalling primitive. There is no per-primitive FIFO
+    /// here because the wake is purely time-driven: the scheduler advances
+    /// `VirtualClockMs` one tick at a time, and once it crosses the deadline
+    /// the driver fires `Scheduler.fireSleepTimeout`, which flips the status
+    /// back to `Runnable`. The IL `Sleep(int)` call site has already
+    /// advanced past itself (Sleep returns `void`, so there is no
+    /// eval-stack slot to rewrite at park time — distinguishes this from
+    /// `BlockedOnJoin`/`BlockedOnSyncBlockWait` et al., which use the
+    /// optimistic-push-then-rewrite pattern).
+    ///
+    /// `deadlineMs = None` is an infinite sleep (`Thread.Sleep(-1)` /
+    /// `Timeout.Infinite`), which currently parks the thread forever
+    /// because `Thread.Interrupt` is not yet implemented (a future slice
+    /// that wires interrupt will be the only way out of an infinite
+    /// sleep — matching real CoreCLR semantics). `Some ms` is a finite
+    /// timeout (`Thread.Sleep(ms)` with `ms > 0`), expressed as the
+    /// absolute virtual-clock millisecond at which the sleep expires.
+    /// `Thread.Sleep(0)` does not produce a `BlockedOnSleep` transition
+    /// at all: it is a no-op handled inline at the call site (the BCL
+    /// uses it as a yield hint; PawPrint has no preemption to invoke).
+    /// Storing the deadline in the status itself rather than in a
+    /// parallel map makes the invariant "no deadline once Runnable
+    /// again" structural — a wake naturally forgets it.
+    | BlockedOnSleep of deadlineMs : int64 option
     /// This thread has executed its final `ret`; it will never run again. Its state is kept
     /// only so other threads can observe termination (e.g. to satisfy Join).
     | Terminated
@@ -202,6 +228,7 @@ module ThreadStatus =
         | ThreadStatus.BlockedOnSyncBlockAcquire _ -> false
         | ThreadStatus.BlockedOnSyncBlockWait _ -> false
         | ThreadStatus.BlockedOnWaitHandle _ -> false
+        | ThreadStatus.BlockedOnSleep _ -> false
 
 type ThreadState =
     {


### PR DESCRIPTION
## Summary
- Adds a `ThreadStatus.BlockedOnSleep of deadlineMs : int64 option` variant and routes `Thread.Sleep(int)` / `Thread.Sleep(TimeSpan)` via the `ThreadNative_Sleep` QCall onto it. `Some ms` is an absolute virtual-clock deadline; `None` is infinite (`Sleep(-1)` / `Timeout.Infinite`).
- Plumbs the new variant through `Program.fireExpiredDeadlines` (sort group 5, after the existing 0–4 used by LowLevelMonitor wait / SyncBlock wait / SyncBlock acquire / WaitHandle / Join) and dispatches expired sleepers to a new `Scheduler.fireSleepTimeout` that flips the status back to `Runnable`. No eval-stack rewrite is needed (Sleep returns `void`), which is the only structural distinction from the existing optimistic-push-then-rewrite primitives.
- `Sleep(0)` is a no-op (no status transition — matches the BCL's use of it as a yield hint, which PawPrint has no preemption to invoke). `Sleep(-1)` parks with `None` and will currently deadlock since `Thread.Interrupt` is not yet wired (matches real CoreCLR semantics modulo the missing interrupt path). Sub-`-1` fails loud because the BCL pre-validates.
- New pure test `WoofWare.PawPrint.Test/sourcesPure/ThreadSleep.cs` exercises `Sleep(50)`; oracle-equivalence catches regressions.

## Test plan
- [x] `nix develop -c dotnet build WoofWare.PawPrint.slnx`
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --filter "Name~ThreadSleep"` (1/1 passed)
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj --filter "Name~Thread|Name~Monitor|Name~Wait|Name~Sleep|Name~Lock|Name~Mutex|Name~Semaphore|Name~Event"` (236/236 passed)
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` (1309/1309 passed)
- [x] `nix develop -c dotnet fantomas .` (no reformat)
- [x] `codex review --base main` (no discrete correctness issues found)

🤖 Generated with [Claude Code](https://claude.com/claude-code)