### PR TITLE
Implement SystemNative_GetCryptographicallySecureRandomBytes

### DIFF
--- a/WoofWare.PawPrint.Test/TestNonCryptoRandom.fs
+++ b/WoofWare.PawPrint.Test/TestNonCryptoRandom.fs
@@ -142,6 +142,22 @@ module TestNonCryptoRandom =
         |> shouldEqual NonCryptoRandom.initialState
 
     [<Test>]
+    let ``EmulatedKernel.initial seeds CryptoRandomState distinctly`` () : unit =
+        // `SystemNative_GetCryptographicallySecureRandomBytes` draws from its
+        // own stream so that non-crypto consumers (`new Random()`, `HashCode`,
+        // Marvin) can't shift the bytes `Guid.NewGuid` observes. That property
+        // only holds if the two seeds actually differ: sharing a seed would
+        // make the two streams emit identical byte sequences from a fresh
+        // kernel, which is both surprising and a sign the streams got merged.
+        EmulatedKernel.initial.CryptoRandomState
+        |> shouldEqual EmulatedKernel.cryptoRandomInitialState
+
+        EmulatedKernel.initial.CryptoRandomState |> shouldNotEqual 0UL
+
+        EmulatedKernel.initial.CryptoRandomState
+        |> shouldNotEqual EmulatedKernel.initial.NonCryptoRandomState
+
+    [<Test>]
     let ``nextDouble is pure in the starting state`` () : unit =
         // Same input state ⇒ same (value, newState). Determinism is the
         // whole point — schedule fuzzing needs to be able to replay a seed

--- a/WoofWare.PawPrint.Test/sourcesPure/GuidNewGuid.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/GuidNewGuid.cs
@@ -1,0 +1,34 @@
+using System;
+
+// `Guid.NewGuid()` on Unix is a thin shell over
+// `SystemNative_GetCryptographicallySecureRandomBytes`: Guid.Unix.cs draws
+// `sizeof(Guid)` bytes straight over the struct's storage, then forces the
+// RFC 4122 version-4 and variant-10xx bits. This test asserts the parts of
+// that contract that are true of every correct implementation, so it can run
+// against the real CLR and PawPrint alike.
+class Program
+{
+    static int Main(string[] args)
+    {
+        Guid a = Guid.NewGuid();
+        Guid b = Guid.NewGuid();
+
+        if (a == Guid.Empty) return 1;
+        if (a == b) return 2;
+
+        byte[] bytes = a.ToByteArray();
+        if (bytes.Length != 16) return 3;
+
+        // `ToByteArray` emits the first three fields little-endian, so
+        // `time_hi_and_version` (the 16-bit `_c` field) occupies indices 6
+        // and 7 with its most significant byte at index 7. RFC 4122 puts the
+        // version in that byte's high nibble; Guid.NewGuid forces it to 4.
+        if ((bytes[7] & 0xF0) != 0x40) return 4;
+
+        // `clock_seq_hi_and_reserved` is the `_d` byte, at index 8. The
+        // variant field is its top two bits, forced to 0b10.
+        if ((bytes[8] & 0xC0) != 0x80) return 5;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/SystemNativeGetCryptographicallySecureRandomBytes.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/SystemNativeGetCryptographicallySecureRandomBytes.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Runtime.InteropServices;
+
+// Exercises the SystemNative_GetCryptographicallySecureRandomBytes PawPrint
+// handler directly via a P/Invoke stub, mirroring the declaration CoreLib
+// itself uses (`Interop.Sys.GetCryptographicallySecureRandomBytes(byte*, int)
+// -> int`, where 0 means success and CoreLib's wrapper throws
+// CryptographicException on anything else).
+//
+// This test runs against both the real CLR and PawPrint, so it can only
+// assert properties that hold of *any* correct implementation: the return
+// code, that the callee writes within exactly the requested window, and that
+// two successive draws differ. It deliberately does not pin exact bytes —
+// PawPrint's substitute stream is a seeded splitmix64 (deterministic by
+// design), while the host draws from real OS entropy.
+class Program
+{
+    [DllImport("libSystem.Native", EntryPoint = "SystemNative_GetCryptographicallySecureRandomBytes")]
+    static unsafe extern int GetCryptographicallySecureRandomBytes(byte* buffer, int length);
+
+    const int Capacity = 64;
+    const int Draw = 32;
+    const byte Sentinel = 0xAB;
+
+    static unsafe void Fill(byte* buffer)
+    {
+        for (int i = 0; i < Capacity; i++)
+        {
+            buffer[i] = Sentinel;
+        }
+    }
+
+    static unsafe bool TailIsIntact(byte* buffer)
+    {
+        for (int i = Draw; i < Capacity; i++)
+        {
+            if (buffer[i] != Sentinel) return false;
+        }
+
+        return true;
+    }
+
+    static unsafe int Main(string[] args)
+    {
+        byte* first = stackalloc byte[Capacity];
+        byte* second = stackalloc byte[Capacity];
+
+        Fill(first);
+        Fill(second);
+
+        // A zero-length draw succeeds and touches nothing. CoreLib reaches
+        // this path whenever it hands over an empty span.
+        if (GetCryptographicallySecureRandomBytes(first, 0) != 0) return 1;
+
+        for (int i = 0; i < Capacity; i++)
+        {
+            if (first[i] != Sentinel) return 2;
+        }
+
+        if (GetCryptographicallySecureRandomBytes(first, Draw) != 0) return 3;
+        if (!TailIsIntact(first)) return 4;
+
+        if (GetCryptographicallySecureRandomBytes(second, Draw) != 0) return 5;
+        if (!TailIsIntact(second)) return 6;
+
+        // Two successive 32-byte draws must differ. A stuck implementation
+        // (one that never writes, or writes a constant) fails here; a
+        // correct one collides with probability 2^-256, which is not a
+        // flakiness source anybody will ever observe.
+        bool identical = true;
+
+        for (int i = 0; i < Draw; i++)
+        {
+            if (first[i] != second[i])
+            {
+                identical = false;
+                break;
+            }
+        }
+
+        if (identical) return 7;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/EmulatedKernel.fs
+++ b/WoofWare.PawPrint/EmulatedKernel.fs
@@ -387,6 +387,27 @@ type EmulatedKernel =
         /// `Random()` ctor retries until it sees a non-zero seed, so a
         /// constant-zero substitute would hang at construction time.
         NonCryptoRandomState : uint64
+        /// Deterministic state for the splitmix64 PRNG that backs
+        /// `SystemNative_GetCryptographicallySecureRandomBytes` — the entry
+        /// point `Guid.NewGuid` draws its 16 bytes from on Unix, and the one
+        /// CoreLib's `Interop.GetCryptographicallySecureRandomBytes` wrapper
+        /// turns into a `CryptographicException` on any non-zero return.
+        /// PawPrint substitutes the same seeded PRNG it uses for the
+        /// non-crypto entry point: the output is emphatically *not*
+        /// cryptographically secure, but nothing inside a deterministic
+        /// interpreter can be, and reproducibility is the property this
+        /// runtime exists to provide. Guests that need real entropy must not
+        /// run under PawPrint.
+        ///
+        /// Deliberately a *separate* stream from `NonCryptoRandomState`,
+        /// per the guidance on `NonCryptoRandom`: sharing one state would
+        /// make an added `new Random()` (or any other non-crypto consumer)
+        /// silently shift every subsequent `Guid.NewGuid`, which is exactly
+        /// the kind of spooky action at a distance that makes a recorded
+        /// trace hard to reason about. Seeded from a constant distinct from
+        /// `NonCryptoRandom.initialState` so the two streams do not emit
+        /// identical byte sequences.
+        CryptoRandomState : uint64
         /// Ordered, append-only log of every write the guest has performed
         /// against a writable standard stream via `SystemNative_Write`.
         /// Each entry carries the destination `Role` and the exact byte
@@ -437,6 +458,15 @@ module EmulatedKernel =
     let defaultEnvironment : Map<string, string> =
         Map.ofList [ "DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "1" ]
 
+    /// Seed for `EmulatedKernel.CryptoRandomState`. The first 64 bits of the
+    /// fractional part of pi — a nothing-up-my-sleeve constant chosen purely
+    /// so that the crypto-entropy stream starts somewhere other than
+    /// `NonCryptoRandom.initialState` (the golden-ratio constant). Any
+    /// non-zero value distinct from that one would do; splitmix64 has no weak
+    /// seeds. Changing it changes every `Guid.NewGuid` a recorded trace
+    /// observes, so treat it as part of PawPrint's replay contract.
+    let cryptoRandomInitialState : uint64 = 0x243F6A8885A308D3UL
+
     let initial : EmulatedKernel =
         {
             LastPInvokeError = 0
@@ -453,6 +483,7 @@ module EmulatedKernel =
             StepCounter = 0L
             VirtualClockMs = 0L
             NonCryptoRandomState = NonCryptoRandom.initialState
+            CryptoRandomState = cryptoRandomInitialState
             OutputLog = ImmutableArray<OutputLogEntry>.Empty
             Environment = defaultEnvironment
             Signals = SignalState.empty

--- a/WoofWare.PawPrint/Native/NativeSystemNative.fs
+++ b/WoofWare.PawPrint/Native/NativeSystemNative.fs
@@ -94,6 +94,85 @@ module NativeSystemNative =
         | CliType.Numeric (CliNumericType.Int32 count) -> checkedCount (int64 count)
         | other -> failwith $"%s{operation}: expected UIntPtr allocation size, got %O{other}"
 
+    /// Shared body of `SystemNative_GetNonCryptographicallySecureRandomBytes`
+    /// and `SystemNative_GetCryptographicallySecureRandomBytes`. The two entry
+    /// points declare the identical `(byte* buffer, int32 bufferLength)`
+    /// argument list and differ only in which host entropy source backs them
+    /// (and, here, in which kernel PRNG stream they advance), so the decode,
+    /// validation, and buffer-fill are factored into one place.
+    ///
+    /// CoreCLR fills these buffers from the host: `arc4random_buf` on
+    /// BSD/macOS, BCrypt/`BCryptGenRandom` on Windows, `/dev/urandom` (XOR'd
+    /// with `lrand48()` for the non-crypto variant) on Linux — see
+    /// minipal/random.c. PawPrint refuses host entropy because the whole
+    /// runtime is built around bit-for-bit reproducibility, so we substitute a
+    /// seeded splitmix64 step. That is *strictly* more deterministic than the
+    /// real CLR (where each Random ctor, Guid.NewGuid, Marvin seed, and
+    /// HashCode seed is unreproducible) and is what enables time-travel
+    /// debugging across runs that touch any of those paths. It also means the
+    /// "cryptographically secure" entry point is nothing of the sort under
+    /// PawPrint; no deterministic interpreter can honour that contract, and a
+    /// guest whose security depends on it must not run here.
+    ///
+    /// Returning a constant (e.g. all zeros) is not viable: the BCL's Random
+    /// ctor at Random.Xoshiro{128,256}StarStarImpl explicitly retries until
+    /// the buffer is non-zero, so a constant-zero substitute hangs at
+    /// `new Random()`.
+    ///
+    /// Returns the updated machine state and the advanced PRNG state; the
+    /// caller writes the latter back to whichever kernel field it owns.
+    let private drawRandomBytesInto
+        (ctx : NativeCallContext)
+        (operation : string)
+        (prngState : uint64)
+        : IlMachineState * uint64
+        =
+        let state = ctx.State
+
+        let buffer =
+            NativeCall.managedPointerOfPointerArgument operation "buffer" ctx.Instruction.Arguments.[0]
+
+        let length = NativeCall.int32Argument operation ctx.Instruction.Arguments.[1]
+
+        if length < 0 then
+            // CoreCLR's `pal_random.c` does not validate `bufferLength`;
+            // a negative value would underflow `(size_t)bufferLength` in
+            // the C call. CoreLib callers never pass negative lengths,
+            // so seeing one here means a guest bug we want to surface
+            // rather than a silently truncated buffer.
+            failwith $"%s{operation}: bufferLength %d{length} is negative"
+        elif length = 0 then
+            // Match the C behaviour of `arc4random_buf(buf, 0)` /
+            // `read(fd, buf, 0)`: no-op, do not even dereference
+            // `buffer` (which CoreLib may pass as a null pointer
+            // for an empty span), and do not advance the PRNG.
+            state, prngState
+        else
+            match buffer with
+            | ManagedPointerSource.Null ->
+                failwith
+                    $"%s{operation}: refused to fill %d{length} bytes through null buffer pointer (CoreLib should not invoke this entry point with a null destination for a non-zero length)"
+            | _ ->
+                let bytes, newPrngState = NonCryptoRandom.drawBytes length prngState
+
+                let byteConcreteType =
+                    NativeCall.requiredByteConcreteType operation ctx.BaseClassTypes state
+
+                let mutable state = state
+
+                for i = 0 to length - 1 do
+                    let dest =
+                        ManagedPointerByteView.addByteOffset ctx.BaseClassTypes state byteConcreteType i buffer
+
+                    state <-
+                        IlMachineState.writeManagedByrefBytesOrTypedCell
+                            ctx.BaseClassTypes
+                            state
+                            dest
+                            (CliType.Numeric (CliNumericType.UInt8 bytes.[i]))
+
+                state, newPrngState
+
     let tryExecute (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
@@ -462,76 +541,55 @@ module NativeSystemNative =
           [ ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.Byte)
             ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32 ],
           MethodReturnType.Void ->
-            // CoreCLR fills this buffer from the host's non-crypto PRNG
-            // (`arc4random_buf` on BSD/macOS, BCrypt on Windows,
-            // `/dev/urandom` XOR'd with `lrand48()` on Linux — see
-            // minipal/random.c). PawPrint refuses host entropy because the
-            // whole runtime is built around bit-for-bit reproducibility,
-            // so we substitute a seeded splitmix64 step kept in
-            // `EmulatedKernel.NonCryptoRandomState`. That is *strictly*
-            // more deterministic than the real CLR (where each Random
-            // ctor, Guid.NewGuid, Marvin seed, and HashCode seed is
-            // unreproducible) and is what enables time-travel
-            // debugging across runs that touch any of those paths.
+            let state, newPrngState =
+                drawRandomBytesInto
+                    ctx
+                    "SystemNative_GetNonCryptographicallySecureRandomBytes"
+                    state.Kernel.NonCryptoRandomState
+
+            state.MapKernel (fun kernel ->
+                { kernel with
+                    NonCryptoRandomState = newPrngState
+                }
+            )
+            |> NativeHandlerResult.completed
+            |> Some
+        | Some "SystemNative_GetCryptographicallySecureRandomBytes",
+          [ ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.Byte)
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32 ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
+            // Same substitute PRNG as the non-crypto entry point (see
+            // `drawRandomBytesInto`), drawn from its own kernel stream so
+            // that a guest's `Random`/`HashCode` draws don't perturb the
+            // sequence `Guid.NewGuid` observes.
             //
-            // Returning a constant (e.g. all zeros) is not viable: the
-            // BCL's Random ctor at Random.Xoshiro{128,256}StarStarImpl
-            // explicitly retries until the buffer is non-zero, so a
-            // constant-zero substitute hangs at `new Random()`.
-            let operation = "SystemNative_GetNonCryptographicallySecureRandomBytes"
-
-            let buffer =
-                NativeCall.managedPointerOfPointerArgument operation "buffer" instruction.Arguments.[0]
-
-            let length = NativeCall.int32Argument operation instruction.Arguments.[1]
-
-            if length < 0 then
-                // CoreCLR's `pal_random.c` does not validate `bufferLength`;
-                // a negative value would underflow `(size_t)bufferLength` in
-                // the C call. CoreLib callers never pass negative lengths,
-                // so seeing one here means a guest bug we want to surface
-                // rather than a silently truncated buffer.
-                failwith $"%s{operation}: bufferLength %d{length} is negative"
+            // Unlike its non-crypto sibling this entry point reports status:
+            // `Interop.GetCryptographicallySecureRandomBytes` branches on the
+            // result with `brfalse` and throws `CryptographicException` for
+            // anything non-zero. PawPrint's substitute has no failure mode —
+            // there is no host entropy source to be exhausted or unreadable —
+            // so it always reports success. Malformed arguments abort loudly
+            // inside `drawRandomBytesInto` rather than being reported as
+            // entropy failure, because a negative length or a null
+            // destination is a guest/interpreter bug, not the condition
+            // `CryptographicException` is meant to describe.
+            let state, newPrngState =
+                drawRandomBytesInto
+                    ctx
+                    "SystemNative_GetCryptographicallySecureRandomBytes"
+                    state.Kernel.CryptoRandomState
 
             let state =
-                if length = 0 then
-                    // Match the C behaviour of `arc4random_buf(buf, 0)` /
-                    // `read(fd, buf, 0)`: no-op, do not even dereference
-                    // `buffer` (which CoreLib may pass as a null pointer
-                    // for an empty span).
-                    state
-                else
-                    match buffer with
-                    | ManagedPointerSource.Null ->
-                        failwith
-                            $"%s{operation}: refused to fill %d{length} bytes through null buffer pointer (CoreLib should not invoke this entry point with a null destination for a non-zero length)"
-                    | _ ->
-                        let bytes, newPrngState =
-                            NonCryptoRandom.drawBytes length state.Kernel.NonCryptoRandomState
+                state.MapKernel (fun kernel ->
+                    { kernel with
+                        CryptoRandomState = newPrngState
+                    }
+                )
 
-                        let byteConcreteType =
-                            NativeCall.requiredByteConcreteType operation ctx.BaseClassTypes state
-
-                        let mutable state = state
-
-                        for i = 0 to length - 1 do
-                            let dest =
-                                ManagedPointerByteView.addByteOffset ctx.BaseClassTypes state byteConcreteType i buffer
-
-                            state <-
-                                IlMachineState.writeManagedByrefBytesOrTypedCell
-                                    ctx.BaseClassTypes
-                                    state
-                                    dest
-                                    (CliType.Numeric (CliNumericType.UInt8 bytes.[i]))
-
-                        state.MapKernel (fun kernel ->
-                            { kernel with
-                                NonCryptoRandomState = newPrngState
-                            }
-                        )
-
-            NativeHandlerResult.completed state |> Some
+            state
+            |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread
+            |> NativeHandlerResult.completed
+            |> Some
         | Some "SystemNative_Free", [ ConcretePointer _ ], MethodReturnType.Void ->
             let ptr =
                 NativeCall.managedPointerOfPointerArgument "SystemNative_Free" "ptr" instruction.Arguments.[0]


### PR DESCRIPTION
`Guid.NewGuid()` on Unix goes straight through
`Interop.Sys.GetCryptographicallySecureRandomBytes(byte*, int) -> int`, which
PawPrint did not implement — so any guest that minted a Guid died at the
P/Invoke boundary with `Unimplemented native method`.

Confirmed against the shipped CoreLib rather than from memory:

```
// Interop::static GetCryptographicallySecureRandomBytes(ptr[uint8], int32) : void
IL_0002: Call     Interop/Sys::GetCryptographicallySecureRandomBytes
IL_0007: UnaryConst.Brfalse_s 6
IL_0009: Newobj   System.Security.Cryptography.CryptographicException::.ctor
IL_000E: Throw
```

So 0 means success, and CoreLib's wrapper throws `CryptographicException` on
anything else.

## Approach

Implemented the same way as its already-supported non-crypto sibling: a seeded
splitmix64 substitute for host entropy, because bit-for-bit reproducibility is
the property this runtime exists to provide and no deterministic interpreter can
honour the "cryptographically secure" contract anyway. **Under PawPrint this
entry point is not cryptographically secure in any sense**; that is documented
at both the kernel field and the handler.

Two notes on the shape:

* The entry point reports status, unlike its sibling. PawPrint's substitute has
  no failure mode — there is no host entropy source to be exhausted or
  unreadable — so it always returns 0. Malformed arguments (negative length,
  null destination for a non-zero length) still abort loudly rather than
  masquerading as an entropy failure, since those are guest/interpreter bugs
  rather than the condition `CryptographicException` describes.
* It draws from its own `EmulatedKernel.CryptoRandomState` stream rather than
  sharing `NonCryptoRandomState`. This follows the guidance already on
  `NonCryptoRandom`: sharing one state would make an added `new Random()` (or
  any other non-crypto consumer) silently shift every subsequent
  `Guid.NewGuid`, which is exactly the kind of action at a distance that makes
  a recorded trace hard to reason about. Seeded from a distinct
  nothing-up-my-sleeve constant so the two streams do not emit identical bytes
  from a fresh kernel.

The decode/validate/fill body is now shared between the two entry points, which
declare the identical `(byte* buffer, int32 bufferLength)` argument list.

## Tests

Written before the implementation and observed failing on `Unimplemented native
method`, then passing:

* `sourcesPure/SystemNativeGetCryptographicallySecureRandomBytes.cs` — direct
  P/Invoke stub mirroring CoreLib's declaration. Runs against the real CLR and
  PawPrint alike, so it asserts only what holds of any correct implementation:
  return code 0, zero-length draw is a no-op, the sentinel tail past the
  requested length is untouched, and two successive draws differ.
* `sourcesPure/GuidNewGuid.cs` — end-to-end `Guid.NewGuid()`, checking the RFC
  4122 version-4 and variant-10xx bits. This passes, so it does not need to go
  in `unimplemented`.
* `TestNonCryptoRandom.fs` — the two kernel seeds are non-zero and distinct,
  pinning the property the separate-stream decision rests on.

Full suite: 1443/1443 passing. `codex review --base main` found nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)