### PR TITLE
Model newobj's variable-size-object convention for System.String

### DIFF
--- a/WoofWare.PawPrint.Test/TestFaultHandlers.fs
+++ b/WoofWare.PawPrint.Test/TestFaultHandlers.fs
@@ -135,7 +135,7 @@ module TestFaultHandlers =
             {
                 JumpTo = callerFrameId
                 WasInitialisingType = None
-                WasConstructingObj = None
+                Constructing = ConstructionState.NotConstructing
                 CallSiteIlOpIndex = threadState.MethodState.IlOpIndex
                 DispatchAsExceptionOnReturn = false
                 WrapExceptionInTargetInvocation = false

--- a/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
+++ b/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
@@ -3101,7 +3101,12 @@ public unsafe struct PointerWrapper
             match frame.ReturnState with
             | Some returnState ->
                 returnState.DispatchAsExceptionOnReturn |> shouldEqual true
-                returnState.WasConstructingObj |> Option.isSome |> shouldEqual true
+
+                // NullReferenceException is a fixed-size type, so the exception object was
+                // allocated up front and handed to the ctor as `this`.
+                match returnState.Constructing with
+                | ConstructionState.Constructing _ -> ()
+                | other -> failwith $"Expected the NullReferenceException ctor frame to be constructing, got %O{other}"
             | None -> failwith "Expected NullReferenceException constructor frame to have a return state"
         | other -> failwith $"Expected Stind_ref wrapped null to raise a managed exception, got %O{other}"
 

--- a/WoofWare.PawPrint.Test/TestVariableSizeNewobj.fs
+++ b/WoofWare.PawPrint.Test/TestVariableSizeNewobj.fs
@@ -1,0 +1,240 @@
+namespace WoofWare.Pawprint.Test
+
+open System.Collections.Immutable
+open System.IO
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.DotnetRuntimeLocator
+open WoofWare.PawPrint
+open WoofWare.PawPrint.ExternImplementations
+open WoofWare.PawPrint.Test
+
+/// `newobj` on `System.String` is the CLR's variable-size-object case
+/// (`CORINFO_FLG_VAROBJSIZE`, set because String's MethodTable
+/// `HasComponentSize`): the runtime allocates nothing up front and passes no
+/// `this`; the constructor allocates and *returns* the object. See
+/// `src/coreclr/jit/importer.cpp` ("At present this can only be String",
+/// `newObjThisPtr = nullptr`) and `src/coreclr/interpreter/compiler.cpp`
+/// (`doCallInsteadOfNew = true`).
+///
+/// These tests pin the observable consequence of modelling that correctly:
+/// `newobj String::.ctor(...)` must not leave a half-built placeholder String
+/// on the managed heap.
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestVariableSizeNewobj =
+    let private assy = typeof<RunResult>.Assembly
+
+    /// Is this the concrete handle for `System.String`?
+    let private isSystemString (state : IlMachineState) (handle : ConcreteTypeHandle) : bool =
+        match AllConcreteTypes.lookup handle state.ConcreteTypes with
+        | None -> false
+        | Some ct ->
+            ct.Assembly.Name = "System.Private.CoreLib"
+            && ct.Namespace = "System"
+            && ct.Name = "String"
+            && ct.Generics.IsEmpty
+
+    /// PawPrint's String representation is split: the managed object carries only
+    /// `_stringLength`, while the characters (including the metadata-level
+    /// `_firstChar`) live in `ManagedHeap.StringArrayData`, reached through the
+    /// `StringContents` and `StringDataOffsets` side-tables. Every String-typed
+    /// heap object is therefore required to appear in both side-tables --
+    /// `ManagedHeap.getStringChar`, `setStringChar`, `stringsEqual` and
+    /// `RuntimeFieldProjection`'s `_firstChar` handling all fail loudly otherwise.
+    ///
+    /// Returns the addresses that violate that invariant, with which side-table
+    /// each is missing from.
+    let private unregisteredStringObjects (state : IlMachineState) : (ManagedHeapAddress * string) list =
+        state.ManagedHeap.NonArrayObjects
+        |> Map.toList
+        |> List.choose (fun (addr, object) ->
+            if not (isSystemString state object.ConcreteType) then
+                None
+            else
+
+            let hasContents = state.ManagedHeap.StringContents.ContainsKey addr
+            let hasDataOffset = state.ManagedHeap.StringDataOffsets.ContainsKey addr
+
+            if hasContents && hasDataOffset then
+                None
+            else
+                Some (addr, $"StringContents=%b{hasContents}, StringDataOffsets=%b{hasDataOffset}")
+        )
+
+    let private countStringObjects (state : IlMachineState) : int =
+        state.ManagedHeap.NonArrayObjects
+        |> Map.toSeq
+        |> Seq.filter (fun (_, object) -> isSystemString state object.ConcreteType)
+        |> Seq.length
+
+    /// Compile `source` and run it through PawPrint, returning the final machine
+    /// state. Fails the test if the guest does not exit cleanly with code 0.
+    let private runToNormalExit (sourceName : string) (source : string) : IlMachineState =
+        let image = Roslyn.compile [ source ]
+
+        let messages, loggerFactory =
+            LoggerFactory.makeTestWithProperties [ "source_file", sourceName ]
+
+        use _loggerFactoryResource = loggerFactory
+
+        let dotnetRuntimes =
+            DotnetRuntime.SelectForDll assy.Location |> ImmutableArray.CreateRange
+
+        use peImage = new MemoryStream (image)
+
+        try
+            let nativeImpls = NativeImpls.PassThru ()
+
+            match Program.run loggerFactory (Some sourceName) peImage dotnetRuntimes nativeImpls Map.empty None [] with
+            | RunOutcome.NormalExit (state, terminatingThread) ->
+                match state.ThreadState.[terminatingThread].MethodState.EvaluationStack.Values with
+                | EvalStackValue.Int32 0 :: _ -> ()
+                | other -> failwith $"%s{sourceName}: expected guest exit code 0, got %O{other}"
+
+                state
+            | other -> failwith $"%s{sourceName}: expected a normal exit, got %O{other}"
+        with _ ->
+            for message in messages () do
+                System.Console.Error.WriteLine $"{message}"
+
+            reraise ()
+
+    let private charPointerCtorSource =
+        """
+using System;
+
+unsafe class VarObjSizeNewobjCharPointer
+{
+    static int Main(string[] args)
+    {
+        char[] chars = { 'h', 'e', 'l', 'l', 'o', '\0' };
+        fixed (char* p = chars)
+        {
+            string s = new string(p);
+            if (s != "hello")
+                return 1;
+        }
+
+        // The null and empty cases both return the canonical interned empty
+        // string, so they must not allocate a String object at all.
+        string fromNull = new string((char*)null);
+        if (fromNull.Length != 0)
+            return 2;
+        if (!ReferenceEquals(fromNull, ""))
+            return 3;
+
+        return 0;
+    }
+}
+"""
+
+    let private spanCtorSource =
+        """
+using System;
+
+unsafe class VarObjSizeNewobjSpan
+{
+    static int Main(string[] args)
+    {
+        char* buf = stackalloc char[3];
+        buf[0] = 'a';
+        buf[1] = 'b';
+        buf[2] = 'c';
+
+        string s = new string(new ReadOnlySpan<char>(buf, 3));
+        if (s != "abc")
+            return 1;
+
+        // Zero length collapses onto the interned empty string, allocating nothing.
+        string empty = new string(new ReadOnlySpan<char>(buf, 0));
+        if (!ReferenceEquals(empty, ""))
+            return 2;
+
+        return 0;
+    }
+}
+"""
+
+    [<Test>]
+    let ``newobj String..ctor(char*) leaves no unregistered String on the heap`` () : unit =
+        let state = runToNormalExit "VarObjSizeNewobjCharPointer.cs" charPointerCtorSource
+
+        unregisteredStringObjects state |> shouldEqual []
+
+    [<Test>]
+    let ``newobj String..ctor(ReadOnlySpan<char>) leaves no unregistered String on the heap`` () : unit =
+        let state = runToNormalExit "VarObjSizeNewobjSpan.cs" spanCtorSource
+
+        unregisteredStringObjects state |> shouldEqual []
+
+    /// The BCL allocates strings of its own during startup, so an absolute count is
+    /// not assertable. A *differential* count is: these two programs are identical
+    /// except that the second performs two extra `newobj String::.ctor(char*)`
+    /// instructions, so the heap must end up with exactly two more String objects.
+    ///
+    /// This is the sharp statement of the calling convention. When `newobj`
+    /// allocated a placeholder as well, each extra `newobj` cost *two* String
+    /// objects, and the delta was 4.
+    let private oneNewobjSource =
+        """
+using System;
+
+unsafe class VarObjSizeNewobjOne
+{
+    static int Main(string[] args)
+    {
+        char[] chars = { 'h', 'e', 'l', 'l', 'o', '\0' };
+        fixed (char* p = chars)
+        {
+            string s = new string(p);
+            if (s != "hello")
+                return 1;
+            if (s.Length != 5)
+                return 2;
+            if (s.Length != 5)
+                return 3;
+        }
+
+        return 0;
+    }
+}
+"""
+
+    let private threeNewobjSource =
+        """
+using System;
+
+unsafe class VarObjSizeNewobjThree
+{
+    static int Main(string[] args)
+    {
+        char[] chars = { 'h', 'e', 'l', 'l', 'o', '\0' };
+        fixed (char* p = chars)
+        {
+            string s = new string(p);
+            string t = new string(p);
+            string u = new string(p);
+            if (s != "hello")
+                return 1;
+            if (t.Length != 5)
+                return 2;
+            if (u.Length != 5)
+                return 3;
+        }
+
+        return 0;
+    }
+}
+"""
+
+    [<Test>]
+    let ``each extra String newobj allocates exactly one String`` () : unit =
+        let one =
+            runToNormalExit "VarObjSizeNewobjOne.cs" oneNewobjSource |> countStringObjects
+
+        let three =
+            runToNormalExit "VarObjSizeNewobjThree.cs" threeNewobjSource
+            |> countStringObjects
+
+        three - one |> shouldEqual 2

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -84,6 +84,7 @@
     <Compile Include="TestNativeEventSource.fs" />
     <Compile Include="TestSchedulerVoluntaryYield.fs" />
     <Compile Include="TestSchedulerPct.fs" />
+    <Compile Include="TestVariableSizeNewobj.fs" />
     <Compile Include="TestPureCases.fs" />
     <Compile Include="TestFSharpPureCases.fs" />
     <Compile Include="TestImpureCases.fs" />

--- a/WoofWare.PawPrint.Test/sourcesPure/StringCtorReadOnlySpan.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/StringCtorReadOnlySpan.cs
@@ -1,0 +1,78 @@
+using System;
+
+unsafe class StringCtorReadOnlySpan
+{
+    static int TestPointerBackedSpan()
+    {
+        char* buf = stackalloc char[3];
+        buf[0] = 'a';
+        buf[1] = 'b';
+        buf[2] = 'c';
+
+        ReadOnlySpan<char> span = new ReadOnlySpan<char>(buf, 3);
+        string s = new string(span);
+        if (s.Length != 3)
+            return 1;
+        if (s != "abc")
+            return 2;
+
+        return 0;
+    }
+
+    static int TestEmptySpanIsCanonicalEmptyString()
+    {
+        char* buf = stackalloc char[1];
+        buf[0] = 'z';
+
+        // A zero-length span allocates nothing: PawPrint collapses empty-string
+        // allocations onto the interned "" so reference comparisons agree with .NET.
+        ReadOnlySpan<char> span = new ReadOnlySpan<char>(buf, 0);
+        string s = new string(span);
+        if (s.Length != 0)
+            return 10;
+        if (!ReferenceEquals(s, ""))
+            return 11;
+
+        return 0;
+    }
+
+    static int TestEmbeddedNullIsPreserved()
+    {
+        // Unlike the char* constructor, the span constructor copies exactly Length
+        // chars and does not stop at a NUL.
+        char* buf = stackalloc char[3];
+        buf[0] = 'a';
+        buf[1] = '\0';
+        buf[2] = 'c';
+
+        ReadOnlySpan<char> span = new ReadOnlySpan<char>(buf, 3);
+        string s = new string(span);
+        if (s.Length != 3)
+            return 20;
+        if (s[0] != 'a')
+            return 21;
+        if (s[1] != '\0')
+            return 22;
+        if (s[2] != 'c')
+            return 23;
+
+        return 0;
+    }
+
+    static int Main(string[] args)
+    {
+        int result = TestPointerBackedSpan();
+        if (result != 0)
+            return result;
+
+        result = TestEmptySpanIsCanonicalEmptyString();
+        if (result != 0)
+            return result;
+
+        result = TestEmbeddedNullIsPreserved();
+        if (result != 0)
+            return result;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/AbstractMachine.fs
+++ b/WoofWare.PawPrint/AbstractMachine.fs
@@ -177,7 +177,7 @@ module AbstractMachine =
                     loggerFactory
                     baseClassTypes
                     None
-                    None
+                    ConstructionState.NotConstructing
                     false
                     false
                     false

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -63,8 +63,8 @@ module IlMachineState =
 
     let mapFrame = IlMachineThreadState.mapFrame
 
-    let withReplacedConstructedObject =
-        IlMachineThreadState.withReplacedConstructedObject
+    let withSuppliedConstructedObject =
+        IlMachineThreadState.withSuppliedConstructedObject
 
     let markActiveFrameWrapInTargetInvocation =
         IlMachineThreadState.markActiveFrameWrapInTargetInvocation

--- a/WoofWare.PawPrint/IlMachineStateExecution.fs
+++ b/WoofWare.PawPrint/IlMachineStateExecution.fs
@@ -793,7 +793,7 @@ module IlMachineStateExecution =
         (loggerFactory : ILoggerFactory)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (wasInitialising : ConcreteTypeHandle option)
-        (wasConstructing : ManagedHeapAddress option)
+        (wasConstructing : ConstructionState)
         (performInterfaceResolution : bool)
         (wasClassConstructor : bool)
         (advanceProgramCounterOfCaller : bool)
@@ -1074,7 +1074,7 @@ module IlMachineStateExecution =
                         loggerFactory
                         baseClassTypes
                         None
-                        (Some allocatedAddr)
+                        (ConstructionState.Constructing allocatedAddr)
                         false
                         false
                         advanceProgramCounterOfCaller
@@ -1211,73 +1211,90 @@ module IlMachineStateExecution =
             else
                 CliType.ObjectRef None
 
+        // Pop exactly the method's declared parameters, leaving no `this` slot in the
+        // resulting `Arguments` array. Shared by genuinely static methods and by
+        // variable-size constructors, which CoreCLR calls with no `this` at all (see
+        // `ConstructionState.ConstructingVariableSize`).
+        let popDeclaredParametersOnly () =
+            let args = ImmutableArray.CreateBuilder methodToCall.Parameters.Length
+            let mutable currentState = activeMethodState
+
+            for i = methodToCall.Parameters.Length - 1 downto 0 do
+                let arg, newState = popAndCoerceArg argZeroObjects.[i] currentState
+                args.Add arg
+                currentState <- newState
+
+            args.Reverse ()
+            args.ToImmutable (), currentState
+
         // Collect arguments based on calling convention
         let args, afterPop =
             if methodToCall.IsStatic then
-                // Static method: pop args in reverse order
-                let args = ImmutableArray.CreateBuilder methodToCall.Parameters.Length
-                let mutable currentState = activeMethodState
-
-                for i = methodToCall.Parameters.Length - 1 downto 0 do
-                    let arg, newState = popAndCoerceArg argZeroObjects.[i] currentState
-                    args.Add arg
-                    currentState <- newState
-
-                args.Reverse ()
-                args.ToImmutable (), currentState
+                popDeclaredParametersOnly ()
             else
+
+            match wasConstructing with
+            | ConstructionState.ConstructingVariableSize ->
+                // Variable-size constructor: `executeNewobj` pushed no `this`, so the eval
+                // stack holds only the declared arguments. The constructor's `Arguments`
+                // array is correspondingly `this`-less, and the object it allocates is
+                // handed back via `withSuppliedConstructedObject`.
+                popDeclaredParametersOnly ()
+            | ConstructionState.Constructing _ ->
                 // Instance method: handle `this` pointer
                 let argCount = methodToCall.Parameters.Length
                 let args = ImmutableArray.CreateBuilder (argCount + 1)
                 let mutable currentState = activeMethodState
                 let thisArgTarget = thisArgCoercionTarget methodToCall
 
-                match wasConstructing with
-                | Some _ ->
-                    // Constructor: `this` is on top of stack, by our own odd little calling convention
-                    // where Newobj puts the object pointer on top
-                    let thisArg, newState = popAndCoerceArg thisArgTarget currentState
+                // Constructor: `this` is on top of stack, by our own odd little calling convention
+                // where Newobj puts the object pointer on top
+                let thisArg, newState = popAndCoerceArg thisArgTarget currentState
 
+                currentState <- newState
+
+                // Pop remaining args in reverse
+                for i = argCount - 1 downto 0 do
+                    let arg, newState = popAndCoerceArg argZeroObjects.[i] currentState
+                    args.Add arg
                     currentState <- newState
 
-                    // Pop remaining args in reverse
-                    for i = argCount - 1 downto 0 do
-                        let arg, newState = popAndCoerceArg argZeroObjects.[i] currentState
-                        args.Add arg
-                        currentState <- newState
+                args.Add thisArg
+                args.Reverse ()
+                args.ToImmutable (), currentState
+            | ConstructionState.NotConstructing ->
+                // Instance method: handle `this` pointer
+                let argCount = methodToCall.Parameters.Length
+                let args = ImmutableArray.CreateBuilder (argCount + 1)
+                let mutable currentState = activeMethodState
+                let thisArgTarget = thisArgCoercionTarget methodToCall
 
-                    args.Add thisArg
-                    args.Reverse ()
-                    args.ToImmutable (), currentState
-                | None ->
-                    // Regular instance method: args then `this`
-                    for i = argCount - 1 downto 0 do
-                        let arg, newState = popAndCoerceArg argZeroObjects.[i] currentState
-                        args.Add arg
-                        currentState <- newState
-
-                    let thisArg, newState =
-                        let rawThis, newState = MethodState.popFromStack currentState
-
-                        let coerced =
-                            match thisArgTarget, rawThis with
-                            | CliType.RuntimePointer _, EvalStackValue.ObjectRef addr ->
-                                // Boxed value type receiver: implicit unbox to managed pointer
-                                // into the heap object's value data.
-                                CliType.RuntimePointer (
-                                    CliRuntimePointer.Managed (
-                                        ManagedPointerSource.Byref (ByrefRoot.HeapValue addr, [])
-                                    )
-                                )
-                            | _ -> EvalStackValue.toCliTypeCoerced thisArgTarget rawThis
-
-                        coerced, newState
-
-                    args.Add thisArg
+                // Regular instance method: args then `this`
+                for i = argCount - 1 downto 0 do
+                    let arg, newState = popAndCoerceArg argZeroObjects.[i] currentState
+                    args.Add arg
                     currentState <- newState
 
-                    args.Reverse ()
-                    args.ToImmutable (), currentState
+                let thisArg, newState =
+                    let rawThis, newState = MethodState.popFromStack currentState
+
+                    let coerced =
+                        match thisArgTarget, rawThis with
+                        | CliType.RuntimePointer _, EvalStackValue.ObjectRef addr ->
+                            // Boxed value type receiver: implicit unbox to managed pointer
+                            // into the heap object's value data.
+                            CliType.RuntimePointer (
+                                CliRuntimePointer.Managed (ManagedPointerSource.Byref (ByrefRoot.HeapValue addr, []))
+                            )
+                        | _ -> EvalStackValue.toCliTypeCoerced thisArgTarget rawThis
+
+                    coerced, newState
+
+                args.Add thisArg
+                currentState <- newState
+
+                args.Reverse ()
+                args.ToImmutable (), currentState
 
         // Helper to create new frame with assembly loading
         let rec createNewFrame state =
@@ -1286,7 +1303,7 @@ module IlMachineStateExecution =
                     {
                         JumpTo = threadState.ActiveMethodState
                         WasInitialisingType = wasInitialising
-                        WasConstructingObj = wasConstructing
+                        Constructing = wasConstructing
                         CallSiteIlOpIndex = callSiteIlOpIndexOverride |> Option.defaultValue afterPop.IlOpIndex
                         DispatchAsExceptionOnReturn = dispatchAsExceptionOnReturn
                         WrapExceptionInTargetInvocation = wrapExceptionInTargetInvocation
@@ -1485,7 +1502,7 @@ module IlMachineStateExecution =
                     loggerFactory
                     baseClassTypes
                     (Some ty)
-                    None
+                    ConstructionState.NotConstructing
                     true
                     true
                     false
@@ -1626,7 +1643,7 @@ module IlMachineStateExecution =
             loggerFactory
             baseClassTypes
             None
-            (Some addr) // weAreConstructingObj
+            (ConstructionState.Constructing addr) // weAreConstructingObj
             false // no interface resolution
             false // wasClassConstructor
             false // do NOT advance caller PC — dispatch needs the faulting instruction's offset

--- a/WoofWare.PawPrint/IlMachineThreadState.fs
+++ b/WoofWare.PawPrint/IlMachineThreadState.fs
@@ -38,12 +38,22 @@ module IlMachineThreadState =
             ThreadState = state.ThreadState |> Map.add thread threadState
         }
 
-    /// Replace the `WasConstructingObj` of the active frame's `ReturnState` with `Some newAddr`.
-    /// Used by InternalCall constructors that allocate the constructed object themselves
-    /// (e.g. `String..ctor(char*)`): the placeholder allocated by `executeNewobj` is discarded
-    /// and the next `returnStackFrame` pushes `newAddr` onto the caller's eval stack instead.
-    /// Fails loudly if invoked outside a constructor frame.
-    let withReplacedConstructedObject
+    /// Nominate `newAddr` as the object constructed by the active variable-size
+    /// constructor frame, moving its `ConstructionState` from `ConstructingVariableSize`
+    /// to `Constructing newAddr`. The next `returnStackFrame` then pushes `newAddr` onto
+    /// the caller's eval stack, completing the `newobj`.
+    ///
+    /// This is the second half of the `CORINFO_FLG_VAROBJSIZE` calling convention (see
+    /// `ConstructionState.ConstructingVariableSize`): `executeNewobj` deliberately
+    /// allocated nothing and passed no `this`, so the constructor — currently only
+    /// `String..ctor(char*)` and `String..ctor(ReadOnlySpan<char>)` — is the sole party
+    /// that knows the object's address.
+    ///
+    /// Fails loudly if the active frame is not a variable-size constructor frame: calling
+    /// it on a fixed-size `Constructing` frame would silently orphan the object that
+    /// `newobj` already allocated and handed the ctor as `this`, which is exactly the
+    /// class of bug this convention exists to prevent.
+    let withSuppliedConstructedObject
         (newAddr : ManagedHeapAddress)
         (thread : ThreadId)
         (state : IlMachineState)
@@ -56,18 +66,21 @@ module IlMachineThreadState =
             match frame.ReturnState with
             | None ->
                 failwith
-                    $"withReplacedConstructedObject: active frame %s{frame.ExecutingMethod.Name} has no ReturnState; cannot redirect a non-existent constructor return"
+                    $"withSuppliedConstructedObject: active frame %s{frame.ExecutingMethod.Name} has no ReturnState; cannot supply an object for a non-existent constructor return"
             | Some returnState ->
-                match returnState.WasConstructingObj with
-                | None ->
+                match returnState.Constructing with
+                | ConstructionState.NotConstructing ->
                     failwith
-                        $"withReplacedConstructedObject: active frame %s{frame.ExecutingMethod.Name} is not a constructor frame (WasConstructingObj is None)"
-                | Some _ ->
+                        $"withSuppliedConstructedObject: active frame %s{frame.ExecutingMethod.Name} is not a constructor frame (ConstructionState is NotConstructing)"
+                | ConstructionState.Constructing existing ->
+                    failwith
+                        $"withSuppliedConstructedObject: active frame %s{frame.ExecutingMethod.Name} is a fixed-size constructor frame already constructing %O{existing}; only variable-size (CORINFO_FLG_VAROBJSIZE) constructors supply their own object, and overwriting here would orphan the object newobj passed as `this`"
+                | ConstructionState.ConstructingVariableSize ->
                     { frame with
                         ReturnState =
                             Some
                                 { returnState with
-                                    WasConstructingObj = Some newAddr
+                                    Constructing = ConstructionState.Constructing newAddr
                                 }
                     }
 
@@ -181,11 +194,12 @@ module IlMachineThreadState =
         match threadStateWithSyntheticFrame.MethodState.ReturnState with
         | None -> ReturnFrameResult.NoFrameToReturn
         | Some returnState ->
-            match returnState.WasConstructingObj with
-            | Some _ ->
+            match returnState.Constructing with
+            | ConstructionState.Constructing _
+            | ConstructionState.ConstructingVariableSize ->
                 failwith
                     $"Synthetic stack frame %s{threadStateWithSyntheticFrame.MethodState.ExecutingMethod.Name} unexpectedly represented object construction"
-            | None ->
+            | ConstructionState.NotConstructing ->
                 if returnState.DispatchAsExceptionOnReturn then
                     failwith
                         $"Synthetic stack frame %s{threadStateWithSyntheticFrame.MethodState.ExecutingMethod.Name} unexpectedly requested exception dispatch on return"
@@ -249,8 +263,16 @@ module IlMachineThreadState =
                 ThreadState = state.ThreadState |> Map.add currentThread threadState
             }
 
-        match returnState.WasConstructingObj with
-        | Some constructing ->
+        match returnState.Constructing with
+        | ConstructionState.ConstructingVariableSize ->
+            // The variable-size (CORINFO_FLG_VAROBJSIZE) convention: `newobj` allocated
+            // nothing and passed no `this`, so the constructor was the only party that
+            // could name the object. Reaching `ret` without having called
+            // `withSuppliedConstructedObject` means it never did, and there is nothing
+            // to push for the pending `newobj`.
+            failwith
+                $"Variable-size constructor %s{returningMethodState.ExecutingMethod.Name} returned without supplying a constructed object; it must call IlMachineState.withSuppliedConstructedObject before returning"
+        | ConstructionState.Constructing constructing ->
             if returnState.DispatchAsExceptionOnReturn then
                 // This ctor was constructing a runtime-synthesised exception object.
                 // Don't push it onto the eval stack; signal to the caller that exception
@@ -280,7 +302,7 @@ module IlMachineThreadState =
             else
                 state |> pushToEvalStack (CliType.ofManagedObject constructing) currentThread
             |> ReturnFrameResult.NormalReturn
-        | None ->
+        | ConstructionState.NotConstructing ->
             let retType = returningMethodState.ExecutingMethod.Signature.ReturnType
 
             match retType, returningMethodState.EvaluationStack.Values with

--- a/WoofWare.PawPrint/IntrinsicHelpers.fs
+++ b/WoofWare.PawPrint/IntrinsicHelpers.fs
@@ -739,12 +739,18 @@ module internal IntrinsicHelpers =
 
     let popPointerBackedSpanConstructorArgs
         (currentThread : ThreadId)
-        (wasConstructing : ManagedHeapAddress option)
+        (wasConstructing : ConstructionState)
         (state : IlMachineState)
         : ManagedPointerSource * ManagedPointerSource * int * IlMachineState
         =
         match wasConstructing with
-        | Some _ ->
+        | ConstructionState.ConstructingVariableSize ->
+            // `Span<T>`/`ReadOnlySpan<T>` are fixed-size value types, so `newobj` on them
+            // always takes the fixed-size path. Reaching here would mean `executeNewobj`
+            // classified a ref-like struct as CORINFO_FLG_VAROBJSIZE.
+            failwith
+                "Span pointer constructor was entered under the variable-size (CORINFO_FLG_VAROBJSIZE) newobj convention, but Span<T> has a fixed instance size"
+        | ConstructionState.Constructing _ ->
             let thisArg, state = IlMachineState.popEvalStack currentThread state
             let lengthArg, state = IlMachineState.popEvalStack currentThread state
             let sourceArg, state = IlMachineState.popEvalStack currentThread state
@@ -762,7 +768,7 @@ module internal IntrinsicHelpers =
             let sourcePtr = managedPointerOfPointerArgument "Span pointer constructor" sourceArg
 
             thisPtr, sourcePtr, length, state
-        | None ->
+        | ConstructionState.NotConstructing ->
             let lengthArg, state = IlMachineState.popEvalStack currentThread state
             let sourceArg, state = IlMachineState.popEvalStack currentThread state
             let thisArg, state = IlMachineState.popEvalStack currentThread state
@@ -805,7 +811,7 @@ module internal IntrinsicHelpers =
         (loggerFactory : ILoggerFactory)
         (baseClassTypes : BaseClassTypes<_>)
         (currentThread : ThreadId)
-        (wasConstructing : ManagedHeapAddress option)
+        (wasConstructing : ConstructionState)
         (methodToCall : WoofWare.PawPrint.MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>)
         (state : IlMachineState)
         : IlMachineState
@@ -891,8 +897,13 @@ module internal IntrinsicHelpers =
 
         let state =
             match wasConstructing with
-            | None -> state
-            | Some constructing ->
+            | ConstructionState.NotConstructing -> state
+            | ConstructionState.ConstructingVariableSize ->
+                // Already rejected by `popPointerBackedSpanConstructorArgs` above; restated
+                // here so this match stays exhaustive without a silent fallthrough.
+                failwith
+                    "Span pointer constructor was entered under the variable-size (CORINFO_FLG_VAROBJSIZE) newobj convention, but Span<T> has a fixed instance size"
+            | ConstructionState.Constructing constructing ->
                 let constructed = state.ManagedHeap.NonArrayObjects.[constructing]
 
                 state

--- a/WoofWare.PawPrint/IntrinsicHelpers.fsi
+++ b/WoofWare.PawPrint/IntrinsicHelpers.fsi
@@ -72,7 +72,7 @@ module internal IntrinsicHelpers =
         loggerFactory : ILoggerFactory ->
         baseClassTypes : BaseClassTypes<DumpedAssembly> ->
         currentThread : ThreadId ->
-        wasConstructing : ManagedHeapAddress option ->
+        wasConstructing : ConstructionState ->
         methodToCall : WoofWare.PawPrint.MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle> ->
         state : IlMachineState ->
             IlMachineState

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -24,7 +24,7 @@ module Intrinsics =
     let call
         (loggerFactory : ILoggerFactory)
         (baseClassTypes : BaseClassTypes<_>)
-        (wasConstructing : ManagedHeapAddress option)
+        (wasConstructing : ConstructionState)
         (methodToCall : WoofWare.PawPrint.MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>)
         (currentThread : ThreadId)
         (state : IlMachineState)

--- a/WoofWare.PawPrint/MethodState.fs
+++ b/WoofWare.PawPrint/MethodState.fs
@@ -589,19 +589,49 @@ module NativeMemoryPool =
         let updated = MemoryBlock.writeBytes (string blockId) offset bytes block
         setBlock blockId updated pool
 
+/// Whether a frame was entered by a `newobj` in its caller, and if so under which of
+/// the CLI's two object-construction calling conventions. On return, this decides what
+/// (if anything) gets pushed onto the caller's evaluation stack.
+type ConstructionState =
+    /// The frame was entered by an ordinary `call`/`callvirt`, not a `newobj`. Whatever
+    /// the method's signature says it returns is what gets pushed.
+    | NotConstructing
+    /// Fixed-size object: `newobj` allocated the object *before* the constructor ran and
+    /// passed its address as `this`, so the address is known up front. On return we push
+    /// that address (or, for value types, the object's now-complete contents).
+    | Constructing of ManagedHeapAddress
+    /// Variable-size object, i.e. one whose instance size depends on its constructor
+    /// arguments. CoreCLR flags these `CORINFO_FLG_VAROBJSIZE` (set whenever the
+    /// MethodTable `HasComponentSize`; see `jitinterface.cpp`), and both the JIT and the
+    /// CoreCLR interpreter special-case `newobj` on them: nothing is allocated up front
+    /// and *no `this` is passed* — the constructor allocates the object itself and
+    /// effectively returns it, despite a `void` signature. See `importer.cpp`
+    /// ("At present this can only be String", `newObjThisPtr = nullptr`) and
+    /// `interpreter/compiler.cpp` (`doCallInsteadOfNew = true`).
+    ///
+    /// Arrays are the CLI's other variable-size case, but they never reach here: array
+    /// `newobj` is diverted to the multi-dim allocation path in `executeNewobj`, and
+    /// szarrays go through `newarr`. So in practice this case means `System.String`.
+    ///
+    /// A frame in this state has not yet nominated its object. The constructor must call
+    /// `IlMachineState.withSuppliedConstructedObject`, which moves it to `Constructing`;
+    /// `returnStackFrame` fails loudly on a frame that returns still in this state.
+    | ConstructingVariableSize
+
 type MethodReturnState =
     {
         /// Handle to the caller's frame
         JumpTo : FrameId
         WasInitialisingType : ConcreteTypeHandle option
-        /// The Newobj instruction means we need to push a reference immediately after Ret.
-        WasConstructingObj : ManagedHeapAddress option
+        /// Whether a Newobj instruction in the caller is awaiting an object reference to be
+        /// pushed immediately after Ret, and under which construction calling convention.
+        Constructing : ConstructionState
         /// The IL offset of the call/callvirt/newobj instruction in the caller that created
         /// this frame. Exception dispatch must use this (not the caller's resumed IlOpIndex)
         /// so that handler lookup sees the call site inside the protected region, even when
         /// the advanced resume PC falls outside it.
         CallSiteIlOpIndex : int
-        /// When true, the constructed object (WasConstructingObj) should be dispatched as a
+        /// When true, the constructed object (see `Constructing`) should be dispatched as a
         /// managed exception on return instead of being pushed onto the caller's eval stack.
         /// Used by raiseRuntimeException to run exception ctors via the dispatch loop.
         DispatchAsExceptionOnReturn : bool
@@ -803,6 +833,9 @@ and MethodState =
     /// `args` must be populated with entries of the right type.
     /// If `method` is an instance method, `args` must be of length 1+numParams.
     /// If `method` is static, `args` must be of length numParams.
+    /// The exception is a frame entered under the variable-size newobj convention
+    /// (`ConstructionState.ConstructingVariableSize`), which receives no `this` despite
+    /// the constructor being an instance method, and so takes numParams entries.
     static member Empty
         (concreteTypes : AllConcreteTypes)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
@@ -815,13 +848,34 @@ and MethodState =
         : Result<MethodState, WoofWare.PawPrint.AssemblyReference list>
         =
         do
-            if method.IsStatic then
-                if args.Length <> method.Parameters.Length then
-                    failwith
-                        $"Static method {method.Name} should have had %i{method.Parameters.Length} parameters, but was given %i{args.Length}"
-            else if args.Length <> method.Parameters.Length + 1 then
+            // A frame entered under the variable-size (CORINFO_FLG_VAROBJSIZE) newobj
+            // convention gets no `this` slot even though the constructor is an instance
+            // method: CoreCLR calls it with a null this-pointer and the constructor
+            // allocates the object itself. See `ConstructionState.ConstructingVariableSize`.
+            let isVariableSizeCtorFrame =
+                match returnState with
+                | None -> false
+                | Some returnState ->
+                    match returnState.Constructing with
+                    | ConstructionState.ConstructingVariableSize -> true
+                    | ConstructionState.Constructing _
+                    | ConstructionState.NotConstructing -> false
+
+            let expectsThis = not method.IsStatic && not isVariableSizeCtorFrame
+
+            let expected = method.Parameters.Length + (if expectsThis then 1 else 0)
+
+            if args.Length <> expected then
+                let shape =
+                    if method.IsStatic then
+                        "Static method"
+                    elif isVariableSizeCtorFrame then
+                        "Variable-size constructor"
+                    else
+                        "Non-static method"
+
                 failwith
-                    $"Non-static method {method.Name} should have had %i{method.Parameters.Length + 1} parameters, but was given %i{args.Length}"
+                    $"%s{shape} {method.Name} should have had %i{expected} parameters, but was given %i{args.Length}"
 
         let localVariableSig =
             match MethodInfo.tryIlBody method with

--- a/WoofWare.PawPrint/Native/NativeCustomAttribute.fs
+++ b/WoofWare.PawPrint/Native/NativeCustomAttribute.fs
@@ -441,7 +441,7 @@ module NativeCustomAttribute =
                         ctx.LoggerFactory
                         ctx.BaseClassTypes
                         None
-                        None
+                        ConstructionState.NotConstructing
                         false
                         false
                         false

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
@@ -741,7 +741,7 @@ module NativeRuntimeTypeQCall =
                         ctx.LoggerFactory
                         ctx.BaseClassTypes
                         None
-                        None
+                        ConstructionState.NotConstructing
                         false
                         false
                         false

--- a/WoofWare.PawPrint/Native/NativeString.fs
+++ b/WoofWare.PawPrint/Native/NativeString.fs
@@ -135,15 +135,15 @@ module NativeString =
             // https://github.com/dotnet/runtime/blob/v10.0.7/src/coreclr/System.Private.CoreLib/src/System/String.CoreCLR.cs
             let operation = "String..ctor(ReadOnlySpan<char>)"
 
-            // Newobj-driven constructor frames carry `this` as Arguments.[0]
-            // (the placeholder allocated by executeNewobj) and the user-visible
-            // ReadOnlySpan<char> as Arguments.[1].
-            if instruction.Arguments.Length <> 2 then
+            // String is a variable-size object, so `executeNewobj` allocated nothing and
+            // passed no `this` (see ConstructionState.ConstructingVariableSize). The frame's
+            // only argument is the user-visible ReadOnlySpan<char>.
+            if instruction.Arguments.Length <> 1 then
                 failwith
-                    $"%s{operation}: expected 2 arguments (this, ReadOnlySpan<char>) after matching signature, got %d{instruction.Arguments.Length}"
+                    $"%s{operation}: expected 1 argument (ReadOnlySpan<char>) after matching signature, got %d{instruction.Arguments.Length}"
 
             let span : CliValueType =
-                match CliType.unwrapPrimitiveLikeDeep instruction.Arguments.[1] with
+                match CliType.unwrapPrimitiveLikeDeep instruction.Arguments.[0] with
                 | CliType.ValueType vt -> vt
                 | other -> failwith $"%s{operation}: expected ReadOnlySpan<char> value type, got %O{other}"
 
@@ -241,10 +241,11 @@ module NativeString =
                 else
                     IlMachineState.allocateManagedString ctx.LoggerFactory ctx.BaseClassTypes contents state
 
-            // Redirect the pending newobj result to our freshly-allocated string;
-            // the placeholder allocated by executeNewobj is left as garbage.
+            // Hand the freshly-allocated string back to the pending newobj: under the
+            // variable-size convention the constructor is the only party that knows the
+            // object's address, and `returnStackFrame` pushes it on our behalf.
             state
-            |> IlMachineState.withReplacedConstructedObject newAddr ctx.Thread
+            |> IlMachineState.withSuppliedConstructedObject newAddr ctx.Thread
             |> fun state -> NativeHandlerResult.completed state
             |> Some
         | "System.Private.CoreLib",
@@ -255,15 +256,15 @@ module NativeString =
           MethodReturnType.Void ->
             let operation = "String..ctor(char*)"
 
-            // Newobj-driven constructor frames carry `this` as Arguments.[0]
-            // (the placeholder allocated by executeNewobj) and the user-visible
-            // char* as Arguments.[1].
-            if instruction.Arguments.Length <> 2 then
+            // String is a variable-size object, so `executeNewobj` allocated nothing and
+            // passed no `this` (see ConstructionState.ConstructingVariableSize). The frame's
+            // only argument is the user-visible char*.
+            if instruction.Arguments.Length <> 1 then
                 failwith
-                    $"%s{operation}: expected 2 arguments (this, char*) after matching signature, got %d{instruction.Arguments.Length}"
+                    $"%s{operation}: expected 1 argument (char*) after matching signature, got %d{instruction.Arguments.Length}"
 
             let ptr =
-                NativeCall.managedPointerOfPointerArgument operation "value" instruction.Arguments.[1]
+                NativeCall.managedPointerOfPointerArgument operation "value" instruction.Arguments.[0]
 
             // CoreCLR's String.Ctor(char*) returns String.Empty when ptr == null
             // or the first char is NUL, rather than throwing or allocating fresh.
@@ -291,10 +292,11 @@ module NativeString =
                 else
                     IlMachineState.allocateManagedString ctx.LoggerFactory ctx.BaseClassTypes contents state
 
-            // Redirect the pending newobj result to our freshly-allocated string;
-            // the placeholder allocated by executeNewobj is left as garbage.
+            // Hand the freshly-allocated string back to the pending newobj: under the
+            // variable-size convention the constructor is the only party that knows the
+            // object's address, and `returnStackFrame` pushes it on our behalf.
             state
-            |> IlMachineState.withReplacedConstructedObject newAddr ctx.Thread
+            |> IlMachineState.withSuppliedConstructedObject newAddr ctx.Thread
             |> fun state -> NativeHandlerResult.completed state
             |> Some
         | _ -> None

--- a/WoofWare.PawPrint/UnaryMetadataCallOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataCallOps.fs
@@ -642,7 +642,7 @@ module internal UnaryMetadataCallOps =
                 loggerFactory
                 baseClassTypes
                 None
-                None
+                ConstructionState.NotConstructing
                 false
                 false
                 true
@@ -1032,7 +1032,7 @@ module internal UnaryMetadataCallOps =
             loggerFactory
             baseClassTypes
             None
-            None
+            ConstructionState.NotConstructing
             performInterfaceResolution
             false
             true

--- a/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
@@ -258,6 +258,41 @@ module internal UnaryMetadataObjectOps =
                 ctorType.Name
             )
 
+        // The CLI's variable-size-object case: types whose instance size depends on the
+        // constructor arguments, which CoreCLR flags `CORINFO_FLG_VAROBJSIZE` (set whenever
+        // the MethodTable `HasComponentSize` — see `vm/jitinterface.cpp`). The runtime cannot
+        // allocate before the constructor runs, so it allocates nothing and passes no `this`;
+        // the constructor allocates the object and effectively returns it. Both the JIT
+        // (`jit/importer.cpp`, CEE_NEWOBJ: "At present this can only be String",
+        // `newObjThisPtr = nullptr`) and the CoreCLR interpreter (`interpreter/compiler.cpp`,
+        // `doCallInsteadOfNew = true`) special-case it this way.
+        //
+        // Arrays are the CLI's only other variable-size case and never reach here:
+        // multi-dimensional array constructors were diverted to `executeMultiDimArrayNewobj`
+        // above, and szarrays go through `newarr` rather than `newobj`. So, exactly as CoreCLR
+        // asserts, this is System.String and nothing else.
+        if TypeInfo.NominallyEqual ctorType baseClassTypes.String then
+            let threadState = state.ThreadState.[thread]
+
+            IlMachineStateExecution.callMethod
+                loggerFactory
+                baseClassTypes
+                None
+                ConstructionState.ConstructingVariableSize
+                false
+                false
+                true
+                concretizedCtor.Generics
+                concretizedCtor
+                thread
+                threadState
+                None
+                false
+                false // wrapExceptionInTargetInvocation
+                state,
+            WhatWeDid.Executed
+        else
+
         let state, allFields =
             IlMachineState.collectAllInstanceFields loggerFactory baseClassTypes state declaringTypeHandle
 
@@ -299,7 +334,7 @@ module internal UnaryMetadataObjectOps =
             loggerFactory
             baseClassTypes
             None
-            (Some allocatedAddr)
+            (ConstructionState.Constructing allocatedAddr)
             false
             false
             true


### PR DESCRIPTION
Closes #477.

## The problem

`newobj String::.ctor(...)` allocated a placeholder String, handed it to the constructor as `this`, and then the native handler redirected the pending result to a *different*, properly-built string via `withReplacedConstructedObject` — leaving the placeholder on the heap as garbage.

That placeholder was not merely wasteful. It was a String-typed heap object registered in neither `StringContents` nor `StringDataOffsets`, and — unlike every string built by `allocateManagedString` — it carried a materialised `_firstChar` field cell. Both are invariants the rest of the runtime relies on: `ManagedHeap.getStringChar`, `setStringChar`, `stringsEqual` and `RuntimeFieldProjection`'s `_firstChar` handling all fail loudly on an unregistered String, and `allocateManagedString` documents at length why `_firstChar` must not exist as a second source of truth.

I traced it and nothing reached the placeholder — the ctor frame's `Arguments.[0]` is its only holder, and that frame is popped immediately — so this was latent rather than live.

## The fix

Model what the CLR actually does. String is a variable-size object: CoreCLR flags it `CORINFO_FLG_VAROBJSIZE` because its MethodTable `HasComponentSize` (`vm/jitinterface.cpp`), and for those `newobj` allocates nothing and passes no `this` — the constructor allocates and effectively returns the object. Both the JIT (`jit/importer.cpp`, CEE_NEWOBJ: *"At present this can only be String"*, `newObjThisPtr = nullptr`) and the CoreCLR interpreter (`interpreter/compiler.cpp`, `doCallInsteadOfNew = true`) special-case it this way. Arrays are the only other variable-size case and never reach `executeNewobj`'s general path.

`MethodReturnState.WasConstructingObj : ManagedHeapAddress option` becomes `Constructing : ConstructionState`, a three-case DU (`NotConstructing` / `Constructing of addr` / `ConstructingVariableSize`), so the compiler locates every site that has to care:

- `executeNewobj` skips both the allocation and the `this` push for String
- `callMethod` pops such a frame's arguments with no `this` slot
- `MethodState.Empty`'s arity check knows the frame is legitimately `this`-less
- `withReplacedConstructedObject` becomes `withSuppliedConstructedObject`, a checked `ConstructingVariableSize -> Constructing addr` transition that rejects both other states
- `returnStackFrame` fails loudly on a variable-size ctor that returns without nominating its object
- the two `NativeString` handlers read their real argument from `Arguments.[0]` rather than `Arguments.[1]`

## Tests

Written first, and observed failing.

- `TestVariableSizeNewobj` asserts no String-typed heap object is left unregistered after either constructor runs, and pins the calling convention *differentially*: two extra `newobj String::.ctor(char*)` instructions must cost exactly two extra String objects. That assertion produced `4` before and `2` after.
- `sourcesPure/StringCtorReadOnlySpan.cs` gives the span constructor its first end-to-end coverage, cross-checked against the real runtime by the standard harness. Since I shifted that handler's argument index with no existing coverage, I verified the test bites by temporarily restoring the old index (`IndexOutOfRangeException`).

Full suite: 1435 passed, 0 failed. `codex review --base main` found no issues.

## Considered and not done

A guard in `allocateManagedObject` refusing to allocate a `System.String` outside `allocateManagedString`. It needs `BaseClassTypes` threaded through ~25 call sites, and a String-only predicate would be arbitrary — arrays have a special heap representation too and would slip through the same hole. If that guard is worth having, the honest version is a single allocator that dispatches on special representations, which is its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)