### PR TITLE
IlDump --attrs-only mode for custom attributes

### DIFF
--- a/WoofWare.PawPrint.Domain/AttributeFormatting.fs
+++ b/WoofWare.PawPrint.Domain/AttributeFormatting.fs
@@ -189,10 +189,42 @@ module AttributeFormatting =
             | false, _ -> $"MemberRef(%O{handle})"
         | other -> sprintf "%O" other
 
+    /// Substitute occurrences of <c>GenericTypeParameter idx</c> in
+    /// <paramref name="td"/> with the corresponding type from
+    /// <paramref name="typeArgs"/>. Out-of-range indices are left unchanged so
+    /// the consumer can still distinguish "no substitution possible" from a
+    /// successful resolution. <c>GenericMethodParameter</c> is *not* touched —
+    /// those are bound by the enclosing method, not the type spec.
+    let rec private substituteTypeArgs (typeArgs : TypeDefn list) (td : TypeDefn) : TypeDefn =
+        match td with
+        | TypeDefn.GenericTypeParameter idx when idx >= 0 && idx < List.length typeArgs -> List.item idx typeArgs
+        | TypeDefn.Array (elt, rank) -> TypeDefn.Array (substituteTypeArgs typeArgs elt, rank)
+        | TypeDefn.OneDimensionalArrayLowerBoundZero elt ->
+            TypeDefn.OneDimensionalArrayLowerBoundZero (substituteTypeArgs typeArgs elt)
+        | TypeDefn.Pinned t -> TypeDefn.Pinned (substituteTypeArgs typeArgs t)
+        | TypeDefn.Pointer t -> TypeDefn.Pointer (substituteTypeArgs typeArgs t)
+        | TypeDefn.Byref t -> TypeDefn.Byref (substituteTypeArgs typeArgs t)
+        | TypeDefn.Modified (orig, after, req) ->
+            TypeDefn.Modified (substituteTypeArgs typeArgs orig, substituteTypeArgs typeArgs after, req)
+        | TypeDefn.GenericInstantiation (generic, args) ->
+            let generic' = substituteTypeArgs typeArgs generic
+
+            let args' =
+                args
+                |> Seq.map (substituteTypeArgs typeArgs)
+                |> System.Collections.Immutable.ImmutableArray.CreateRange
+
+            TypeDefn.GenericInstantiation (generic', args')
+        | _ -> td
+
     /// Resolve the parameter types declared on the attribute's constructor, so
     /// that the blob reader can be invoked. Returns <c>None</c> if the ctor
     /// token is not a kind we know how to look up (e.g. MethodSpec) or the
-    /// member-ref signature is a field rather than a method.
+    /// member-ref signature is a field rather than a method. When the parent
+    /// of a MemberRef is a <c>TypeSpecification</c> holding a closed generic,
+    /// the TypeSpec's args are substituted into the ctor's parameter types so
+    /// a parameter declared as <c>T</c> resolves to its concrete instantiation
+    /// before the blob decoder runs.
     let private tryConstructorParamTypes (assembly : DumpedAssembly) (attr : CustomAttribute) : TypeDefn list option =
         match attr.Constructor with
         | MetadataToken.MethodDef handle ->
@@ -203,7 +235,21 @@ module AttributeFormatting =
             match assembly.Members.TryGetValue handle with
             | true, m ->
                 match m.Signature with
-                | MemberSignature.Method ms -> Some ms.ParameterTypes
+                | MemberSignature.Method ms ->
+                    let paramTypes =
+                        match m.Parent with
+                        | MetadataToken.TypeSpecification tsHandle ->
+                            match assembly.TypeSpecs.TryGetValue tsHandle with
+                            | true, ts ->
+                                match ts.Signature with
+                                | TypeDefn.GenericInstantiation (_, typeArgs) ->
+                                    let argList = List.ofSeq typeArgs
+                                    ms.ParameterTypes |> List.map (substituteTypeArgs argList)
+                                | _ -> ms.ParameterTypes
+                            | false, _ -> ms.ParameterTypes
+                        | _ -> ms.ParameterTypes
+
+                    Some paramTypes
                 | MemberSignature.Field _ -> None
             | false, _ -> None
         | _ -> None
@@ -237,8 +283,11 @@ module AttributeFormatting =
         | CustomAttribFixedArg.U4 v -> sprintf "%du" v
         | CustomAttribFixedArg.I8 v -> sprintf "%dL" v
         | CustomAttribFixedArg.U8 v -> sprintf "%duL" v
-        | CustomAttribFixedArg.R4 v -> sprintf "%gf" v
-        | CustomAttribFixedArg.R8 v -> sprintf "%g" v
+        | CustomAttribFixedArg.R4 v ->
+            // "R" round-trips the metadata-stored bit pattern; "%g"'s default
+            // precision silently truncates values like 1.234567f.
+            sprintf "%sf" (v.ToString ("R", System.Globalization.CultureInfo.InvariantCulture))
+        | CustomAttribFixedArg.R8 v -> v.ToString ("R", System.Globalization.CultureInfo.InvariantCulture)
         | CustomAttribFixedArg.String None -> "null"
         | CustomAttribFixedArg.String (Some s) -> sprintf "\"%s\"" (IlFormatting.escapeStringLiteral s)
         | CustomAttribFixedArg.Array None -> "null"

--- a/WoofWare.PawPrint.Domain/AttributeFormatting.fs
+++ b/WoofWare.PawPrint.Domain/AttributeFormatting.fs
@@ -1,0 +1,280 @@
+namespace WoofWare.PawPrint
+
+open System
+open System.Reflection.Metadata.Ecma335
+
+/// <summary>
+/// Helpers for rendering custom attribute applications in the comment-prefixed
+/// IlDump style. The "Attribute" suffix on attribute type names is stripped
+/// (so <c>SerializableAttribute</c> renders as <c>[Serializable]</c>); blobs
+/// whose ctor signature the reader can't decode fall back to a raw hex dump.
+/// </summary>
+[<RequireQualifiedAccess>]
+module AttributeFormatting =
+
+    /// <summary>
+    /// Returns the custom attributes applied to <paramref name="parent"/> via the
+    /// assembly's <c>CustomAttributesByParentToken</c> index, materialised from the
+    /// <c>Attributes</c> dictionary. Attribute order matches the metadata order.
+    /// </summary>
+    let attributesFor (assembly : DumpedAssembly) (parent : MetadataToken) : CustomAttribute list =
+        let parentRawToken = MetadataToken.toInt parent
+
+        match assembly.CustomAttributesByParentToken.TryGetValue parentRawToken with
+        | false, _ -> []
+        | true, attrTokens ->
+            attrTokens
+            |> Seq.choose (fun t ->
+                let rowNum = t &&& 0x00FFFFFF
+                let handle = MetadataTokens.CustomAttributeHandle rowNum
+
+                match assembly.Attributes.TryGetValue handle with
+                | true, attr -> Some attr
+                | false, _ -> None
+            )
+            |> List.ofSeq
+
+    /// Strip a trailing "Attribute" suffix from a simple type name. The bare
+    /// name "Attribute" is preserved (no infinite-strip).
+    let private stripAttributeSuffix (name : string) : string =
+        let suffix = "Attribute"
+
+        if name.EndsWith (suffix, StringComparison.Ordinal) && name.Length > suffix.Length then
+            name.Substring (0, name.Length - suffix.Length)
+        else
+            name
+
+    /// Apply <c>stripAttributeSuffix</c> to the last name segment of a qualified
+    /// type name (segments are separated by '.' or '/'). The namespace prefix
+    /// and any outer-type prefix are preserved unchanged.
+    let private stripAttributeSuffixOnLastSegment (qualified : string) : string =
+        let lastSlash = qualified.LastIndexOf '/'
+        let lastDot = qualified.LastIndexOf '.'
+        let sep = max lastSlash lastDot
+
+        if sep < 0 then
+            stripAttributeSuffix qualified
+        else
+            let head = qualified.Substring (0, sep + 1)
+            let tail = qualified.Substring (sep + 1)
+            head + stripAttributeSuffix tail
+
+    /// <summary>
+    /// The display name of the attribute type, i.e. the type whose constructor
+    /// <paramref name="attr"/>.Constructor points at. The conventional trailing
+    /// <c>Attribute</c> suffix is stripped from the simple name; the namespace
+    /// (and any outer-type prefix for nested attribute types) is retained.
+    /// </summary>
+    let attributeTypeName (assembly : DumpedAssembly) (attr : CustomAttribute) : string =
+        match attr.Constructor with
+        | MetadataToken.MethodDef handle ->
+            match assembly.Methods.TryGetValue handle with
+            | true, m ->
+                let typeHandle = m.DeclaringType.Definition.Get
+
+                match assembly.TypeDefs.TryGetValue typeHandle with
+                | true, td ->
+                    IlFormatting.qualifyTypeName assembly.TypeDefs td
+                    |> stripAttributeSuffixOnLastSegment
+                | false, _ -> $"TypeDef(%O{typeHandle})"
+            | false, _ -> $"MethodDef(%O{handle})"
+        | MetadataToken.MemberReference handle ->
+            match assembly.Members.TryGetValue handle with
+            | true, m ->
+                IlFormatting.formatMetadataToken assembly m.Parent
+                |> stripAttributeSuffixOnLastSegment
+            | false, _ -> $"MemberRef(%O{handle})"
+        | other -> sprintf "%O" other
+
+    /// Resolve the parameter types declared on the attribute's constructor, so
+    /// that the blob reader can be invoked. Returns <c>None</c> if the ctor
+    /// token is not a kind we know how to look up (e.g. MethodSpec) or the
+    /// member-ref signature is a field rather than a method.
+    let private tryConstructorParamTypes (assembly : DumpedAssembly) (attr : CustomAttribute) : TypeDefn list option =
+        match attr.Constructor with
+        | MetadataToken.MethodDef handle ->
+            match assembly.Methods.TryGetValue handle with
+            | true, m -> Some m.RawSignature.ParameterTypes
+            | false, _ -> None
+        | MetadataToken.MemberReference handle ->
+            match assembly.Members.TryGetValue handle with
+            | true, m ->
+                match m.Signature with
+                | MemberSignature.Method ms -> Some ms.ParameterTypes
+                | MemberSignature.Field _ -> None
+            | false, _ -> None
+        | _ -> None
+
+    /// <summary>
+    /// Render a single decoded fixed arg in a form suitable for inclusion in a
+    /// <c>[Attr(...)]</c> application. Strings and chars are escaped via
+    /// <see cref="IlFormatting.escapeStringLiteral"/>; SZARRAYs render as
+    /// brace-delimited element lists; the null variants of String and Array
+    /// both render as <c>null</c>.
+    /// </summary>
+    let rec formatFixedArg (arg : CustomAttribFixedArg) : string =
+        match arg with
+        | CustomAttribFixedArg.Bool b -> if b then "true" else "false"
+        | CustomAttribFixedArg.Char c -> sprintf "'%s'" (IlFormatting.escapeStringLiteral (string c))
+        | CustomAttribFixedArg.I1 v -> sprintf "%dy" v
+        | CustomAttribFixedArg.U1 v -> sprintf "%duy" v
+        | CustomAttribFixedArg.I2 v -> sprintf "%ds" v
+        | CustomAttribFixedArg.U2 v -> sprintf "%dus" v
+        | CustomAttribFixedArg.I4 v -> sprintf "%d" v
+        | CustomAttribFixedArg.U4 v -> sprintf "%du" v
+        | CustomAttribFixedArg.I8 v -> sprintf "%dL" v
+        | CustomAttribFixedArg.U8 v -> sprintf "%duL" v
+        | CustomAttribFixedArg.R4 v -> sprintf "%gf" v
+        | CustomAttribFixedArg.R8 v -> sprintf "%g" v
+        | CustomAttribFixedArg.String None -> "null"
+        | CustomAttribFixedArg.String (Some s) -> sprintf "\"%s\"" (IlFormatting.escapeStringLiteral s)
+        | CustomAttribFixedArg.Array None -> "null"
+        | CustomAttribFixedArg.Array (Some elts) ->
+            let inner = elts |> List.map formatFixedArg |> String.concat ", "
+            sprintf "{ %s }" inner
+
+    /// Dump the attribute's raw <c>Value</c> blob as space-separated hex bytes.
+    /// Used when the structured decoder can't make progress.
+    let private formatBlobAsHex (attr : CustomAttribute) : string =
+        attr.Value |> Seq.map (sprintf "%02X") |> String.concat " "
+
+    /// Decoded form of a blob: positional args and the raw <c>NumNamed</c>
+    /// count (so callers can surface its presence without us having to decode
+    /// the named-args section in this PR).
+    type private DecodedBlob =
+        {
+            Args : CustomAttribFixedArg list
+            NumNamed : uint16
+        }
+
+    let private tryDecodeBlob (assembly : DumpedAssembly) (attr : CustomAttribute) : Result<DecodedBlob, string> =
+        match tryConstructorParamTypes assembly attr with
+        | None -> Error "unresolved ctor"
+        | Some paramTypes ->
+            match CustomAttribute.readFixedArgs paramTypes attr.Value with
+            | Error msg -> Error msg
+            | Ok (args, offset) ->
+                let numNamed =
+                    let remaining = attr.Value.Length - offset
+
+                    if remaining >= 2 then
+                        (uint16 attr.Value.[offset]) ||| ((uint16 attr.Value.[offset + 1]) <<< 8)
+                    else
+                        0us
+
+                Ok
+                    {
+                        Args = args
+                        NumNamed = numNamed
+                    }
+
+    /// <summary>
+    /// Render an attribute as <c>[Name(args) /* +N named */]</c>. Empty
+    /// positional argument lists collapse to <c>[Name]</c>; when there are no
+    /// positional args but named args are present, the comment trails the
+    /// name directly. Blobs whose ctor signature is unresolved or whose
+    /// decode fails fall back to a parenthesised hex dump.
+    /// </summary>
+    let formatAttributeApplication (assembly : DumpedAssembly) (attr : CustomAttribute) : string =
+        let name = attributeTypeName assembly attr
+
+        match tryDecodeBlob assembly attr with
+        | Error _ ->
+            if attr.Value.Length = 0 then
+                sprintf "[%s]" name
+            else
+                sprintf "[%s(/* blob: %s */)]" name (formatBlobAsHex attr)
+        | Ok decoded ->
+            let argsClause =
+                if List.isEmpty decoded.Args then
+                    ""
+                else
+                    let argsStr = decoded.Args |> List.map formatFixedArg |> String.concat ", "
+
+                    sprintf "(%s)" argsStr
+
+            let namedSuffix =
+                if decoded.NumNamed = 0us then
+                    ""
+                else
+                    sprintf " /* +%d named */" decoded.NumNamed
+
+            sprintf "[%s%s%s]" name argsClause namedSuffix
+
+    /// Render the generic-parameter clause shown after a type or method name
+    /// (e.g. <c>&lt;T, U&gt;</c>). Returns <c>""</c> if there are no generics.
+    let private formatGenericsClause (generics : GenericParamFromMetadata seq) : string =
+        let names = generics |> Seq.map (fun (param, _) -> param.Name) |> List.ofSeq
+
+        if List.isEmpty names then
+            ""
+        else
+            sprintf "<%s>" (String.concat ", " names)
+
+    /// <summary>
+    /// Comment-prefixed header for a TypeDef in attribute-dump mode,
+    /// including a <c>&lt;T, U&gt;</c> clause when the type is generic.
+    /// </summary>
+    let typeHeader (assembly : DumpedAssembly) (typeInfo : TypeInfo<GenericParamFromMetadata, TypeDefn>) : string =
+        let qualified = IlFormatting.qualifyTypeName assembly.TypeDefs typeInfo
+        let generics = formatGenericsClause typeInfo.Generics
+        sprintf "// type %s%s" qualified generics
+
+    /// <summary>
+    /// Comment-prefixed header for a MethodDef in attribute-dump mode. The
+    /// owning type's qualified name is supplied by the caller (so a type-level
+    /// walk doesn't re-resolve it per method).
+    /// </summary>
+    let methodHeader
+        (qualifiedTypeName : string)
+        (method : MethodInfo<GenericParamFromMetadata, GenericParamFromMetadata, TypeDefn>)
+        : string
+        =
+        let staticStr = if method.IsStatic then "static " else ""
+        let generics = formatGenericsClause method.Generics
+
+        let paramTypes =
+            method.RawSignature.ParameterTypes
+            |> List.map (fun p -> sprintf "%O" p)
+            |> String.concat ", "
+
+        sprintf
+            "// method %s::%s%s%s(%s) : %O"
+            qualifiedTypeName
+            staticStr
+            method.Name
+            generics
+            paramTypes
+            method.RawSignature.ReturnType
+
+    /// Comment-prefixed header for a FieldDef.
+    let fieldHeader (qualifiedTypeName : string) (field : FieldInfo<GenericParamFromMetadata, TypeDefn>) : string =
+        sprintf "// field %s::%s : %O" qualifiedTypeName field.Name field.Signature
+
+    /// Comment-prefixed header for an EventDef.
+    let eventHeader (qualifiedTypeName : string) (event : EventDefn) : string =
+        sprintf "// event %s::%s" qualifiedTypeName event.Name
+
+    /// Comment-prefixed header for a PropertyDef. PropertyDef has no domain
+    /// type, so the name is supplied by the IlDump caller after reading the
+    /// metadata reader's PropertyDefinitions table.
+    let propertyHeader (qualifiedTypeName : string) (propertyName : string) : string =
+        sprintf "// property %s::%s" qualifiedTypeName propertyName
+
+    /// <summary>
+    /// Render an owner header followed by one indented <c>[Attr(args)]</c>
+    /// line per attribute, or an empty list if the owner has no attributes.
+    /// The header is always a comment-prefixed line so it interleaves with
+    /// the existing IL-dump format.
+    /// </summary>
+    let renderOwnerLines (assembly : DumpedAssembly) (header : string) (parent : MetadataToken) : string list =
+        let attrs = attributesFor assembly parent
+
+        match attrs with
+        | [] -> []
+        | _ ->
+            [
+                yield header
+                for attr in attrs do
+                    yield sprintf "//   %s" (formatAttributeApplication assembly attr)
+            ]

--- a/WoofWare.PawPrint.Domain/AttributeFormatting.fs
+++ b/WoofWare.PawPrint.Domain/AttributeFormatting.fs
@@ -123,7 +123,8 @@ module AttributeFormatting =
         | TypeDefn.GenericInstantiation (generic, args) ->
             let baseName = renderAttributeTypeFromTypeDefn assembly generic
 
-            let argsStr = args |> Seq.map (fun a -> sprintf "%O" a) |> String.concat ", "
+            let argsStr =
+                args |> Seq.map (renderAttributeTypeFromTypeDefn assembly) |> String.concat ", "
 
             sprintf "%s<%s>" baseName argsStr
         | TypeDefn.FromDefinition (identity, _) ->
@@ -174,7 +175,8 @@ module AttributeFormatting =
                             let baseName =
                                 renderAttributeTypeFromTypeDefn assembly generic |> prettifyGenericAttributeBase
 
-                            let argsStr = args |> Seq.map (fun a -> sprintf "%O" a) |> String.concat ", "
+                            let argsStr =
+                                args |> Seq.map (renderAttributeTypeFromTypeDefn assembly) |> String.concat ", "
 
                             sprintf "%s<%s>" baseName argsStr
                         | other ->

--- a/WoofWare.PawPrint.Domain/AttributeFormatting.fs
+++ b/WoofWare.PawPrint.Domain/AttributeFormatting.fs
@@ -423,6 +423,17 @@ module AttributeFormatting =
     let propertyHeader (qualifiedTypeName : string) (propertyName : string) : string =
         sprintf "// property %s::%s" qualifiedTypeName propertyName
 
+    /// Comment-prefixed header for the assembly manifest row. The simple
+    /// assembly name is used (rather than the full versioned name) so the
+    /// header matches the style of the other comment-prefixed headers.
+    let assemblyHeader (assembly : DumpedAssembly) : string =
+        sprintf "// assembly %s" assembly.Name.Name
+
+    /// Comment-prefixed header for the module definition. The module name is
+    /// supplied by the caller after reading the metadata reader's
+    /// ModuleDefinition row.
+    let moduleHeader (moduleName : string) : string = sprintf "// module %s" moduleName
+
     /// <summary>
     /// Render an owner header followed by one indented <c>[Attr(args)]</c>
     /// line per attribute, or an empty list if the owner has no attributes.

--- a/WoofWare.PawPrint.Domain/AttributeFormatting.fs
+++ b/WoofWare.PawPrint.Domain/AttributeFormatting.fs
@@ -44,6 +44,22 @@ module AttributeFormatting =
         else
             name
 
+    /// Strip a CLI generic arity suffix (e.g. <c>`1</c>) from the end of a
+    /// simple name. Only digit sequences after a single backtick are removed;
+    /// anything else is returned unchanged.
+    let private stripGenericArity (name : string) : string =
+        let idx = name.LastIndexOf '`'
+
+        if idx > 0 && idx < name.Length - 1 then
+            let rest = name.Substring (idx + 1)
+
+            if rest |> Seq.forall Char.IsDigit then
+                name.Substring (0, idx)
+            else
+                name
+        else
+            name
+
     /// Apply <c>stripAttributeSuffix</c> to the last name segment of a qualified
     /// type name (segments are separated by '.' or '/'). The namespace prefix
     /// and any outer-type prefix are preserved unchanged.
@@ -59,11 +75,75 @@ module AttributeFormatting =
             let tail = qualified.Substring (sep + 1)
             head + stripAttributeSuffix tail
 
+    /// Apply <c>stripGenericArity</c> followed by <c>stripAttributeSuffix</c>
+    /// to the last name segment of a qualified type name. This is the rendering
+    /// the human reader wants for a generic attribute: <c>MyAttribute`1</c>
+    /// becomes <c>My</c>, ready for an explicit <c>&lt;args&gt;</c> suffix.
+    let private prettifyGenericAttributeBase (qualified : string) : string =
+        let lastSlash = qualified.LastIndexOf '/'
+        let lastDot = qualified.LastIndexOf '.'
+        let sep = max lastSlash lastDot
+
+        let head, tail =
+            if sep < 0 then
+                "", qualified
+            else
+                qualified.Substring (0, sep + 1), qualified.Substring (sep + 1)
+
+        head + (tail |> stripGenericArity |> stripAttributeSuffix)
+
+    /// Format a TypeRef as <c>Namespace.Name</c>, walking the
+    /// <c>ResolutionScope</c> chain to prefix any outer types (separated by
+    /// <c>/</c>). The leading namespace is omitted for nested types.
+    let private formatTypeRef (assembly : DumpedAssembly) (tr : TypeRef) : string =
+        let rec qualify (r : TypeRef) : string =
+            match r.ResolutionScope with
+            | TypeRefResolutionScope.TypeRef parentHandle ->
+                match assembly.TypeRefs.TryGetValue parentHandle with
+                | true, parent -> sprintf "%s/%s" (qualify parent) r.Name
+                | false, _ -> r.Name
+            | _ ->
+                if String.IsNullOrEmpty r.Namespace then
+                    r.Name
+                else
+                    sprintf "%s.%s" r.Namespace r.Name
+
+        qualify tr
+
+    /// <summary>
+    /// Render the display name of an attribute type expressed as a
+    /// <see cref="TypeDefn"/>: typically the signature of a
+    /// <c>TypeSpecification</c> used as the parent of a constructor
+    /// <c>MemberReference</c>. Generic instantiations are rendered as
+    /// <c>Base&lt;arg, ...&gt;</c>. Falls back to the TypeDefn's default
+    /// <c>ToString</c> when the inner type cannot be resolved locally.
+    /// </summary>
+    let rec private renderAttributeTypeFromTypeDefn (assembly : DumpedAssembly) (td : TypeDefn) : string =
+        match td with
+        | TypeDefn.GenericInstantiation (generic, args) ->
+            let baseName = renderAttributeTypeFromTypeDefn assembly generic
+
+            let argsStr = args |> Seq.map (fun a -> sprintf "%O" a) |> String.concat ", "
+
+            sprintf "%s<%s>" baseName argsStr
+        | TypeDefn.FromDefinition (identity, _) ->
+            if identity.AssemblyFullName = assembly.Name.FullName then
+                match assembly.TypeDefs.TryGetValue identity.TypeDefinition.Get with
+                | true, td -> IlFormatting.qualifyTypeName assembly.TypeDefs td
+                | false, _ -> sprintf "%O" td
+            else
+                sprintf "%O" td
+        | TypeDefn.FromReference (typeRef, _) -> formatTypeRef assembly typeRef
+        | _ -> sprintf "%O" td
+
     /// <summary>
     /// The display name of the attribute type, i.e. the type whose constructor
     /// <paramref name="attr"/>.Constructor points at. The conventional trailing
     /// <c>Attribute</c> suffix is stripped from the simple name; the namespace
     /// (and any outer-type prefix for nested attribute types) is retained.
+    /// Generic attributes whose ctor parent is a <c>TypeSpecification</c> are
+    /// rendered as <c>Base&lt;args&gt;</c>, with the suffix stripped from
+    /// <c>Base</c> rather than from the full <c>Base&lt;args&gt;</c> string.
     /// </summary>
     let attributeTypeName (assembly : DumpedAssembly) (attr : CustomAttribute) : string =
         match attr.Constructor with
@@ -81,8 +161,29 @@ module AttributeFormatting =
         | MetadataToken.MemberReference handle ->
             match assembly.Members.TryGetValue handle with
             | true, m ->
-                IlFormatting.formatMetadataToken assembly m.Parent
-                |> stripAttributeSuffixOnLastSegment
+                match m.Parent with
+                | MetadataToken.TypeSpecification tsHandle ->
+                    match assembly.TypeSpecs.TryGetValue tsHandle with
+                    | true, ts ->
+                        match ts.Signature with
+                        | TypeDefn.GenericInstantiation (generic, args) ->
+                            // Strip the CLI arity marker AND the "Attribute" suffix from
+                            // the generic *head*: an explicit "<args>" follows, so e.g.
+                            // "MyGenericAttribute`1" becomes "MyGeneric", which we then
+                            // combine with the rendered args.
+                            let baseName =
+                                renderAttributeTypeFromTypeDefn assembly generic |> prettifyGenericAttributeBase
+
+                            let argsStr = args |> Seq.map (fun a -> sprintf "%O" a) |> String.concat ", "
+
+                            sprintf "%s<%s>" baseName argsStr
+                        | other ->
+                            renderAttributeTypeFromTypeDefn assembly other
+                            |> stripAttributeSuffixOnLastSegment
+                    | false, _ -> $"TypeSpec(%O{tsHandle})"
+                | _ ->
+                    IlFormatting.formatMetadataToken assembly m.Parent
+                    |> stripAttributeSuffixOnLastSegment
             | false, _ -> $"MemberRef(%O{handle})"
         | other -> sprintf "%O" other
 
@@ -115,7 +216,17 @@ module AttributeFormatting =
     let rec formatFixedArg (arg : CustomAttribFixedArg) : string =
         match arg with
         | CustomAttribFixedArg.Bool b -> if b then "true" else "false"
-        | CustomAttribFixedArg.Char c -> sprintf "'%s'" (IlFormatting.escapeStringLiteral (string c))
+        | CustomAttribFixedArg.Char c ->
+            // escapeStringLiteral handles backslash and the usual whitespace/null escapes,
+            // but is targeted at double-quoted strings and so leaves '\'' as-is. Escape it
+            // here so a single-quote char doesn't render as the ambiguous '''.
+            let escaped =
+                if c = '\'' then
+                    "\\'"
+                else
+                    IlFormatting.escapeStringLiteral (string c)
+
+            sprintf "'%s'" escaped
         | CustomAttribFixedArg.I1 v -> sprintf "%dy" v
         | CustomAttribFixedArg.U1 v -> sprintf "%duy" v
         | CustomAttribFixedArg.I2 v -> sprintf "%ds" v

--- a/WoofWare.PawPrint.Domain/WoofWare.PawPrint.Domain.fsproj
+++ b/WoofWare.PawPrint.Domain/WoofWare.PawPrint.Domain.fsproj
@@ -38,6 +38,7 @@
         <Compile Include="Assembly.fs" />
         <Compile Include="AccessCheck.fs" />
         <Compile Include="IlFormatting.fs" />
+        <Compile Include="AttributeFormatting.fs" />
         <Compile Include="TypeConcretisation.fs" />
     </ItemGroup>
 

--- a/WoofWare.PawPrint.IlDump/Program.fs
+++ b/WoofWare.PawPrint.IlDump/Program.fs
@@ -2,10 +2,15 @@ namespace WoofWare.PawPrint.IlDump
 
 open System
 open System.IO
+open System.Reflection.Metadata
 open Microsoft.Extensions.Logging
 open WoofWare.PawPrint
 
 module Program =
+
+    type private Mode =
+        | Default
+        | AttrsOnly
 
     let private printMethod
         (assembly : DumpedAssembly)
@@ -18,16 +23,108 @@ module Program =
 
         printfn ""
 
+    /// Emit attribute-only output for a single type: the type's own attribute
+    /// lines (if any), followed by attribute lines for each filter-matching
+    /// method, field, property, and event. Members with no attributes are
+    /// silently skipped. The type header itself is only emitted if at least
+    /// one of those produces output. Returns true iff any lines were emitted.
+    let private printTypeAttrs
+        (assembly : DumpedAssembly)
+        (memberFilter : string option)
+        (typeInfo : TypeInfo<GenericParamFromMetadata, TypeDefn>)
+        : bool
+        =
+        let qualified = IlFormatting.qualifyTypeName assembly.TypeDefs typeInfo
+
+        let typeHeader = AttributeFormatting.typeHeader assembly typeInfo
+
+        let typeLines =
+            AttributeFormatting.renderOwnerLines
+                assembly
+                typeHeader
+                (MetadataToken.TypeDefinition typeInfo.TypeDefHandle)
+
+        let memberNameMatches (name : string) : bool =
+            match memberFilter with
+            | None -> true
+            | Some filter -> name.Contains (filter, StringComparison.OrdinalIgnoreCase)
+
+        let methodGroups =
+            typeInfo.Methods
+            |> List.filter (fun m -> memberNameMatches m.Name)
+            |> List.map (fun m ->
+                let header = AttributeFormatting.methodHeader qualified m
+                AttributeFormatting.renderOwnerLines assembly header (MetadataToken.MethodDef m.Handle)
+            )
+
+        let fieldGroups =
+            typeInfo.Fields
+            |> List.filter (fun f -> memberNameMatches f.Name)
+            |> List.map (fun f ->
+                let header = AttributeFormatting.fieldHeader qualified f
+                AttributeFormatting.renderOwnerLines assembly header (MetadataToken.FieldDefinition f.Handle)
+            )
+
+        // Properties live only in the metadata reader: there is no domain type.
+        let propertyGroups =
+            let mr = assembly.PeReader.GetMetadataReader ()
+            let typeDef = mr.GetTypeDefinition typeInfo.TypeDefHandle
+
+            [
+                for propHandle in typeDef.GetProperties () do
+                    let prop = mr.GetPropertyDefinition propHandle
+                    let name = mr.GetString prop.Name
+
+                    if memberNameMatches name then
+                        let header = AttributeFormatting.propertyHeader qualified name
+                        let token = MetadataToken.PropertyDefinition propHandle
+                        yield AttributeFormatting.renderOwnerLines assembly header token
+            ]
+
+        let eventGroups =
+            [
+                for evt in typeInfo.Events do
+                    if memberNameMatches evt.Name then
+                        let header = AttributeFormatting.eventHeader qualified evt
+                        let token = MetadataToken.EventDefinition evt.Handle
+                        yield AttributeFormatting.renderOwnerLines assembly header token
+            ]
+
+        let nonEmptyGroups =
+            [ typeLines ] @ methodGroups @ fieldGroups @ propertyGroups @ eventGroups
+            |> List.filter (not << List.isEmpty)
+
+        if List.isEmpty nonEmptyGroups then
+            false
+        else
+            let mutable first = true
+
+            for group in nonEmptyGroups do
+                if not first then
+                    printfn ""
+
+                for line in group do
+                    printfn $"%s{line}"
+
+                first <- false
+
+            true
+
     [<EntryPoint>]
     let main (argv : string[]) : int =
-        let args = argv |> Array.toList
+        let mode, args =
+            match Array.toList argv with
+            | "--attrs-only" :: rest -> Mode.AttrsOnly, rest
+            | other -> Mode.Default, other
 
         match args with
         | [] ->
-            eprintfn "Usage: dotnet run --project WoofWare.PawPrint.IlDump -- <dll-path> [TypeName] [MethodName]"
+            eprintfn
+                "Usage: dotnet run --project WoofWare.PawPrint.IlDump -- [--attrs-only] <dll-path> [TypeName] [MemberName]"
+
             1
         | dllPath :: rest ->
-            let typeFilter, methodFilter =
+            let typeFilter, memberFilter =
                 match rest with
                 | [] -> None, None
                 | [ t ] -> Some t, None
@@ -41,23 +138,46 @@ module Program =
 
             let assembly = Assembly.readFile loggerFactory dllPath
 
-            for kvp in assembly.TypeDefs do
-                let typeInfo = kvp.Value
-                let qualifiedName = IlFormatting.qualifyTypeName assembly.TypeDefs typeInfo
+            match mode with
+            | Mode.Default ->
+                for kvp in assembly.TypeDefs do
+                    let typeInfo = kvp.Value
+                    let qualifiedName = IlFormatting.qualifyTypeName assembly.TypeDefs typeInfo
 
-                let typeMatches =
-                    match typeFilter with
-                    | None -> true
-                    | Some filter -> qualifiedName.Contains (filter, StringComparison.OrdinalIgnoreCase)
+                    let typeMatches =
+                        match typeFilter with
+                        | None -> true
+                        | Some filter -> qualifiedName.Contains (filter, StringComparison.OrdinalIgnoreCase)
 
-                if typeMatches then
-                    for method in typeInfo.Methods do
-                        let methodMatches =
-                            match methodFilter with
-                            | None -> true
-                            | Some filter -> method.Name.Contains (filter, StringComparison.OrdinalIgnoreCase)
+                    if typeMatches then
+                        for method in typeInfo.Methods do
+                            let methodMatches =
+                                match memberFilter with
+                                | None -> true
+                                | Some filter -> method.Name.Contains (filter, StringComparison.OrdinalIgnoreCase)
 
-                        if methodMatches then
-                            printMethod assembly qualifiedName method
+                            if methodMatches then
+                                printMethod assembly qualifiedName method
+
+            | Mode.AttrsOnly ->
+                let mutable anyEmitted = false
+
+                for kvp in assembly.TypeDefs do
+                    let typeInfo = kvp.Value
+                    let qualifiedName = IlFormatting.qualifyTypeName assembly.TypeDefs typeInfo
+
+                    let typeMatches =
+                        match typeFilter with
+                        | None -> true
+                        | Some filter -> qualifiedName.Contains (filter, StringComparison.OrdinalIgnoreCase)
+
+                    if typeMatches then
+                        if anyEmitted then
+                            printfn ""
+
+                        let emitted = printTypeAttrs assembly memberFilter typeInfo
+
+                        if emitted then
+                            anyEmitted <- true
 
             0

--- a/WoofWare.PawPrint.IlDump/Program.fs
+++ b/WoofWare.PawPrint.IlDump/Program.fs
@@ -3,6 +3,7 @@ namespace WoofWare.PawPrint.IlDump
 open System
 open System.IO
 open System.Reflection.Metadata
+open System.Reflection.Metadata.Ecma335
 open Microsoft.Extensions.Logging
 open WoofWare.PawPrint
 
@@ -171,6 +172,37 @@ module Program =
 
             | Mode.AttrsOnly ->
                 let mutable anyEmitted = false
+
+                let printOwnerGroup (header : string) (parent : MetadataToken) : unit =
+                    let lines = AttributeFormatting.renderOwnerLines assembly header parent
+
+                    if not (List.isEmpty lines) then
+                        if anyEmitted then
+                            printfn ""
+
+                        for line in lines do
+                            printfn $"%s{line}"
+
+                        anyEmitted <- true
+
+                // Assembly- and module-scoped attributes (e.g. [assembly: InternalsVisibleTo],
+                // [module: SkipLocalsInit]) live under the singleton AssemblyDefinition /
+                // ModuleDefinition rows, not under any type. Emit them up front when the user
+                // hasn't narrowed the scope with a type filter; a type filter scopes the
+                // output to types and should suppress these.
+                if Option.isNone typeFilter then
+                    printOwnerGroup
+                        (AttributeFormatting.assemblyHeader assembly)
+                        (MetadataToken.AssemblyDefinition EntityHandle.AssemblyDefinition)
+
+                    let moduleName =
+                        let mr = assembly.PeReader.GetMetadataReader ()
+                        let moduleDef = mr.GetModuleDefinition ()
+                        mr.GetString moduleDef.Name
+
+                    printOwnerGroup
+                        (AttributeFormatting.moduleHeader moduleName)
+                        (MetadataToken.ModuleDefinition EntityHandle.ModuleDefinition)
 
                 for kvp in assembly.TypeDefs do
                     let typeInfo = kvp.Value

--- a/WoofWare.PawPrint.IlDump/Program.fs
+++ b/WoofWare.PawPrint.IlDump/Program.fs
@@ -27,10 +27,14 @@ module Program =
     /// lines (if any), followed by attribute lines for each filter-matching
     /// method, field, property, and event. Members with no attributes are
     /// silently skipped. The type header itself is only emitted if at least
-    /// one of those produces output. Returns true iff any lines were emitted.
+    /// one of those produces output. When this emits any lines and
+    /// <paramref name="isFirstType"/> is false, a leading blank line is printed
+    /// to separate from the previous type. Returns true iff any lines were
+    /// emitted.
     let private printTypeAttrs
         (assembly : DumpedAssembly)
         (memberFilter : string option)
+        (isFirstType : bool)
         (typeInfo : TypeInfo<GenericParamFromMetadata, TypeDefn>)
         : bool
         =
@@ -97,6 +101,12 @@ module Program =
         if List.isEmpty nonEmptyGroups then
             false
         else
+            // Separate from the previous type only now that we know there's
+            // something to emit — otherwise broad filters that skip multiple
+            // types would leave a trail of blank separator lines.
+            if not isFirstType then
+                printfn ""
+
             let mutable first = true
 
             for group in nonEmptyGroups do
@@ -172,10 +182,7 @@ module Program =
                         | Some filter -> qualifiedName.Contains (filter, StringComparison.OrdinalIgnoreCase)
 
                     if typeMatches then
-                        if anyEmitted then
-                            printfn ""
-
-                        let emitted = printTypeAttrs assembly memberFilter typeInfo
+                        let emitted = printTypeAttrs assembly memberFilter (not anyEmitted) typeInfo
 
                         if emitted then
                             anyEmitted <- true

--- a/WoofWare.PawPrint.Test/TestAttributeFormatting.fs
+++ b/WoofWare.PawPrint.Test/TestAttributeFormatting.fs
@@ -434,3 +434,51 @@ public class Target { }
 
         for n in names do
             n.Contains "<type defined in" |> shouldEqual false
+
+    // ----- assembly- and module-scoped attributes ---------------------------
+
+    [<Test>]
+    let ``renderOwnerLines emits assembly-scoped attributes for AssemblyDefinition token`` () : unit =
+        // [assembly: ...] attributes are stored in the metadata reader's
+        // CustomAttributes table with parent token AssemblyDefinition (row 1).
+        // The attrs-only walker must look them up via that singleton token, not
+        // skip over them because they aren't owned by any TypeDef.
+        let source =
+            """
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("SomeFriendAssembly")]
+
+public class Placeholder { }
+"""
+
+        let image =
+            Roslyn.compileAssembly
+                "AssemblyScopedAttributeFormattingTest"
+                Microsoft.CodeAnalysis.OutputKind.DynamicallyLinkedLibrary
+                []
+                [ source ]
+
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use stream = new System.IO.MemoryStream (image)
+        let assembly = global.WoofWare.PawPrint.AssemblyApi.read loggerFactory None stream
+
+        let header = AttributeFormatting.assemblyHeader assembly
+
+        let lines =
+            AttributeFormatting.renderOwnerLines
+                assembly
+                header
+                (MetadataToken.AssemblyDefinition System.Reflection.Metadata.EntityHandle.AssemblyDefinition)
+
+        // The header should be the first line, and at least one rendered application line
+        // should mention the friend assembly name from the InternalsVisibleTo attribute.
+        match lines with
+        | [] -> failwith "expected at least the assembly header plus one InternalsVisibleTo line"
+        | first :: rest ->
+            first |> shouldEqual header
+
+            let mentionsFriend = rest |> List.exists (fun l -> l.Contains "SomeFriendAssembly")
+
+            if not mentionsFriend then
+                failwithf "actual rendered lines: %s" (lines |> String.concat " | ")

--- a/WoofWare.PawPrint.Test/TestAttributeFormatting.fs
+++ b/WoofWare.PawPrint.Test/TestAttributeFormatting.fs
@@ -36,6 +36,16 @@ module TestAttributeFormatting =
         |> shouldEqual "'\\n'"
 
     [<Test>]
+    let ``formatFixedArg Char escapes single quote unambiguously`` () : unit =
+        // Without escape, this would render as the ambiguous '''.
+        AttributeFormatting.formatFixedArg (CustomAttribFixedArg.Char '\'')
+        |> shouldEqual "'\\''"
+
+        // Backslash must still be escaped (and not double-escaped).
+        AttributeFormatting.formatFixedArg (CustomAttribFixedArg.Char '\\')
+        |> shouldEqual "'\\\\'"
+
+    [<Test>]
     let ``formatFixedArg integers carry suffixes`` () : unit =
         AttributeFormatting.formatFixedArg (CustomAttribFixedArg.I1 -1y)
         |> shouldEqual "-1y"
@@ -262,3 +272,51 @@ module TestAttributeFormatting =
             MetadataToken.MethodDef (System.Reflection.Metadata.Ecma335.MetadataTokens.MethodDefinitionHandle 0xFFFFFF)
 
         AttributeFormatting.attributesFor corelib bogus |> shouldEqual []
+
+    // ----- generic attribute applications (TypeSpec ctor parent) -----------------
+
+    [<Test>]
+    let ``attributeTypeName renders generic attribute with its type argument and strips Attribute suffix`` () : unit =
+        // A generic attribute's ctor lives on a MemberRef whose Parent is a TypeSpecification;
+        // without TypeSpec handling, the rendered name comes from TypeDefn.ToString and loses
+        // the attribute's actual name.
+        let source =
+            """
+using System;
+
+[AttributeUsage(AttributeTargets.All)]
+public class MyGenericAttribute<T> : Attribute { }
+
+[MyGeneric<string>]
+public class Target { }
+"""
+
+        let image =
+            Roslyn.compileAssembly
+                "GenericAttributeFormattingTest"
+                Microsoft.CodeAnalysis.OutputKind.DynamicallyLinkedLibrary
+                []
+                [ source ]
+
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use stream = new System.IO.MemoryStream (image)
+        let assembly = global.WoofWare.PawPrint.AssemblyApi.read loggerFactory None stream
+
+        let target = assembly.TypeDefs.Values |> Seq.find (fun td -> td.Name = "Target")
+
+        let attrs =
+            AttributeFormatting.attributesFor assembly (MetadataToken.TypeDefinition target.TypeDefHandle)
+
+        let names = attrs |> List.map (AttributeFormatting.attributeTypeName assembly)
+
+        // We should see exactly one attribute application on Target, and its rendered name
+        // must contain the simple "MyGeneric<...>" (suffix stripped) — not "<type defined in ...>".
+        let found =
+            names
+            |> List.exists (fun n -> n.EndsWith ("MyGeneric<string>", System.StringComparison.Ordinal))
+
+        if not found then
+            failwithf "actual rendered names: %s" (names |> String.concat " ; ")
+
+        for n in names do
+            n.Contains "<type defined in" |> shouldEqual false

--- a/WoofWare.PawPrint.Test/TestAttributeFormatting.fs
+++ b/WoofWare.PawPrint.Test/TestAttributeFormatting.fs
@@ -72,6 +72,30 @@ module TestAttributeFormatting =
         |> shouldEqual "9uL"
 
     [<Test>]
+    let ``formatFixedArg R4 and R8 round-trip their stored value`` () : unit =
+        // Pick a value that "%g" would truncate at its default precision; the rendered string
+        // must reparse to the exact original bits.
+        let v8 = 1.234567890123456
+        let rendered8 = AttributeFormatting.formatFixedArg (CustomAttribFixedArg.R8 v8)
+
+        let parsed8 =
+            System.Double.Parse (rendered8, System.Globalization.CultureInfo.InvariantCulture)
+
+        parsed8 |> shouldEqual v8
+
+        let v4 = 1.2345678f
+        let rendered4 = AttributeFormatting.formatFixedArg (CustomAttribFixedArg.R4 v4)
+        rendered4.EndsWith "f" |> shouldEqual true
+
+        let parsed4 =
+            System.Single.Parse (
+                rendered4.Substring (0, rendered4.Length - 1),
+                System.Globalization.CultureInfo.InvariantCulture
+            )
+
+        parsed4 |> shouldEqual v4
+
+    [<Test>]
     let ``formatFixedArg String None is null and String Some is quoted-escaped`` () : unit =
         AttributeFormatting.formatFixedArg (CustomAttribFixedArg.String None)
         |> shouldEqual "null"
@@ -320,6 +344,51 @@ public class Target { }
 
         for n in names do
             n.Contains "<type defined in" |> shouldEqual false
+
+    [<Test>]
+    let ``formatAttributeApplication decodes a closed-generic ctor whose param is the type parameter`` () : unit =
+        // ms.ParameterTypes on the MemberRef references the open generic via
+        // GenericTypeParameter 0. Without substitution, the blob decoder hits the
+        // unsupported generic-param case and we'd fall back to a raw hex blob — even
+        // though the TypeSpec parent already pins T = int.
+        let source =
+            """
+using System;
+
+[AttributeUsage(AttributeTargets.All)]
+public class MyGenericAttribute<T> : Attribute
+{
+    public MyGenericAttribute(T value) { }
+}
+
+[MyGeneric<int>(42)]
+public class Target { }
+"""
+
+        let image =
+            Roslyn.compileAssembly
+                "GenericAttributeFormattingClosedCtorTest"
+                Microsoft.CodeAnalysis.OutputKind.DynamicallyLinkedLibrary
+                []
+                [ source ]
+
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use stream = new System.IO.MemoryStream (image)
+        let assembly = global.WoofWare.PawPrint.AssemblyApi.read loggerFactory None stream
+
+        let target = assembly.TypeDefs.Values |> Seq.find (fun td -> td.Name = "Target")
+
+        let rendered =
+            AttributeFormatting.attributesFor assembly (MetadataToken.TypeDefinition target.TypeDefHandle)
+            |> List.map (AttributeFormatting.formatAttributeApplication assembly)
+
+        // The decoded form must show the literal 42 — not a "/* blob:" fallback.
+        let found =
+            rendered
+            |> List.exists (fun r -> r.Contains "(42)" && not (r.Contains "/* blob:"))
+
+        if not found then
+            failwithf "actual rendered applications: %s" (rendered |> String.concat " ; ")
 
     [<Test>]
     let ``attributeTypeName renders user-defined type argument by qualified name`` () : unit =

--- a/WoofWare.PawPrint.Test/TestAttributeFormatting.fs
+++ b/WoofWare.PawPrint.Test/TestAttributeFormatting.fs
@@ -1,0 +1,264 @@
+namespace WoofWare.PawPrint.Test
+
+open System.Collections.Immutable
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestAttributeFormatting =
+
+    // The factory is intentionally undisposed: the returned DumpedAssembly.Logger closes
+    // over its sinks, and disposing while the assembly is still live would silently drop
+    // events.
+    let private corelib : DumpedAssembly =
+        let corelibPath = typeof<obj>.Assembly.Location
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        Assembly.readFile loggerFactory corelibPath
+
+    // ----- formatFixedArg (pure unit tests) ---------------------------------
+
+    [<Test>]
+    let ``formatFixedArg Bool true / false`` () : unit =
+        AttributeFormatting.formatFixedArg (CustomAttribFixedArg.Bool true)
+        |> shouldEqual "true"
+
+        AttributeFormatting.formatFixedArg (CustomAttribFixedArg.Bool false)
+        |> shouldEqual "false"
+
+    [<Test>]
+    let ``formatFixedArg Char escapes specials`` () : unit =
+        AttributeFormatting.formatFixedArg (CustomAttribFixedArg.Char 'A')
+        |> shouldEqual "'A'"
+
+        AttributeFormatting.formatFixedArg (CustomAttribFixedArg.Char '\n')
+        |> shouldEqual "'\\n'"
+
+    [<Test>]
+    let ``formatFixedArg integers carry suffixes`` () : unit =
+        AttributeFormatting.formatFixedArg (CustomAttribFixedArg.I1 -1y)
+        |> shouldEqual "-1y"
+
+        AttributeFormatting.formatFixedArg (CustomAttribFixedArg.U1 255uy)
+        |> shouldEqual "255uy"
+
+        AttributeFormatting.formatFixedArg (CustomAttribFixedArg.I2 -2s)
+        |> shouldEqual "-2s"
+
+        AttributeFormatting.formatFixedArg (CustomAttribFixedArg.U2 7us)
+        |> shouldEqual "7us"
+
+        AttributeFormatting.formatFixedArg (CustomAttribFixedArg.I4 42)
+        |> shouldEqual "42"
+
+        AttributeFormatting.formatFixedArg (CustomAttribFixedArg.U4 4u)
+        |> shouldEqual "4u"
+
+        AttributeFormatting.formatFixedArg (CustomAttribFixedArg.I8 -9L)
+        |> shouldEqual "-9L"
+
+        AttributeFormatting.formatFixedArg (CustomAttribFixedArg.U8 9UL)
+        |> shouldEqual "9uL"
+
+    [<Test>]
+    let ``formatFixedArg String None is null and String Some is quoted-escaped`` () : unit =
+        AttributeFormatting.formatFixedArg (CustomAttribFixedArg.String None)
+        |> shouldEqual "null"
+
+        AttributeFormatting.formatFixedArg (CustomAttribFixedArg.String (Some ""))
+        |> shouldEqual "\"\""
+
+        AttributeFormatting.formatFixedArg (CustomAttribFixedArg.String (Some "a\"b"))
+        |> shouldEqual "\"a\\\"b\""
+
+    [<Test>]
+    let ``formatFixedArg Array None is null; empty is empty braces; non-empty is comma-separated`` () : unit =
+        AttributeFormatting.formatFixedArg (CustomAttribFixedArg.Array None)
+        |> shouldEqual "null"
+
+        AttributeFormatting.formatFixedArg (CustomAttribFixedArg.Array (Some []))
+        |> shouldEqual "{  }"
+
+        AttributeFormatting.formatFixedArg (
+            CustomAttribFixedArg.Array (Some [ CustomAttribFixedArg.I4 1 ; CustomAttribFixedArg.I4 2 ])
+        )
+        |> shouldEqual "{ 1, 2 }"
+
+    [<Test>]
+    let ``formatFixedArg Array nests`` () : unit =
+        let arg =
+            CustomAttribFixedArg.Array (
+                Some
+                    [
+                        CustomAttribFixedArg.Array (Some [ CustomAttribFixedArg.U1 1uy ; CustomAttribFixedArg.U1 2uy ])
+                        CustomAttribFixedArg.Array None
+                    ]
+            )
+
+        AttributeFormatting.formatFixedArg arg |> shouldEqual "{ { 1uy, 2uy }, null }"
+
+    // ----- attributeTypeName: strips "Attribute" suffix ---------------------
+
+    let private findTypeByName (qualified : string) : TypeInfo<GenericParamFromMetadata, TypeDefn> =
+        corelib.TypeDefs.Values
+        |> Seq.find (fun td ->
+            let n = IlFormatting.qualifyTypeName corelib.TypeDefs td
+            n = qualified
+        )
+
+    [<Test>]
+    let ``attributeTypeName strips Attribute suffix from corelib SerializableAttribute`` () : unit =
+        // System.SerializableAttribute is applied to System.Exception. Find its application.
+        let exn = findTypeByName "System.Exception"
+
+        let attrs =
+            AttributeFormatting.attributesFor corelib (MetadataToken.TypeDefinition exn.TypeDefHandle)
+
+        let names = attrs |> List.map (AttributeFormatting.attributeTypeName corelib)
+
+        // Every rendered name should retain its namespace, and none should retain the literal "Attribute" suffix.
+        for name in names do
+            if name.EndsWith ("Attribute", System.StringComparison.Ordinal) then
+                failwithf "attributeTypeName did not strip Attribute suffix from %s" name
+
+        // TypeForwardedFromAttribute is one of the attributes applied; check that it's rendered with the
+        // namespace intact (i.e., dot-separated, no leading dot).
+        names
+        |> List.exists (fun n -> n = "System.Runtime.CompilerServices.TypeForwardedFrom")
+        |> shouldEqual true
+
+    [<Test>]
+    let ``attributeTypeName keeps bare "Attribute" intact (not stripped to empty)`` () : unit =
+        // We can't easily construct a CustomAttribute pointing at the literal "Attribute" type
+        // without scaffolding, but the suffix-stripping helper's contract is testable directly
+        // by exercising attributeTypeName on attributes from corelib and checking no empty name
+        // appears (which is what the suffix-stripper would produce if it stripped from a name
+        // equal to "Attribute").
+        for kvp in corelib.TypeDefs do
+            let attrs =
+                AttributeFormatting.attributesFor corelib (MetadataToken.TypeDefinition kvp.Value.TypeDefHandle)
+
+            for attr in attrs do
+                let name = AttributeFormatting.attributeTypeName corelib attr
+
+                if name = "" then
+                    failwithf "attributeTypeName produced empty string for an attribute on %O" kvp.Value
+
+    // ----- formatAttributeApplication: end-to-end against corelib -----------
+
+    [<Test>]
+    let ``System.Exception has [Serializable]-style attribute applications`` () : unit =
+        let exn = findTypeByName "System.Exception"
+
+        let attrs =
+            AttributeFormatting.attributesFor corelib (MetadataToken.TypeDefinition exn.TypeDefHandle)
+
+        let rendered =
+            attrs |> List.map (AttributeFormatting.formatAttributeApplication corelib)
+
+        // Every rendering should be a [..] application.
+        for r in rendered do
+            r.StartsWith ('[') |> shouldEqual true
+            r.EndsWith (']') |> shouldEqual true
+
+        // TypeForwardedFrom is present with a string arg.
+        rendered
+        |> List.exists (fun r -> r.Contains "[System.Runtime.CompilerServices.TypeForwardedFrom(\"mscorlib")
+        |> shouldEqual true
+
+    [<Test>]
+    let ``formatAttributeApplication emits hex blob fallback when decoding fails`` () : unit =
+        // The reader doesn't yet handle ENUM/TYPE/TAGGED_OBJECT ctor args, so any attribute whose
+        // ctor takes one (e.g. anything with an enum) lands in the fallback path. Corelib has many
+        // such attributes; search for the first one rather than pinning to a specific ctor that
+        // could be reorganised between dotnet releases.
+        let allRenderings =
+            seq {
+                for kvp in corelib.TypeDefs do
+                    let ti = kvp.Value
+
+                    for m in ti.Methods do
+                        for attr in AttributeFormatting.attributesFor corelib (MetadataToken.MethodDef m.Handle) do
+                            yield AttributeFormatting.formatAttributeApplication corelib attr
+            }
+
+        allRenderings
+        |> Seq.exists (fun r -> r.Contains "(/* blob:")
+        |> shouldEqual true
+
+    [<Test>]
+    let ``formatAttributeApplication surfaces named-args count`` () : unit =
+        // System.Exception::OnDeserialized and ::.ctor(...) have attribute applications with named args.
+        // Find at least one rendering that contains the "+N named" annotation.
+        let exn = findTypeByName "System.Exception"
+
+        let allRenderings =
+            seq {
+                for m in exn.Methods do
+                    for attr in AttributeFormatting.attributesFor corelib (MetadataToken.MethodDef m.Handle) do
+                        yield AttributeFormatting.formatAttributeApplication corelib attr
+            }
+            |> Seq.toList
+
+        allRenderings
+        |> List.exists (fun r -> r.Contains "named */]")
+        |> shouldEqual true
+
+    // ----- type header includes generics -------------------------------------
+
+    [<Test>]
+    let ``typeHeader for generic List<T> includes the <T> clause`` () : unit =
+        let listOfT = findTypeByName "System.Collections.Generic.List`1"
+        let header = AttributeFormatting.typeHeader corelib listOfT
+
+        header.StartsWith "// type System.Collections.Generic.List`1<"
+        |> shouldEqual true
+
+        header.EndsWith ">" |> shouldEqual true
+
+    [<Test>]
+    let ``typeHeader for non-generic Exception omits any angle-bracket clause`` () : unit =
+        let exn = findTypeByName "System.Exception"
+        let header = AttributeFormatting.typeHeader corelib exn
+        header |> shouldEqual "// type System.Exception"
+
+    // ----- renderOwnerLines: skips empty owners ------------------------------
+
+    [<Test>]
+    let ``renderOwnerLines returns empty for a token with no attributes`` () : unit =
+        // CustomAttributeHandle 0 is a row that never exists in the index (rows are 1-based).
+        // Build a token whose parent never has attributes: use a TypeDefinition handle with row
+        // 0xFFFFFF, which won't appear in the index.
+        let bogus =
+            MetadataToken.TypeDefinition (
+                System.Reflection.Metadata.Ecma335.MetadataTokens.TypeDefinitionHandle 0xFFFFFF
+            )
+
+        AttributeFormatting.renderOwnerLines corelib "// type Bogus" bogus
+        |> shouldEqual []
+
+    [<Test>]
+    let ``renderOwnerLines emits header + one indented line per attribute`` () : unit =
+        let exn = findTypeByName "System.Exception"
+
+        let lines =
+            AttributeFormatting.renderOwnerLines
+                corelib
+                "// type System.Exception"
+                (MetadataToken.TypeDefinition exn.TypeDefHandle)
+
+        // First line is the header; subsequent lines are indented attribute applications.
+        lines.Head |> shouldEqual "// type System.Exception"
+
+        for line in List.tail lines do
+            line.StartsWith "//   [" |> shouldEqual true
+            line.EndsWith "]" |> shouldEqual true
+
+    [<Test>]
+    let ``attributesFor returns no attributes for owners outside the index`` () : unit =
+        // Use a fresh CustomAttributeHandle which is unlikely to be in the dictionary.
+        let bogus =
+            MetadataToken.MethodDef (System.Reflection.Metadata.Ecma335.MetadataTokens.MethodDefinitionHandle 0xFFFFFF)
+
+        AttributeFormatting.attributesFor corelib bogus |> shouldEqual []

--- a/WoofWare.PawPrint.Test/TestAttributeFormatting.fs
+++ b/WoofWare.PawPrint.Test/TestAttributeFormatting.fs
@@ -320,3 +320,48 @@ public class Target { }
 
         for n in names do
             n.Contains "<type defined in" |> shouldEqual false
+
+    [<Test>]
+    let ``attributeTypeName renders user-defined type argument by qualified name`` () : unit =
+        // The args of a generic-attribute instantiation are themselves TypeDefns;
+        // user-defined ones must be routed through the same resolver as the head,
+        // otherwise they collapse to "<type defined in ...>".
+        let source =
+            """
+using System;
+
+public class ArgType { }
+
+[AttributeUsage(AttributeTargets.All)]
+public class MyGenericAttribute<T> : Attribute { }
+
+[MyGeneric<ArgType>]
+public class Target { }
+"""
+
+        let image =
+            Roslyn.compileAssembly
+                "GenericAttributeFormattingUserArgTest"
+                Microsoft.CodeAnalysis.OutputKind.DynamicallyLinkedLibrary
+                []
+                [ source ]
+
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use stream = new System.IO.MemoryStream (image)
+        let assembly = global.WoofWare.PawPrint.AssemblyApi.read loggerFactory None stream
+
+        let target = assembly.TypeDefs.Values |> Seq.find (fun td -> td.Name = "Target")
+
+        let names =
+            AttributeFormatting.attributesFor assembly (MetadataToken.TypeDefinition target.TypeDefHandle)
+            |> List.map (AttributeFormatting.attributeTypeName assembly)
+
+        let found =
+            names
+            |> List.exists (fun n -> n.EndsWith ("MyGeneric<ArgType>", System.StringComparison.Ordinal))
+
+        if not found then
+            failwithf "actual rendered names: %s" (names |> String.concat " ; ")
+
+        for n in names do
+            n.Contains "<type defined in" |> shouldEqual false

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="TestAssemblyReadCache.fs" />
     <Compile Include="TestCustomAttributeBlob.fs" />
     <Compile Include="TestCustomAttribValueLowering.fs" />
+    <Compile Include="TestAttributeFormatting.fs" />
     <Compile Include="TestFriendAssemblies.fs" />
     <Compile Include="TestAccessCheck.fs" />
     <Compile Include="RealRuntime.fs" />


### PR DESCRIPTION
## Summary

- Adds an `--attrs-only` mode to `WoofWare.PawPrint.IlDump` that prints each owner's custom attributes (without the surrounding IL body) as `// type|method|field|property|event|assembly|module ...` headers followed by indented `[Attr(args)]` lines.
- Adds `WoofWare.PawPrint.AttributeFormatting` (a `[<RequireQualifiedAccess>]` module in `WoofWare.PawPrint.Domain`) for the rendering itself: blob decoding via `CustomAttribute.readFixedArgs`, hex-blob fallback when the ctor signature can't be resolved, `Attribute`-suffix stripping with the namespace/outer-type prefix preserved, generic attribute rendering (`MyGeneric<int>` etc.), TypeSpec-arg substitution into ctor parameter types so closed-generic ctors with `T`-typed params decode rather than fall back to hex, R4/R8 round-trip via `ToString("R", InvariantCulture)`, and `// assembly` / `// module` headers so assembly- and module-scoped attributes (`InternalsVisibleTo`, `TargetFramework`, `SkipLocalsInit`, …) are surfaced.
- Uses the existing `DumpedAssembly.CustomAttributesByParentToken` index rather than threading new fields into every domain type.

## Test plan

- [x] `nix develop -c dotnet test WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj` — 1419 tests pass, including 22 new `TestAttributeFormatting` cases covering `formatFixedArg` (incl. float round-trip and char single-quote escape), `attributeTypeName` (suffix stripping, generic head + args, user-defined args), `formatAttributeApplication` (well-formed bracket form, hex-blob fallback, named-args annotation, closed-generic ctor with T-typed param), `typeHeader`, `renderOwnerLines` (empty / non-empty), and assembly-scoped `[assembly: InternalsVisibleTo]` rendering.
- [x] `nix develop -c dotnet fantomas .` clean.
- [x] Several `codex review --base main` iterations; the final pass returned no actionable findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)