### PR TITLE
Implement XplatEventLogger QCalls deterministically

### DIFF
--- a/WoofWare.PawPrint.Test/TestNativeEventSource.fs
+++ b/WoofWare.PawPrint.Test/TestNativeEventSource.fs
@@ -67,6 +67,7 @@ public static class Entry
                 dotnetRuntimes
                 (MockEnv.make ())
                 Map.empty
+                None
                 []
         with
         | Program.ProgramStartResult.Ready prepared -> prepared

--- a/WoofWare.PawPrint.Test/TestNativeEventSource.fs
+++ b/WoofWare.PawPrint.Test/TestNativeEventSource.fs
@@ -1,0 +1,399 @@
+namespace WoofWare.PawPrint.Test
+
+open System.Collections.Immutable
+open System.IO
+open FsUnitTyped
+open Microsoft.CodeAnalysis
+open NUnit.Framework
+open WoofWare.DotnetRuntimeLocator
+open WoofWare.PawPrint
+open WoofWare.PawPrint.ExternImplementations
+
+/// Direct-call tests for the `XplatEventLogger` QCall handlers in
+/// `NativeEventSource`. The handlers are reached from Linux-built CoreLib
+/// only (FEATURE_EVENTSOURCE_XPLAT-gated), so we can't rely on the host
+/// CoreLib exposing `XplatEventLogger` at all — instead we drive the
+/// dispatcher synthetically: a real concretized method has its
+/// `Signature` overridden to the shape the matcher expects, and we hand a
+/// record-updated `TypeInfo` to `NativeCallContext` so the namespace/name
+/// arms fire.
+///
+/// What this pins down:
+///   * `tryParseClrConfigDword` matches CoreCLR's hex-default DWORD
+///     parsing (radix 16, optional `0x` prefix tolerated).
+///   * `lookupClrConfigString` honours the `DOTNET_*` → `COMPlus_*`
+///     priority and discards empty values, mirroring
+///     `clrconfig.cpp`:`EnvGetString`.
+///   * The `IsEventSourceLoggingEnabled` arm of `tryExecuteQCall` returns
+///     Int32 0/1 according to the env-honouring rules.
+///   * The `LogEventSource` arm fails loud (so a guest with
+///     `DOTNET_EnableEventLog=1` that actually emits an EventSource event
+///     surfaces a clear diagnostic, rather than silently losing the
+///     event).
+[<TestFixture>]
+module TestNativeEventSource =
+
+    let private trivialSource : string =
+        """
+public static class Entry
+{
+    public static int Main(string[] args)
+    {
+        return 0;
+    }
+}
+"""
+
+    let private prepareProgram (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory) : Program.PreparedProgram =
+        let image =
+            Roslyn.compileAssemblyWithResources
+                "NativeEventSourceTest"
+                OutputKind.ConsoleApplication
+                []
+                []
+                [ trivialSource ]
+
+        let dotnetRuntimes =
+            DotnetRuntime.SelectForDll (typeof<RunResult>.Assembly.Location)
+            |> ImmutableArray.CreateRange
+
+        use peImage = new MemoryStream (image)
+
+        match
+            Program.prepare
+                loggerFactory
+                (Some "NativeEventSourceTest.cs")
+                peImage
+                dotnetRuntimes
+                (MockEnv.make ())
+                Map.empty
+                []
+        with
+        | Program.ProgramStartResult.Ready prepared -> prepared
+        | Program.ProgramStartResult.CompletedBeforeMain outcome ->
+            failwith $"expected program to be ready before Main, got %O{outcome}"
+
+    /// Resolve and concretize `Thread.YieldInternal` — used purely as a
+    /// donor `MethodInfo<ConcreteTypeHandle, _, _>`. Its `Signature` is
+    /// overridden to whatever shape each test needs; only the surrounding
+    /// MethodInfo fields (DeclaringType, Body, etc.) are reused. The
+    /// dispatcher reads neither, so the donor identity does not leak.
+    let private donorConcretizedMethod
+        (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        : IlMachineState * MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>
+        =
+        let threadType =
+            baseClassTypes.Corelib.TryGetTopLevelTypeDef "System.Threading" "Thread"
+            |> Option.defaultWith (fun () -> failwith "System.Threading.Thread not found in CoreLib")
+
+        let rawMethod =
+            threadType.Methods
+            |> List.filter (fun method ->
+                match method.NativeImport with
+                | Some import ->
+                    import.ModuleName = "QCall"
+                    && import.EntryPointName = "ThreadNative_YieldThread"
+                | None -> false
+            )
+            |> function
+                | [ method ] -> method
+                | _ -> failwith "donor method ThreadNative_YieldThread not found on System.Threading.Thread"
+
+        let state, method, _declaringType =
+            ExecutionConcretization.concretizeMethodWithTypeGenerics
+                loggerFactory
+                baseClassTypes
+                ImmutableArray.Empty
+                rawMethod
+                None
+                baseClassTypes.Corelib.Name
+                ImmutableArray.Empty
+                state
+
+        state, method
+
+    /// Build the synthetic `XplatEventLogger` target type. We start from a
+    /// real CoreLib type (so all the metadata-derived fields are
+    /// well-formed) and override only `Namespace` and `Name` to make the
+    /// dispatcher's namespace/name arms fire.
+    let private xplatTargetType
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        : TypeInfo<GenericParamFromMetadata, TypeDefn>
+        =
+        { baseClassTypes.UInt16 with
+            Namespace = "System.Diagnostics.Tracing"
+            Name = "XplatEventLogger"
+        }
+
+    let private buildContext
+        (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
+        (prepared : Program.PreparedProgram)
+        (state : IlMachineState)
+        (method : MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>)
+        : NativeCallContext
+        =
+        let instruction =
+            { state.ThreadState.[prepared.EntryThread].MethodState with
+                ExecutingMethod = method
+                Arguments = ImmutableArray.Empty
+            }
+
+        {
+            LoggerFactory = loggerFactory
+            Implementations = MockEnv.make ()
+            BaseClassTypes = prepared.BaseClassTypes
+            Thread = prepared.EntryThread
+            State = state
+            Instruction = instruction
+            TargetAssembly = prepared.BaseClassTypes.Corelib
+            TargetType = xplatTargetType prepared.BaseClassTypes
+        }
+
+    let private withEnvironment (env : (string * string) list) (state : IlMachineState) : IlMachineState =
+        state.MapKernel (EmulatedKernel.withEnvironment (Map.ofList env))
+
+    // ---------- Pure helper tests ----------
+
+    [<Test>]
+    let ``tryParseClrConfigDword: empty and whitespace return None`` () : unit =
+        NativeEventSource.tryParseClrConfigDword "" |> shouldEqual None
+        NativeEventSource.tryParseClrConfigDword "   " |> shouldEqual None
+        NativeEventSource.tryParseClrConfigDword "\t" |> shouldEqual None
+
+    [<Test>]
+    let ``tryParseClrConfigDword: hex by default (matches CoreCLR's GetConfigDWORD default radix)`` () : unit =
+        // No `ParseIntegerAsBase10` flag on EnableEventLog ⇒ radix 16.
+        NativeEventSource.tryParseClrConfigDword "1" |> shouldEqual (Some 1u)
+        NativeEventSource.tryParseClrConfigDword "0" |> shouldEqual (Some 0u)
+        NativeEventSource.tryParseClrConfigDword "10" |> shouldEqual (Some 16u)
+        NativeEventSource.tryParseClrConfigDword "ff" |> shouldEqual (Some 255u)
+        NativeEventSource.tryParseClrConfigDword "FF" |> shouldEqual (Some 255u)
+
+        NativeEventSource.tryParseClrConfigDword "deadbeef"
+        |> shouldEqual (Some 0xdeadbeefu)
+
+    [<Test>]
+    let ``tryParseClrConfigDword: 0x prefix is tolerated (matches wcstoul base-16)`` () : unit =
+        NativeEventSource.tryParseClrConfigDword "0x1" |> shouldEqual (Some 1u)
+        NativeEventSource.tryParseClrConfigDword "0X10" |> shouldEqual (Some 16u)
+
+        NativeEventSource.tryParseClrConfigDword "0xDEADBEEF"
+        |> shouldEqual (Some 0xdeadbeefu)
+
+    [<Test>]
+    let ``tryParseClrConfigDword: malformed input returns None (not crash)`` () : unit =
+        NativeEventSource.tryParseClrConfigDword "garbage" |> shouldEqual None
+        NativeEventSource.tryParseClrConfigDword "0xZZ" |> shouldEqual None
+        NativeEventSource.tryParseClrConfigDword "0x" |> shouldEqual None
+        // Larger than uint32.MaxValue — TryParse rejects, we surface None
+        // (CoreCLR would silently overflow inside wcstoul; we err on the
+        // side of treating implausible values as unset).
+        NativeEventSource.tryParseClrConfigDword "100000000" |> shouldEqual None
+
+    [<Test>]
+    let ``tryParseClrConfigDword: surrounding whitespace is trimmed`` () : unit =
+        NativeEventSource.tryParseClrConfigDword "  1  " |> shouldEqual (Some 1u)
+        NativeEventSource.tryParseClrConfigDword "\t0x10\n" |> shouldEqual (Some 16u)
+
+    [<Test>]
+    let ``lookupClrConfigString: DOTNET_ wins over COMPlus_ when both set`` () : unit =
+        let env =
+            Map.ofList [ "DOTNET_TestKnob", "dotnet-value" ; "COMPlus_TestKnob", "complus-value" ]
+
+        NativeEventSource.lookupClrConfigString env "TestKnob"
+        |> shouldEqual (Some "dotnet-value")
+
+    [<Test>]
+    let ``lookupClrConfigString: COMPlus_ is used when DOTNET_ is unset`` () : unit =
+        let env = Map.ofList [ "COMPlus_TestKnob", "complus-value" ]
+
+        NativeEventSource.lookupClrConfigString env "TestKnob"
+        |> shouldEqual (Some "complus-value")
+
+    [<Test>]
+    let ``lookupClrConfigString: empty value is treated as unset (matches CoreCLR's '*ret != W('\0')' filter)``
+        ()
+        : unit
+        =
+        // DOTNET_ is present but empty: skip past it.
+        let env = Map.ofList [ "DOTNET_TestKnob", "" ; "COMPlus_TestKnob", "fallback" ]
+
+        NativeEventSource.lookupClrConfigString env "TestKnob"
+        |> shouldEqual (Some "fallback")
+
+        // Both empty: None
+        let env = Map.ofList [ "DOTNET_TestKnob", "" ; "COMPlus_TestKnob", "" ]
+
+        NativeEventSource.lookupClrConfigString env "TestKnob" |> shouldEqual None
+
+    [<Test>]
+    let ``lookupClrConfigString: nothing set returns None`` () : unit =
+        NativeEventSource.lookupClrConfigString Map.empty "EnableEventLog"
+        |> shouldEqual None
+
+    // ---------- Dispatcher tests ----------
+
+    /// Override the donor method's signature to `() -> int32`, then drive
+    /// the dispatcher and read back the value pushed onto the eval stack.
+    let private dispatchIsEnabled
+        (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
+        (prepared : Program.PreparedProgram)
+        (state : IlMachineState)
+        (donor : MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>)
+        : EvalStackValue
+        =
+        let int32Handle =
+            AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes prepared.BaseClassTypes.Int32
+
+        let signature =
+            { donor.Signature with
+                ParameterTypes = []
+                ReturnType = MethodReturnType.Returns int32Handle
+            }
+
+        let method =
+            { donor with
+                Signature = signature
+            }
+
+        let ctx = buildContext loggerFactory prepared state method
+
+        match NativeEventSource.tryExecuteQCall "IsEventSourceLoggingEnabled" ctx with
+        | Some (NativeHandlerResult.Completed (stateAfter, effect)) ->
+            effect |> shouldEqual StepEffect.NoEffect
+            let v, _ = IlMachineState.popEvalStack prepared.EntryThread stateAfter
+            v
+        | other -> failwith $"unexpected IsEventSourceLoggingEnabled result: %O{other}"
+
+    [<Test>]
+    let ``IsEventSourceLoggingEnabled: returns 0 when DOTNET_EnableEventLog is unset`` () : unit =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+        let prepared = prepareProgram loggerFactory
+
+        let state, donor =
+            donorConcretizedMethod loggerFactory prepared.BaseClassTypes prepared.State
+
+        dispatchIsEnabled loggerFactory prepared state donor
+        |> shouldEqual (EvalStackValue.Int32 0)
+
+    [<Test>]
+    let ``IsEventSourceLoggingEnabled: returns 1 when DOTNET_EnableEventLog=1`` () : unit =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+        let prepared = prepareProgram loggerFactory
+
+        let state, donor =
+            donorConcretizedMethod loggerFactory prepared.BaseClassTypes prepared.State
+
+        let state = withEnvironment [ "DOTNET_EnableEventLog", "1" ] state
+
+        dispatchIsEnabled loggerFactory prepared state donor
+        |> shouldEqual (EvalStackValue.Int32 1)
+
+    [<Test>]
+    let ``IsEventSourceLoggingEnabled: returns 0 when DOTNET_EnableEventLog=0`` () : unit =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+        let prepared = prepareProgram loggerFactory
+
+        let state, donor =
+            donorConcretizedMethod loggerFactory prepared.BaseClassTypes prepared.State
+
+        let state = withEnvironment [ "DOTNET_EnableEventLog", "0" ] state
+
+        dispatchIsEnabled loggerFactory prepared state donor
+        |> shouldEqual (EvalStackValue.Int32 0)
+
+    [<Test>]
+    let ``IsEventSourceLoggingEnabled: hex 10 means 16 (nonzero, so TRUE)`` () : unit =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+        let prepared = prepareProgram loggerFactory
+
+        let state, donor =
+            donorConcretizedMethod loggerFactory prepared.BaseClassTypes prepared.State
+
+        let state = withEnvironment [ "DOTNET_EnableEventLog", "10" ] state
+
+        dispatchIsEnabled loggerFactory prepared state donor
+        |> shouldEqual (EvalStackValue.Int32 1)
+
+    [<Test>]
+    let ``IsEventSourceLoggingEnabled: COMPlus_ fallback wires up`` () : unit =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+        let prepared = prepareProgram loggerFactory
+
+        let state, donor =
+            donorConcretizedMethod loggerFactory prepared.BaseClassTypes prepared.State
+        // No DOTNET_ key — only the legacy COMPlus_ knob is set.
+        let state = withEnvironment [ "COMPlus_EnableEventLog", "1" ] state
+
+        dispatchIsEnabled loggerFactory prepared state donor
+        |> shouldEqual (EvalStackValue.Int32 1)
+
+    [<Test>]
+    let ``IsEventSourceLoggingEnabled: malformed value defaults to FALSE`` () : unit =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+        let prepared = prepareProgram loggerFactory
+
+        let state, donor =
+            donorConcretizedMethod loggerFactory prepared.BaseClassTypes prepared.State
+
+        let state = withEnvironment [ "DOTNET_EnableEventLog", "garbage" ] state
+
+        dispatchIsEnabled loggerFactory prepared state donor
+        |> shouldEqual (EvalStackValue.Int32 0)
+
+    [<Test>]
+    let ``LogEventSource: dispatch fires loud failwith (the gate that protects against silent event loss)`` () : unit =
+        // This is the test the user explicitly asked for: flip
+        // `DOTNET_EnableEventLog=1`, drive the dispatcher into the
+        // `LogEventSource` arm, and observe that PawPrint raises rather
+        // than silently no-opping. Even on macOS where the host CoreLib
+        // omits `XplatEventLogger`, the synthetic context still exercises
+        // the dispatcher arm that a Linux guest would reach when
+        // `DOTNET_EnableEventLog=1` causes `InitializePersistentListener`
+        // to build the LTTng-forwarding listener.
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+        let prepared = prepareProgram loggerFactory
+
+        let state, donor =
+            donorConcretizedMethod loggerFactory prepared.BaseClassTypes prepared.State
+
+        let state = withEnvironment [ "DOTNET_EnableEventLog", "1" ] state
+
+        let int32Handle =
+            AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes prepared.BaseClassTypes.Int32
+
+        let uint16Handle =
+            AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes prepared.BaseClassTypes.UInt16
+
+        let charPtrHandle = ConcreteTypeHandle.Pointer uint16Handle
+
+        let signature =
+            { donor.Signature with
+                ParameterTypes = [ int32Handle ; charPtrHandle ; charPtrHandle ; charPtrHandle ]
+                ReturnType = MethodReturnType.Void
+            }
+
+        let method =
+            { donor with
+                Signature = signature
+            }
+
+        let ctx = buildContext loggerFactory prepared state method
+
+        let ex =
+            Assert.Throws (fun () ->
+                NativeEventSource.tryExecuteQCall "LogEventSource" ctx
+                |> ignore<NativeHandlerResult option>
+            )
+
+        ex.Message |> shouldContainText "LogEventSource"
+        ex.Message |> shouldContainText "DOTNET_EnableEventLog=0"

--- a/WoofWare.PawPrint.Test/TestNativeEventSource.fs
+++ b/WoofWare.PawPrint.Test/TestNativeEventSource.fs
@@ -192,10 +192,37 @@ public static class Entry
         NativeEventSource.tryParseClrConfigDword "--1" |> shouldEqual None
 
     [<Test>]
-    let ``tryParseClrConfigDword: overflow returns None (mirrors errno == ERANGE arm)`` () : unit =
-        // 0x100000000 just past UInt32.MaxValue.
+    let ``tryParseClrConfigDword: positive overflow past UINT32_MAX returns None (PAL HOST_64BIT arm)`` () : unit =
+        // PAL_wcstoul's HOST_64BIT post-processing sets `errno = ERANGE` and
+        // clamps to UINT32_MAX whenever the parsed (positive) magnitude is
+        // greater than UINT32_MAX. GetConfigDWORD then rejects.
         NativeEventSource.tryParseClrConfigDword "100000000" |> shouldEqual None
         NativeEventSource.tryParseClrConfigDword "0x100000000" |> shouldEqual None
+        // Just past UINT32_MAX still fits in `unsigned long` on a 64-bit host.
+        NativeEventSource.tryParseClrConfigDword "100000001" |> shouldEqual None
+        // Magnitudes that exceed UINT64_MAX (and therefore `unsigned long`)
+        // make `strtoul` itself set `errno = ERANGE`. PAL_wcstoul never
+        // clears that errno, so we reject for either sign.
+        NativeEventSource.tryParseClrConfigDword "10000000000000000" |> shouldEqual None
+
+        NativeEventSource.tryParseClrConfigDword "-10000000000000000"
+        |> shouldEqual None
+
+    [<Test>]
+    let ``tryParseClrConfigDword: negative overflow past UINT32_MAX truncates to low 32 bits`` () : unit =
+        // Pins the PAL_wcstoul HOST_64BIT special case: with a leading `-`,
+        // `strtoul` parses the magnitude in 64-bit `unsigned long`, applies
+        // two's-complement negation mod 2^64, and the PAL returns that
+        // value cast to `(ULONG)` — i.e. the low 32 bits — without setting
+        // ERANGE. So `DOTNET_EnableEventLog=-100000001` enables logging on
+        // real CoreCLR, and any strict UInt32-based parser would miss it.
+        // -0x100000001 mod 2^64 = 0xFFFFFFFEFFFFFFFF; low 32 bits = 0xFFFFFFFF.
+        NativeEventSource.tryParseClrConfigDword "-100000001"
+        |> shouldEqual (Some 0xFFFFFFFFu)
+        // -0x100000000 mod 2^64 = 0xFFFFFFFF00000000; low 32 bits = 0.
+        NativeEventSource.tryParseClrConfigDword "-100000000" |> shouldEqual (Some 0u)
+        // -0x1FFFFFFFF mod 2^64 = 0xFFFFFFFE00000001; low 32 bits = 1.
+        NativeEventSource.tryParseClrConfigDword "-1FFFFFFFF" |> shouldEqual (Some 1u)
 
     [<Test>]
     let ``tryParseClrConfigDword: parses longest valid prefix (1garbage -> 1)`` () : unit =
@@ -405,6 +432,29 @@ public static class Entry
             donorConcretizedMethod loggerFactory prepared.BaseClassTypes prepared.State
 
         let state = withEnvironment [ "DOTNET_EnableEventLog", "1garbage" ] state
+
+        dispatchIsEnabled loggerFactory prepared state donor
+        |> shouldEqual (EvalStackValue.Int32 1)
+
+    [<Test>]
+    let ``IsEventSourceLoggingEnabled: DOTNET_EnableEventLog=-100000001 enables (PAL_wcstoul 64-bit wrap)`` () : unit =
+        // Pins the PAL_wcstoul HOST_64BIT special case: a negative input
+        // whose magnitude exceeds UINT32_MAX is *not* rejected by the
+        // PAL — `strtoul` parses the magnitude in 64-bit `unsigned long`,
+        // applies two's-complement negation, and the PAL's final
+        // `(ULONG)res` cast truncates to the low 32 bits without setting
+        // ERANGE. -0x100000001 mod 2^64 = 0xFFFFFFFEFFFFFFFF, low 32
+        // bits = 0xFFFFFFFF, gate non-zero → enabled. The previous
+        // UInt32-only parser rejected this magnitude before applying
+        // the sign and would have disabled the gate.
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+        let prepared = prepareProgram loggerFactory
+
+        let state, donor =
+            donorConcretizedMethod loggerFactory prepared.BaseClassTypes prepared.State
+
+        let state = withEnvironment [ "DOTNET_EnableEventLog", "-100000001" ] state
 
         dispatchIsEnabled loggerFactory prepared state donor
         |> shouldEqual (EvalStackValue.Int32 1)

--- a/WoofWare.PawPrint.Test/TestNativeEventSource.fs
+++ b/WoofWare.PawPrint.Test/TestNativeEventSource.fs
@@ -183,19 +183,56 @@ public static class Entry
         |> shouldEqual (Some 0xdeadbeefu)
 
     [<Test>]
-    let ``tryParseClrConfigDword: malformed input returns None (not crash)`` () : unit =
+    let ``tryParseClrConfigDword: input with no parseable digits returns None`` () : unit =
         NativeEventSource.tryParseClrConfigDword "garbage" |> shouldEqual None
-        NativeEventSource.tryParseClrConfigDword "0xZZ" |> shouldEqual None
-        NativeEventSource.tryParseClrConfigDword "0x" |> shouldEqual None
-        // Larger than uint32.MaxValue — TryParse rejects, we surface None
-        // (CoreCLR would silently overflow inside wcstoul; we err on the
-        // side of treating implausible values as unset).
-        NativeEventSource.tryParseClrConfigDword "100000000" |> shouldEqual None
+        NativeEventSource.tryParseClrConfigDword "+" |> shouldEqual None
+        NativeEventSource.tryParseClrConfigDword "-" |> shouldEqual None
+        // No hex digit after the sign: `wcstoul` resets endPtr to val and
+        // returns 0; we surface None (the gate treats both as disabled).
+        NativeEventSource.tryParseClrConfigDword "--1" |> shouldEqual None
 
     [<Test>]
-    let ``tryParseClrConfigDword: surrounding whitespace is trimmed`` () : unit =
+    let ``tryParseClrConfigDword: overflow returns None (mirrors errno == ERANGE arm)`` () : unit =
+        // 0x100000000 just past UInt32.MaxValue.
+        NativeEventSource.tryParseClrConfigDword "100000000" |> shouldEqual None
+        NativeEventSource.tryParseClrConfigDword "0x100000000" |> shouldEqual None
+
+    [<Test>]
+    let ``tryParseClrConfigDword: parses longest valid prefix (1garbage -> 1)`` () : unit =
+        // `wcstoul` does not require the whole string to be valid — it
+        // returns the prefix and sets endPtr past it. CoreCLR's
+        // `endPtr != val` check then accepts the result. We must too,
+        // otherwise `DOTNET_EnableEventLog=1garbage` reads as disabled
+        // here but enabled on real CoreCLR.
+        NativeEventSource.tryParseClrConfigDword "1garbage" |> shouldEqual (Some 1u)
+        NativeEventSource.tryParseClrConfigDword "ff thanks" |> shouldEqual (Some 0xffu)
+        NativeEventSource.tryParseClrConfigDword "0XYZ" |> shouldEqual (Some 0u)
+
+    [<Test>]
+    let ``tryParseClrConfigDword: 0x without trailing hex digit parses the leading 0`` () : unit =
+        // `wcstoul` sees the `0` as a digit and the `x` as a stop character.
+        // The leading `0` is consumed (endPtr advances past it), so
+        // CoreCLR returns success with value 0.
+        NativeEventSource.tryParseClrConfigDword "0x" |> shouldEqual (Some 0u)
+        NativeEventSource.tryParseClrConfigDword "0xZZ" |> shouldEqual (Some 0u)
+
+    [<Test>]
+    let ``tryParseClrConfigDword: sign is honoured via two's complement wraparound`` () : unit =
+        // `wcstoul` accepts a leading sign and wraps the negation modulo
+        // 2^32, so `-1` becomes `0xFFFFFFFF` (non-zero → enables the
+        // gate). CoreCLR's `IsEventSourceLoggingEnabled` therefore treats
+        // `DOTNET_EnableEventLog=-1` as enabled; we must as well.
+        NativeEventSource.tryParseClrConfigDword "+1" |> shouldEqual (Some 1u)
+        NativeEventSource.tryParseClrConfigDword "-1" |> shouldEqual (Some 0xFFFFFFFFu)
+        NativeEventSource.tryParseClrConfigDword "-0" |> shouldEqual (Some 0u)
+
+    [<Test>]
+    let ``tryParseClrConfigDword: leading whitespace is skipped`` () : unit =
+        NativeEventSource.tryParseClrConfigDword "  1" |> shouldEqual (Some 1u)
+        NativeEventSource.tryParseClrConfigDword "\t0x10" |> shouldEqual (Some 16u)
+        // Whitespace after the digits stops parsing but does not invalidate
+        // the prefix.
         NativeEventSource.tryParseClrConfigDword "  1  " |> shouldEqual (Some 1u)
-        NativeEventSource.tryParseClrConfigDword "\t0x10\n" |> shouldEqual (Some 16u)
 
     [<Test>]
     let ``lookupClrConfigString: DOTNET_ wins over COMPlus_ when both set`` () : unit =
@@ -336,7 +373,44 @@ public static class Entry
         |> shouldEqual (EvalStackValue.Int32 1)
 
     [<Test>]
-    let ``IsEventSourceLoggingEnabled: malformed value defaults to FALSE`` () : unit =
+    let ``IsEventSourceLoggingEnabled: DOTNET_EnableEventLog=-1 enables (wcstoul wraps to 0xFFFFFFFF)`` () : unit =
+        // Pins the wcstoul-compatible behaviour: CoreCLR's
+        // `GetConfigDWORD` accepts the leading sign, two's-complement
+        // wraps the value, and the gate reads any non-zero DWORD as
+        // enabled. A strict UInt32.TryParse would have rejected this and
+        // disabled the gate — that divergence is what Codex caught.
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+        let prepared = prepareProgram loggerFactory
+
+        let state, donor =
+            donorConcretizedMethod loggerFactory prepared.BaseClassTypes prepared.State
+
+        let state = withEnvironment [ "DOTNET_EnableEventLog", "-1" ] state
+
+        dispatchIsEnabled loggerFactory prepared state donor
+        |> shouldEqual (EvalStackValue.Int32 1)
+
+    [<Test>]
+    let ``IsEventSourceLoggingEnabled: DOTNET_EnableEventLog=1garbage enables (longest-prefix parse)`` () : unit =
+        // `wcstoul` returns the parsed prefix and leaves the rest in
+        // endPtr; CoreCLR accepts this as a successful parse. We must
+        // too, otherwise the gate disagrees with the real runtime for
+        // typo-laden env values.
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+        let prepared = prepareProgram loggerFactory
+
+        let state, donor =
+            donorConcretizedMethod loggerFactory prepared.BaseClassTypes prepared.State
+
+        let state = withEnvironment [ "DOTNET_EnableEventLog", "1garbage" ] state
+
+        dispatchIsEnabled loggerFactory prepared state donor
+        |> shouldEqual (EvalStackValue.Int32 1)
+
+    [<Test>]
+    let ``IsEventSourceLoggingEnabled: malformed value with no parseable digits defaults to FALSE`` () : unit =
         let _, loggerFactory = LoggerFactory.makeTest ()
         use _loggerFactoryResource = loggerFactory
         let prepared = prepareProgram loggerFactory

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -78,6 +78,7 @@
     <Compile Include="TestWaitHandle.fs" />
     <Compile Include="TestSyncBlockMonitor.fs" />
     <Compile Include="TestNativeThreadYield.fs" />
+    <Compile Include="TestNativeEventSource.fs" />
     <Compile Include="TestSchedulerVoluntaryYield.fs" />
     <Compile Include="TestSchedulerPct.fs" />
     <Compile Include="TestPureCases.fs" />

--- a/WoofWare.PawPrint/Native/NativeEventSource.fs
+++ b/WoofWare.PawPrint/Native/NativeEventSource.fs
@@ -2,28 +2,106 @@ namespace WoofWare.PawPrint
 
 [<RequireQualifiedAccess>]
 module NativeEventSource =
-    /// QCalls declared on `System.Diagnostics.Tracing.XplatEventLogger` and reached
-    /// from CoreLib only when `FEATURE_EVENTSOURCE_XPLAT` was defined at CoreLib
-    /// build time (i.e. the Linux-built `System.Private.CoreLib`). They are still
-    /// registered unconditionally because PawPrint always dispatches against the
-    /// host runtime's CoreLib, which can be the Linux one on a Linux dev box or
-    /// CI runner.
+    /// Parse a CLRConfig DWORD env-var value the way CoreCLR does for
+    /// `EnableEventLog`: `wcstoul(val, &endPtr, 16)` — hex by default, with the
+    /// optional `0x` prefix tolerated. Returns `None` if the value is empty or
+    /// fails to parse (CoreCLR's `GetConfigDWORD` falls back to the default
+    /// value, which is `0` for `EnableEventLog`).
     ///
-    /// PawPrint does not connect to any external tracing consumer (LTTng,
-    /// EventPipe, etc.), so the deterministic answers are:
-    ///   * `EventSource_GetClrConfig`: report "no config set" by returning a
-    ///     null UTF-16 pointer. CoreLib's `new string((char*)null)` then yields
-    ///     `String.Empty`, matching real CoreCLR when the named config knob is
-    ///     unset (see NativeString.fs / `String..ctor(char*)`).
-    ///   * `IsEventSourceLoggingEnabled`: return `FALSE` so
-    ///     `XplatEventLogger.InitializePersistentListener` skips creating the
-    ///     listener entirely. This is the truthful answer in a host with no
-    ///     tracing consumer attached.
-    ///   * `LogEventSource`: void no-op. With `IsEventSourceLoggingEnabled`
-    ///     returning false the listener is never created and this entry point
-    ///     should be unreachable from `OnEventWritten`, but implementing it
-    ///     defensively keeps PawPrint robust against guests that import it
-    ///     directly.
+    /// `EnableEventLog` is declared via `RETAIL_CONFIG_DWORD_INFO` with no
+    /// `ParseIntegerAsBase10` flag (see `clrconfigvalues.h:580`), so the radix
+    /// is 16. Both `1` and `0x1` therefore mean TRUE; `10` means 16 (also
+    /// TRUE); `0` and `0x0` mean FALSE. We don't need the full DWORD value —
+    /// `IsEventSourceLoggingEnabled` only asks whether it's non-zero — but
+    /// the parser is shaped to surface the value so future knobs that care
+    /// about the numeric magnitude can reuse it.
+    ///
+    /// Exposed as `internal` so the test assembly can pin the parser's
+    /// behaviour directly without going through the QCall dispatcher.
+    let internal tryParseClrConfigDword (raw : string) : uint32 option =
+        let trimmed = raw.Trim ()
+
+        if System.String.IsNullOrEmpty trimmed then
+            None
+        else
+            let hexBody =
+                if trimmed.StartsWith ("0x", System.StringComparison.OrdinalIgnoreCase) then
+                    trimmed.Substring 2
+                else
+                    trimmed
+
+            match
+                System.UInt32.TryParse (
+                    hexBody,
+                    System.Globalization.NumberStyles.HexNumber,
+                    System.Globalization.CultureInfo.InvariantCulture
+                )
+            with
+            | true, value -> Some value
+            | false, _ -> None
+
+    /// Look up a CLRConfig string knob in the guest's emulated environment,
+    /// mirroring CoreCLR's `EnvGetString` priority: try `DOTNET_<name>` first,
+    /// then `COMPlus_<name>` as a fallback. Returns `None` for an unset or
+    /// empty value (CoreCLR's `GetConfigString` also discards the empty
+    /// string via the `*ret != W('\0')` check in `clrconfig.cpp:288`).
+    let internal lookupClrConfigString (env : Map<string, string>) (name : string) : string option =
+        let tryEnv (key : string) : string option =
+            match Map.tryFind key env with
+            | Some value when value.Length > 0 -> Some value
+            | _ -> None
+
+        match tryEnv $"DOTNET_%s{name}" with
+        | Some v -> Some v
+        | None -> tryEnv $"COMPlus_%s{name}"
+
+    /// Encode `s` as UTF-16-LE bytes followed by a two-byte NUL terminator,
+    /// ready to be written into a freshly-allocated native-memory block whose
+    /// address is then handed back to the guest as a `char*`. The CoreLib
+    /// consumer (`new string((char*)EventSource_GetClrConfig(name))`) scans
+    /// for the terminator, so the trailing two zero bytes are load-bearing.
+    let private packUtf16WithNullTerminator (s : string) : byte[] =
+        let buffer = Array.zeroCreate ((s.Length + 1) * 2)
+        let written = System.Text.Encoding.Unicode.GetBytes (s, 0, s.Length, buffer, 0)
+
+        if written <> s.Length * 2 then
+            failwith
+                $"NativeEventSource.packUtf16WithNullTerminator: expected %d{s.Length * 2} bytes for %d{s.Length} UTF-16 code units, got %d{written}"
+
+        buffer
+
+    /// QCalls declared on `System.Diagnostics.Tracing.XplatEventLogger` and
+    /// reached from CoreLib only when `FEATURE_EVENTSOURCE_XPLAT` was defined
+    /// at CoreLib build time (i.e. the Linux-built `System.Private.CoreLib`).
+    /// They are still registered unconditionally because PawPrint always
+    /// dispatches against the host runtime's CoreLib, which can be the Linux
+    /// one on a Linux dev box or CI runner.
+    ///
+    /// All three handlers are faithful to CoreCLR with respect to the guest's
+    /// emulated environment:
+    ///
+    ///   * `EventSource_GetClrConfig(name)` returns the value of
+    ///     `DOTNET_<name>` (or the `COMPlus_<name>` fallback) from
+    ///     `state.Kernel.Environment`, encoded as a freshly-allocated
+    ///     UTF-16 buffer with a NUL terminator. Unset/empty values yield a
+    ///     null pointer, matching CoreCLR's behaviour when the knob is
+    ///     absent (CoreLib's `new string((char*)null)` then collapses to
+    ///     `String.Empty`).
+    ///
+    ///   * `IsEventSourceLoggingEnabled()` returns the value of
+    ///     `DOTNET_EnableEventLog` parsed as a CLRConfig DWORD (hex by
+    ///     default; see `tryParseClrConfigDword`), defaulting to `0`
+    ///     (FALSE) when unset or malformed. This matches
+    ///     `XplatEventLogger::IsEventLoggingEnabled()` in
+    ///     `eventtracebase.h:489`. When the result is FALSE the persistent
+    ///     listener is never created and `LogEventSource` is unreachable.
+    ///
+    ///   * `LogEventSource(...)` fails loud. It is only reachable when the
+    ///     guest enabled tracing via `DOTNET_EnableEventLog`, and PawPrint
+    ///     has no LTTng / EventPipe consumer to forward the event to.
+    ///     Silently dropping the event would hide a real signal — if you
+    ///     want a no-op, set `DOTNET_EnableEventLog=0` (or unset it) so
+    ///     the listener never gets constructed.
     let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
@@ -42,13 +120,46 @@ module NativeEventSource =
           "XplatEventLogger",
           [ ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt16) ],
           MethodReturnType.Returns (ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.Char)) ->
-            // The single argument is the UTF-16 config-name pointer (marshalled
-            // from the C# `string` parameter); intentionally not read because
-            // PawPrint has no configured EventSource knobs.
-            state
-            |> IlMachineState.pushToEvalStack' (EvalStackValue.ManagedPointer ManagedPointerSource.Null) ctx.Thread
-            |> NativeHandlerResult.completed
-            |> Some
+            let operation = "EventSource_GetClrConfig"
+
+            let namePtr =
+                NativeCall.managedPointerOfPointerArgument operation "configName" instruction.Arguments.[0]
+
+            let configName =
+                NativeCall.readNullTerminatedUtf16 operation ctx.BaseClassTypes state namePtr
+
+            match lookupClrConfigString state.Kernel.Environment configName with
+            | None ->
+                state
+                |> IlMachineState.pushToEvalStack' (EvalStackValue.ManagedPointer ManagedPointerSource.Null) ctx.Thread
+                |> NativeHandlerResult.completed
+                |> Some
+            | Some value ->
+                let bytes = packUtf16WithNullTerminator value
+
+                let ptr, state =
+                    IlMachineThreadState.allocateNativeMemory
+                        MemoryBlockInitialization.ZeroInitialized
+                        bytes.Length
+                        state
+
+                let blockId =
+                    match ptr with
+                    | ManagedPointerSource.Byref (ByrefRoot.NativeMemoryByte (blockId, 0), []) -> blockId
+                    | other ->
+                        failwith $"%s{operation}: allocateNativeMemory returned an unexpected pointer shape (%O{other})"
+
+                let state =
+                    state.MapKernel (fun k ->
+                        { k with
+                            NativeMemoryPool = NativeMemoryPool.writeBytes blockId 0 bytes k.NativeMemoryPool
+                        }
+                    )
+
+                state
+                |> IlMachineState.pushToEvalStack' (EvalStackValue.ManagedPointer ptr) ctx.Thread
+                |> NativeHandlerResult.completed
+                |> Some
 
         | "IsEventSourceLoggingEnabled",
           "System.Private.CoreLib",
@@ -59,9 +170,19 @@ module NativeEventSource =
             // The C# wrapper carries `[return: MarshalAs(UnmanagedType.Bool)]`,
             // which causes the LibraryImport source generator to declare the
             // underlying QCall as `int32`-returning (the wrapper converts via
-            // `cgt.un`). Push 0 (FALSE) — we have no tracing consumer.
+            // `cgt.un`).
+            let enabled =
+                match lookupClrConfigString state.Kernel.Environment "EnableEventLog" with
+                | None -> false
+                | Some raw ->
+                    match tryParseClrConfigDword raw with
+                    | None -> false
+                    | Some value -> value <> 0u
+
+            let resultInt = if enabled then 1 else 0
+
             state
-            |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread
+            |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 resultInt) ctx.Thread
             |> NativeHandlerResult.completed
             |> Some
 
@@ -74,8 +195,13 @@ module NativeEventSource =
             ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt16)
             ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt16) ],
           MethodReturnType.Void ->
-            // No-op: PawPrint discards the event. Arguments (event ID, event
-            // name, event source name, payload) are intentionally not read.
-            state |> NativeHandlerResult.completed |> Some
+            // Only reachable when the guest enabled tracing via
+            // `DOTNET_EnableEventLog`; the `XplatEventLogger` listener forwards
+            // every observed `EventSource` event here, expecting CoreCLR to
+            // hand it to LTTng. PawPrint has no LTTng / EventPipe consumer,
+            // so silently dropping the event would lose data the guest asked
+            // us to surface. Fail loud and point at the opt-out knob.
+            failwith
+                "LogEventSource: PawPrint has no LTTng/EventPipe consumer to forward EventSource events to. Set DOTNET_EnableEventLog=0 (or unset it) so XplatEventLogger.InitializePersistentListener never builds the listener that calls into this QCall."
 
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeEventSource.fs
+++ b/WoofWare.PawPrint/Native/NativeEventSource.fs
@@ -9,22 +9,41 @@ module NativeEventSource =
     /// because `EnableEventLog` is declared via `RETAIL_CONFIG_DWORD_INFO`
     /// with no `ParseIntegerAsBase10` flag (`clrconfigvalues.h:580`).
     ///
-    /// To mirror `wcstoul` we:
+    /// The Unix PAL's `PAL_wcstoul` (`pal/src/cruntime/wchar.cpp:281–324`)
+    /// is a thin wrapper around glibc `strtoul`, which on a 64-bit host
+    /// works in `unsigned long` (64-bit). On `HOST_64BIT` the PAL post-
+    /// processes the result: if `strtoul` returned > UINT32_MAX and the
+    /// input was *positive*, it clamps to `UINT32_MAX` and sets
+    /// `errno = ERANGE`; if the input was *negative*, it leaves the
+    /// value untouched and lets the final `(ULONG)res` cast truncate to
+    /// the low 32 bits (because that mirrors Windows' 32-bit `long`
+    /// behaviour). This means a guest setting
+    /// `DOTNET_EnableEventLog=-100000001` reads as enabled on real
+    /// CoreCLR — the 64-bit two's-complement wrap leaves the low 32
+    /// bits at `0xFFFFFFFF`, non-zero.
+    ///
+    /// To mirror that here we:
     ///   * skip leading whitespace;
-    ///   * accept a single optional `+` / `-` sign (negation wraps via
-    ///     two's complement, so `-1` becomes `0xFFFFFFFF` — non-zero,
-    ///     which the gate reads as TRUE);
+    ///   * accept a single optional `+` / `-` sign;
     ///   * accept (but do not require) an optional `0x` / `0X` radix
     ///     prefix, but only when it is followed by at least one hex
     ///     digit (otherwise the leading `0` is itself the digit and the
     ///     `x` becomes a stop character);
     ///   * consume the longest hex-digit prefix and ignore everything
-    ///     after it (so `1garbage` parses as 1, matching `wcstoul`).
+    ///     after it (so `1garbage` parses as 1, matching `wcstoul`);
+    ///   * parse the magnitude as `uint64` to capture values that fit in
+    ///     `unsigned long` but exceed `UInt32.MaxValue`;
+    ///   * apply the sign in 64-bit arithmetic (so `-1` becomes
+    ///     `0xFFFFFFFFFFFFFFFF`), then truncate to `uint32` to mirror
+    ///     the final `(ULONG)res` cast.
     ///
-    /// We return `None` iff no digits could be consumed (CoreCLR's
-    /// `endPtr == val` arm) or the parsed value would overflow `uint32`
-    /// (CoreCLR's `errno == ERANGE` arm). The caller treats `None` as
-    /// the default `0`, i.e. disabled.
+    /// We return `None` in CoreCLR's two failure arms only:
+    ///   * `endPtr == val` — no digits were consumed.
+    ///   * `errno == ERANGE` — either the magnitude exceeded `uint64`
+    ///     (`strtoul` itself sets ERANGE, regardless of sign) or the
+    ///     magnitude fit in 64 bits but was positive and exceeded
+    ///     `UINT32_MAX` (PAL's HOST_64BIT post-processing arm). The
+    ///     caller treats `None` as the default `0`, i.e. disabled.
     ///
     /// `IsEventSourceLoggingEnabled` only asks whether the parsed value
     /// is non-zero, but the parser is shaped to surface the full DWORD
@@ -74,18 +93,34 @@ module NativeEventSource =
                 let hexBody = trimmed.Substring (bodyStart, idx - bodyStart)
 
                 match
-                    System.UInt32.TryParse (
+                    System.UInt64.TryParse (
                         hexBody,
                         System.Globalization.NumberStyles.HexNumber,
                         System.Globalization.CultureInfo.InvariantCulture
                     )
                 with
-                | true, value -> if negate then Some (0u - value) else Some value
                 | false, _ ->
-                    // Overflow — `wcstoul` sets `errno = ERANGE`, and
-                    // `GetConfigDWORD` rejects via that arm. Surface as
-                    // `None` so the caller falls back to the default.
+                    // Magnitude exceeds `uint64`, so glibc `strtoul`
+                    // itself sets `errno = ERANGE`. PAL_wcstoul never
+                    // clears that errno (its HOST_64BIT post-processing
+                    // only adds an additional ERANGE arm for positive
+                    // 32-bit overflows), so `GetConfigDWORD` rejects
+                    // via the errno arm for both signs.
                     None
+                | true, magnitude ->
+                    if (not negate) && magnitude > uint64 System.UInt32.MaxValue then
+                        // Positive value whose magnitude exceeds
+                        // UINT32_MAX. PAL_wcstoul's HOST_64BIT branch
+                        // clamps to UINT32_MAX and sets `errno = ERANGE`,
+                        // which `GetConfigDWORD` then rejects.
+                        None
+                    else
+                        // Negation happens in `unsigned long` (mod 2^64)
+                        // inside strtoul, and the final `(ULONG)res`
+                        // cast truncates to the low 32 bits. We mirror
+                        // both steps explicitly.
+                        let wrapped = if negate then 0UL - magnitude else magnitude
+                        Some (uint32 wrapped)
 
     /// Look up a CLRConfig string knob in the guest's emulated environment,
     /// mirroring CoreCLR's `EnvGetString` priority: try `DOTNET_<name>` first,

--- a/WoofWare.PawPrint/Native/NativeEventSource.fs
+++ b/WoofWare.PawPrint/Native/NativeEventSource.fs
@@ -1,0 +1,81 @@
+namespace WoofWare.PawPrint
+
+[<RequireQualifiedAccess>]
+module NativeEventSource =
+    /// QCalls declared on `System.Diagnostics.Tracing.XplatEventLogger` and reached
+    /// from CoreLib only when `FEATURE_EVENTSOURCE_XPLAT` was defined at CoreLib
+    /// build time (i.e. the Linux-built `System.Private.CoreLib`). They are still
+    /// registered unconditionally because PawPrint always dispatches against the
+    /// host runtime's CoreLib, which can be the Linux one on a Linux dev box or
+    /// CI runner.
+    ///
+    /// PawPrint does not connect to any external tracing consumer (LTTng,
+    /// EventPipe, etc.), so the deterministic answers are:
+    ///   * `EventSource_GetClrConfig`: report "no config set" by returning a
+    ///     null UTF-16 pointer. CoreLib's `new string((char*)null)` then yields
+    ///     `String.Empty`, matching real CoreCLR when the named config knob is
+    ///     unset (see NativeString.fs / `String..ctor(char*)`).
+    ///   * `IsEventSourceLoggingEnabled`: return `FALSE` so
+    ///     `XplatEventLogger.InitializePersistentListener` skips creating the
+    ///     listener entirely. This is the truthful answer in a host with no
+    ///     tracing consumer attached.
+    ///   * `LogEventSource`: void no-op. With `IsEventSourceLoggingEnabled`
+    ///     returning false the listener is never created and this entry point
+    ///     should be unreachable from `OnEventWritten`, but implementing it
+    ///     defensively keeps PawPrint robust against guests that import it
+    ///     directly.
+    let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : NativeHandlerResult option =
+        let state = ctx.State
+        let instruction = ctx.Instruction
+
+        match
+            entryPoint,
+            ctx.TargetAssembly.Name.Name,
+            ctx.TargetType.Namespace,
+            ctx.TargetType.Name,
+            instruction.ExecutingMethod.Signature.ParameterTypes,
+            instruction.ExecutingMethod.Signature.ReturnType
+        with
+        | "EventSource_GetClrConfig",
+          "System.Private.CoreLib",
+          "System.Diagnostics.Tracing",
+          "XplatEventLogger",
+          [ ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt16) ],
+          MethodReturnType.Returns (ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.Char)) ->
+            // The single argument is the UTF-16 config-name pointer (marshalled
+            // from the C# `string` parameter); intentionally not read because
+            // PawPrint has no configured EventSource knobs.
+            state
+            |> IlMachineState.pushToEvalStack' (EvalStackValue.ManagedPointer ManagedPointerSource.Null) ctx.Thread
+            |> NativeHandlerResult.completed
+            |> Some
+
+        | "IsEventSourceLoggingEnabled",
+          "System.Private.CoreLib",
+          "System.Diagnostics.Tracing",
+          "XplatEventLogger",
+          [],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
+            // The C# wrapper carries `[return: MarshalAs(UnmanagedType.Bool)]`,
+            // which causes the LibraryImport source generator to declare the
+            // underlying QCall as `int32`-returning (the wrapper converts via
+            // `cgt.un`). Push 0 (FALSE) — we have no tracing consumer.
+            state
+            |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread
+            |> NativeHandlerResult.completed
+            |> Some
+
+        | "LogEventSource",
+          "System.Private.CoreLib",
+          "System.Diagnostics.Tracing",
+          "XplatEventLogger",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32
+            ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt16)
+            ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt16)
+            ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.UInt16) ],
+          MethodReturnType.Void ->
+            // No-op: PawPrint discards the event. Arguments (event ID, event
+            // name, event source name, payload) are intentionally not read.
+            state |> NativeHandlerResult.completed |> Some
+
+        | _ -> None

--- a/WoofWare.PawPrint/Native/NativeEventSource.fs
+++ b/WoofWare.PawPrint/Native/NativeEventSource.fs
@@ -3,42 +3,89 @@ namespace WoofWare.PawPrint
 [<RequireQualifiedAccess>]
 module NativeEventSource =
     /// Parse a CLRConfig DWORD env-var value the way CoreCLR does for
-    /// `EnableEventLog`: `wcstoul(val, &endPtr, 16)` — hex by default, with the
-    /// optional `0x` prefix tolerated. Returns `None` if the value is empty or
-    /// fails to parse (CoreCLR's `GetConfigDWORD` falls back to the default
-    /// value, which is `0` for `EnableEventLog`).
+    /// `EnableEventLog` — `u16_strtoul(val, &endPtr, 16)` with the
+    /// success condition `errno != ERANGE && endPtr != val` (see
+    /// `GetConfigDWORD` in `clrconfig.cpp:228`). The radix is 16
+    /// because `EnableEventLog` is declared via `RETAIL_CONFIG_DWORD_INFO`
+    /// with no `ParseIntegerAsBase10` flag (`clrconfigvalues.h:580`).
     ///
-    /// `EnableEventLog` is declared via `RETAIL_CONFIG_DWORD_INFO` with no
-    /// `ParseIntegerAsBase10` flag (see `clrconfigvalues.h:580`), so the radix
-    /// is 16. Both `1` and `0x1` therefore mean TRUE; `10` means 16 (also
-    /// TRUE); `0` and `0x0` mean FALSE. We don't need the full DWORD value —
-    /// `IsEventSourceLoggingEnabled` only asks whether it's non-zero — but
-    /// the parser is shaped to surface the value so future knobs that care
-    /// about the numeric magnitude can reuse it.
+    /// To mirror `wcstoul` we:
+    ///   * skip leading whitespace;
+    ///   * accept a single optional `+` / `-` sign (negation wraps via
+    ///     two's complement, so `-1` becomes `0xFFFFFFFF` — non-zero,
+    ///     which the gate reads as TRUE);
+    ///   * accept (but do not require) an optional `0x` / `0X` radix
+    ///     prefix, but only when it is followed by at least one hex
+    ///     digit (otherwise the leading `0` is itself the digit and the
+    ///     `x` becomes a stop character);
+    ///   * consume the longest hex-digit prefix and ignore everything
+    ///     after it (so `1garbage` parses as 1, matching `wcstoul`).
+    ///
+    /// We return `None` iff no digits could be consumed (CoreCLR's
+    /// `endPtr == val` arm) or the parsed value would overflow `uint32`
+    /// (CoreCLR's `errno == ERANGE` arm). The caller treats `None` as
+    /// the default `0`, i.e. disabled.
+    ///
+    /// `IsEventSourceLoggingEnabled` only asks whether the parsed value
+    /// is non-zero, but the parser is shaped to surface the full DWORD
+    /// so future knobs that care about the numeric magnitude can reuse it.
     ///
     /// Exposed as `internal` so the test assembly can pin the parser's
     /// behaviour directly without going through the QCall dispatcher.
     let internal tryParseClrConfigDword (raw : string) : uint32 option =
-        let trimmed = raw.Trim ()
+        let isHexDigit (c : char) : bool =
+            (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+
+        let trimmed = raw.TrimStart ()
 
         if System.String.IsNullOrEmpty trimmed then
             None
         else
-            let hexBody =
-                if trimmed.StartsWith ("0x", System.StringComparison.OrdinalIgnoreCase) then
-                    trimmed.Substring 2
-                else
-                    trimmed
+            let signStart, negate =
+                match trimmed.[0] with
+                | '+' -> 1, false
+                | '-' -> 1, true
+                | _ -> 0, false
 
-            match
-                System.UInt32.TryParse (
-                    hexBody,
-                    System.Globalization.NumberStyles.HexNumber,
-                    System.Globalization.CultureInfo.InvariantCulture
-                )
-            with
-            | true, value -> Some value
-            | false, _ -> None
+            // Optional `0x` / `0X` radix prefix — only treated as a prefix
+            // when at least one hex digit follows it. Otherwise the `0`
+            // is itself the parsed digit and the `x` becomes the
+            // stop character (matching `wcstoul`'s longest-valid-prefix
+            // semantics).
+            let bodyStart =
+                if
+                    signStart + 2 < trimmed.Length
+                    && trimmed.[signStart] = '0'
+                    && (trimmed.[signStart + 1] = 'x' || trimmed.[signStart + 1] = 'X')
+                    && isHexDigit trimmed.[signStart + 2]
+                then
+                    signStart + 2
+                else
+                    signStart
+
+            let mutable idx = bodyStart
+
+            while idx < trimmed.Length && isHexDigit trimmed.[idx] do
+                idx <- idx + 1
+
+            if idx = bodyStart then
+                None
+            else
+                let hexBody = trimmed.Substring (bodyStart, idx - bodyStart)
+
+                match
+                    System.UInt32.TryParse (
+                        hexBody,
+                        System.Globalization.NumberStyles.HexNumber,
+                        System.Globalization.CultureInfo.InvariantCulture
+                    )
+                with
+                | true, value -> if negate then Some (0u - value) else Some value
+                | false, _ ->
+                    // Overflow — `wcstoul` sets `errno = ERANGE`, and
+                    // `GetConfigDWORD` rejects via that arm. Surface as
+                    // `None` so the caller falls back to the default.
+                    None
 
     /// Look up a CLRConfig string knob in the guest's emulated environment,
     /// mirroring CoreCLR's `EnvGetString` priority: try `DOTNET_<name>` first,

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -66,6 +66,13 @@ module NativeQCall =
             "EventPipeInternal_SignalSession", NativeEventPipe.tryExecuteQCall "EventPipeInternal_SignalSession"
             "EventPipeInternal_WaitForSessionSignal",
             NativeEventPipe.tryExecuteQCall "EventPipeInternal_WaitForSessionSignal"
+            // `XplatEventLogger` QCalls, present only in Linux-built CoreLibs
+            // (FEATURE_EVENTSOURCE_XPLAT). PawPrint never connects to an
+            // external tracing consumer, so the deterministic answers are
+            // "no knob set" / "logging disabled" / "no-op".
+            "EventSource_GetClrConfig", NativeEventSource.tryExecuteQCall "EventSource_GetClrConfig"
+            "IsEventSourceLoggingEnabled", NativeEventSource.tryExecuteQCall "IsEventSourceLoggingEnabled"
+            "LogEventSource", NativeEventSource.tryExecuteQCall "LogEventSource"
             "Signature_Init", NativeSignature.tryExecuteQCall "Signature_Init"
             "Signature_GetCustomModifiersAtOffset",
             NativeSignature.tryExecuteQCall "Signature_GetCustomModifiersAtOffset"

--- a/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
+++ b/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
@@ -113,6 +113,7 @@
     <Compile Include="Native\NativeThreading.fs" />
     <Compile Include="Native\NativeDebugger.fs" />
     <Compile Include="Native\NativeEventPipe.fs" />
+    <Compile Include="Native\NativeEventSource.fs" />
     <Compile Include="Native\NativeCustomAttribute.fs" />
     <Compile Include="Native\NativeQCall.fs" />
     <Compile Include="Native\NativeType.fs" />


### PR DESCRIPTION
## Summary

Implements the three `XplatEventLogger` QCalls (`EventSource_GetClrConfig`, `IsEventSourceLoggingEnabled`, `LogEventSource`) directly in a new `NativeEventSource` module. These QCalls are only present in CoreLibs built with `FEATURE_EVENTSOURCE_XPLAT` (the Linux build), but PawPrint always dispatches against the host runtime's CoreLib, so they must be registered unconditionally.

The handlers honour the guest's emulated environment rather than no-opping:

- **`EventSource_GetClrConfig(name)`** looks up `DOTNET_<name>` (falling back to `COMPlus_<name>`) in `state.Kernel.Environment`, encodes the value as a freshly-allocated UTF-16 buffer with a NUL terminator, and returns the pointer. Unset/empty values yield a null pointer (CoreLib's `new string((char*)null)` then collapses to `String.Empty`), matching CoreCLR's `GetConfigString` and `EnvGetString` behaviour (`clrconfig.cpp:131`, `:288`).

- **`IsEventSourceLoggingEnabled()`** parses `DOTNET_EnableEventLog` as a CLRConfig DWORD and returns `Int32 1` iff the parsed value is non-zero. Defaults to disabled when the knob is unset or unparseable. This faithfully mirrors `XplatEventLogger::IsEventLoggingEnabled()` (`eventtracebase.h:489`) — when it returns false, `InitializePersistentListener` short-circuits and `LogEventSource` is unreachable. The C# wrapper carries `[return: MarshalAs(UnmanagedType.Bool)]`, so the underlying QCall is `int32`-returning; the wrapper converts via `cgt.un`.

- **`LogEventSource(...)`** fails loud. It is only reachable when the guest enables tracing via `DOTNET_EnableEventLog`, and PawPrint has no LTTng / EventPipe consumer to forward events to. Silently dropping the event would lose data the guest asked us to surface; the failwith points at the opt-out knob (`DOTNET_EnableEventLog=0`) for guests that don't actually care about the trace stream.

### `tryParseClrConfigDword`: matching CoreCLR's PAL_wcstoul

`EnableEventLog` is declared via `RETAIL_CONFIG_DWORD_INFO` with no `ParseIntegerAsBase10` flag (`clrconfigvalues.h:580`), so `GetConfigDWORD` (`clrconfig.cpp:228`) parses with radix 16. The implementation mirrors the Unix PAL's `PAL_wcstoul` (`pal/src/cruntime/wchar.cpp:281-324`), which wraps glibc `strtoul` on a 64-bit host (`unsigned long` is 64-bit):

- Skip leading whitespace; accept an optional `+` / `-` sign.
- Accept an optional `0x` / `0X` radix prefix, but only when at least one hex digit follows it (otherwise the leading `0` is itself the parsed digit and `x` is the stop character).
- Consume the longest hex-digit prefix and ignore everything after it (so `1garbage` parses as `1`).
- Parse the magnitude as `uint64`, then apply the sign in 64-bit arithmetic and truncate to `uint32`. This captures the PAL's HOST_64BIT special case: a negative input whose magnitude exceeds `UINT32_MAX` is **not** rejected — `strtoul` parses it in 64-bit, two's-complement wraps the negation, and the PAL's final `(ULONG)res` cast truncates to the low 32 bits without setting `ERANGE`. So `DOTNET_EnableEventLog=-100000001` enables logging on real CoreCLR (low 32 bits = `0xFFFFFFFF`).
- Return `None` only in CoreCLR's two failure arms: `endPtr == val` (no digits consumed) or `errno == ERANGE` (magnitude exceeded `uint64`, or positive magnitude exceeded `UINT32_MAX` — the PAL's HOST_64BIT clamp-and-set-ERANGE arm). The caller treats `None` as the default `0`, i.e. disabled.

### Files

- `WoofWare.PawPrint/Native/NativeEventSource.fs` — new module with the three handlers, the parser, and the env-lookup helper.
- `WoofWare.PawPrint/Native/NativeQCall.fs` — registers the three handlers.
- `WoofWare.PawPrint/WoofWare.PawPrint.fsproj` — adds the new file.
- `WoofWare.PawPrint.Test/TestNativeEventSource.fs` — 24 direct tests (see below).
- `WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — adds the new test file.

## Test plan

The macOS CoreLib does not contain `XplatEventLogger` (it's `FEATURE_EVENTSOURCE_XPLAT`-gated for Linux), so we can't drive the new handlers through a normal end-to-end IL fixture on the local dev box. Instead, the tests build a synthetic `NativeCallContext` directly: a real concretized donor method (`Thread.YieldInternal`) has its `Signature` overridden to the shape each test needs, and a record-updated `TypeInfo` provides the `XplatEventLogger` namespace/name. The dispatcher reads neither the donor identity nor the donor declaring type, so this is sound.

- [x] **Pure helper tests** (10):
    - `tryParseClrConfigDword`: empty/whitespace → None; hex by default; `0x` prefix tolerated; longest-prefix parsing (`1garbage` → 1, `ff thanks` → 0xff, `0XYZ` → 0); `0x` without trailing hex parses the leading `0`; sign with two's-complement wraparound (`+1` → 1, `-1` → 0xFFFFFFFF, `-0` → 0); leading whitespace skipped; positive overflow past UINT32_MAX → None (PAL HOST_64BIT ERANGE arm); negative overflow past UINT32_MAX truncates to low 32 bits (Codex-flagged case: `-100000001` → 0xFFFFFFFF, `-100000000` → 0, `-1FFFFFFFF` → 1); no-digits → None.
    - `lookupClrConfigString`: `DOTNET_` wins over `COMPlus_`; `COMPlus_` fallback when `DOTNET_` unset; empty value treated as unset (mirrors CoreCLR's `*ret != W('\0')` filter); nothing set → None.

- [x] **Dispatcher tests for `IsEventSourceLoggingEnabled`** (9): unset → 0; `=0` → 0; `=1` → 1; hex `10` (= 16) → 1; `COMPlus_EnableEventLog=1` wired up; malformed value with no parseable digits → 0; `=-1` enables (wcstoul wraps to `0xFFFFFFFF`); `=1garbage` enables (longest-prefix parse); `=-100000001` enables (PAL_wcstoul 64-bit wrap — Codex-flagged regression).

- [x] **Dispatcher test for `LogEventSource`** (1): synthesizes the 4-arg signature and asserts the failwith fires with a message that points at the `DOTNET_EnableEventLog=0` opt-out.

- [x] Full local test suite passes: 1376 tests on macOS (`nix develop -c dotnet test --configuration Release`).
- [x] Two rounds of `codex review --base main`; final review returned no actionable findings.
- [ ] Linux CI exercises the new handlers through CoreLib's `XplatEventLogger` callers as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)