### PR TITLE
Carry EventDefinitionHandle on EventDefn

### DIFF
--- a/WoofWare.PawPrint.Domain/EventDefn.fs
+++ b/WoofWare.PawPrint.Domain/EventDefn.fs
@@ -5,6 +5,10 @@ open System.Reflection.Metadata
 
 type EventDefn =
     {
+        /// The metadata handle identifying this event's row in the Event table
+        /// (ECMA-335 §II.22.13). Meaningful only relative to the assembly whose
+        /// MetadataReader produced it.
+        Handle : EventDefinitionHandle
         Name : string
         Attrs : EventAttributes
     }
@@ -12,10 +16,11 @@ type EventDefn =
 [<RequireQualifiedAccess>]
 module EventDefn =
 
-    let make (mr : MetadataReader) (event : EventDefinition) : EventDefn =
+    let make (mr : MetadataReader) (handle : EventDefinitionHandle) (event : EventDefinition) : EventDefn =
         let name = mr.GetString event.Name
 
         {
+            Handle = handle
             Name = name
             Attrs = event.Attributes
         }

--- a/WoofWare.PawPrint.Domain/TypeInfo.fs
+++ b/WoofWare.PawPrint.Domain/TypeInfo.fs
@@ -367,7 +367,7 @@ module TypeInfo =
 
             for evt in typeDef.GetEvents () do
                 metadataReader.GetEventDefinition evt
-                |> EventDefn.make metadataReader
+                |> EventDefn.make metadataReader evt
                 |> result.Add
 
             result.ToImmutable ()


### PR DESCRIPTION
## Summary
- Add `Handle : EventDefinitionHandle` to `EventDefn` and populate it in `EventDefn.make`.
- Update the sole construction site in `TypeInfo.fs` to pass the handle.

Discarded handles can't be looked up later. The upcoming IlDump attribute mode needs to query each event's `CustomAttributesByParentToken` entry, which requires its handle. This is the first of a small sequence of PRs preparing IlDump to dump custom attributes for types, methods, fields, events, properties, and generic parameters.

## Test plan
- [x] `nix develop -c dotnet build WoofWare.PawPrint.slnx` — clean.
- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 1387/1387 pass.
- [x] `nix develop -c dotnet fantomas .` — no formatting changes.
- [x] `codex review --base main` — no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)