### PR TITLE
Load base-type-chain assemblies for every handle concretizeMethod emits

### DIFF
--- a/WoofWare.PawPrint.Domain/TypeConcretisation.fs
+++ b/WoofWare.PawPrint.Domain/TypeConcretisation.fs
@@ -1005,6 +1005,78 @@ module Concretization =
         let typeDef = assy.TypeDefs.[typeDefinitionHandle]
         ensureBaseTypeAssembliesLoaded loadAssembly assemblies assy.Name typeDef.BaseType
 
+    /// Force-load every assembly needed to walk the base-type chain of the given
+    /// concrete handle (and any handles it structurally wraps, and its generic
+    /// arguments). CliType.zeroOf invokes DumpedAssembly.isValueType on a concretized
+    /// type to decide whether it needs a zeroed value-type layout or a null reference;
+    /// that walk fails hard if a TypeRef along the base chain points at an assembly
+    /// which has not yet been loaded. concretizeMethod calls this on every handle it
+    /// emits (locals, parameter types, and the return type) so that subsequent
+    /// zero-initialization is guaranteed to have every assembly it needs.
+    ///
+    /// The `visited` set is shared across sibling calls so the same handle is not
+    /// walked twice within one concretizeMethod invocation.
+    let rec ensureBaseAssembliesLoadedForConcreteHandle
+        (loadAssembly : IAssemblyLoad)
+        (concreteTypes : AllConcreteTypes)
+        (visited : System.Collections.Generic.HashSet<ConcreteTypeHandle>)
+        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (handle : ConcreteTypeHandle)
+        : ImmutableDictionary<string, DumpedAssembly>
+        =
+        if not (visited.Add handle) then
+            assemblies
+        else
+            match handle with
+            | ConcreteTypeHandle.Byref inner
+            | ConcreteTypeHandle.Pointer inner
+            | ConcreteTypeHandle.OneDimArrayZero inner ->
+                // Byrefs, pointers, and arrays have no base-type chain of their own
+                // (zeroOf answers them structurally without touching isValueType),
+                // but the element type may still be zeroed later — e.g. via ldobj into
+                // a struct local — so recurse into it.
+                ensureBaseAssembliesLoadedForConcreteHandle loadAssembly concreteTypes visited assemblies inner
+            | ConcreteTypeHandle.Array (element, _) ->
+                ensureBaseAssembliesLoadedForConcreteHandle loadAssembly concreteTypes visited assemblies element
+            | ConcreteTypeHandle.FunctionPointer signature ->
+                let assemblies =
+                    signature.ParameterTypes
+                    |> List.fold
+                        (fun assemblies h ->
+                            ensureBaseAssembliesLoadedForConcreteHandle loadAssembly concreteTypes visited assemblies h
+                        )
+                        assemblies
+
+                match signature.ReturnType with
+                | MethodReturnType.Void -> assemblies
+                | MethodReturnType.Returns h ->
+                    ensureBaseAssembliesLoadedForConcreteHandle loadAssembly concreteTypes visited assemblies h
+            | ConcreteTypeHandle.Concrete _ ->
+                match AllConcreteTypes.lookup handle concreteTypes with
+                | None -> assemblies
+                | Some concreteType ->
+                    let assemblies =
+                        ensureTypeDefinitionBaseAssembliesLoaded
+                            loadAssembly
+                            assemblies
+                            concreteType.Assembly
+                            concreteType.Definition.Get
+
+                    // Generic arguments may themselves appear in later zeroOf calls
+                    // (via field concretization or via ldobj-style access on generic
+                    // fields), so ensure their base chains are loaded too.
+                    concreteType.Generics
+                    |> Seq.fold
+                        (fun assemblies genHandle ->
+                            ensureBaseAssembliesLoadedForConcreteHandle
+                                loadAssembly
+                                concreteTypes
+                                visited
+                                assemblies
+                                genHandle
+                        )
+                        assemblies
+
     /// Concretize a method's signature and body
     let concretizeMethod
         (ctx : AllConcreteTypes)
@@ -1142,7 +1214,60 @@ module Concretization =
                 IsStatic = method.IsStatic
             }
 
-        concretizedMethod, concCtx2.ConcreteTypes, concCtx2.LoadedAssemblies
+        // Every ConcreteTypeHandle this method emits is subsequently fed to
+        // CliType.zeroOf: locals when the frame is set up (MethodState.Empty),
+        // each parameter handle when the caller coerces arguments before invoke
+        // (IlMachineStateExecution.callMethod), and the return handle when a
+        // non-void method returns (IlMachineThreadState.ret). zeroOf's base-type
+        // walk crashes if a TypeRef along the chain points at an unloaded
+        // assembly, so we make sure every such assembly is loaded now — while
+        // we still hold the IAssemblyLoad capability — rather than deferring
+        // to the effectful edge that only sees a strict assembly-dictionary.
+        let visited = System.Collections.Generic.HashSet<ConcreteTypeHandle> ()
+        let assemblies = concCtx2.LoadedAssemblies
+
+        let assemblies =
+            signature.ParameterTypes
+            |> List.fold
+                (fun assemblies h ->
+                    ensureBaseAssembliesLoadedForConcreteHandle
+                        loadAssembly
+                        concCtx2.ConcreteTypes
+                        visited
+                        assemblies
+                        h
+                )
+                assemblies
+
+        let assemblies =
+            match signature.ReturnType with
+            | MethodReturnType.Void -> assemblies
+            | MethodReturnType.Returns h ->
+                ensureBaseAssembliesLoadedForConcreteHandle loadAssembly concCtx2.ConcreteTypes visited assemblies h
+
+        let assemblies =
+            match body with
+            | MethodBody.Il instr ->
+                match instr.LocalVars with
+                | None -> assemblies
+                | Some vars ->
+                    vars
+                    |> Seq.fold
+                        (fun assemblies h ->
+                            ensureBaseAssembliesLoadedForConcreteHandle
+                                loadAssembly
+                                concCtx2.ConcreteTypes
+                                visited
+                                assemblies
+                                h
+                        )
+                        assemblies
+            | MethodBody.InternalCall
+            | MethodBody.PInvoke
+            | MethodBody.RuntimeProvided _
+            | MethodBody.Abstract -> assemblies
+
+        concretizedMethod, concCtx2.ConcreteTypes, assemblies
 
     let rec concreteHandleToTypeDefn
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)

--- a/WoofWare.PawPrint.Domain/TypeConcretisation.fs
+++ b/WoofWare.PawPrint.Domain/TypeConcretisation.fs
@@ -1013,16 +1013,29 @@ module Concretization =
     /// type. Every one of those isValueType walks fails hard if a TypeRef along
     /// its base chain points at an assembly which has not yet been loaded.
     ///
-    /// This helper mirrors zeroOf's traversal: it loads the base chain of the top
-    /// type, its structural sub-handles (byref/pointer/array element, function-
-    /// pointer parameters and return, generic arguments), and — if the type is a
-    /// value type — recursively primes every non-static field. Field types are
-    /// concretized under the outer type's generic context in the process, so the
-    /// caller receives an updated `AllConcreteTypes` as well.
+    /// This helper mirrors zeroOf's traversal exactly:
+    ///   * Byref/Pointer/Array/OneDimArrayZero/FunctionPointer wrapper handles
+    ///     terminate in zeroOf without inspecting their component types, so we
+    ///     don't recurse into them here either. Recursing would follow paths
+    ///     zeroOf never takes, and — for recursively constructed but legal types
+    ///     such as `struct S<T> { S<S<T>>[] Items; }` — that expansion would
+    ///     stack-overflow because every synthesised instantiation is a distinct
+    ///     handle the visited-set can't collapse.
+    ///   * A nominal reference type also terminates in zeroOf (as `ObjectRef
+    ///     None`), so once we've loaded its own base chain we stop; we do NOT
+    ///     recurse into its generic arguments or fields.
+    ///   * A nominal value type is the only case where zeroOf recurses into
+    ///     fields. Each non-static field's TypeDefn is concretized under the
+    ///     outer type's generic context (that's how generic-parameter
+    ///     substitution happens) and then walked. Generic arguments only need
+    ///     priming to the extent they surface as field types, so we don't visit
+    ///     them separately.
     ///
-    /// concretizeMethod calls this on every ConcreteTypeHandle it emits (locals,
-    /// parameter types, return type), sharing a single `visited` set so the same
-    /// handle is not walked twice within one concretizeMethod invocation.
+    /// concretizeMethod calls this on every ConcreteTypeHandle a subsequent
+    /// zeroOf could encounter for a given method — locals, parameter and return
+    /// types, plus the method's own and declaring type's generic arguments,
+    /// which some intrinsics feed directly into cliTypeZeroOfHandle. A single
+    /// `visited` set is shared across the sweep so no handle is walked twice.
     let rec ensureBaseAssembliesLoadedForConcreteHandle
         (loadAssembly : IAssemblyLoad)
         (baseTypes : BaseClassTypes<DumpedAssembly>)
@@ -1036,53 +1049,13 @@ module Concretization =
             assemblies, concreteTypes
         else
             match handle with
-            | ConcreteTypeHandle.Byref inner
-            | ConcreteTypeHandle.Pointer inner
-            | ConcreteTypeHandle.OneDimArrayZero inner ->
-                // Byrefs, pointers, and arrays have no base-type chain of their own
-                // (zeroOf answers them structurally without touching isValueType),
-                // but the element type may still be zeroed later — e.g. via ldobj into
-                // a struct local — so recurse into it.
-                ensureBaseAssembliesLoadedForConcreteHandle
-                    loadAssembly
-                    baseTypes
-                    visited
-                    assemblies
-                    concreteTypes
-                    inner
-            | ConcreteTypeHandle.Array (element, _) ->
-                ensureBaseAssembliesLoadedForConcreteHandle
-                    loadAssembly
-                    baseTypes
-                    visited
-                    assemblies
-                    concreteTypes
-                    element
-            | ConcreteTypeHandle.FunctionPointer signature ->
-                let assemblies, concreteTypes =
-                    signature.ParameterTypes
-                    |> List.fold
-                        (fun (assemblies, concreteTypes) h ->
-                            ensureBaseAssembliesLoadedForConcreteHandle
-                                loadAssembly
-                                baseTypes
-                                visited
-                                assemblies
-                                concreteTypes
-                                h
-                        )
-                        (assemblies, concreteTypes)
-
-                match signature.ReturnType with
-                | MethodReturnType.Void -> assemblies, concreteTypes
-                | MethodReturnType.Returns h ->
-                    ensureBaseAssembliesLoadedForConcreteHandle
-                        loadAssembly
-                        baseTypes
-                        visited
-                        assemblies
-                        concreteTypes
-                        h
+            | ConcreteTypeHandle.Byref _
+            | ConcreteTypeHandle.Pointer _
+            | ConcreteTypeHandle.OneDimArrayZero _
+            | ConcreteTypeHandle.Array _
+            | ConcreteTypeHandle.FunctionPointer _ ->
+                // Terminal in zeroOf — see the doc comment above.
+                assemblies, concreteTypes
             | ConcreteTypeHandle.Concrete _ ->
                 match AllConcreteTypes.lookup handle concreteTypes with
                 | None -> assemblies, concreteTypes
@@ -1094,35 +1067,24 @@ module Concretization =
                             concreteType.Assembly
                             concreteType.Definition.Get
 
-                    // Generic arguments may themselves appear in later zeroOf calls
-                    // (via field concretization or via ldobj-style access on generic
-                    // fields), so ensure their base chains are loaded too.
-                    let assemblies, concreteTypes =
-                        concreteType.Generics
-                        |> Seq.fold
-                            (fun (assemblies, concreteTypes) genHandle ->
-                                ensureBaseAssembliesLoadedForConcreteHandle
-                                    loadAssembly
-                                    baseTypes
-                                    visited
-                                    assemblies
-                                    concreteTypes
-                                    genHandle
-                            )
-                            (assemblies, concreteTypes)
-
-                    // If the type is a value type, zeroOf will recursively
-                    // zero-initialise every non-static instance field, so each
-                    // field type's own base-chain assemblies must also be loaded.
-                    // Concretize each field's TypeDefn under the outer type's
-                    // generic context, then recurse. The base-chain load above
-                    // is what makes this isValueType call safe.
                     let outerAssembly = assemblies.[concreteType.Assembly.FullName]
                     let outerTypeDef = outerAssembly.TypeDefs.[concreteType.Definition.Get]
 
+                    // Reference types terminate in zeroOf as null; fields (and,
+                    // by extension, generic arguments only reachable via fields)
+                    // are never inspected. Do NOT descend — descent into a
+                    // reference type's generics or fields can loop forever on
+                    // legal shapes such as `class Box<T> {}` used inside
+                    // `struct S<T> { Box<S<S<T>>> F; }`.
                     if not (DumpedAssembly.isValueType baseTypes assemblies outerTypeDef) then
                         assemblies, concreteTypes
                     else
+                        // Value type: zeroOf recurses into every non-static
+                        // instance field, so each field type's own base-chain
+                        // assemblies must also be loaded. Concretize each
+                        // field's TypeDefn under the outer type's generic
+                        // context (this covers any generic-parameter uses
+                        // inside the field type), then recurse.
                         outerTypeDef.Fields
                         |> List.filter (fun field -> not (field.Attributes.HasFlag FieldAttributes.Static))
                         |> List.fold
@@ -1297,57 +1259,49 @@ module Concretization =
         // CliType.zeroOf: locals when the frame is set up (MethodState.Empty),
         // each parameter handle when the caller coerces arguments before invoke
         // (IlMachineStateExecution.callMethod), and the return handle when a
-        // non-void method returns (IlMachineThreadState.ret). zeroOf's base-type
-        // walk crashes if a TypeRef along the chain points at an unloaded
-        // assembly, so we make sure every such assembly is loaded now — while
-        // we still hold the IAssemblyLoad capability — rather than deferring
-        // to the effectful edge that only sees a strict assembly-dictionary.
+        // non-void method returns (IlMachineThreadState.ret). Some intrinsics
+        // — Unsafe.SizeOf<T>, Span<T>.Clear, and their siblings — also feed
+        // handles from MethodInfo.Generics and DeclaringType.Generics directly
+        // into zeroOf without those handles ever appearing in the signature.
+        // zeroOf's base-type walk crashes if a TypeRef along the chain points
+        // at an unloaded assembly, so we make sure every such assembly is
+        // loaded now — while we still hold the IAssemblyLoad capability —
+        // rather than deferring to the effectful edge that only sees a strict
+        // assembly-dictionary.
         let visited = System.Collections.Generic.HashSet<ConcreteTypeHandle> ()
         let assemblies = concCtx2.LoadedAssemblies
         let concreteTypes = concCtx2.ConcreteTypes
 
+        let primeHandle (assemblies, concreteTypes) h =
+            ensureBaseAssembliesLoadedForConcreteHandle loadAssembly baseTypes visited assemblies concreteTypes h
+
         let assemblies, concreteTypes =
-            signature.ParameterTypes
-            |> List.fold
-                (fun (assemblies, concreteTypes) h ->
-                    ensureBaseAssembliesLoadedForConcreteHandle
-                        loadAssembly
-                        baseTypes
-                        visited
-                        assemblies
-                        concreteTypes
-                        h
-                )
-                (assemblies, concreteTypes)
+            signature.ParameterTypes |> List.fold primeHandle (assemblies, concreteTypes)
 
         let assemblies, concreteTypes =
             match signature.ReturnType with
             | MethodReturnType.Void -> assemblies, concreteTypes
-            | MethodReturnType.Returns h ->
-                ensureBaseAssembliesLoadedForConcreteHandle loadAssembly baseTypes visited assemblies concreteTypes h
+            | MethodReturnType.Returns h -> primeHandle (assemblies, concreteTypes) h
 
         let assemblies, concreteTypes =
             match body with
             | MethodBody.Il instr ->
                 match instr.LocalVars with
                 | None -> assemblies, concreteTypes
-                | Some vars ->
-                    vars
-                    |> Seq.fold
-                        (fun (assemblies, concreteTypes) h ->
-                            ensureBaseAssembliesLoadedForConcreteHandle
-                                loadAssembly
-                                baseTypes
-                                visited
-                                assemblies
-                                concreteTypes
-                                h
-                        )
-                        (assemblies, concreteTypes)
+                | Some vars -> vars |> Seq.fold primeHandle (assemblies, concreteTypes)
             | MethodBody.InternalCall
             | MethodBody.PInvoke
             | MethodBody.RuntimeProvided _
             | MethodBody.Abstract -> assemblies, concreteTypes
+
+        // Method-level generic arguments (Unsafe.SizeOf<T> etc read T here).
+        let assemblies, concreteTypes =
+            genericHandles |> Seq.fold primeHandle (assemblies, concreteTypes)
+
+        // Declaring-type generic arguments (Span<T>.Clear etc read T here).
+        let assemblies, concreteTypes =
+            concretizedDeclaringType.Generics
+            |> Seq.fold primeHandle (assemblies, concreteTypes)
 
         concretizedMethod, concreteTypes, assemblies
 

--- a/WoofWare.PawPrint.Domain/TypeConcretisation.fs
+++ b/WoofWare.PawPrint.Domain/TypeConcretisation.fs
@@ -1005,27 +1005,35 @@ module Concretization =
         let typeDef = assy.TypeDefs.[typeDefinitionHandle]
         ensureBaseTypeAssembliesLoaded loadAssembly assemblies assy.Name typeDef.BaseType
 
-    /// Force-load every assembly needed to walk the base-type chain of the given
-    /// concrete handle (and any handles it structurally wraps, and its generic
-    /// arguments). CliType.zeroOf invokes DumpedAssembly.isValueType on a concretized
-    /// type to decide whether it needs a zeroed value-type layout or a null reference;
-    /// that walk fails hard if a TypeRef along the base chain points at an assembly
-    /// which has not yet been loaded. concretizeMethod calls this on every handle it
-    /// emits (locals, parameter types, and the return type) so that subsequent
-    /// zero-initialization is guaranteed to have every assembly it needs.
+    /// Force-load every assembly needed for CliType.zeroOf to zero-initialise the
+    /// given concrete handle. zeroOf calls DumpedAssembly.isValueType on the top
+    /// type to decide between a zeroed value-type layout and a null reference; if
+    /// the type turns out to be a value type, zeroOf recursively zeros each
+    /// non-static field, which repeats the same isValueType decision on the field
+    /// type. Every one of those isValueType walks fails hard if a TypeRef along
+    /// its base chain points at an assembly which has not yet been loaded.
     ///
-    /// The `visited` set is shared across sibling calls so the same handle is not
-    /// walked twice within one concretizeMethod invocation.
+    /// This helper mirrors zeroOf's traversal: it loads the base chain of the top
+    /// type, its structural sub-handles (byref/pointer/array element, function-
+    /// pointer parameters and return, generic arguments), and — if the type is a
+    /// value type — recursively primes every non-static field. Field types are
+    /// concretized under the outer type's generic context in the process, so the
+    /// caller receives an updated `AllConcreteTypes` as well.
+    ///
+    /// concretizeMethod calls this on every ConcreteTypeHandle it emits (locals,
+    /// parameter types, return type), sharing a single `visited` set so the same
+    /// handle is not walked twice within one concretizeMethod invocation.
     let rec ensureBaseAssembliesLoadedForConcreteHandle
         (loadAssembly : IAssemblyLoad)
-        (concreteTypes : AllConcreteTypes)
+        (baseTypes : BaseClassTypes<DumpedAssembly>)
         (visited : System.Collections.Generic.HashSet<ConcreteTypeHandle>)
         (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (concreteTypes : AllConcreteTypes)
         (handle : ConcreteTypeHandle)
-        : ImmutableDictionary<string, DumpedAssembly>
+        : ImmutableDictionary<string, DumpedAssembly> * AllConcreteTypes
         =
         if not (visited.Add handle) then
-            assemblies
+            assemblies, concreteTypes
         else
             match handle with
             | ConcreteTypeHandle.Byref inner
@@ -1035,25 +1043,49 @@ module Concretization =
                 // (zeroOf answers them structurally without touching isValueType),
                 // but the element type may still be zeroed later — e.g. via ldobj into
                 // a struct local — so recurse into it.
-                ensureBaseAssembliesLoadedForConcreteHandle loadAssembly concreteTypes visited assemblies inner
+                ensureBaseAssembliesLoadedForConcreteHandle
+                    loadAssembly
+                    baseTypes
+                    visited
+                    assemblies
+                    concreteTypes
+                    inner
             | ConcreteTypeHandle.Array (element, _) ->
-                ensureBaseAssembliesLoadedForConcreteHandle loadAssembly concreteTypes visited assemblies element
+                ensureBaseAssembliesLoadedForConcreteHandle
+                    loadAssembly
+                    baseTypes
+                    visited
+                    assemblies
+                    concreteTypes
+                    element
             | ConcreteTypeHandle.FunctionPointer signature ->
-                let assemblies =
+                let assemblies, concreteTypes =
                     signature.ParameterTypes
                     |> List.fold
-                        (fun assemblies h ->
-                            ensureBaseAssembliesLoadedForConcreteHandle loadAssembly concreteTypes visited assemblies h
+                        (fun (assemblies, concreteTypes) h ->
+                            ensureBaseAssembliesLoadedForConcreteHandle
+                                loadAssembly
+                                baseTypes
+                                visited
+                                assemblies
+                                concreteTypes
+                                h
                         )
-                        assemblies
+                        (assemblies, concreteTypes)
 
                 match signature.ReturnType with
-                | MethodReturnType.Void -> assemblies
+                | MethodReturnType.Void -> assemblies, concreteTypes
                 | MethodReturnType.Returns h ->
-                    ensureBaseAssembliesLoadedForConcreteHandle loadAssembly concreteTypes visited assemblies h
+                    ensureBaseAssembliesLoadedForConcreteHandle
+                        loadAssembly
+                        baseTypes
+                        visited
+                        assemblies
+                        concreteTypes
+                        h
             | ConcreteTypeHandle.Concrete _ ->
                 match AllConcreteTypes.lookup handle concreteTypes with
-                | None -> assemblies
+                | None -> assemblies, concreteTypes
                 | Some concreteType ->
                     let assemblies =
                         ensureTypeDefinitionBaseAssembliesLoaded
@@ -1065,17 +1097,64 @@ module Concretization =
                     // Generic arguments may themselves appear in later zeroOf calls
                     // (via field concretization or via ldobj-style access on generic
                     // fields), so ensure their base chains are loaded too.
-                    concreteType.Generics
-                    |> Seq.fold
-                        (fun assemblies genHandle ->
-                            ensureBaseAssembliesLoadedForConcreteHandle
-                                loadAssembly
-                                concreteTypes
-                                visited
-                                assemblies
-                                genHandle
-                        )
-                        assemblies
+                    let assemblies, concreteTypes =
+                        concreteType.Generics
+                        |> Seq.fold
+                            (fun (assemblies, concreteTypes) genHandle ->
+                                ensureBaseAssembliesLoadedForConcreteHandle
+                                    loadAssembly
+                                    baseTypes
+                                    visited
+                                    assemblies
+                                    concreteTypes
+                                    genHandle
+                            )
+                            (assemblies, concreteTypes)
+
+                    // If the type is a value type, zeroOf will recursively
+                    // zero-initialise every non-static instance field, so each
+                    // field type's own base-chain assemblies must also be loaded.
+                    // Concretize each field's TypeDefn under the outer type's
+                    // generic context, then recurse. The base-chain load above
+                    // is what makes this isValueType call safe.
+                    let outerAssembly = assemblies.[concreteType.Assembly.FullName]
+                    let outerTypeDef = outerAssembly.TypeDefs.[concreteType.Definition.Get]
+
+                    if not (DumpedAssembly.isValueType baseTypes assemblies outerTypeDef) then
+                        assemblies, concreteTypes
+                    else
+                        outerTypeDef.Fields
+                        |> List.filter (fun field -> not (field.Attributes.HasFlag FieldAttributes.Static))
+                        |> List.fold
+                            (fun (assemblies, concreteTypes) field ->
+                                let ctx : TypeConcretization.ConcretizationContext<DumpedAssembly> =
+                                    {
+                                        TypeConcretization.ConcretizationContext.ConcreteTypes = concreteTypes
+                                        TypeConcretization.ConcretizationContext.LoadedAssemblies = assemblies
+                                        TypeConcretization.ConcretizationContext.BaseTypes = baseTypes
+                                    }
+
+                                // Fields never carry method-level generics; the
+                                // outer type's already-concretized generic
+                                // arguments cover the field's substitution.
+                                let fieldHandle, ctx =
+                                    TypeConcretization.concretizeType
+                                        ctx
+                                        loadAssembly
+                                        concreteType.Assembly
+                                        concreteType.Generics
+                                        ImmutableArray.Empty
+                                        field.Signature
+
+                                ensureBaseAssembliesLoadedForConcreteHandle
+                                    loadAssembly
+                                    baseTypes
+                                    visited
+                                    ctx.LoadedAssemblies
+                                    ctx.ConcreteTypes
+                                    fieldHandle
+                            )
+                            (assemblies, concreteTypes)
 
     /// Concretize a method's signature and body
     let concretizeMethod
@@ -1225,49 +1304,52 @@ module Concretization =
         // to the effectful edge that only sees a strict assembly-dictionary.
         let visited = System.Collections.Generic.HashSet<ConcreteTypeHandle> ()
         let assemblies = concCtx2.LoadedAssemblies
+        let concreteTypes = concCtx2.ConcreteTypes
 
-        let assemblies =
+        let assemblies, concreteTypes =
             signature.ParameterTypes
             |> List.fold
-                (fun assemblies h ->
+                (fun (assemblies, concreteTypes) h ->
                     ensureBaseAssembliesLoadedForConcreteHandle
                         loadAssembly
-                        concCtx2.ConcreteTypes
+                        baseTypes
                         visited
                         assemblies
+                        concreteTypes
                         h
                 )
-                assemblies
+                (assemblies, concreteTypes)
 
-        let assemblies =
+        let assemblies, concreteTypes =
             match signature.ReturnType with
-            | MethodReturnType.Void -> assemblies
+            | MethodReturnType.Void -> assemblies, concreteTypes
             | MethodReturnType.Returns h ->
-                ensureBaseAssembliesLoadedForConcreteHandle loadAssembly concCtx2.ConcreteTypes visited assemblies h
+                ensureBaseAssembliesLoadedForConcreteHandle loadAssembly baseTypes visited assemblies concreteTypes h
 
-        let assemblies =
+        let assemblies, concreteTypes =
             match body with
             | MethodBody.Il instr ->
                 match instr.LocalVars with
-                | None -> assemblies
+                | None -> assemblies, concreteTypes
                 | Some vars ->
                     vars
                     |> Seq.fold
-                        (fun assemblies h ->
+                        (fun (assemblies, concreteTypes) h ->
                             ensureBaseAssembliesLoadedForConcreteHandle
                                 loadAssembly
-                                concCtx2.ConcreteTypes
+                                baseTypes
                                 visited
                                 assemblies
+                                concreteTypes
                                 h
                         )
-                        assemblies
+                        (assemblies, concreteTypes)
             | MethodBody.InternalCall
             | MethodBody.PInvoke
             | MethodBody.RuntimeProvided _
-            | MethodBody.Abstract -> assemblies
+            | MethodBody.Abstract -> assemblies, concreteTypes
 
-        concretizedMethod, concCtx2.ConcreteTypes, assemblies
+        concretizedMethod, concreteTypes, assemblies
 
     let rec concreteHandleToTypeDefn
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)

--- a/WoofWare.PawPrint.Test/TestZeroOfBaseAssemblies.fs
+++ b/WoofWare.PawPrint.Test/TestZeroOfBaseAssemblies.fs
@@ -12,23 +12,17 @@ open WoofWare.PawPrint
 
 /// Regression coverage for the invariant that concretizeMethod leaves every
 /// ConcreteTypeHandle it emits (locals, parameters, return type) in a state
-/// where CliType.zeroOf can safely walk its base-type chain — i.e. every
+/// where CliType.zeroOf can safely walk its base-type chain - i.e. every
 /// assembly reachable from a base-type TypeRef is already loaded.
-///
-/// The failure mode this guards is DumpedAssembly.getTypeRef crashing with
-/// "seems pretty unlikely that we could have constructed this object without
-/// loading its base type" when zeroOf → isValueType hits a TypeRef pointing at
-/// an assembly (typically a facade like netstandard) that has not been force-
-/// loaded yet.
 [<TestFixture>]
 [<Parallelizable(ParallelScope.All)>]
 module TestZeroOfBaseAssemblies =
 
     /// FSharp.Core built against netstandard2.1 references `netstandard` for
     /// BCL primitives (including System.ValueType, the base of every F#
-    /// [<Struct>] type). Concretizing a struct from this DLL does not need
+    /// Struct type). Concretizing a struct from this DLL does not need
     /// netstandard, but zero-initialising an instance of that struct does.
-    let private fsharpCoreNetstandard21Path : string =
+    let private fsharpCoreNetstandard21Path' () : string =
         let nugetRoot =
             match Environment.GetEnvironmentVariable "NUGET_PACKAGES" with
             | null
@@ -90,7 +84,7 @@ module TestZeroOfBaseAssemblies =
                 =
                 let referencedInAssembly =
                     match loadedAssemblies.TryGetValue referencedIn.FullName with
-                    | false, _ -> failwithf "Missing loaded assembly %s" referencedIn.FullName
+                    | false, _ -> failwithf $"Missing loaded assembly %s{referencedIn.FullName}"
                     | true, assy -> assy
 
                 let assemblyRef = referencedInAssembly.AssemblyReferences.[handle]
@@ -105,7 +99,7 @@ module TestZeroOfBaseAssemblies =
                             if File.Exists candidate then Some candidate else None
                         )
                         |> Option.defaultWith (fun () ->
-                            failwithf "Test setup could not locate assembly %s on disk" assemblyRef.Name.FullName
+                            failwithf $"Test setup could not locate assembly %s{assemblyRef.Name.FullName} on disk"
                         )
 
                     let dumped = readAssembly path
@@ -118,13 +112,16 @@ module TestZeroOfBaseAssemblies =
             failwith "Expected FSharpValueOption`1 in netstandard2.1 FSharp.Core; nuget layout may have changed"
         )
 
+    let fsharpCoreNetstandard21Path : string Lazy =
+        System.Lazy<_>.Create fsharpCoreNetstandard21Path'
+
     [<Test>]
     let ``ensureBaseAssembliesLoadedForConcreteHandle loads facade assembly reachable via base-type TypeRef``
         ()
         : unit
         =
         let corelib = readAssembly corelibPath
-        let fsharpCore = readAssembly fsharpCoreNetstandard21Path
+        let fsharpCore = readAssembly fsharpCoreNetstandard21Path.Value
 
         let baseTypes = Corelib.getBaseTypes corelib
 
@@ -222,7 +219,7 @@ module TestZeroOfBaseAssemblies =
     [<Test>]
     let ``helper is idempotent and cycle-safe against repeated calls on the same handle`` () : unit =
         let corelib = readAssembly corelibPath
-        let fsharpCore = readAssembly fsharpCoreNetstandard21Path
+        let fsharpCore = readAssembly fsharpCoreNetstandard21Path.Value
         let baseTypes = Corelib.getBaseTypes corelib
 
         let loaded : ImmutableDictionary<string, DumpedAssembly> =
@@ -292,7 +289,7 @@ module TestZeroOfBaseAssemblies =
         // base chain. Without that recursion, zeroOf would still crash when it
         // descended into the field.
         let corelib = readAssembly corelibPath
-        let fsharpCore = readAssembly fsharpCoreNetstandard21Path
+        let fsharpCore = readAssembly fsharpCoreNetstandard21Path.Value
         let baseTypes = Corelib.getBaseTypes corelib
         assertNetstandardAvailable ()
 
@@ -300,7 +297,7 @@ module TestZeroOfBaseAssemblies =
         // that references the netstandard2.1 FSharp.Core we already loaded.
         let outerAssemblyBytes : byte[] =
             let fsharpCoreRef =
-                MetadataReference.CreateFromFile fsharpCoreNetstandard21Path :> MetadataReference
+                MetadataReference.CreateFromFile fsharpCoreNetstandard21Path.Value :> MetadataReference
 
             let source =
                 """
@@ -319,7 +316,7 @@ public struct Outer
         let outerAssembly : DumpedAssembly =
             let _, loggerFactory = LoggerFactory.makeTest ()
             use stream = new MemoryStream (outerAssemblyBytes)
-            global.WoofWare.PawPrint.AssemblyApi.read loggerFactory None stream
+            AssemblyApi.read loggerFactory None stream
 
         let loadAssembly = OnDemandAssemblyLoad [ runtimeDir ]
 
@@ -395,7 +392,7 @@ public struct Outer
 
         let _, loggerFactory = LoggerFactory.makeTest ()
         use stream = new MemoryStream (bytes)
-        global.WoofWare.PawPrint.AssemblyApi.read loggerFactory None stream
+        AssemblyApi.read loggerFactory None stream
 
     [<Test>]
     let ``priming terminates for recursively-nested struct with array-of-recursive field`` () : unit =
@@ -462,13 +459,13 @@ public struct S<T>
             concretizeCtx.LoadedAssemblies
             concretizeCtx.ConcreteTypes
             handle
-        |> ignore
+        |> ignore<_ * _>
 
     [<Test>]
     let ``priming does not descend into generic arguments of reference types`` () : unit =
         // A reference type is terminal in CliType.zeroOf — it becomes
         // `ObjectRef None` without inspecting either its fields or its
-        // generic arguments. The helper must respect that or it will loop
+        // generic arguments. The helper must respect that, or it will loop
         // forever on a legal shape like `struct S<T> { Box<S<S<T>>> F; }`,
         // where the recursion goes S<int> → Box<S<S<int>>> → S<S<int>> →
         // Box<S<S<S<int>>>> → ...
@@ -527,18 +524,18 @@ public struct S<T>
             concretizeCtx.LoadedAssemblies
             concretizeCtx.ConcreteTypes
             handle
-        |> ignore
+        |> ignore<_ * _>
 
     [<Test>]
     let ``concretizeMethod primes method-level generic arguments used only by intrinsics`` () : unit =
         // Regression for Unsafe.SizeOf<T> / Span<T>.Clear / etc: their
         // intrinsic dispatch reads T from methodToCall.Generics (or the
-        // declaring type's generics), NOT from the method's own signature.
+        // declaring type's generics), not from the method's own signature.
         // If concretizeMethod doesn't prime those generic-argument handles,
         // subsequent cliTypeZeroOfHandle on T can still crash with the
         // unloaded-base-assembly exception.
         let corelib = readAssembly corelibPath
-        let fsharpCore = readAssembly fsharpCoreNetstandard21Path
+        let fsharpCore = readAssembly fsharpCoreNetstandard21Path.Value
         let baseTypes = Corelib.getBaseTypes corelib
         assertNetstandardAvailable ()
 
@@ -572,7 +569,7 @@ public static class C
         let loadAssembly = OnDemandAssemblyLoad [ runtimeDir ]
 
         // Concretize FSharpValueOption<int> into the concreteTypes dictionary
-        // (still with netstandard NOT loaded), so we can pass its handle as
+        // (still with netstandard not yet loaded), so we can pass its handle as
         // the method's generic argument. Concretization does not walk base
         // types, so netstandard remains absent at this point.
         let valueOptionTypeDef = getValueOptionTypeDef fsharpCore

--- a/WoofWare.PawPrint.Test/TestZeroOfBaseAssemblies.fs
+++ b/WoofWare.PawPrint.Test/TestZeroOfBaseAssemblies.fs
@@ -1,0 +1,280 @@
+namespace WoofWare.PawPrint.Test
+
+open System
+open System.Collections.Immutable
+open System.IO
+open System.Reflection
+open System.Reflection.Metadata
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+/// Regression coverage for the invariant that concretizeMethod leaves every
+/// ConcreteTypeHandle it emits (locals, parameters, return type) in a state
+/// where CliType.zeroOf can safely walk its base-type chain — i.e. every
+/// assembly reachable from a base-type TypeRef is already loaded.
+///
+/// The failure mode this guards is DumpedAssembly.getTypeRef crashing with
+/// "seems pretty unlikely that we could have constructed this object without
+/// loading its base type" when zeroOf → isValueType hits a TypeRef pointing at
+/// an assembly (typically a facade like netstandard) that has not been force-
+/// loaded yet.
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestZeroOfBaseAssemblies =
+
+    /// FSharp.Core built against netstandard2.1 references `netstandard` for
+    /// BCL primitives (including System.ValueType, the base of every F#
+    /// [<Struct>] type). Concretizing a struct from this DLL does not need
+    /// netstandard, but zero-initialising an instance of that struct does.
+    let private fsharpCoreNetstandard21Path : string =
+        let nugetRoot =
+            match Environment.GetEnvironmentVariable "NUGET_PACKAGES" with
+            | null
+            | "" -> Path.Combine (Environment.GetFolderPath Environment.SpecialFolder.UserProfile, ".nuget", "packages")
+            | value -> value
+
+        let fsharpCoreDir = Path.Combine (nugetRoot, "fsharp.core")
+
+        if not (Directory.Exists fsharpCoreDir) then
+            Assert.Ignore
+                $"FSharp.Core nuget package not found under %s{fsharpCoreDir}; skipping netstandard2.1 base-chain regression."
+
+        let candidate =
+            Directory.EnumerateDirectories fsharpCoreDir
+            |> Seq.choose (fun versionDir ->
+                let dll = Path.Combine (versionDir, "lib", "netstandard2.1", "FSharp.Core.dll")
+
+                if File.Exists dll then Some dll else None
+            )
+            |> Seq.tryHead
+
+        match candidate with
+        | Some dll -> dll
+        | None ->
+            Assert.Ignore
+                "No FSharp.Core/*/lib/netstandard2.1/FSharp.Core.dll found; skipping netstandard2.1 base-chain regression."
+
+            failwith "unreachable"
+
+    let private corelibPath : string = typeof<obj>.Assembly.Location
+
+    /// netstandard.dll and every BCL facade this test may need ship alongside
+    /// System.Private.CoreLib in every Microsoft.NETCore.App runtime we test
+    /// against; a directory-scoped IAssemblyLoad can resolve them on demand.
+    let private runtimeDir : string = Path.GetDirectoryName corelibPath
+
+    let private assertNetstandardAvailable () : unit =
+        let candidate = Path.Combine (runtimeDir, "netstandard.dll")
+
+        if not (File.Exists candidate) then
+            Assert.Ignore $"netstandard.dll not found next to corelib at %s{candidate}"
+
+    let private readAssembly (path : string) : DumpedAssembly =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        Assembly.readFile loggerFactory path
+
+    /// An IAssemblyLoad that resolves references by searching a set of
+    /// directories on disk for a DLL matching the referenced assembly's
+    /// simple name (`Foo` → `Foo.dll`). All BCL/facade assemblies live next
+    /// to System.Private.CoreLib, so a single directory lookup suffices for
+    /// this test's needs.
+    type private OnDemandAssemblyLoad (searchDirs : string list) =
+        interface IAssemblyLoad with
+            member _.LoadAssembly
+                (loadedAssemblies : ImmutableDictionary<string, DumpedAssembly>)
+                (referencedIn : AssemblyName)
+                (handle : AssemblyReferenceHandle)
+                : ImmutableDictionary<string, DumpedAssembly> * DumpedAssembly
+                =
+                let referencedInAssembly =
+                    match loadedAssemblies.TryGetValue referencedIn.FullName with
+                    | false, _ -> failwithf "Missing loaded assembly %s" referencedIn.FullName
+                    | true, assy -> assy
+
+                let assemblyRef = referencedInAssembly.AssemblyReferences.[handle]
+
+                match loadedAssemblies.TryGetValue assemblyRef.Name.FullName with
+                | true, assy -> loadedAssemblies, assy
+                | false, _ ->
+                    let path =
+                        searchDirs
+                        |> List.tryPick (fun dir ->
+                            let candidate = Path.Combine (dir, assemblyRef.Name.Name + ".dll")
+                            if File.Exists candidate then Some candidate else None
+                        )
+                        |> Option.defaultWith (fun () ->
+                            failwithf "Test setup could not locate assembly %s on disk" assemblyRef.Name.FullName
+                        )
+
+                    let dumped = readAssembly path
+                    loadedAssemblies.SetItem (dumped.Name.FullName, dumped), dumped
+
+    /// Look up FSharpValueOption`1 in the netstandard2.1 build of FSharp.Core.
+    let private getValueOptionTypeDef (fsharpCore : DumpedAssembly) : TypeInfo<GenericParamFromMetadata, TypeDefn> =
+        fsharpCore.TryGetTopLevelTypeDef "Microsoft.FSharp.Core" "FSharpValueOption`1"
+        |> Option.defaultWith (fun () ->
+            failwith "Expected FSharpValueOption`1 in netstandard2.1 FSharp.Core; nuget layout may have changed"
+        )
+
+    [<Test>]
+    let ``ensureBaseAssembliesLoadedForConcreteHandle loads facade assembly reachable via base-type TypeRef``
+        ()
+        : unit
+        =
+        let corelib = readAssembly corelibPath
+        let fsharpCore = readAssembly fsharpCoreNetstandard21Path
+
+        let baseTypes = Corelib.getBaseTypes corelib
+
+        // Prime loadedAssemblies with corelib + FSharp.Core (netstandard2.1),
+        // but NOT netstandard itself — that's the facade FSharp.Core's base
+        // TypeRefs point at.
+        let loaded : ImmutableDictionary<string, DumpedAssembly> =
+            [ corelib ; fsharpCore ]
+            |> Seq.map (fun a -> System.Collections.Generic.KeyValuePair (a.Name.FullName, a))
+            |> ImmutableDictionary.CreateRange
+
+        loaded.ContainsKey "netstandard, Version=2.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51"
+        |> shouldEqual false
+
+        assertNetstandardAvailable ()
+        let loadAssembly = OnDemandAssemblyLoad [ runtimeDir ]
+
+        // Concretize FSharpValueOption<int>. Concretization itself does not walk
+        // base types, so it should not trigger a netstandard load.
+        let valueOptionTypeDef = getValueOptionTypeDef fsharpCore
+
+        let concretizeCtx : TypeConcretization.ConcretizationContext<DumpedAssembly> =
+            {
+                ConcreteTypes = Corelib.concretizeAll loaded baseTypes AllConcreteTypes.Empty
+                LoadedAssemblies = loaded
+                BaseTypes = baseTypes
+            }
+
+        // FSharpValueOption`1 is [<Struct>], so its signature-kind is ValueType.
+        // We hardcode this rather than calling DumpedAssembly.signatureTypeKind,
+        // which itself would trigger the same base-chain walk we're trying to
+        // exercise the fix for.
+        let valueOptionInt : TypeDefn =
+            let identity = valueOptionTypeDef.Identity
+
+            TypeDefn.GenericInstantiation (
+                TypeDefn.FromDefinition (identity, SignatureTypeKind.ValueType),
+                ImmutableArray.CreateRange [ TypeDefn.PrimitiveType PrimitiveType.Int32 ]
+            )
+
+        let handle, concretizeCtx =
+            TypeConcretization.concretizeType
+                concretizeCtx
+                (loadAssembly :> IAssemblyLoad)
+                fsharpCore.Name
+                ImmutableArray.Empty
+                ImmutableArray.Empty
+                valueOptionInt
+
+        // Sanity: concretization itself did not need netstandard.
+        let netstandardLoadedAfterConcretize =
+            concretizeCtx.LoadedAssemblies.Keys
+            |> Seq.exists (fun (n : string) -> n.StartsWith ("netstandard,", StringComparison.OrdinalIgnoreCase))
+
+        netstandardLoadedAfterConcretize |> shouldEqual false
+
+        // The bug: calling isValueType directly on the metadata now would crash
+        // with "seems pretty unlikely...", because FSharpValueOption's base
+        // TypeRef points at System.ValueType in netstandard (not yet loaded).
+        let isValueTypeBeforeHelper =
+            try
+                DumpedAssembly.isValueType baseTypes concretizeCtx.LoadedAssemblies valueOptionTypeDef
+                |> Ok
+            with e ->
+                Error e.Message
+
+        match isValueTypeBeforeHelper with
+        | Ok _ ->
+            Assert.Fail
+                "Expected isValueType to fail before running ensureBaseAssembliesLoadedForConcreteHandle; the test scenario no longer exercises the bug."
+        | Error msg -> msg |> shouldContainText "seems pretty unlikely"
+
+        // The fix: run the helper, then isValueType must succeed against the
+        // returned assemblies dict.
+        let visited = System.Collections.Generic.HashSet<ConcreteTypeHandle> ()
+
+        let loadedAfterHelper =
+            Concretization.ensureBaseAssembliesLoadedForConcreteHandle
+                (loadAssembly :> IAssemblyLoad)
+                concretizeCtx.ConcreteTypes
+                visited
+                concretizeCtx.LoadedAssemblies
+                handle
+
+        // netstandard is now loaded.
+        loadedAfterHelper.Keys
+        |> Seq.exists (fun (n : string) -> n.StartsWith ("netstandard,", StringComparison.OrdinalIgnoreCase))
+        |> shouldEqual true
+
+        // isValueType now succeeds — FSharpValueOption is a struct.
+        DumpedAssembly.isValueType baseTypes loadedAfterHelper valueOptionTypeDef
+        |> shouldEqual true
+
+    [<Test>]
+    let ``helper is idempotent and cycle-safe against repeated calls on the same handle`` () : unit =
+        let corelib = readAssembly corelibPath
+        let fsharpCore = readAssembly fsharpCoreNetstandard21Path
+        let baseTypes = Corelib.getBaseTypes corelib
+
+        let loaded : ImmutableDictionary<string, DumpedAssembly> =
+            [ corelib ; fsharpCore ]
+            |> Seq.map (fun a -> System.Collections.Generic.KeyValuePair (a.Name.FullName, a))
+            |> ImmutableDictionary.CreateRange
+
+        assertNetstandardAvailable ()
+        let loadAssembly = OnDemandAssemblyLoad [ runtimeDir ]
+
+        let concretizeCtx : TypeConcretization.ConcretizationContext<DumpedAssembly> =
+            {
+                ConcreteTypes = Corelib.concretizeAll loaded baseTypes AllConcreteTypes.Empty
+                LoadedAssemblies = loaded
+                BaseTypes = baseTypes
+            }
+
+        let valueOptionTypeDef = getValueOptionTypeDef fsharpCore
+
+        let valueOptionInt : TypeDefn =
+            TypeDefn.GenericInstantiation (
+                TypeDefn.FromDefinition (valueOptionTypeDef.Identity, SignatureTypeKind.ValueType),
+                ImmutableArray.CreateRange [ TypeDefn.PrimitiveType PrimitiveType.Int32 ]
+            )
+
+        let handle, concretizeCtx =
+            TypeConcretization.concretizeType
+                concretizeCtx
+                (loadAssembly :> IAssemblyLoad)
+                fsharpCore.Name
+                ImmutableArray.Empty
+                ImmutableArray.Empty
+                valueOptionInt
+
+        // Two back-to-back calls (fresh visited each time) must both return
+        // assembly dicts containing netstandard, and the second must not throw
+        // or attempt any redundant work that would break with a "already loaded"
+        // condition. Sharing visited across a single call is required only to
+        // bound work within one call; between calls, the dict itself is the
+        // idempotence guarantee.
+        let firstRun =
+            Concretization.ensureBaseAssembliesLoadedForConcreteHandle
+                (loadAssembly :> IAssemblyLoad)
+                concretizeCtx.ConcreteTypes
+                (System.Collections.Generic.HashSet ())
+                concretizeCtx.LoadedAssemblies
+                handle
+
+        let secondRun =
+            Concretization.ensureBaseAssembliesLoadedForConcreteHandle
+                (loadAssembly :> IAssemblyLoad)
+                concretizeCtx.ConcreteTypes
+                (System.Collections.Generic.HashSet ())
+                firstRun
+                handle
+
+        secondRun.Count |> shouldEqual firstRun.Count

--- a/WoofWare.PawPrint.Test/TestZeroOfBaseAssemblies.fs
+++ b/WoofWare.PawPrint.Test/TestZeroOfBaseAssemblies.fs
@@ -6,6 +6,7 @@ open System.IO
 open System.Reflection
 open System.Reflection.Metadata
 open FsUnitTyped
+open Microsoft.CodeAnalysis
 open NUnit.Framework
 open WoofWare.PawPrint
 
@@ -200,12 +201,13 @@ module TestZeroOfBaseAssemblies =
         // returned assemblies dict.
         let visited = System.Collections.Generic.HashSet<ConcreteTypeHandle> ()
 
-        let loadedAfterHelper =
+        let loadedAfterHelper, _ =
             Concretization.ensureBaseAssembliesLoadedForConcreteHandle
                 (loadAssembly :> IAssemblyLoad)
-                concretizeCtx.ConcreteTypes
+                baseTypes
                 visited
                 concretizeCtx.LoadedAssemblies
+                concretizeCtx.ConcreteTypes
                 handle
 
         // netstandard is now loaded.
@@ -261,20 +263,126 @@ module TestZeroOfBaseAssemblies =
         // condition. Sharing visited across a single call is required only to
         // bound work within one call; between calls, the dict itself is the
         // idempotence guarantee.
-        let firstRun =
+        let firstRun, firstCtx =
             Concretization.ensureBaseAssembliesLoadedForConcreteHandle
                 (loadAssembly :> IAssemblyLoad)
-                concretizeCtx.ConcreteTypes
+                baseTypes
                 (System.Collections.Generic.HashSet ())
                 concretizeCtx.LoadedAssemblies
+                concretizeCtx.ConcreteTypes
                 handle
 
-        let secondRun =
+        let secondRun, _ =
             Concretization.ensureBaseAssembliesLoadedForConcreteHandle
                 (loadAssembly :> IAssemblyLoad)
-                concretizeCtx.ConcreteTypes
+                baseTypes
                 (System.Collections.Generic.HashSet ())
                 firstRun
+                firstCtx
                 handle
 
         secondRun.Count |> shouldEqual firstRun.Count
+
+    [<Test>]
+    let ``helper recurses into instance fields of value types`` () : unit =
+        // Nested-struct regression: the outer struct's own base chain resolves
+        // against System.Runtime (already loaded via corelib references), so
+        // loading the outer's base chain does NOT drag in netstandard. netstandard
+        // becomes necessary only via the field walk into FSharpValueOption`1's
+        // base chain. Without that recursion, zeroOf would still crash when it
+        // descended into the field.
+        let corelib = readAssembly corelibPath
+        let fsharpCore = readAssembly fsharpCoreNetstandard21Path
+        let baseTypes = Corelib.getBaseTypes corelib
+        assertNetstandardAvailable ()
+
+        // Build a C# library `struct Outer { FSharpValueOption<int> Inner; }`
+        // that references the netstandard2.1 FSharp.Core we already loaded.
+        let outerAssemblyBytes : byte[] =
+            let fsharpCoreRef =
+                MetadataReference.CreateFromFile fsharpCoreNetstandard21Path :> MetadataReference
+
+            let source =
+                """
+public struct Outer
+{
+    public Microsoft.FSharp.Core.FSharpValueOption<int> Inner;
+}
+"""
+
+            Roslyn.compileAssembly
+                "NestedStructRegression"
+                OutputKind.DynamicallyLinkedLibrary
+                [ fsharpCoreRef ]
+                [ source ]
+
+        let outerAssembly : DumpedAssembly =
+            let _, loggerFactory = LoggerFactory.makeTest ()
+            use stream = new MemoryStream (outerAssemblyBytes)
+            global.WoofWare.PawPrint.AssemblyApi.read loggerFactory None stream
+
+        let loadAssembly = OnDemandAssemblyLoad [ runtimeDir ]
+
+        // Prime with corelib + FSharp.Core + the wrapper. Deliberately leave
+        // netstandard out; the wrapper's own base chain doesn't need it.
+        let loaded : ImmutableDictionary<string, DumpedAssembly> =
+            [ corelib ; fsharpCore ; outerAssembly ]
+            |> Seq.map (fun a -> System.Collections.Generic.KeyValuePair (a.Name.FullName, a))
+            |> ImmutableDictionary.CreateRange
+
+        let outerTypeDef =
+            outerAssembly.TryGetTopLevelTypeDef "" "Outer"
+            |> Option.defaultWith (fun () -> failwith "Failed to find compiled Outer struct in the test assembly")
+
+        let concretizeCtx : TypeConcretization.ConcretizationContext<DumpedAssembly> =
+            {
+                ConcreteTypes = Corelib.concretizeAll loaded baseTypes AllConcreteTypes.Empty
+                LoadedAssemblies = loaded
+                BaseTypes = baseTypes
+            }
+
+        let outerHandle, concretizeCtx =
+            TypeConcretization.concretizeType
+                concretizeCtx
+                (loadAssembly :> IAssemblyLoad)
+                outerAssembly.Name
+                ImmutableArray.Empty
+                ImmutableArray.Empty
+                (TypeDefn.FromDefinition (outerTypeDef.Identity, SignatureTypeKind.ValueType))
+
+        // Sanity: Outer's own base-chain load does not need netstandard.
+        // We measure the state before running the helper, by explicitly
+        // loading only the outer's base chain and confirming netstandard is
+        // still absent.
+        let assembliesAfterOuterBaseChain =
+            Concretization.ensureTypeDefinitionBaseAssembliesLoaded
+                (loadAssembly :> IAssemblyLoad)
+                concretizeCtx.LoadedAssemblies
+                outerAssembly.Name
+                outerTypeDef.TypeDefHandle
+
+        assembliesAfterOuterBaseChain.Keys
+        |> Seq.exists (fun (n : string) -> n.StartsWith ("netstandard,", StringComparison.OrdinalIgnoreCase))
+        |> shouldEqual false
+
+        // Now run the full helper. It must descend into Outer's instance
+        // field (FSharpValueOption<int>) and, through that field's base chain,
+        // finally load netstandard.
+        let loadedAfterHelper, _ =
+            Concretization.ensureBaseAssembliesLoadedForConcreteHandle
+                (loadAssembly :> IAssemblyLoad)
+                baseTypes
+                (System.Collections.Generic.HashSet ())
+                assembliesAfterOuterBaseChain
+                concretizeCtx.ConcreteTypes
+                outerHandle
+
+        loadedAfterHelper.Keys
+        |> Seq.exists (fun (n : string) -> n.StartsWith ("netstandard,", StringComparison.OrdinalIgnoreCase))
+        |> shouldEqual true
+
+        // And isValueType on the nested field type succeeds too.
+        let valueOptionTypeDef = getValueOptionTypeDef fsharpCore
+
+        DumpedAssembly.isValueType baseTypes loadedAfterHelper valueOptionTypeDef
+        |> shouldEqual true

--- a/WoofWare.PawPrint.Test/TestZeroOfBaseAssemblies.fs
+++ b/WoofWare.PawPrint.Test/TestZeroOfBaseAssemblies.fs
@@ -386,3 +386,237 @@ public struct Outer
 
         DumpedAssembly.isValueType baseTypes loadedAfterHelper valueOptionTypeDef
         |> shouldEqual true
+
+    /// Shared setup for the recursively-constructed-type regressions: compile
+    /// a single small C# library and load it alongside corelib.
+    let private loadCompiledLibrary (assemblyName : string) (source : string) : DumpedAssembly =
+        let bytes =
+            Roslyn.compileAssembly assemblyName OutputKind.DynamicallyLinkedLibrary [] [ source ]
+
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use stream = new MemoryStream (bytes)
+        global.WoofWare.PawPrint.AssemblyApi.read loggerFactory None stream
+
+    [<Test>]
+    let ``priming terminates for recursively-nested struct with array-of-recursive field`` () : unit =
+        // ECMA-335 forbids a struct that directly contains itself by value
+        // (infinite size), but it is perfectly legal for a struct's field to
+        // be an *array* of a deeper instantiation of itself. Arrays are
+        // terminal in CliType.zeroOf (returned as `ObjectRef None` without
+        // inspecting their element type), so the helper must also treat them
+        // as terminal — otherwise priming `S<int>` would synthesise
+        // `S<S<int>>`, then `S<S<S<int>>>`, and so on forever, because every
+        // synthesised instantiation is a distinct ConcreteTypeHandle the
+        // visited-set cannot collapse.
+        let corelib = readAssembly corelibPath
+        let baseTypes = Corelib.getBaseTypes corelib
+
+        let asm =
+            loadCompiledLibrary
+                "ArrayRecursiveStructRegression"
+                """
+public struct S<T>
+{
+    public S<S<T>>[] Items;
+}
+"""
+
+        let sTypeDef =
+            asm.TryGetTopLevelTypeDef "" "S`1"
+            |> Option.defaultWith (fun () -> failwith "Failed to find compiled struct S<T>")
+
+        let loaded : ImmutableDictionary<string, DumpedAssembly> =
+            [ corelib ; asm ]
+            |> Seq.map (fun a -> System.Collections.Generic.KeyValuePair (a.Name.FullName, a))
+            |> ImmutableDictionary.CreateRange
+
+        let loadAssembly = OnDemandAssemblyLoad [ runtimeDir ]
+
+        let concretizeCtx : TypeConcretization.ConcretizationContext<DumpedAssembly> =
+            {
+                ConcreteTypes = Corelib.concretizeAll loaded baseTypes AllConcreteTypes.Empty
+                LoadedAssemblies = loaded
+                BaseTypes = baseTypes
+            }
+
+        let sIntDefn : TypeDefn =
+            TypeDefn.GenericInstantiation (
+                TypeDefn.FromDefinition (sTypeDef.Identity, SignatureTypeKind.ValueType),
+                ImmutableArray.CreateRange [ TypeDefn.PrimitiveType PrimitiveType.Int32 ]
+            )
+
+        let handle, concretizeCtx =
+            TypeConcretization.concretizeType
+                concretizeCtx
+                (loadAssembly :> IAssemblyLoad)
+                asm.Name
+                ImmutableArray.Empty
+                ImmutableArray.Empty
+                sIntDefn
+
+        // The helper must terminate (i.e. not blow the stack or run forever).
+        Concretization.ensureBaseAssembliesLoadedForConcreteHandle
+            (loadAssembly :> IAssemblyLoad)
+            baseTypes
+            (System.Collections.Generic.HashSet ())
+            concretizeCtx.LoadedAssemblies
+            concretizeCtx.ConcreteTypes
+            handle
+        |> ignore
+
+    [<Test>]
+    let ``priming does not descend into generic arguments of reference types`` () : unit =
+        // A reference type is terminal in CliType.zeroOf — it becomes
+        // `ObjectRef None` without inspecting either its fields or its
+        // generic arguments. The helper must respect that or it will loop
+        // forever on a legal shape like `struct S<T> { Box<S<S<T>>> F; }`,
+        // where the recursion goes S<int> → Box<S<S<int>>> → S<S<int>> →
+        // Box<S<S<S<int>>>> → ...
+        let corelib = readAssembly corelibPath
+        let baseTypes = Corelib.getBaseTypes corelib
+
+        let asm =
+            loadCompiledLibrary
+                "RefTypeRecursiveGenericArgRegression"
+                """
+public class Box<T> { }
+public struct S<T>
+{
+    public Box<S<S<T>>> Field;
+}
+"""
+
+        let sTypeDef =
+            asm.TryGetTopLevelTypeDef "" "S`1"
+            |> Option.defaultWith (fun () -> failwith "Failed to find compiled struct S<T>")
+
+        let loaded : ImmutableDictionary<string, DumpedAssembly> =
+            [ corelib ; asm ]
+            |> Seq.map (fun a -> System.Collections.Generic.KeyValuePair (a.Name.FullName, a))
+            |> ImmutableDictionary.CreateRange
+
+        let loadAssembly = OnDemandAssemblyLoad [ runtimeDir ]
+
+        let concretizeCtx : TypeConcretization.ConcretizationContext<DumpedAssembly> =
+            {
+                ConcreteTypes = Corelib.concretizeAll loaded baseTypes AllConcreteTypes.Empty
+                LoadedAssemblies = loaded
+                BaseTypes = baseTypes
+            }
+
+        let sIntDefn : TypeDefn =
+            TypeDefn.GenericInstantiation (
+                TypeDefn.FromDefinition (sTypeDef.Identity, SignatureTypeKind.ValueType),
+                ImmutableArray.CreateRange [ TypeDefn.PrimitiveType PrimitiveType.Int32 ]
+            )
+
+        let handle, concretizeCtx =
+            TypeConcretization.concretizeType
+                concretizeCtx
+                (loadAssembly :> IAssemblyLoad)
+                asm.Name
+                ImmutableArray.Empty
+                ImmutableArray.Empty
+                sIntDefn
+
+        // Must terminate.
+        Concretization.ensureBaseAssembliesLoadedForConcreteHandle
+            (loadAssembly :> IAssemblyLoad)
+            baseTypes
+            (System.Collections.Generic.HashSet ())
+            concretizeCtx.LoadedAssemblies
+            concretizeCtx.ConcreteTypes
+            handle
+        |> ignore
+
+    [<Test>]
+    let ``concretizeMethod primes method-level generic arguments used only by intrinsics`` () : unit =
+        // Regression for Unsafe.SizeOf<T> / Span<T>.Clear / etc: their
+        // intrinsic dispatch reads T from methodToCall.Generics (or the
+        // declaring type's generics), NOT from the method's own signature.
+        // If concretizeMethod doesn't prime those generic-argument handles,
+        // subsequent cliTypeZeroOfHandle on T can still crash with the
+        // unloaded-base-assembly exception.
+        let corelib = readAssembly corelibPath
+        let fsharpCore = readAssembly fsharpCoreNetstandard21Path
+        let baseTypes = Corelib.getBaseTypes corelib
+        assertNetstandardAvailable ()
+
+        // A minimal generic method that never mentions T in its signature —
+        // the only place T appears is in methodToCall.Generics after
+        // concretization.
+        let asm =
+            loadCompiledLibrary
+                "IntrinsicGenericArgRegression"
+                """
+public static class C
+{
+    public static void M<T>() {}
+}
+"""
+
+        let holderTypeDef =
+            asm.TryGetTopLevelTypeDef "" "C"
+            |> Option.defaultWith (fun () -> failwith "Failed to find compiled type C")
+
+        let mMethod =
+            holderTypeDef.Methods
+            |> List.tryFind (fun m -> m.Name = "M")
+            |> Option.defaultWith (fun () -> failwith "Failed to find method M<T>")
+
+        let loaded : ImmutableDictionary<string, DumpedAssembly> =
+            [ corelib ; fsharpCore ; asm ]
+            |> Seq.map (fun a -> System.Collections.Generic.KeyValuePair (a.Name.FullName, a))
+            |> ImmutableDictionary.CreateRange
+
+        let loadAssembly = OnDemandAssemblyLoad [ runtimeDir ]
+
+        // Concretize FSharpValueOption<int> into the concreteTypes dictionary
+        // (still with netstandard NOT loaded), so we can pass its handle as
+        // the method's generic argument. Concretization does not walk base
+        // types, so netstandard remains absent at this point.
+        let valueOptionTypeDef = getValueOptionTypeDef fsharpCore
+
+        let valueOptionInt : TypeDefn =
+            TypeDefn.GenericInstantiation (
+                TypeDefn.FromDefinition (valueOptionTypeDef.Identity, SignatureTypeKind.ValueType),
+                ImmutableArray.CreateRange [ TypeDefn.PrimitiveType PrimitiveType.Int32 ]
+            )
+
+        let concretizeCtx : TypeConcretization.ConcretizationContext<DumpedAssembly> =
+            {
+                ConcreteTypes = Corelib.concretizeAll loaded baseTypes AllConcreteTypes.Empty
+                LoadedAssemblies = loaded
+                BaseTypes = baseTypes
+            }
+
+        let valueOptionHandle, concretizeCtx =
+            TypeConcretization.concretizeType
+                concretizeCtx
+                (loadAssembly :> IAssemblyLoad)
+                fsharpCore.Name
+                ImmutableArray.Empty
+                ImmutableArray.Empty
+                valueOptionInt
+
+        // Sanity: concretization alone did not need netstandard.
+        concretizeCtx.LoadedAssemblies.Keys
+        |> Seq.exists (fun (n : string) -> n.StartsWith ("netstandard,", StringComparison.OrdinalIgnoreCase))
+        |> shouldEqual false
+
+        let _, _, loadedAfter =
+            Concretization.concretizeMethod
+                concretizeCtx.ConcreteTypes
+                (loadAssembly :> IAssemblyLoad)
+                concretizeCtx.LoadedAssemblies
+                baseTypes
+                mMethod
+                ImmutableArray.Empty
+                (ImmutableArray.CreateRange [ valueOptionHandle ])
+
+        // The sweep must have primed the method's generic argument, which
+        // means walking FSharpValueOption<int>'s base chain, which means
+        // netstandard is now loaded.
+        loadedAfter.Keys
+        |> Seq.exists (fun (n : string) -> n.StartsWith ("netstandard,", StringComparison.OrdinalIgnoreCase))
+        |> shouldEqual true

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -54,6 +54,7 @@
     <Compile Include="TestMethodHandleRegistry.fs" />
     <Compile Include="TestMethodReturnType.fs" />
     <Compile Include="TestFunctionPointerConcretization.fs" />
+    <Compile Include="TestZeroOfBaseAssemblies.fs" />
     <Compile Include="TestGenericParamConstraints.fs" />
     <Compile Include="TestGcHandleRegistry.fs" />
     <Compile Include="TestFileDescriptorRegistry.fs" />


### PR DESCRIPTION
Fixes #666.

We were not eagerly loading the assemblies for the base-type-finding walk in method parameters or return types.
