### PR TITLE
Move NonCryptoRandom to Domain; add nextDouble/nextInt32Below

### DIFF
--- a/WoofWare.PawPrint.Domain/NonCryptoRandom.fs
+++ b/WoofWare.PawPrint.Domain/NonCryptoRandom.fs
@@ -1,0 +1,126 @@
+namespace WoofWare.PawPrint
+
+/// Deterministic non-cryptographic PRNG that backs
+/// `SystemNative_GetNonCryptographicallySecureRandomBytes` and any future
+/// in-runtime consumer that wants a reproducible random stream. This is the
+/// `splitmix64` step from Vigna's reference at
+/// <http://prng.di.unimi.it/splitmix64.c>: stateful, full-period over the
+/// 2^64 64-bit states, and famously fine for *seeding* other PRNGs (which
+/// is exactly what the BCL does here — it feeds the buffer into
+/// `Random.XoshiroImpl`, `Marvin.DefaultSeed`, `HashCode`'s seed, etc.).
+///
+/// Quality is intentionally non-cryptographic; that matches the entry-point
+/// name. The state being non-zero is preserved across the step (splitmix64
+/// has no fixed points other than `0 -> 0x9E3779B97F4A7C15`-style transient
+/// behaviour from a zero start, which is why `initialState` seeds with the
+/// golden-ratio constant rather than zero).
+///
+/// Why hand-implemented: `System.Random`'s algorithm is implementation-defined
+/// and has changed across .NET versions, so "same seed yields the same
+/// sequence" isn't actually guaranteed by the framework. Determinism across
+/// host versions is a hard requirement for WoofWare.PawPrint, so we pin a
+/// stable algorithm with a fully-specified output here. Distinct callers
+/// (kernel-backed `Random`, schedule fuzzer, etc.) should each hold their
+/// own `uint64` state so that one consumer's draws don't perturb another's
+/// stream.
+[<RequireQualifiedAccess>]
+module NonCryptoRandom =
+    /// `floor(2^64 / phi)`, the same constant the reference splitmix64 uses
+    /// as its weyl increment. Picked as the default initial state so a
+    /// fresh interpreter doesn't start from zero (which would still produce
+    /// a non-zero output after one step, but is the documented degenerate
+    /// input for splitmix64-style mixers).
+    let initialState : uint64 = 0x9E3779B97F4A7C15UL
+
+    /// Advance the splitmix64 state by one step and return the 64-bit
+    /// output drawn from the new state. Reference implementation:
+    /// <http://prng.di.unimi.it/splitmix64.c>. Pure: same input state
+    /// produces the same `(output, newState)` pair on every call.
+    let step (state : uint64) : uint64 * uint64 =
+        let newState = state + 0x9E3779B97F4A7C15UL
+        let mutable z = newState
+        z <- (z ^^^ (z >>> 30)) * 0xBF58476D1CE4E5B9UL
+        z <- (z ^^^ (z >>> 27)) * 0x94D049BB133111EBUL
+        z <- z ^^^ (z >>> 31)
+        z, newState
+
+    /// Draw `count` pseudo-random bytes from the splitmix64 state. Returns
+    /// the bytes in little-endian unpack order from each 64-bit step, plus
+    /// the new state. `count` must be non-negative; a negative count is a
+    /// caller bug and the function will fail loudly.
+    let drawBytes (count : int) (state : uint64) : byte[] * uint64 =
+        if count < 0 then
+            failwith $"NonCryptoRandom.drawBytes: byte count %d{count} is negative"
+
+        let buffer = Array.zeroCreate<byte> count
+        let mutable state = state
+        let mutable i = 0
+
+        while i < count do
+            let output, newState = step state
+            state <- newState
+            let remaining = count - i
+            let chunk = if remaining > 8 then 8 else remaining
+
+            for j = 0 to chunk - 1 do
+                buffer.[i + j] <- byte (output >>> (8 * j))
+
+            i <- i + chunk
+
+        buffer, state
+
+    /// Draw a uniform double in [0.0, 1.0). Uses the top 53 bits of the next
+    /// 64-bit output — the maximum exactly representable in an IEEE-754
+    /// binary64 mantissa. Discarding the low 11 bits keeps the distribution
+    /// unbiased: every representable value in [0, 1) with the canonical
+    /// 53-bit-mantissa spacing is equally likely.
+    ///
+    /// Pure: same input state produces the same `(value, newState)`.
+    let nextDouble (state : uint64) : double * uint64 =
+        let output, newState = step state
+        // 2^53 = 9007199254740992. We multiply by the reciprocal rather than
+        // dividing because the reciprocal is exactly representable (it's a
+        // power of two) and the multiplication is therefore exact too — no
+        // rounding is introduced by the scale.
+        let value = double (output >>> 11) * (1.0 / 9007199254740992.0)
+        value, newState
+
+    /// Draw a uniform `int` in `[0, bound)`. Requires `bound > 0`; fails loudly
+    /// otherwise — a non-positive bound is a caller bug, and silently returning
+    /// `0` would hide the upstream mistake.
+    ///
+    /// Uses unbiased rejection sampling: the small number of `uint64` values
+    /// at the top of the range that would map unevenly under `n % bound` are
+    /// rejected so every output in `[0, bound)` is equally likely. Rejection
+    /// probability is at most `bound / 2^64`, so for any int-sized bound
+    /// (≤ 2^31 - 1) the expected number of `step` calls per draw differs
+    /// from 1 by less than 2^-33; in practice the loop body essentially
+    /// never runs twice.
+    ///
+    /// Pure: same input state produces the same `(value, newState)`.
+    let nextInt32Below (bound : int) (state : uint64) : int * uint64 =
+        if bound <= 0 then
+            failwith $"NonCryptoRandom.nextInt32Below: bound %d{bound} must be positive"
+
+        let boundU = uint64 bound
+        // `threshold` is `2^64 mod bound`: the number of `uint64` values in the
+        // partial bucket at the top of the range that must be rejected to keep
+        // `n % bound` unbiased. Computed without overflow as
+        // `(UInt64.MaxValue mod bound + 1) mod bound`, since
+        // `2^64 mod bound = ((2^64 - 1) mod bound + 1) mod bound`.
+        let threshold = (System.UInt64.MaxValue % boundU + 1UL) % boundU
+        // Acceptable region is `[0, 2^64 - threshold)`. Equivalently,
+        // `n` is acceptable iff `n <= UInt64.MaxValue - threshold`. When
+        // `threshold = 0` (bound divides 2^64, i.e. bound is a power of two),
+        // this is `n <= UInt64.MaxValue`, which trivially accepts everything.
+        let acceptUpTo = System.UInt64.MaxValue - threshold
+
+        let rec loop state =
+            let n, newState = step state
+
+            if n <= acceptUpTo then
+                int (n % boundU), newState
+            else
+                loop newState
+
+        loop state

--- a/WoofWare.PawPrint.Domain/WoofWare.PawPrint.Domain.fsproj
+++ b/WoofWare.PawPrint.Domain/WoofWare.PawPrint.Domain.fsproj
@@ -9,6 +9,7 @@
         <Compile Include="StringToken.fs" />
         <Compile Include="Constants.fs" />
         <Compile Include="ImmutableArray.fs" />
+        <Compile Include="NonCryptoRandom.fs" />
         <Compile Include="Tokens.fs" />
         <Compile Include="TypeRef.fs" />
         <Compile Include="IlOp.fs" />

--- a/WoofWare.PawPrint.Test/TestNonCryptoRandom.fs
+++ b/WoofWare.PawPrint.Test/TestNonCryptoRandom.fs
@@ -140,3 +140,145 @@ module TestNonCryptoRandom =
         // the bytes every Guid.NewGuid/Random/HashCode draws.
         EmulatedKernel.initial.NonCryptoRandomState
         |> shouldEqual NonCryptoRandom.initialState
+
+    [<Test>]
+    let ``nextDouble is pure in the starting state`` () : unit =
+        // Same input state ⇒ same (value, newState). Determinism is the
+        // whole point — schedule fuzzing needs to be able to replay a seed
+        // and observe identical doubles draws on the path that fed off it.
+        let property (state : uint64) : bool =
+            NonCryptoRandom.nextDouble state = NonCryptoRandom.nextDouble state
+
+        Check.One (propertyConfig, property)
+
+    [<Test>]
+    let ``nextDouble lies in [0, 1)`` () : unit =
+        // The probabilistic-concurrency scheduler will compare these
+        // draws against op-weight thresholds, so a value of exactly 1.0
+        // (or worse, > 1.0) would silently let a w=1.0 op skip a switch
+        // it should always take. The masking-then-scaling formula
+        // discards the low 11 bits so this invariant holds by construction;
+        // the test pins it.
+        let property (state : uint64) : bool =
+            let v, _ = NonCryptoRandom.nextDouble state
+            v >= 0.0 && v < 1.0
+
+        Check.One (propertyConfig, property)
+
+    [<Test>]
+    let ``nextDouble advances state by exactly one step`` () : unit =
+        // The (state -> step) -> (output, newState) shape is the contract
+        // the rest of the runtime assumes. If nextDouble somehow consumed
+        // two steps internally, callers interleaving doubles with bytes
+        // draws would observe stream desynchronisation that's hard to
+        // diagnose. Pin the equivalence.
+        let property (state : uint64) : bool =
+            let _, doubleState = NonCryptoRandom.nextDouble state
+            let _, stepState = NonCryptoRandom.step state
+            doubleState = stepState
+
+        Check.One (propertyConfig, property)
+
+    [<Test>]
+    let ``nextDouble mean over 50k samples is near 0.5`` () : unit =
+        // Sanity check that the [0, 1) draws are *roughly* uniform — not a
+        // statistical certificate (splitmix64 isn't crypto), just enough
+        // to catch a wholesale bias (e.g. an off-by-one in the bit shift).
+        // For n=50_000 independent uniform [0,1) samples, σ = 1/√(12·n)
+        // ≈ 0.00129. A ±0.01 window is ~7.7σ, so the failure probability
+        // under a correct implementation is well under 1 in 10^14.
+        let rec accumulate (state : uint64) (n : int) (acc : double) : double =
+            if n = 0 then
+                acc
+            else
+                let v, newState = NonCryptoRandom.nextDouble state
+                accumulate newState (n - 1) (acc + v)
+
+        let n = 50_000
+        let total = accumulate 12345UL n 0.0
+        let mean = total / double n
+        abs (mean - 0.5) |> shouldBeSmallerThan 0.01
+
+    [<Test>]
+    let ``nextInt32Below is pure in the starting state`` () : unit =
+        let property (state : uint64) (bound : PositiveInt) : bool =
+            let first = NonCryptoRandom.nextInt32Below bound.Get state
+            let second = NonCryptoRandom.nextInt32Below bound.Get state
+            first = second
+
+        Check.One (propertyConfig, property)
+
+    [<Test>]
+    let ``nextInt32Below result lies in [0, bound)`` () : unit =
+        // The scheduler will index a list-of-runnable-threads by this
+        // value, so an out-of-range result would crash with an obscure
+        // IndexOutOfRange far from the actual bug. Pin the invariant.
+        let property (state : uint64) (bound : PositiveInt) : bool =
+            let v, _ = NonCryptoRandom.nextInt32Below bound.Get state
+            v >= 0 && v < bound.Get
+
+        Check.One (propertyConfig, property)
+
+    [<Test>]
+    let ``nextInt32Below 1 always returns 0 without advancing state`` () : unit =
+        // Bound=1 has only one valid output. The rejection-sampling
+        // threshold collapses to "accept everything", so the function
+        // takes exactly one step regardless of input state — but the
+        // caller perspective is that 0 always comes back. (We don't
+        // assert the state change here because doing so would couple
+        // the test to the rejection-sampling internals; the contract
+        // is just "result = 0".)
+        let property (state : uint64) : bool =
+            let v, _ = NonCryptoRandom.nextInt32Below 1 state
+            v = 0
+
+        Check.One (propertyConfig, property)
+
+    [<Test>]
+    let ``nextInt32Below rejects non-positive bound`` () : unit =
+        // A non-positive bound is a caller bug. Silently returning 0
+        // would mask the upstream mistake; the test pins the loud
+        // failure to ensure no future "be helpful" refactor swallows
+        // the contract.
+        (fun () -> NonCryptoRandom.nextInt32Below 0 0UL |> ignore) |> shouldFail<exn>
+
+        (fun () -> NonCryptoRandom.nextInt32Below -1 0UL |> ignore) |> shouldFail<exn>
+
+        (fun () -> NonCryptoRandom.nextInt32Below System.Int32.MinValue 0UL |> ignore)
+        |> shouldFail<exn>
+
+    [<Test>]
+    let ``nextInt32Below is roughly uniform for small bounds`` () : unit =
+        // Aggregate 60_000 draws into 6 buckets and assert every bucket
+        // is within ±10% of the expected count of 10_000. Under a
+        // correct unbiased implementation each bucket has σ ≈ √(n·p·(1-p))
+        // ≈ √(60000 · 1/6 · 5/6) ≈ 91, so the ±1000 window is over 10σ.
+        // Failure under a correct implementation is astronomically
+        // unlikely; a biased implementation (e.g. plain `% bound` with
+        // no rejection) at this small bound has no detectable effect,
+        // so this is a wholesale-correctness check, not a calibration.
+        let bound = 6
+        let n = 60_000
+
+        let counts = Array.zeroCreate<int> bound
+
+        let rec accumulate state n =
+            if n = 0 then
+                ()
+            else
+                let v, newState = NonCryptoRandom.nextInt32Below bound state
+                counts.[v] <- counts.[v] + 1
+                accumulate newState (n - 1)
+
+        accumulate 0x1234567890ABCDEFUL n
+
+        let expected = n / bound
+        let tolerance = expected / 10
+
+        for bucket = 0 to bound - 1 do
+            let count = counts.[bucket]
+            let delta = abs (count - expected)
+
+            if delta > tolerance then
+                Assert.Fail
+                    $"Bucket %d{bucket} had count %d{count}, expected ~%d{expected} (±%d{tolerance}); delta %d{delta}"

--- a/WoofWare.PawPrint/EmulatedKernel.fs
+++ b/WoofWare.PawPrint/EmulatedKernel.fs
@@ -425,65 +425,6 @@ type EmulatedKernel =
         Signals : SignalState
     }
 
-/// Deterministic non-cryptographic PRNG that backs
-/// `SystemNative_GetNonCryptographicallySecureRandomBytes`. This is the
-/// `splitmix64` step from Vigna's reference at
-/// <http://prng.di.unimi.it/splitmix64.c>: stateful, full-period over the
-/// 2^64 64-bit states, and famously fine for *seeding* other PRNGs (which
-/// is exactly what the BCL does here — it feeds the buffer into
-/// `Random.XoshiroImpl`, `Marvin.DefaultSeed`, `HashCode`'s seed, etc.).
-///
-/// Quality is intentionally non-cryptographic; that matches the entry-point
-/// name. The state being non-zero is preserved across the step (splitmix64
-/// has no fixed points other than `0 -> 0x9E3779B97F4A7C15`-style transient
-/// behaviour from a zero start, which is why `initial` seeds with the
-/// golden-ratio constant rather than zero).
-[<RequireQualifiedAccess>]
-module NonCryptoRandom =
-    /// `floor(2^64 / phi)`, the same constant the reference splitmix64 uses
-    /// as its weyl increment. Picked as the default initial state so a
-    /// fresh interpreter doesn't start from zero (which would still produce
-    /// a non-zero output after one step, but is the documented degenerate
-    /// input for splitmix64-style mixers).
-    let initialState : uint64 = 0x9E3779B97F4A7C15UL
-
-    /// Advance the splitmix64 state by one step and return the 64-bit
-    /// output drawn from the new state. Reference implementation:
-    /// <http://prng.di.unimi.it/splitmix64.c>. Pure: same input state
-    /// produces the same `(output, newState)` pair on every call.
-    let step (state : uint64) : uint64 * uint64 =
-        let newState = state + 0x9E3779B97F4A7C15UL
-        let mutable z = newState
-        z <- (z ^^^ (z >>> 30)) * 0xBF58476D1CE4E5B9UL
-        z <- (z ^^^ (z >>> 27)) * 0x94D049BB133111EBUL
-        z <- z ^^^ (z >>> 31)
-        z, newState
-
-    /// Draw `count` pseudo-random bytes from the splitmix64 state. Returns
-    /// the bytes in little-endian unpack order from each 64-bit step, plus
-    /// the new state. `count` must be non-negative; a negative count is a
-    /// caller bug and the function will fail loudly.
-    let drawBytes (count : int) (state : uint64) : byte[] * uint64 =
-        if count < 0 then
-            failwith $"NonCryptoRandom.drawBytes: byte count %d{count} is negative"
-
-        let buffer = Array.zeroCreate<byte> count
-        let mutable state = state
-        let mutable i = 0
-
-        while i < count do
-            let output, newState = step state
-            state <- newState
-            let remaining = count - i
-            let chunk = if remaining > 8 then 8 else remaining
-
-            for j = 0 to chunk - 1 do
-                buffer.[i + j] <- byte (output >>> (8 * j))
-
-            i <- i + chunk
-
-        buffer, state
-
 [<RequireQualifiedAccess>]
 module EmulatedKernel =
     /// Default environment variables for a freshly-minted simulated process.


### PR DESCRIPTION
## Summary
- Lifts the splitmix64 module out of `EmulatedKernel.fs` — where it was wedged because its only consumer was `SystemNative` — into `WoofWare.PawPrint.Domain` so unrelated consumers (most immediately the forthcoming PCT scheduler) can hold their own state without depending on the kernel.
- Adds two helpers: `nextDouble : uint64 -> double * uint64` (top-53-bits / 2^53, unbiased) and `nextInt32Below : int -> uint64 -> int * uint64` (unbiased rejection sampling, loud on non-positive bound).
- Pure relocation in `EmulatedKernel.fs` — no behaviour change for `SystemNative` or any other existing caller.

Sets up the seam the PCT scheduler will plug into: separate scheduler RNG state so guest `Random` draws don't perturb the schedule, and vice versa.

## Test plan
- [x] `dotnet test --filter "Name~NonCryptoRandom"` — 20 tests pass (existing 11 + new 9 covering `nextDouble`/`nextInt32Below`).
- [x] Full test suite — 1338 passed, 0 failed.
- [x] `fantomas` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)