### PR TITLE
Plumb SchedulerState through IlMachineState ahead of PCT policy

### DIFF
--- a/WoofWare.PawPrint.Test/TestSignalDispatcherThread.fs
+++ b/WoofWare.PawPrint.Test/TestSignalDispatcherThread.fs
@@ -113,7 +113,7 @@ module TestSignalDispatcherThread =
                         ]
             }
 
-        Scheduler.chooseNext (ThreadId -1) state |> shouldEqual (Some runnable)
+        Scheduler.chooseNext (ThreadId -1) state |> snd |> shouldEqual (Some runnable)
 
     [<Test>]
     let ``scheduler returns None when only Parked threads exist`` () : unit =
@@ -135,4 +135,4 @@ module TestSignalDispatcherThread =
                         ]
             }
 
-        Scheduler.chooseNext (ThreadId -1) state |> shouldEqual None
+        Scheduler.chooseNext (ThreadId -1) state |> snd |> shouldEqual None

--- a/WoofWare.PawPrint/IlMachineStateModel.fs
+++ b/WoofWare.PawPrint/IlMachineStateModel.fs
@@ -63,6 +63,14 @@ type IlMachineState =
         /// sub-record because the rest of `IlMachineState` models the CIL
         /// execution layer, not the kernel surface PawPrint refuses to use.
         Kernel : EmulatedKernel
+        /// Scheduling policy state. `RoundRobin` reproduces the legacy
+        /// deterministic ordering and is the default for runs that don't
+        /// request fuzzing; `Pct _` carries the live priority assignment
+        /// and splitmix64 RNG state for Probabilistic Concurrency Testing.
+        /// Lives here (rather than on `EmulatedKernel`) because the scheduler
+        /// is an interpreter-level concern — it isn't a syscall the guest
+        /// can observe or perturb.
+        Scheduling : SchedulerState
     }
 
     member this.WithKernel (kernel : EmulatedKernel) : IlMachineState =

--- a/WoofWare.PawPrint/IlMachineThreadState.fs
+++ b/WoofWare.PawPrint/IlMachineThreadState.fs
@@ -338,6 +338,7 @@ module IlMachineThreadState =
                 NextManagedThreadId = 2
                 PointerHashCounters = PointerHashCounters.empty
                 Kernel = EmulatedKernel.initial
+                Scheduling = SchedulerState.RoundRobin
             }
 
         state.WithLoadedAssembly assyName entryAssembly

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -427,9 +427,14 @@ module Program =
         // not a scheduler tick — it is the resolution of a timeout that
         // would otherwise be invisible.
         let rec advanceUntilRunnableOrQuiescent (state : IlMachineState) : IlMachineState =
-            match Scheduler.chooseNext prepared.LastRan state with
-            | Some _ -> state
-            | None ->
+            // Use the policy-independent existence check rather than calling
+            // `chooseNext` and discarding its returned state: a stochastic
+            // policy would otherwise advance its RNG once per deadline-jump
+            // probe, perturbing the scheduling stream without ever observing
+            // the result.
+            if Scheduler.hasAnyRunnable state then
+                state
+            else
                 match nextDeadline state with
                 | None -> state
                 | Some target ->
@@ -447,7 +452,19 @@ module Program =
                 State = advanceUntilRunnableOrQuiescent prepared.State
             }
 
-        match Scheduler.chooseNext prepared.LastRan prepared.State with
+        let scheduledState, scheduledChoice =
+            Scheduler.chooseNext prepared.LastRan prepared.State
+
+        // Adopt the scheduler-updated state before stepping so that any RNG
+        // advancement the policy performed is reflected in the run-forward
+        // state — otherwise replaying the same seed would diverge on the
+        // first stochastic decision.
+        let prepared =
+            { prepared with
+                State = scheduledState
+            }
+
+        match scheduledChoice with
         | None ->
             // No Runnable threads and the entry thread didn't hit its ret. Every
             // remaining thread is blocked, so progress is impossible.

--- a/WoofWare.PawPrint/Scheduler.fs
+++ b/WoofWare.PawPrint/Scheduler.fs
@@ -18,32 +18,66 @@ namespace WoofWare.PawPrint
 [<RequireQualifiedAccess>]
 module Scheduler =
 
-    /// Pick the next thread to run using a deterministic round-robin policy: among
-    /// the Runnable threads, prefer the lowest id strictly greater than `lastRan`;
-    /// if there isn't one, wrap to the lowest id overall. The policy is intentionally
-    /// *not* sticky — staying on the most-recently-run thread minimises interleaving,
-    /// which is the opposite of what a pruning harness wants. Returns `None` iff no
-    /// thread is Runnable, which the driver treats as deadlock.
-    let chooseNext (lastRan : ThreadId) (state : IlMachineState) : ThreadId option =
-        let runnable =
-            state.ThreadState
-            |> Map.toSeq
-            |> Seq.choose (fun (tid, ts) ->
-                match ts.Status with
-                | ThreadStatus.Runnable -> Some tid
-                | _ -> None
-            )
-            |> Seq.sortBy (fun (ThreadId i) -> i)
-            |> Seq.toList
+    /// Enumerate the Runnable threads in ascending id order. Used by every
+    /// policy: the set of candidates is policy-independent, only the choice
+    /// among them differs. Kept private so policies stay enumerable here.
+    let private runnableThreads (state : IlMachineState) : ThreadId list =
+        state.ThreadState
+        |> Map.toSeq
+        |> Seq.choose (fun (tid, ts) ->
+            match ts.Status with
+            | ThreadStatus.Runnable -> Some tid
+            | _ -> None
+        )
+        |> Seq.sortBy (fun (ThreadId i) -> i)
+        |> Seq.toList
 
-        match runnable with
-        | [] -> None
-        | _ ->
-            let (ThreadId lastRanId) = lastRan
+    /// Does any thread currently have status `Runnable`? Used by the
+    /// deadline-advance loop in `Program.fs` to decide whether jumping the
+    /// virtual clock has made progress; that check is policy-independent
+    /// (every scheduler returns `None` from `chooseNext` iff no thread is
+    /// Runnable), so callers should reach for this helper instead of
+    /// invoking `chooseNext` and discarding its returned state.
+    let hasAnyRunnable (state : IlMachineState) : bool =
+        not (List.isEmpty (runnableThreads state))
 
-            runnable
-            |> List.tryFind (fun (ThreadId i) -> i > lastRanId)
-            |> Option.orElse (List.tryHead runnable)
+    /// Pick the next thread to run, returning the (possibly-updated) machine
+    /// state alongside the choice so that stochastic policies can thread
+    /// their RNG state forward. The `RoundRobin` policy is pure in `state`
+    /// (the returned state is `=` to the input) and reproduces the legacy
+    /// deterministic ordering: among the Runnable threads, prefer the
+    /// lowest id strictly greater than `lastRan`; if there isn't one, wrap
+    /// to the lowest id overall. The policy is intentionally *not* sticky
+    /// — staying on the most-recently-run thread minimises interleaving,
+    /// which is the opposite of what a pruning harness wants.
+    ///
+    /// Returns `None` for the choice iff no thread is Runnable, which the
+    /// driver treats as deadlock; the state is still returned so the caller
+    /// always handles the same shape regardless of the outcome.
+    let chooseNext (lastRan : ThreadId) (state : IlMachineState) : IlMachineState * ThreadId option =
+        match state.Scheduling with
+        | SchedulerState.RoundRobin ->
+            let runnable = runnableThreads state
+
+            let chosen =
+                match runnable with
+                | [] -> None
+                | _ ->
+                    let (ThreadId lastRanId) = lastRan
+
+                    runnable
+                    |> List.tryFind (fun (ThreadId i) -> i > lastRanId)
+                    |> Option.orElse (List.tryHead runnable)
+
+            state, chosen
+        | SchedulerState.Pct _ ->
+            // The PCT decision logic lands in a follow-up PR. Until then
+            // nothing constructs `Pct _` (the default is `RoundRobin`), so
+            // reaching this branch indicates a partially-wired harness;
+            // fail loud rather than silently fall back to round-robin and
+            // mask the mistake.
+            failwith
+                "Scheduler.chooseNext: PCT scheduling policy is not yet implemented; only RoundRobin is supported in this build."
 
     /// Set `thread`'s status. Used by the LowLevelMonitor state machine, which
     /// owns the registry-side bookkeeping (queues, owner) but routes every

--- a/WoofWare.PawPrint/SchedulerState.fs
+++ b/WoofWare.PawPrint/SchedulerState.fs
@@ -1,0 +1,42 @@
+namespace WoofWare.PawPrint
+
+/// State owned by the schedule-fuzzing PCT (Probabilistic Concurrency Testing)
+/// policy: a deterministic splitmix64 RNG state plus the current
+/// per-thread priority assignment. Burckhardt et al.'s original PCT
+/// algorithm uses a fixed switch budget `d`; we instead drive demotion
+/// from per-step `ContextSwitchPrior` weights, so the priority map is
+/// resampled lazily rather than constructed up-front.
+///
+/// Each thread is sampled into `[0, 1)` on first observation. Demotion
+/// resamples the running thread's priority; the next chosen thread is
+/// whichever Runnable thread has the maximum priority. `Map<ThreadId, double>`
+/// keeps this purely functional so that schedule replay is bit-exact.
+type PctState =
+    {
+        /// splitmix64 state, advanced via `NonCryptoRandom.step` /
+        /// `NonCryptoRandom.nextDouble` / `NonCryptoRandom.nextInt32Below`
+        /// whenever the scheduler needs a uniform draw. Threading the
+        /// state through every decision is what keeps the run reproducible
+        /// from a seed.
+        Rng : uint64
+        /// Priority assigned to each thread the scheduler has observed.
+        /// Entries are inserted lazily (on first scheduling decision that
+        /// sees the thread) and removed on termination so that a terminated
+        /// thread's slot cannot leak into a later choice.
+        Priorities : Map<ThreadId, double>
+    }
+
+/// The scheduling policy in effect for the current run. `RoundRobin` is
+/// the default and reproduces the legacy deterministic-ordering behaviour:
+/// among the Runnable threads, prefer the lowest id strictly greater than
+/// `lastRan`, wrapping to the lowest id overall. `Pct` carries the live
+/// PCT state for schedule fuzzing and is selected by the harness via a
+/// seed on `PreparedProgram`.
+///
+/// Encoded as a DU rather than a behavioural strategy object so that the
+/// set of policies stays enumerable in one place: pattern matches on
+/// `state.Scheduling` are exhaustive and the compiler reminds you to
+/// extend every decision point when a new policy lands.
+type SchedulerState =
+    | RoundRobin
+    | Pct of PctState

--- a/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
+++ b/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="Result.fs" />
     <Compile Include="Corelib.fs" />
     <Compile Include="AbstractMachineDomain.fs" />
+    <Compile Include="SchedulerState.fs" />
     <Compile Include="FieldId.fs" />
     <Compile Include="ManagedPointerSource.fs" />
     <Compile Include="NativeIntSource.fs" />


### PR DESCRIPTION
## Summary

PR A of a two-PR series wiring Probabilistic Concurrency Testing into the scheduler. This PR is plumbing-only — no behaviour change.

- Add `Scheduling : SchedulerState` field to `IlMachineState`, defaulting to `RoundRobin`.
- Define `SchedulerState = RoundRobin | Pct of PctState` and `PctState = { Rng : uint64; Priorities : Map<ThreadId, double> }`. `Pct _` is defined but unreachable in this PR; reaching it would `failwith`.
- Widen `Scheduler.chooseNext` to return `(IlMachineState * ThreadId option)` so a future stochastic policy can thread RNG state forward.
- Add `Scheduler.hasAnyRunnable` and switch the deadline-advance probe in `Program.fs` to it, so a stochastic policy won't burn RNG draws on quiescence checks whose result is discarded.

PR B will add the `--seed N` CLI flag, the `PreparedProgram.Seed` field, the priority-sampling/demotion logic in `chooseNext`, and the PCT-specific tests.

## Test plan
- [x] `nix develop -c dotnet build` (clean)
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 1338 passed, 0 failed, identical to main
- [x] `nix develop -c dotnet fantomas .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)