### PR TITLE
Implement the `tail.` prefix as an executed no-op

### DIFF
--- a/WoofWare.PawPrint.Test.FSharpPureCases/Main.fs
+++ b/WoofWare.PawPrint.Test.FSharpPureCases/Main.fs
@@ -5,4 +5,5 @@ let main (argv : string array) : int =
     match argv.[0] with
     | "Placeholder" -> Placeholder.main argv.[1..]
     | "CeqBranch" -> CeqBranch.main argv.[1..]
+    | "TailCall" -> TailCall.main argv.[1..]
     | name -> failwith $"Unknown test case: {name}"

--- a/WoofWare.PawPrint.Test.FSharpPureCases/TailCall.fs
+++ b/WoofWare.PawPrint.Test.FSharpPureCases/TailCall.fs
@@ -1,0 +1,30 @@
+module TailCall
+
+/// Mutual recursion: FSC cannot rewrite these into a loop, so with `--tailcalls+`
+/// (the Release default) it emits the `tail.` prefix on the cross-calls.
+let rec private isEven (n : int) : bool = if n = 0 then true else isOdd (n - 1)
+
+and private isOdd (n : int) : bool = if n = 0 then false else isEven (n - 1)
+
+/// A tail call through a first-class function value: FSC emits `tail. callvirt`
+/// on `FSharpFunc<_,_>::Invoke`. `NoInlining` keeps the optimiser from inlining
+/// the body into the caller, where the call would no longer be in tail position
+/// and the prefix would vanish.
+[<System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)>]
+let private applyTail (f : int -> int) (x : int) : int = f x
+
+let private double (x : int) : int = x * 2
+
+let private triple (x : int) : int = x * 3
+
+let main (argv : string array) : int =
+    // Choose the function at runtime so FSC can't inline `applyTail` down to a
+    // constant and delete the `tail. callvirt` we're trying to exercise.
+    let chosen : int -> int = if argv.Length > 0 then triple else double
+
+    if not (isEven 10) then 1
+    elif isEven 11 then 2
+    elif not (isOdd 7) then 3
+    elif isOdd 8 then 4
+    elif applyTail chosen 21 <> 42 then 5
+    else 0

--- a/WoofWare.PawPrint.Test.FSharpPureCases/WoofWare.PawPrint.Test.FSharpPureCases.fsproj
+++ b/WoofWare.PawPrint.Test.FSharpPureCases/WoofWare.PawPrint.Test.FSharpPureCases.fsproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <Compile Include="Placeholder.fs" />
     <Compile Include="CeqBranch.fs" />
+    <Compile Include="TailCall.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
 

--- a/WoofWare.PawPrint.Test/TestFSharpPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestFSharpPureCases.fs
@@ -97,7 +97,7 @@ module TestFSharpPureCases =
         publishOnce.Force ()
         File.ReadAllBytes dllPath
 
-    let testCases : string list = [ "Placeholder" ; "CeqBranch" ]
+    let testCases : string list = [ "Placeholder" ; "CeqBranch" ; "TailCall" ]
 
     // PawPrint cannot yet allocate string argv (Program.allocateArgs is unimplemented),
     // so all F# test cases that require argv dispatch are unimplemented for now.
@@ -185,6 +185,43 @@ module TestFSharpPureCases =
             Assert.Inconclusive $"Test case '%s{testCaseName}' is not yet implemented in PawPrint"
 
         runTest testCaseName
+
+    /// The `TailCall` case only covers the `tail.` prefix if FSC actually emits it, which
+    /// depends on the optimiser (Release + `--tailcalls+`) and on the exact shapes in
+    /// TailCall.fs. Without this guard, a compiler change that stopped emitting `tail.`
+    /// would leave `F# pure tests(TailCall)` silently passing while covering nothing.
+    /// If this fails, re-inspect the IL (`dotnet run --project WoofWare.PawPrint.IlDump --
+    /// <published dll> TailCall`) and reshape TailCall.fs until the prefix comes back.
+    [<Test>]
+    let ``TailCall case really does contain tail. prefixes`` () : unit =
+        let image = loadImage ()
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+        use peImage = new MemoryStream (image)
+
+        let assy = Assembly.read loggerFactory (Some dllPath) peImage
+
+        let tailPrefixed =
+            assy.TypeDefs.Values
+            |> Seq.collect (fun typeInfo -> typeInfo.Methods)
+            |> Seq.filter (fun methodInfo ->
+                methodInfo.DeclaringType.Name = "TailCall"
+                && match MethodInfo.tryIlBody methodInfo with
+                   | None -> false
+                   | Some instructions ->
+                       instructions.Instructions
+                       |> List.exists (fun (op, _offset) ->
+                           match op with
+                           | IlOp.Nullary NullaryIlOp.Tail -> true
+                           | _ -> false
+                       )
+            )
+            |> Seq.map (fun methodInfo -> methodInfo.Name)
+            |> Set.ofSeq
+
+        // `isEven`/`isOdd` are `tail. call`; `applyTail` is `tail. callvirt`. All three are
+        // reached from `TailCall.main`, so the end-to-end case really executes the prefix.
+        tailPrefixed |> shouldEqual (Set.ofList [ "isEven" ; "isOdd" ; "applyTail" ])
 
     [<TestCaseSource(nameof unimplemented)>]
     let ``Unimplemented F# tests have correct real-runtime behaviour`` (testCaseName : string) =

--- a/WoofWare.PawPrint.Test/TestNullaryIlOp.fs
+++ b/WoofWare.PawPrint.Test/TestNullaryIlOp.fs
@@ -431,3 +431,27 @@ module TestNullaryIlOp =
             executeNegCase case
 
         Check.One (config, Prop.forAll (Arb.fromGen genNegCase) executeNegCase)
+
+    /// PawPrint deliberately ignores `tail.` (see NullaryIlOp.fs), so the only thing it
+    /// may do is step over its own two bytes: the arguments the following call will pop
+    /// must be left untouched, and no prefix state may be left behind on the frame for a
+    /// later instruction to trip over.
+    [<Test>]
+    let ``Tail is an executed no-op that steps over its two-byte encoding`` () : unit =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+
+        let input = EvalStackValue.Int32 42
+        let state, thread = stateWithNullary loggerFactory NullaryIlOp.Tail input
+
+        match NullaryIlOp.execute loggerFactory baseClassTypes state thread NullaryIlOp.Tail with
+        | ExecutionResult.Stepped (state, whatWeDid, _) ->
+            whatWeDid |> shouldEqual WhatWeDid.Executed
+
+            let methodState = state.ThreadState.[thread].MethodState
+            methodState.EvaluationStack.Values |> shouldEqual [ input ]
+            methodState.PendingPrefix |> shouldEqual PrefixState.empty
+
+            methodState.IlOpIndex
+            |> shouldEqual (IlOp.NumberOfBytes (IlOp.Nullary NullaryIlOp.Tail))
+        | other -> failwith $"Expected Tail to step, got %O{other}"

--- a/WoofWare.PawPrint/MethodState.fs
+++ b/WoofWare.PawPrint/MethodState.fs
@@ -16,6 +16,9 @@ type PrefixState =
         /// `volatile.` (III.2.5) — applies to the next ldind/stind/ldfld/stfld/ldobj/stobj/initblk/cpblk.
         Volatile : bool
         /// `tail.` (III.2.4) — applies to the next call/callvirt/calli.
+        /// PawPrint never sets this: `tail.` executes as a no-op (see `NullaryIlOp.execute`),
+        /// so there is nothing for the following call to consume. It exists for a future
+        /// implementation that actually releases the caller's frame.
         Tail : bool
         /// `unaligned. alignment` (III.2.3) — applies to the next ldind/stind/ldfld/stfld/ldobj/stobj/initblk/cpblk.
         Unaligned : uint8 option

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -2176,7 +2176,34 @@ module NullaryIlOp =
             |> IlMachineState.advanceProgramCounter currentThread
             |> Tuple.withRight WhatWeDid.Executed
             |> ExecutionResult.stepped
-        | Tail -> failwith "TODO: Tail unimplemented"
+        | Tail ->
+            // ECMA-335 III.2.4: `tail.` asks for the caller's frame to be released before
+            // control transfers to the following call/callvirt/calli. Declining that request
+            // is a behaviour the CLI itself exhibits — the spec has the frame silently
+            // retained when the callee is more trusted, and CoreCLR's importer additionally
+            // drops explicit tail calls whenever the caller is synchronized, is a reverse
+            // P/Invoke, is varargs, the callee is native, or the return types aren't tailcall
+            // compatible (see jit/importercalls.cpp `szCanTailCallFailReason`), emitting an
+            // ordinary call instead.
+            //
+            // So PawPrint executes the prefix as a no-op: `tail.` is required to be followed
+            // by a call whose result is immediately `ret`urned, so keeping the frame alive
+            // for that one extra call changes nothing observable except (a) frame lifetime,
+            // which matters only to code that illegally hands out byrefs into the dying
+            // frame, and (b) the depth of the frame stack. Two divergences we accept for now:
+            // a guest stack trace captured inside the callee names the caller that a real
+            // tail call would have erased, and a program that relies on `tail.` for unbounded
+            // recursion (FSC emits it for mutual recursion) grows PawPrint's heap-allocated
+            // frame stack without bound rather than running in constant space. PawPrint
+            // enforces no frame-count limit, so the guest sees no StackOverflowException.
+            //
+            // Nothing is recorded in `PendingPrefix`: a flag set here and read by nobody
+            // would be a lie in the machine state, and the following call has no clearing
+            // logic for it.
+            state
+            |> IlMachineState.advanceProgramCounter currentThread
+            |> Tuple.withRight WhatWeDid.Executed
+            |> ExecutionResult.stepped
         | Conv_ovf_i_un -> failwith "TODO: Conv_ovf_i_un unimplemented"
         | Conv_ovf_u_un -> failwith "TODO: Conv_ovf_u_un unimplemented"
         | Conv_ovf_i1_un -> failwith "TODO: Conv_ovf_i1_un unimplemented"


### PR DESCRIPTION
ECMA-335 III.2.4 asks for the caller's frame to be released before the following call, but it's not guest-visible if we simply ignore that.