### PR TITLE
NuGet packaging — Stage 2: metadata, IsPackable gating, packed README

### DIFF
--- a/CSharpExample/CSharpExample.csproj
+++ b/CSharpExample/CSharpExample.csproj
@@ -7,6 +7,7 @@
       <WarningsAsErrors>false</WarningsAsErrors>
       <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
       <EnableDefaultItems>false</EnableDefaultItems>
+      <IsPackable>false</IsPackable>
     </PropertyGroup>
 
   <ItemGroup>

--- a/HelloWorld/HelloWorld.fsproj
+++ b/HelloWorld/HelloWorld.fsproj
@@ -4,6 +4,7 @@
       <OutputType>Exe</OutputType>
       <TargetFramework>net10.0</TargetFramework>
       <SelfContained>true</SelfContained>
+      <IsPackable>false</IsPackable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/WoofWare.PawPrint.App/WoofWare.PawPrint.App.fsproj
+++ b/WoofWare.PawPrint.App/WoofWare.PawPrint.App.fsproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);FS3511</NoWarn>
   </PropertyGroup>
 

--- a/WoofWare.PawPrint.Domain/WoofWare.PawPrint.Domain.fsproj
+++ b/WoofWare.PawPrint.Domain/WoofWare.PawPrint.Domain.fsproj
@@ -3,6 +3,16 @@
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <IsPackable>true</IsPackable>
+        <PackageId>WoofWare.PawPrint.Domain</PackageId>
+        <Authors>Patrick Stevens</Authors>
+        <Copyright>Copyright (c) Patrick Stevens 2026</Copyright>
+        <Description>Shared domain types for WoofWare.PawPrint, an experimental fully-deterministic, fully-managed .NET IL interpreter: IL opcodes, the emulated type system, and metadata-handle wrappers.</Description>
+        <RepositoryType>git</RepositoryType>
+        <RepositoryUrl>https://github.com/Smaug123/WoofWare.PawPrint</RepositoryUrl>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageTags>dotnet;il;interpreter;metadata;fsharp;woofware</PackageTags>
     </PropertyGroup>
 
     <ItemGroup>
@@ -45,6 +55,10 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.2" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="..\README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 
 </Project>

--- a/WoofWare.PawPrint.IlDump/WoofWare.PawPrint.IlDump.fsproj
+++ b/WoofWare.PawPrint.IlDump/WoofWare.PawPrint.IlDump.fsproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/WoofWare.PawPrint.Logging/WoofWare.PawPrint.Logging.fsproj
+++ b/WoofWare.PawPrint.Logging/WoofWare.PawPrint.Logging.fsproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/WoofWare.PawPrint.Test.FSharpPureCases/WoofWare.PawPrint.Test.FSharpPureCases.fsproj
+++ b/WoofWare.PawPrint.Test.FSharpPureCases/WoofWare.PawPrint.Test.FSharpPureCases.fsproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
+++ b/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
@@ -3,6 +3,16 @@
   <PropertyGroup>
     <WoofWareMyriadPluginsVersion>7.0.7</WoofWareMyriadPluginsVersion>
     <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>true</IsPackable>
+    <PackageId>WoofWare.PawPrint</PackageId>
+    <Authors>Patrick Stevens</Authors>
+    <Copyright>Copyright (c) Patrick Stevens 2026</Copyright>
+    <Description>An experimental, fully-deterministic, fully-managed .NET IL interpreter written in F#. It reimplements P/Invoke in managed code and keeps all state in memory, enabling time-travel debugging and fuzzing over thread execution order. Emulates .NET 10.</Description>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/Smaug123/WoofWare.PawPrint</RepositoryUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageTags>dotnet;runtime;il-interpreter;deterministic;net10;time-travel;fsharp;woofware</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
@@ -140,5 +150,9 @@
 
   <ItemGroup>
     <ProjectReference Include="..\WoofWare.PawPrint.Domain\WoofWare.PawPrint.Domain.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Second of the NuGet series (Stage 1 / independent versioning is already in `main`). Makes `WoofWare.PawPrint` and `WoofWare.PawPrint.Domain` publishable, mirroring the WoofWare.Myriad pattern.

## What

- **Per-`.fsproj` metadata** on Domain + PawPrint: `Authors`, `Copyright`, `Description`, `RepositoryType`/`Url`, `PackageLicenseExpression=MIT`, `PackageReadmeFile`, `PackageTags`, `PackageId`, explicit `IsPackable=true`.
- **Packed README**: `<None Include="..\README.md" Pack="true" PackagePath="\" />` in each.
- **`IsPackable=false`** on every non-published project (App, IlDump, Logging, Test.FSharpPureCases, HelloWorld, CSharpExample) — explicit per-project, matching Myriad and the existing Test/Performance convention.

## Verified

`dotnet pack WoofWare.PawPrint.slnx -c Release` emits **exactly two** nupkgs. The PawPrint `.nuspec`:
- `id`/`version`/`authors`/`license=MIT`/`readme=README.md`/`repository`+commit/`tags` all correct;
- `README.md` is in the package;
- deps = `WoofWare.PawPrint.Domain >= 0.1.1` (uncapped, per the agreed Myriad-style policy) + `Microsoft.Extensions.Logging.Abstractions`; the Myriad build-time generators are correctly **absent** (`PrivateAssets=all`).

Domain's `.nuspec` is a clean leaf. (Versions show the `-gSHA` prerelease suffix off `main`; clean on `main`.)

## Follow-up (not in this PR)

Both packages currently floor `FSharp.Core` at the net10 SDK's `10.1.203`. If broader consumer compatibility is wanted, pin it lower as Myriad does (`<PackageReference Update="FSharp.Core" .../>`). Left out deliberately to keep this PR scoped.

Stage 3 (the pack/attest/trusted-publish workflow) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)