### PR TITLE
Implement `unbox.any` for `Nullable<T>`

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/UnboxAnyNullableInt.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/UnboxAnyNullableInt.cs
@@ -1,0 +1,47 @@
+// ECMA-335 III.4.33 / CoreCLR `Nullable::UnBox`: `unbox.any Nullable<T>` reconstructs the
+// Nullable from the two forms `box` can produce for one — null, or a boxed `T`.
+//
+// The null case is the interesting one: it is the single value-typed `unbox.any` target that
+// accepts a null operand, yielding a zeroed Nullable rather than raising NullReferenceException.
+//
+// `Cast<T>` forces the `unbox.any !!T` token form, which reaches the same code path via a
+// generic instantiation rather than a direct type token.
+
+public class TestUnboxAnyNullableInt
+{
+    private static T Cast<T>(object o)
+    {
+        return (T) o;
+    }
+
+    public static int Main(string[] argv)
+    {
+        // Boxed T -> Nullable<T> with HasValue = true.
+        object boxed = 42;
+        int? v = (int?) boxed;
+        if (!v.HasValue) return 1;
+        if (v.Value != 42) return 2;
+
+        // Null -> Nullable<T> with HasValue = false, and *not* an exception.
+        object nothing = null;
+        int? w = (int?) nothing;
+        if (w.HasValue) return 3;
+        if (w.GetValueOrDefault() != 0) return 4;
+
+        // Same two cases through the `unbox.any !!T` token form.
+        int? viaGeneric = Cast<int?>(boxed);
+        if (!viaGeneric.HasValue) return 5;
+        if (viaGeneric.Value != 42) return 6;
+
+        int? nullViaGeneric = Cast<int?>(null);
+        if (nullViaGeneric.HasValue) return 7;
+
+        // Default(T) is preserved for a non-zero-defaulting payload too.
+        object boxedFalse = false;
+        bool? b = (bool?) boxedFalse;
+        if (!b.HasValue) return 8;
+        if (b.Value) return 9;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/UnboxAnyNullableNegative.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/UnboxAnyNullableNegative.cs
@@ -1,0 +1,67 @@
+// `unbox.any Nullable<T>` matches the boxed operand against `T` by exact equivalence, not by
+// assignability or numeric widening (CoreCLR `Nullable::IsNullableForTypeHelper` compares against
+// `GetInstantiation()[0]`). Everything that is not a boxed `T` — and not null — raises
+// InvalidCastException.
+
+using System;
+
+public enum Colour
+{
+    Red = 0,
+    Green = 1,
+}
+
+public class TestUnboxAnyNullableNegative
+{
+    private static T Cast<T>(object o)
+    {
+        return (T) o;
+    }
+
+    private static bool CastThrows<T>(object o)
+    {
+        try
+        {
+            T _ = Cast<T>(o);
+            return false;
+        }
+        catch (InvalidCastException)
+        {
+            return true;
+        }
+    }
+
+    public static int Main(string[] argv)
+    {
+        // No widening: a boxed short/long is not a boxed int.
+        if (!CastThrows<int?>((object) 1L)) return 1;
+        if (!CastThrows<int?>((object) (short) 1)) return 2;
+        if (!CastThrows<long?>((object) 1)) return 3;
+
+        // Unsigned counterpart of the same width is still a different type.
+        if (!CastThrows<int?>((object) 1u)) return 4;
+
+        // A reference type is never a boxed T.
+        if (!CastThrows<int?>("hello")) return 5;
+        if (!CastThrows<int?>(new int[] { 1 })) return 6;
+
+        // An enum and its underlying type are distinct for this purpose, both ways round.
+        if (!CastThrows<int?>((object) Colour.Green)) return 7;
+        if (!CastThrows<Colour?>((object) 1)) return 8;
+
+        // An unrelated struct.
+        if (!CastThrows<int?>((object) 1.0)) return 9;
+
+        // Sanity: the matching case really does succeed, so the above are not all throwing
+        // for some unrelated reason.
+        int? ok = Cast<int?>((object) 1);
+        if (!ok.HasValue) return 10;
+        if (ok.Value != 1) return 11;
+
+        Colour? okEnum = Cast<Colour?>((object) Colour.Green);
+        if (!okEnum.HasValue) return 12;
+        if (okEnum.Value != Colour.Green) return 13;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/UnboxAnyNullableRoundTrip.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/UnboxAnyNullableRoundTrip.cs
@@ -1,0 +1,85 @@
+// The composition property that box and unbox.any must jointly satisfy: for every `T?` value x,
+// `(T?)(object)x` equals x — for both the null and the non-null case, and across payload types.
+//
+// This is the property that would catch box and unbox.any disagreeing about the representation:
+// `box` of a `Nullable<T>` erases the Nullable (yielding null or a boxed `T`), so `unbox.any`
+// has to rebuild it from strictly less information than it started with.
+
+using System;
+
+public struct Pair
+{
+    public int A;
+    public int B;
+}
+
+public enum Flavour
+{
+    Sweet = 3,
+}
+
+public class TestUnboxAnyNullableRoundTrip
+{
+    private static bool RoundTripsInt(int? x)
+    {
+        int? back = (int?) (object) x;
+
+        if (back.HasValue != x.HasValue) return false;
+        if (!x.HasValue) return true;
+
+        return back.Value == x.Value;
+    }
+
+    private static bool RoundTripsPair(Pair? x)
+    {
+        Pair? back = (Pair?) (object) x;
+
+        if (back.HasValue != x.HasValue) return false;
+        if (!x.HasValue) return true;
+
+        return back.Value.A == x.Value.A && back.Value.B == x.Value.B;
+    }
+
+    private static bool RoundTripsFlavour(Flavour? x)
+    {
+        Flavour? back = (Flavour?) (object) x;
+
+        if (back.HasValue != x.HasValue) return false;
+        if (!x.HasValue) return true;
+
+        return back.Value == x.Value;
+    }
+
+    public static int Main(string[] argv)
+    {
+        if (!RoundTripsInt(null)) return 1;
+        if (!RoundTripsInt(0)) return 2;
+        if (!RoundTripsInt(-1)) return 3;
+        if (!RoundTripsInt(int.MinValue)) return 4;
+        if (!RoundTripsInt(int.MaxValue)) return 5;
+
+        if (!RoundTripsPair(null)) return 6;
+
+        Pair p = new Pair();
+        p.A = 11;
+        p.B = -22;
+        if (!RoundTripsPair(p)) return 7;
+        if (!RoundTripsPair(new Pair())) return 8;
+
+        if (!RoundTripsFlavour(null)) return 9;
+        if (!RoundTripsFlavour(Flavour.Sweet)) return 10;
+
+        // A null Nullable boxes to a genuine null reference, which is what makes the null
+        // round trip work at all.
+        int? none = null;
+        if ((object) none != null) return 11;
+
+        // A non-null Nullable boxes to a boxed T, not to a boxed Nullable<T>.
+        int? some = 5;
+        object boxedSome = (object) some;
+        if (boxedSome == null) return 12;
+        if (!(boxedSome is int)) return 13;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/UnboxAnyNullableStruct.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/UnboxAnyNullableStruct.cs
@@ -1,0 +1,70 @@
+// `unbox.any Nullable<T>` where `T` is a genuine multi-field user struct rather than a primitive.
+// `box` stores a primitive in a synthetic single-field struct but stores a multi-field struct
+// directly, so the two take different arms when the value is read back out; this pins the
+// multi-field arm, including that every field survives the round trip.
+
+using System;
+
+public struct Point
+{
+    public int X;
+    public long Y;
+    public bool Flag;
+
+    public Point(int x, long y, bool flag)
+    {
+        X = x;
+        Y = y;
+        Flag = flag;
+    }
+}
+
+public class TestUnboxAnyNullableStruct
+{
+    private static T Cast<T>(object o)
+    {
+        return (T) o;
+    }
+
+    public static int Main(string[] argv)
+    {
+        object boxed = new Point(3, 4000000000L, true);
+
+        Point? p = (Point?) boxed;
+        if (!p.HasValue) return 1;
+        if (p.Value.X != 3) return 2;
+        if (p.Value.Y != 4000000000L) return 3;
+        if (!p.Value.Flag) return 4;
+
+        // Same through the `unbox.any !!T` token form.
+        Point? q = Cast<Point?>(boxed);
+        if (!q.HasValue) return 5;
+        if (q.Value.X != 3) return 6;
+        if (q.Value.Y != 4000000000L) return 7;
+        if (!q.Value.Flag) return 8;
+
+        // Null still yields a zeroed Nullable, and the payload is default(Point).
+        Point? none = (Point?) (object) null;
+        if (none.HasValue) return 9;
+
+        Point zero = none.GetValueOrDefault();
+        if (zero.X != 0) return 10;
+        if (zero.Y != 0L) return 11;
+        if (zero.Flag) return 12;
+
+        // A different struct of the same shape is still a different type.
+        bool threw = false;
+        try
+        {
+            Point _ = (Point) (object) 3;
+        }
+        catch (InvalidCastException)
+        {
+            threw = true;
+        }
+
+        if (!threw) return 13;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
@@ -661,6 +661,36 @@ module internal UnaryMetadataObjectOps =
 
         state, WhatWeDid.Executed
 
+    /// The CLI value logically held by a boxed object whose runtime type is `handle`; the inverse
+    /// of the shape `executeBox` writes. Callers must already have established that
+    /// `contents.Declared = handle` — both `executeBox` paths guarantee it, by constructing the
+    /// heap object's contents with `CliValueType.OfFields ... handle`.
+    ///
+    /// Three shapes come back out, matching the three `executeBox` writes:
+    ///   - primitive-like (IntPtr, RuntimeTypeHandle, an enum, ...): keep it wrapped, since the
+    ///     push path flattens it via the `PrimitiveLikeKind` invariant;
+    ///   - a genuine multi-field value type: keep it wrapped;
+    ///   - a bare primitive (Int32, Float64, ...), which `box` stored in a synthetic single-field
+    ///     struct: read field 0 back by offset and size. `box` guarantees that shape, so this is a
+    ///     nominal dereference rather than a structural guess.
+    let private unboxedContents
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (handle : ConcreteTypeHandle)
+        (contents : CliValueType)
+        (state : IlMachineState)
+        : CliType * IlMachineState
+        =
+        if contents.PrimitiveLikeKind.IsSome then
+            CliType.ValueType contents, state
+        else
+            let zero, state = IlMachineState.cliTypeZeroOfHandle state baseClassTypes handle
+
+            match zero with
+            | CliType.ValueType _ -> CliType.ValueType contents, state
+            | _ ->
+                let size = (CliType.SizeOf zero).Size
+                CliValueType.DereferenceFieldAt 0 size contents, state
+
     let executeUnboxAny (ctx : UnaryMetadataIlOpContext) (state : IlMachineState) : IlMachineState * WhatWeDid =
         let loggerFactory = ctx.LoggerFactory
         let baseClassTypes = ctx.BaseClassTypes
@@ -732,7 +762,96 @@ module internal UnaryMetadataObjectOps =
             DumpedAssembly.isValueType baseClassTypes state._LoadedAssemblies targetDefn
 
         if isNullable then
-            failwith "TODO: Unbox_Any for Nullable<T> unimplemented"
+            // ECMA-335 III.4.33 / CoreCLR `Nullable::UnBox` (src/coreclr/vm/object.cpp). `box` of a
+            // `Nullable<T>` never produces a boxed Nullable — it yields null, or a boxed `T` — so
+            // unboxing has to reconstruct the Nullable from those two forms:
+            //   - a null operand yields a zeroed Nullable (`hasValue = false`). This is the one
+            //     value-typed `unbox.any` target that accepts null instead of raising
+            //     NullReferenceException;
+            //   - a boxed `T` yields `hasValue = true` with that value;
+            //   - anything else is an InvalidCastException.
+            // The match against `T` is exact equivalence, not assignability
+            // (`Nullable::IsNullableForTypeHelper` compares against `GetInstantiation()[0]`).
+            if targetConcreteType.Generics.Length <> 1 then
+                failwith
+                    $"Unbox_Any: %O{targetConcreteTypeHandle} classified as System.Nullable`1 but has %d{targetConcreteType.Generics.Length} generic arguments, expected exactly 1"
+
+            let underlyingHandle = targetConcreteType.Generics.[0]
+
+            // Built from the zero rather than hand-rolled, so the layout, field ids and offsets
+            // match every other way a `Nullable<T>` comes into existence.
+            let nullableZero, state =
+                IlMachineState.cliTypeZeroOfHandle state baseClassTypes targetConcreteTypeHandle
+
+            let zeroCvt =
+                match nullableZero with
+                | CliType.ValueType cvt -> cvt
+                | other ->
+                    failwith
+                        $"Unbox_Any: zero of Nullable`1 %O{targetConcreteTypeHandle} was %O{other}, expected a value type"
+
+            match actualObj with
+            | EvalStackValue.NullObjectRef ->
+                state
+                |> IlMachineState.pushToEvalStack nullableZero thread
+                |> IlMachineState.advanceProgramCounter thread
+                |> Tuple.withRight WhatWeDid.Executed
+            | EvalStackValue.ObjectRef addr ->
+                let boxedOpt =
+                    match state.ManagedHeap.NonArrayObjects.TryGetValue addr with
+                    | true, v -> Some v
+                    | false, _ ->
+                        match state.ManagedHeap.Arrays.TryGetValue addr with
+                        // An array can never be a boxed T for any T that Nullable admits.
+                        | true, _ -> None
+                        | false, _ -> failwith $"Unbox_Any: could not find managed object with address {addr}"
+
+                match boxedOpt with
+                | Some boxed when boxed.ConcreteType = underlyingHandle ->
+                    let value, state =
+                        unboxedContents baseClassTypes underlyingHandle boxed.Contents state
+
+                    // No coercion needed: `unboxedContents` decides its shape from
+                    // `cliTypeZeroOfHandle underlyingHandle`, which is the same computation that
+                    // produced the zero of the `value` field we are overwriting.
+                    let hasValueField =
+                        IlMachineState.requiredOwnInstanceFieldId state zeroCvt.Declared "hasValue"
+
+                    let valueField =
+                        IlMachineState.requiredOwnInstanceFieldId state zeroCvt.Declared "value"
+
+                    let result =
+                        zeroCvt
+                        |> CliValueType.WithFieldSetById hasValueField (CliType.ofBool true)
+                        |> CliValueType.WithFieldSetById valueField value
+
+                    state
+                    |> IlMachineState.pushToEvalStack (CliType.ValueType result) thread
+                    |> IlMachineState.advanceProgramCounter thread
+                    |> Tuple.withRight WhatWeDid.Executed
+                | Some boxed when boxed.ConcreteType = targetConcreteTypeHandle ->
+                    // CoreCLR has a "for safety's sake" arm here that copies a genuinely boxed
+                    // `Nullable<T>` straight through. Nothing in this interpreter can produce one:
+                    // `executeBox` never boxes a Nullable as itself, and the only other boxing path
+                    // (the `constrained.` callvirt fallback in UnaryMetadataCallOps) requires the
+                    // method to be unresolvable on the value type and declared on
+                    // Object/ValueType/Enum — whereas `Nullable<T>` overrides all three, and by an
+                    // explicit CoreLib invariant ("Do NOT add any interfaces to Nullable!",
+                    // Nullable.cs) implements no interfaces to dispatch through either.
+                    // So this is unreachable rather than merely untested; fail loudly if that
+                    // assumption ever stops holding, instead of silently answering
+                    // InvalidCastException like the arm below.
+                    failwith
+                        $"Unbox_Any: operand at %O{addr} is a boxed Nullable`1 (%O{targetConcreteTypeHandle}), which no PawPrint boxing path can create; CoreCLR's Nullable::UnBox copies it through, but that arm is deliberately unmodelled here"
+                | Some _
+                | None ->
+                    IlMachineStateExecution.raiseRuntimeException
+                        loggerFactory
+                        baseClassTypes
+                        baseClassTypes.InvalidCastException
+                        thread
+                        state
+            | other -> failwith $"Unbox_Any (Nullable`1 target): unexpected eval stack value {other}"
         elif not isValueType then
             // Reference-type target: behave exactly like castclass.
             castToReferenceType
@@ -780,35 +899,8 @@ module internal UnaryMetadataObjectOps =
                 // underlying integral type (spec's "same type-verifier type"). Needs a generic-method
                 // test to exercise; not in scope for this PR.
                 if boxed.ConcreteType = targetConcreteTypeHandle then
-                    // Push the boxed value back onto the eval stack. The push path
-                    // (EvalStackValue.ofCliType) handles primitive-like value types
-                    // (IntPtr, RuntimeTypeHandle, enums, ...) via the flatten invariant,
-                    // and leaves genuine user-defined value types as UserDefinedValueType.
-                    //
-                    // For primitive targets (Int32, Float64, etc.) the Box path stored
-                    // the value in a single-field struct (e.g. { value__ = Int32 42 }).
-                    // The zero of such types is a non-ValueType CliType, so we detect
-                    // them here and extract the inner field before pushing.
                     let toPush, state =
-                        if boxed.Contents.PrimitiveLikeKind.IsSome then
-                            // Primitive-like (incl. enum): ofCliType will flatten on push.
-                            CliType.ValueType boxed.Contents, state
-                        else
-                            let targetZero, state =
-                                IlMachineState.cliTypeZeroOfHandle state baseClassTypes targetConcreteTypeHandle
-
-                            match targetZero with
-                            | CliType.ValueType _ ->
-                                // Genuine user-defined value type: keep wrapped.
-                                CliType.ValueType boxed.Contents, state
-                            | _ ->
-                                // Primitive target: Box stored the value in a single instance
-                                // field at offset 0 whose Size matches the primitive. Read it
-                                // back by offset/size — the Box path guarantees the shape, so
-                                // this is a nominal dereference, not a structural guess.
-                                let size = (CliType.SizeOf targetZero).Size
-
-                                CliValueType.DereferenceFieldAt 0 size boxed.Contents, state
+                        unboxedContents baseClassTypes targetConcreteTypeHandle boxed.Contents state
 
                     state
                     |> IlMachineState.pushToEvalStack toPush thread


### PR DESCRIPTION
Third in the `unbox.any` series, after #670 (array targets and operands) and #672 (the `isReferenceTypeHandle` cleanup). Both have merged, so this targets `main` directly.

`unbox.any` with a `System.Nullable`1` type token was `failwith "TODO"`, so `int? v = (int?)someObject;` aborted the interpreter.

## Why it needs its own branch

`box` of a `Nullable<T>` *erases* the Nullable — it yields either null (when `hasValue` is false) or a boxed `T`. So `unbox.any` has to rebuild the struct from strictly less information than it started with; it can't just hand back what's on the heap the way the ordinary value-type path does.

Per ECMA-335 III.4.33 and CoreCLR's `Nullable::UnBox` (`src/coreclr/vm/object.cpp:1604`, read from the pinned runtime source):

- a **null** operand yields a zeroed Nullable (`hasValue = false`). This is the one value-typed `unbox.any` target that accepts null rather than raising NullReferenceException;
- a **boxed `T`** yields `hasValue = true` carrying that value. The match against `T` is *exact equivalence*, not assignability — `Nullable::IsNullableForTypeHelper` compares against `GetInstantiation()[0]`, so there is no widening and no enum/underlying interchange;
- **anything else** raises InvalidCastException.

## Implementation notes

The result is built from `cliTypeZeroOfHandle` plus two `WithFieldSetById` writes, so its layout, field ids and offsets match every other way a `Nullable<T>` comes into existence, rather than being hand-rolled via `OfFields`.

No coercion is applied to the `value` write. `unboxedContents` picks its shape from `cliTypeZeroOfHandle underlyingHandle`, which is the same computation that produced the zero of the field being overwritten — so the two shapes agree by construction, and the correctness argument is structural rather than "trust the coercion routine".

Also extracts `unboxedContents` — the inverse of the shape `executeBox` writes — which the non-Nullable value-type branch already contained inline and the Nullable branch needs against the underlying `T`. Same operation in both: in each case the caller has established `contents.Declared = handle`, because both `executeBox` paths construct the heap object's contents with `CliValueType.OfFields ... handle`.

### The one arm deliberately not modelled

CoreCLR has a further "for safety's sake" arm that copies a genuinely boxed `Nullable<T>` straight through. That is unreachable here, and **provably so rather than merely untested**:

- `executeBox` never boxes a Nullable as itself;
- the only other boxing path — the `constrained.` callvirt fallback in `UnaryMetadataCallOps` — requires a method that is unresolvable on the value type *and* declared on `Object`/`ValueType`/`Enum`. `Nullable<T>` overrides all three;
- and it can't be reached through interface dispatch either, by an explicit CoreLib invariant: *"Because we have special type system support that says a boxed Nullable&lt;T&gt; can be used where a boxed T is used, Nullable&lt;T&gt; can not implement any interfaces at all... Do NOT add any interfaces to Nullable!"* (`Nullable.cs`).

It gets an explicit loud `failwith` rather than being folded into the InvalidCastException arm, so the assumption fails *visibly* if it ever stops holding, instead of silently answering the wrong exception.

## Tests

Four differential cases, each **observed failing on the unfixed source first** (all four hit the `TODO` `failwith`; verified by reverting the source and re-running). Every pure case is executed against the real .NET runtime, so the CLR is the oracle.

| Case | Covers |
|---|---|
| `UnboxAnyNullableInt.cs` | boxed `T` and null, via both the direct token and the `unbox.any !!T` generic form |
| `UnboxAnyNullableNegative.cs` | exact-match rule: no widening, no signedness interchange, enum vs underlying both directions, reference operands |
| `UnboxAnyNullableStruct.cs` | multi-field user struct payload (the other `executeBox` arm), all fields checked |
| `UnboxAnyNullableRoundTrip.cs` | the composition property `(T?)(object)x == x` across primitives, structs and enums |

Full suite: 1444 passed, 0 failed. Codex review returned no findings.

## Still open in this area

`unbox` (without `.any`) remains entirely unimplemented (`UnaryMetadataIlOp.fs:66`). It is a genuinely different instruction — it yields a managed pointer into the boxed object rather than a value — and for `Nullable<T>` specifically the CLR raises InvalidOperationException, since there is no boxed Nullable to point into. Not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)