### PR TITLE
Fix the errors in docs/user/run-a-program.md

### DIFF
--- a/docs/user/run-a-program.md
+++ b/docs/user/run-a-program.md
@@ -74,10 +74,12 @@ let runGuest (dllPath : string) : int * ImmutableArray<OutputLogEntry> =
             | EvalStackValue.Int32 i -> i
             | ret -> failwith $"expected program to return an int, but it returned %O{ret}"
 
-    // PawPrint never writes to the host's stdout/stderr during execution: the guest's
-    // writes are accumulated in the kernel's output log, in the order the guest made
-    // them, so that a run stays deterministic and replayable. Drain the log at the end
-    // if you want to see the output.
+    // The guest's own writes to stdout/stderr never reach the host's streams during
+    // execution: they're accumulated in the kernel's output log, in the order the guest
+    // made them, so that a run stays deterministic and replayable. Drain the log at the
+    // end if you want to see the output. (PawPrint's *own* logging is a separate matter:
+    // the `loggerFactory` above sends it wherever you configured, and `AddConsole` with
+    // its default settings will indeed write to the host console during the run.)
     exitCode, terminalState.Kernel.OutputLog
 ```
 

--- a/docs/user/run-a-program.md
+++ b/docs/user/run-a-program.md
@@ -5,57 +5,83 @@ PawPrint is intended to be used in tests, so is primarily a library.
 Use whatever `dotnet build` command you'd usually use to compile an executable DLL, say `/tmp/MyCoolDll.dll`.
 For the most predictable results, I'd probably `dotnet publish --self-contained` this; otherwise you may find [WoofWare.DotnetRuntimeLocator](https://github.com/Smaug123/WoofWare.DotnetRuntimeLocator) fails to locate the correct .NET runtime (although it *should* work).
 
-```fsharp
-let pathToDll = "/tmp/MyCoolDll.dll"
+Besides `WoofWare.PawPrint` itself, the example below needs `WoofWare.DotnetRuntimeLocator` (to find the runtime directories to load the BCL from), `Microsoft.Extensions.Logging`, and `Microsoft.Extensions.Logging.Console`:
 
-use loggerFactory =
-    Microsoft.Extensions.Logging.LoggerFactory.Create(fun builder -> builder.AddConsole ());
-
-use peImage = new System.IO.FileStream (dllPath, System.IO.FileMode.Open, System.IO.FileAccess.Read)
-
-use dotnetRuntimes =
-    WoofWare.DotnetRuntimeLocator.DotnetRuntime.SelectForDll dllPath
-    |> System.Collections.Immutable.ImmutableDictionary.CreateRange
-
-// When PawPrint requires a native call, e.g. a result from System.Environment,
-// just pass through to the host.
-// This actually isn't a pure pass-through: System.Environment.FailFast, for example,
-// is trapped.
-let nativeImpls = WoofWare.PawPrint.NativeImpls.PassThru ()
-
-// I recommend running with at least the default environment variables,
-// because that way you get invariant globalization turned on.
-let environmentVariables = WoofWare.PawPrint.EmulatedKernel.defaultEnvironment
-
-let terminalState, terminatingThread =
-    match
-        WoofWare.PawPrint.Program.run
-            loggerFactory
-            (Some pathToDll)
-            peImage
-            dotnetRuntimes
-            nativeImpls
-            environmentVariables
-            None // use a default thread scheduler; or `Some yourChoiceOfSeed` to explore thread scheduling intelligently
-            [] // argv passed to emulated program
-    with
-    | RunOutcome.GuestUnhandledException (_, _, exn) ->
-        failwith $"Guest threw unhandled exception: %O{exn.ExceptionObject}"
-    | RunOutcome.FailFast (_, _, message) ->
-        let m = message |> Option.defaultValue "<no message>"
-        failwith $"Guest called Environment.FailFast: %s{m}"
-    | RunOutcome.SignalTerminated (_, signal) -> failwith $"Guest was terminated by POSIX signal %O{signal}"
-    | RunOutcome.NormalExit (state, thread) -> state, thread
-    | RunOutcome.ProcessExit (state, thread) -> state, thread
-
-let exitCode =
-    match terminalState.ThreadState.[terminatingThread].MethodState.EvaluationStack.Values with
-    | [] -> failwith "expected program to return a value, but it returned void"
-    | head :: _ ->
-        match head with
-        | EvalStackValue.Int32 i -> i
-        | ret -> failwith $"expected program to return an int, but it returned %O{ret}"
+```xml
+<PackageReference Include="WoofWare.DotnetRuntimeLocator" Version="0.3.2" />
+<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
+<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.2" />
 ```
 
+```fsharp
+open System.Collections.Immutable
+open System.IO
+open Microsoft.Extensions.Logging
+open WoofWare.DotnetRuntimeLocator
+open WoofWare.PawPrint
+open WoofWare.PawPrint.ExternImplementations
+
+/// Runs the guest program at `dllPath`, returning the exit code it asked for
+/// and everything it wrote to stdout/stderr.
+let runGuest (dllPath : string) : int * ImmutableArray<OutputLogEntry> =
+    use loggerFactory =
+        LoggerFactory.Create (fun builder -> builder.AddConsole () |> ignore<ILoggingBuilder>)
+
+    use peImage = new FileStream (dllPath, FileMode.Open, FileAccess.Read)
+
+    // `SelectForDll` returns a `string seq` of candidate runtime directories.
+    let dotnetRuntimes =
+        DotnetRuntime.SelectForDll dllPath |> ImmutableArray.CreateRange
+
+    // When PawPrint requires a native call, e.g. a result from System.Environment,
+    // just pass through to the host.
+    // This actually isn't a pure pass-through: System.Environment.FailFast, for example,
+    // is trapped.
+    let nativeImpls = NativeImpls.PassThru ()
+
+    // Whatever you pass here is overlaid on top of `EmulatedKernel.defaultEnvironment`,
+    // so even `Map.empty` gets you DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1 (invariant
+    // globalization is the only mode PawPrint implements); the keys you supply win over
+    // the defaults. Pass the host's own environment if you want the guest to see it.
+    let environmentVariables : Map<string, string> = Map.empty
+
+    let terminalState, terminatingThread =
+        match
+            Program.run
+                loggerFactory
+                (Some dllPath)
+                peImage
+                dotnetRuntimes
+                nativeImpls
+                environmentVariables
+                None // use a default thread scheduler; or `Some yourChoiceOfSeed` to explore thread scheduling intelligently
+                [] // argv passed to emulated program
+        with
+        | RunOutcome.GuestUnhandledException (_, _, exn) ->
+            failwith $"Guest threw unhandled exception: %O{exn.ExceptionObject}"
+        | RunOutcome.FailFast (_, _, message) ->
+            let m = message |> Option.defaultValue "<no message>"
+            failwith $"Guest called Environment.FailFast: %s{m}"
+        | RunOutcome.SignalTerminated (_, signal) -> failwith $"Guest was terminated by POSIX signal %O{signal}"
+        | RunOutcome.NormalExit (state, thread) -> state, thread
+        | RunOutcome.ProcessExit (state, thread) -> state, thread
+
+    let exitCode =
+        match terminalState.ThreadState.[terminatingThread].MethodState.EvaluationStack.Values with
+        | [] -> failwith "expected program to return a value, but it returned void"
+        | head :: _ ->
+            match head with
+            | EvalStackValue.Int32 i -> i
+            | ret -> failwith $"expected program to return an int, but it returned %O{ret}"
+
+    // PawPrint never writes to the host's stdout/stderr during execution: the guest's
+    // writes are accumulated in the kernel's output log, in the order the guest made
+    // them, so that a run stays deterministic and replayable. Drain the log at the end
+    // if you want to see the output.
+    exitCode, terminalState.Kernel.OutputLog
+```
+
+`RunOutcome.ProcessExit` is the guest having called `System.Environment.Exit`; like `RunOutcome.NormalExit`, it leaves the exit code on top of the relevant thread's evaluation stack, which is why both cases are handled the same way above.
+
 PawPrint's own tests do this, e.g. in [TestImpureCases.fs](../../WoofWare.PawPrint.Test/TestImpureCases.fs) and [TestPureCases.fs](../../WoofWare.PawPrint.Test/TestPureCases.fs).
-We also have [WoofWare.PawPrint.App](../../WoofWare.PawPrint.App/Program.fs), which is a console app that executes a program under PawPrint.
+We also have [WoofWare.PawPrint.App](../../WoofWare.PawPrint.App/Program.fs), which is a console app that executes a program under PawPrint; it shows how to drain the output log to the host's real standard streams, and how to map each `RunOutcome` onto the exit code a real .NET process would have produced.


### PR DESCRIPTION
Closes #665.

The F# sample in `docs/user/run-a-program.md` did not compile. Rather than eyeballing it, I extracted it into a scratch project referencing `WoofWare.PawPrint` and built it: the original produced six compile errors, and the version in this PR compiles with zero errors and zero warnings, and is fantomas-clean.

## Compile errors fixed

The issue listed three; there were six.

1. `ImmutableDictionary.CreateRange` → `ImmutableArray.CreateRange`. `Program.run` takes `ImmutableArray<string>`, and `DotnetRuntime.SelectForDll` returns a `string seq`.
2. `use dotnetRuntimes` → `let`. An `ImmutableArray` is not `IDisposable`, so this was a second, separate type error on the same binding.
3. `pathToDll` was bound but `dllPath` was used. Unified to `dllPath`.
4. `NativeImpls` lives in `WoofWare.PawPrint.ExternImplementations`, not `WoofWare.PawPrint`.
5. `LoggerFactory.Create (fun builder -> builder.AddConsole ())`: the lambda must return `unit`, so it needs `|> ignore<ILoggingBuilder>`. Also dropped a stray C#-style `;`.
6. Replaced the ad-hoc qualification with an explicit `open` preamble — `RunOutcome` and `EvalStackValue` were already being used unqualified, so the snippet silently assumed opens it never showed. The body is now wrapped in a function, because a module-level `use` binding is silently downgraded to `let` (FS0524).

## Prose corrections

- The doc recommended passing `EmulatedKernel.defaultEnvironment` "so that way you get invariant globalization turned on". That's misleading: `Program.run` overlays the caller's environment on top of the defaults, so `Map.empty` already gets `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1`, and caller-supplied keys win. Replaced with an accurate description of the overlay.
- Documented the package references the sample needs (`WoofWare.DotnetRuntimeLocator`, `Microsoft.Extensions.Logging`, `Microsoft.Extensions.Logging.Console`); none of these flow transitively from `WoofWare.PawPrint`, so the snippet wouldn't resolve for a fresh consumer.
- Noted that the guest's stdout/stderr accumulates in `Kernel.OutputLog` rather than streaming to the host, and what `RunOutcome.ProcessExit` means (hence why it and `NormalExit` are handled identically).

## Review

`codex review --base main` flagged one real issue on the first pass: my "PawPrint never writes to the host's stdout/stderr" claim was too broad, since the sample's own `AddConsole()` logger does write to the console at the default information threshold. Narrowed to the guest's own writes (second commit); the re-run came back clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)