### PR TITLE
Allow `unbox.any` between an enum and its underlying primitive

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/UnboxAnyEnumUnderlying.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/UnboxAnyEnumUnderlying.cs
@@ -1,0 +1,74 @@
+// CoreCLR `CastHelpers.Unbox_Helper`: `unbox`/`unbox.any` to a non-Nullable value type succeeds
+// when the handles are identical, OR when both types are in the primitive-value-type category
+// (which includes enums) and their primitive CorElementType are *equal*.
+//
+// An enum reports the CorElementType of its underlying integer, so a boxed enum unboxes to that
+// exact underlying type and vice versa. This is the positive half of the rule; the negatives —
+// including the ones that make this narrower than ECMA's "verification type" equivalence — live
+// in UnboxAnyEnumUnderlyingNegative.cs.
+
+public enum IntEnum : int
+{
+    A = 1,
+    B = 70000,
+}
+
+public enum ByteEnum : byte
+{
+    A = 1,
+}
+
+public enum LongEnum : long
+{
+    A = 5000000000L,
+}
+
+public class TestUnboxAnyEnumUnderlying
+{
+    private static T Cast<T>(object o)
+    {
+        return (T) o;
+    }
+
+    public static int Main(string[] argv)
+    {
+        // Boxed enum -> underlying, via a direct `unbox.any int32` token.
+        object boxedIntEnum = IntEnum.B;
+        int asInt = (int) boxedIntEnum;
+        if (asInt != 70000) return 1;
+
+        // Underlying -> enum, the other direction.
+        object boxedInt = 70000;
+        IntEnum asEnum = (IntEnum) boxedInt;
+        if (asEnum != IntEnum.B) return 2;
+
+        // Both directions again through the `unbox.any !!T` generic token form.
+        if (Cast<int>(boxedIntEnum) != 70000) return 3;
+        if (Cast<IntEnum>(boxedInt) != IntEnum.B) return 4;
+
+        // Narrower underlying types take the same path.
+        object boxedByteEnum = ByteEnum.A;
+        if ((byte) boxedByteEnum != 1) return 5;
+
+        object boxedByte = (byte) 1;
+        if ((ByteEnum) boxedByte != ByteEnum.A) return 6;
+
+        // Wider underlying types too, including a value that does not fit in 32 bits.
+        object boxedLongEnum = LongEnum.A;
+        if ((long) boxedLongEnum != 5000000000L) return 7;
+
+        object boxedLong = 5000000000L;
+        if ((LongEnum) boxedLong != LongEnum.A) return 8;
+
+        // The unboxed value must be usable as its target type, not merely produced: the result
+        // of unboxing an enum to its underlying participates in ordinary integer arithmetic.
+        int sum = (int) boxedIntEnum + 1;
+        if (sum != 70001) return 9;
+
+        // And the enum direction round-trips back through boxing.
+        object reboxed = (object) ((IntEnum) boxedInt);
+        if ((int) reboxed != 70000) return 10;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/UnboxAnyEnumUnderlyingNegative.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/UnboxAnyEnumUnderlyingNegative.cs
@@ -1,0 +1,108 @@
+// The enum/underlying relaxation in `unbox.any` is *equality of primitive CorElementType*, not
+// ECMA-335's verification-type equivalence and not the array-element rule. Those two are strictly
+// wider, and the difference is observable:
+//
+//   - verification types collapse signedness (int32 and uint32 share one), but unbox does not:
+//     I4 != U4, so `(uint)(object)1` throws;
+//   - the array-element rule (CoreCLR `CanCastParam`) *does* collapse signedness, which is why
+//     `(uint[])(object)new int[1]` succeeds while `(uint)(object)1` does not.
+//
+// This file pins the negatives, so that a future implementation cannot drift towards either of
+// the wider rules without a test failing.
+
+using System;
+
+public enum SignedEnum : int
+{
+    A = 1,
+}
+
+public enum UnsignedEnum : uint
+{
+    A = 1,
+}
+
+public enum ShortEnum : short
+{
+    A = 1,
+}
+
+public class TestUnboxAnyEnumUnderlyingNegative
+{
+    private static T Cast<T>(object o)
+    {
+        return (T) o;
+    }
+
+    private static bool Throws<T>(object o)
+    {
+        try
+        {
+            T _ = Cast<T>(o);
+            return false;
+        }
+        catch (InvalidCastException)
+        {
+            return true;
+        }
+    }
+
+    public static int Main(string[] argv)
+    {
+        // Signedness is NOT collapsed, for plain primitives ...
+        if (!Throws<uint>((object) 1)) return 1;
+        if (!Throws<int>((object) 1u)) return 2;
+        if (!Throws<sbyte>((object) (byte) 1)) return 3;
+        if (!Throws<byte>((object) (sbyte) 1)) return 4;
+        if (!Throws<ulong>((object) 1L)) return 5;
+        if (!Throws<UIntPtr>((object) (IntPtr) 1)) return 6;
+
+        // ... nor when an enum is on one side.
+        if (!Throws<uint>((object) SignedEnum.A)) return 7;
+        if (!Throws<int>((object) UnsignedEnum.A)) return 8;
+        if (!Throws<SignedEnum>((object) 1u)) return 9;
+        if (!Throws<UnsignedEnum>((object) 1)) return 10;
+
+        // Two enums sharing a category but not an element type.
+        if (!Throws<UnsignedEnum>((object) SignedEnum.A)) return 11;
+
+        // ... but two *different* enums that share an underlying element type ARE
+        // interconvertible: the rule is element-type equality between two primitive-category
+        // types, and it never asks whether either side is nominally an enum. (Verified against
+        // the real runtime, which accepts this.)
+        if (Cast<SignedEnum2>((object) SignedEnum.A) != SignedEnum2.A) return 12;
+
+        // Distinct element types of the same width are distinct: CHAR != U2, BOOLEAN != U1.
+        if (!Throws<ushort>((object) 'a')) return 13;
+        if (!Throws<char>((object) (ushort) 97)) return 14;
+        if (!Throws<byte>((object) true)) return 15;
+        if (!Throws<bool>((object) (byte) 1)) return 16;
+
+        // Native ints are their own element type, distinct from the fixed-width integers.
+        if (!Throws<long>((object) (IntPtr) 1)) return 17;
+        if (!Throws<IntPtr>((object) 1L)) return 18;
+
+        // No widening or narrowing at all.
+        if (!Throws<long>((object) 1)) return 19;
+        if (!Throws<int>((object) (short) 1)) return 20;
+        if (!Throws<int>((object) ShortEnum.A)) return 21;
+        if (!Throws<double>((object) 1.0f)) return 22;
+        if (!Throws<float>((object) 1.0)) return 23;
+
+        // The relaxation does not reach Nullable: `Nullable<T>` matches its argument by exact
+        // equivalence, so a boxed enum is not a `T?` of its underlying type, or vice versa.
+        if (!Throws<int?>((object) SignedEnum.A)) return 24;
+        if (!Throws<SignedEnum?>((object) 1)) return 25;
+
+        // Sanity: the permitted case really does pass, so the above are not all throwing for
+        // some unrelated reason.
+        if (Cast<int>((object) SignedEnum.A) != 1) return 26;
+
+        return 0;
+    }
+}
+
+public enum SignedEnum2 : int
+{
+    A = 1,
+}

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -1401,6 +1401,50 @@ module IlMachineRuntimeMetadata =
                     | None -> state, None
                     | Some (state, underlying) -> state, builtInPrimitiveIdentity state underlying
 
+    /// Does PawPrint store values of `handle` in the flattened form that the eval stack expects for
+    /// a bare primitive?
+    ///
+    /// True for the built-in primitives themselves, and for enums over the fixed-width integers.
+    /// False for enums over `bool`, `char` or a native int: ECMA-335 II.14.3 permits those and the
+    /// CLR does load them (C# cannot declare one, but Reflection.Emit can), yet
+    /// `CliValueType.IsEnumStructural` deliberately answers false for them, so their storage stays
+    /// a wrapped `CliValueType`.
+    let private unboxMaterialisesFlattened
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (handle : ConcreteTypeHandle)
+        : IlMachineState * bool
+        =
+        let state, isEnum = isEnumValueType loggerFactory baseClassTypes state handle
+
+        if not isEnum then
+            // A built-in primitive is flattened by definition; nothing else reaches here, because
+            // the caller has already established a primitive element identity for `handle`.
+            state, true
+        else
+            match enumUnderlyingHandle loggerFactory baseClassTypes state handle with
+            | None -> state, false
+            | Some (state, underlying) ->
+                let state, underlyingId =
+                    primitiveElementIdentity loggerFactory baseClassTypes state underlying
+
+                match underlyingId with
+                | None -> state, false
+                | Some underlyingId ->
+                    [
+                        baseClassTypes.SByte
+                        baseClassTypes.Byte
+                        baseClassTypes.Int16
+                        baseClassTypes.UInt16
+                        baseClassTypes.Int32
+                        baseClassTypes.UInt32
+                        baseClassTypes.Int64
+                        baseClassTypes.UInt64
+                    ]
+                    |> List.exists (fun ty -> ty.Identity = underlyingId)
+                    |> fun flattenable -> state, flattenable
+
     /// CoreCLR `CastHelpers.Unbox_Helper`: `unbox` and the value-typed form of `unbox.any` accept a
     /// boxed operand when the two handles are identical, or when both types are in the primitive
     /// category and report the *same* primitive element type. That second clause is what lets a
@@ -1438,7 +1482,25 @@ module IlMachineRuntimeMetadata =
 
             match targetPrimitive with
             | None -> state, false
-            | Some targetPrimitive -> state, boxedPrimitive = targetPrimitive
+            | Some targetPrimitive ->
+                if boxedPrimitive <> targetPrimitive then
+                    state, false
+                else
+                    // About to license the relaxation. The unbox will materialise the value from
+                    // the *boxed* object's handle, so that side must be one PawPrint stores
+                    // flattened; otherwise the push would leave a wrapped `UserDefinedValueType`
+                    // where the next instruction expects a bare stack primitive, and misread it.
+                    // Fail loudly rather than answering `false`, which would raise
+                    // InvalidCastException where a real runtime succeeds — a quieter way of being
+                    // wrong. (The target side needs no such check: it never drives materialisation.)
+                    let state, flattened =
+                        unboxMaterialisesFlattened loggerFactory baseClassTypes state boxedType
+
+                    if flattened then
+                        state, true
+                    else
+                        failwith
+                            $"unbox of %O{boxedType} to %O{targetType}: CoreCLR permits this (both report the same primitive element type), but PawPrint does not store the boxed type in flattened form — see CliValueType.IsEnumStructural, which covers only enums over the fixed-width integers, not over bool/char/native int"
 
     /// Does this handle denote a reference type (as opposed to a value type)?
     ///

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -1331,7 +1331,7 @@ module IlMachineRuntimeMetadata =
     /// The identity is returned *exactly*: `Int32` and `UInt32` are different answers, as are
     /// `Char`/`UInt16`, `Boolean`/`Byte` and `IntPtr`/`Int64`. This is deliberately narrower than
     /// both ECMA-335's verification types and the array-element rule below, each of which collapses
-    /// signedness — see `unboxPermitted` for why that distinction is load-bearing.
+    /// signedness — see `unboxPermitted` for why we make that distinction.
     let primitiveElementIdentity
         (loggerFactory : ILoggerFactory)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
@@ -1520,8 +1520,7 @@ module IlMachineRuntimeMetadata =
                     //     unflattened target would abort on the following `stloc`/`stfld` instead.
                     // The identity case never reaches here, so this only ever rejects genuinely
                     // mixed pairs. Fail loudly rather than answering `false`, which would raise
-                    // InvalidCastException where a real runtime succeeds — a quieter way of being
-                    // wrong.
+                    // InvalidCastException where a real runtime would succeed.
                     let state, boxedFlattened =
                         unboxMaterialisesFlattened loggerFactory baseClassTypes state boxedType
 

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -1411,8 +1411,7 @@ module IlMachineRuntimeMetadata =
                 // An enum is in the primitive category too, reporting the element type of its
                 // underlying integer. That underlying must itself be a built-in primitive — the
                 // CLR type loader will not admit an enum whose `value__` is anything else — so
-                // this resolves in exactly one step rather than recursing. Keeping it non-recursive
-                // means malformed metadata answers `None` instead of risking an unbounded walk.
+                // this resolves in exactly one step rather than recursing.
                 let state, isEnum = isEnumValueType loggerFactory baseClassTypes state handle
 
                 if not isEnum then

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -1486,21 +1486,33 @@ module IlMachineRuntimeMetadata =
                 if boxedPrimitive <> targetPrimitive then
                     state, false
                 else
-                    // About to license the relaxation. The unbox will materialise the value from
-                    // the *boxed* object's handle, so that side must be one PawPrint stores
-                    // flattened; otherwise the push would leave a wrapped `UserDefinedValueType`
-                    // where the next instruction expects a bare stack primitive, and misread it.
-                    // Fail loudly rather than answering `false`, which would raise
+                    // About to license the relaxation, which pairs two *different* handles. Both
+                    // sides must be ones PawPrint stores in flattened form, and for different
+                    // reasons:
+                    //   - the boxed side drives materialisation, so an unflattened one would push a
+                    //     wrapped `UserDefinedValueType` where the next instruction expects a bare
+                    //     stack primitive;
+                    //   - the target side is the slot the value lands in, and `toCliTypeCoerced`
+                    //     rejects a bare primitive into a value-type slot unless that slot is
+                    //     primitive-like (see the `failwith` in its `CliType.ValueType` arm), so an
+                    //     unflattened target would abort on the following `stloc`/`stfld` instead.
+                    // The identity case never reaches here, so this only ever rejects genuinely
+                    // mixed pairs. Fail loudly rather than answering `false`, which would raise
                     // InvalidCastException where a real runtime succeeds — a quieter way of being
-                    // wrong. (The target side needs no such check: it never drives materialisation.)
-                    let state, flattened =
+                    // wrong.
+                    let state, boxedFlattened =
                         unboxMaterialisesFlattened loggerFactory baseClassTypes state boxedType
 
-                    if flattened then
+                    let state, targetFlattened =
+                        unboxMaterialisesFlattened loggerFactory baseClassTypes state targetType
+
+                    if boxedFlattened && targetFlattened then
                         state, true
                     else
+                        let offender = if boxedFlattened then targetType else boxedType
+
                         failwith
-                            $"unbox of %O{boxedType} to %O{targetType}: CoreCLR permits this (both report the same primitive element type), but PawPrint does not store the boxed type in flattened form — see CliValueType.IsEnumStructural, which covers only enums over the fixed-width integers, not over bool/char/native int"
+                            $"unbox of %O{boxedType} to %O{targetType}: CoreCLR permits this (both report the same primitive element type), but PawPrint does not store %O{offender} in flattened form — see CliValueType.IsEnumStructural, which covers only enums over the fixed-width integers, not over bool/char/native int"
 
     /// Does this handle denote a reference type (as opposed to a value type)?
     ///

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -1375,7 +1375,28 @@ module IlMachineRuntimeMetadata =
                     ]
                     |> List.exists (fun ty -> ty.Identity = id)
 
-                if isPrimitive then Some id else None
+                if isPrimitive then
+                    Some id
+                else if
+                    // CoreCLR puts three CoreLib handle structs in the primitive category too,
+                    // by name, reporting ELEMENT_TYPE_I — the same element type as `IntPtr`
+                    // (MethodTableBuilder, the `g_RuntimeMethodHandleInternalName` /
+                    // `g_RuntimeFieldHandleInternalName` / `g_RuntimeArgumentHandleName` arms of
+                    // `SetInternalCorElementType`). So `unbox.any IntPtr` on one of them is legal.
+                    // PawPrint already flattens the two `*HandleInternal` structs to a
+                    // runtime-pointer NativeInt, so they can be honoured exactly.
+                    //
+                    // `RuntimeArgumentHandle` is deliberately absent: PawPrint has no
+                    // `PrimitiveLikeKind` for it, so it is not stored flattened and answering
+                    // `Some` here would license an unbox this interpreter cannot materialise.
+                    // It stays unclassified, which costs an InvalidCastException in a case only
+                    // `__arglist` IL can reach.
+                    id = baseClassTypes.RuntimeMethodHandleInternal.Identity
+                    || id = baseClassTypes.RuntimeFieldHandleInternal.Identity
+                then
+                    Some baseClassTypes.IntPtr.Identity
+                else
+                    None
 
         match handle with
         | ConcreteTypeHandle.OneDimArrayZero _
@@ -1419,8 +1440,9 @@ module IlMachineRuntimeMetadata =
         let state, isEnum = isEnumValueType loggerFactory baseClassTypes state handle
 
         if not isEnum then
-            // A built-in primitive is flattened by definition; nothing else reaches here, because
-            // the caller has already established a primitive element identity for `handle`.
+            // The caller has already established a primitive element identity for `handle`, so it
+            // is either a built-in primitive (flattened by definition) or one of the two
+            // `*HandleInternal` structs, which `PrimitiveLikeKind.FlattenToRuntimePointer` flattens.
             state, true
         else
             match enumUnderlyingHandle loggerFactory baseClassTypes state handle with

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -1256,6 +1256,190 @@ module IlMachineRuntimeMetadata =
         | ConcreteTypeHandle.Pointer _
         | ConcreteTypeHandle.FunctionPointer _ -> None
 
+    /// Returns true if `handle` is a CLR enum value type — a nominal type whose immediate runtime
+    /// base is `System.Enum`.
+    let isEnumValueType
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (handle : ConcreteTypeHandle)
+        : IlMachineState * bool
+        =
+        match handle with
+        | ConcreteTypeHandle.OneDimArrayZero _
+        | ConcreteTypeHandle.Array _
+        | ConcreteTypeHandle.Byref _
+        | ConcreteTypeHandle.Pointer _
+        | ConcreteTypeHandle.FunctionPointer _ -> state, false
+        | ConcreteTypeHandle.Concrete _ ->
+            let state, baseHandle =
+                resolveBaseConcreteType loggerFactory baseClassTypes state handle
+
+            match baseHandle with
+            | None -> state, false
+            | Some bh ->
+                match AllConcreteTypes.lookup bh state.ConcreteTypes with
+                | Some baseTy -> state, baseTy.Identity = baseClassTypes.Enum.Identity
+                | None -> state, false
+
+    /// For an enum `ConcreteTypeHandle`, return the `ConcreteTypeHandle` of its underlying integer
+    /// type by concretising the signature of its sole instance field (`value__`, the CLR-reserved
+    /// name for the integer slot of an enum; ECMA-335 §II.14.3). Returns `None` if `handle` is not
+    /// an enum, has no TypeDef row, or — defensively — has a malformed Fields list. The caller is
+    /// expected to have first verified enum-ness via `isEnumValueType`; this helper does the
+    /// metadata read.
+    let enumUnderlyingHandle
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (handle : ConcreteTypeHandle)
+        : (IlMachineState * ConcreteTypeHandle) option
+        =
+        match tryGetConcreteTypeInfo state handle with
+        | None -> None
+        | Some (ct, typeInfo) ->
+            let instanceFields =
+                typeInfo.Fields
+                |> List.filter (fun f -> not (f.Attributes.HasFlag FieldAttributes.Static))
+
+            match instanceFields with
+            | [ valueField ] when valueField.Name = "value__" ->
+                let assy = state._LoadedAssemblies.[ct.Identity.AssemblyFullName]
+
+                let state, underlying =
+                    IlMachineTypeResolution.concretizeType
+                        loggerFactory
+                        baseClassTypes
+                        state
+                        assy.Name
+                        ct.Generics
+                        ImmutableArray.Empty
+                        valueField.Signature
+
+                Some (state, underlying)
+            | _ -> None
+
+    /// CoreCLR `MethodTable::GetPrimitiveCorElementType`, restricted to the question `unbox` asks
+    /// of it: which primitive `CorElementType` does this handle report, if it is in the
+    /// primitive-value-type category at all?
+    ///
+    /// The category is CoreCLR's `enum_flag_Category_PrimitiveValueType`, which *includes enums*
+    /// (see the `// Enum is included` remarks in RuntimeHelpers.CoreCLR.cs); an enum reports the
+    /// element type of its underlying integer. Everything else — user structs, `Nullable\`1`,
+    /// `System.Decimal`, reference types, the structural handles — answers `None`.
+    ///
+    /// The identity is returned *exactly*: `Int32` and `UInt32` are different answers, as are
+    /// `Char`/`UInt16`, `Boolean`/`Byte` and `IntPtr`/`Int64`. This is deliberately narrower than
+    /// both ECMA-335's verification types and the array-element rule below, each of which collapses
+    /// signedness — see `unboxPermitted` for why that distinction is load-bearing.
+    let primitiveElementIdentity
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (handle : ConcreteTypeHandle)
+        : IlMachineState * ResolvedTypeIdentity option
+        =
+        // The built-in primitives, each its own distinct answer. Not a normalisation table: the
+        // pairs that other CLR rules collapse (Int32/UInt32, Char/UInt16, Boolean/Byte,
+        // IntPtr/UIntPtr) are listed separately precisely so they stay distinct here.
+        // Takes `state` explicitly rather than capturing it: `enumUnderlyingHandle` concretises the
+        // underlying type, so the enum branch below must consult the state it returns, not the one
+        // this function was entered with.
+        let builtInPrimitiveIdentity
+            (state : IlMachineState)
+            (handle : ConcreteTypeHandle)
+            : ResolvedTypeIdentity option
+            =
+            match tryGetConcreteTypeInfo state handle with
+            | None -> None
+            | Some (ct, _) when not ct.Generics.IsEmpty -> None
+            | Some (ct, _) ->
+                let id = ct.Identity
+
+                let isPrimitive =
+                    [
+                        baseClassTypes.Boolean
+                        baseClassTypes.Char
+                        baseClassTypes.SByte
+                        baseClassTypes.Byte
+                        baseClassTypes.Int16
+                        baseClassTypes.UInt16
+                        baseClassTypes.Int32
+                        baseClassTypes.UInt32
+                        baseClassTypes.Int64
+                        baseClassTypes.UInt64
+                        baseClassTypes.IntPtr
+                        baseClassTypes.UIntPtr
+                        baseClassTypes.Single
+                        baseClassTypes.Double
+                    ]
+                    |> List.exists (fun ty -> ty.Identity = id)
+
+                if isPrimitive then Some id else None
+
+        match handle with
+        | ConcreteTypeHandle.OneDimArrayZero _
+        | ConcreteTypeHandle.Array _
+        | ConcreteTypeHandle.Byref _
+        | ConcreteTypeHandle.Pointer _
+        | ConcreteTypeHandle.FunctionPointer _ -> state, None
+        | ConcreteTypeHandle.Concrete _ ->
+            match builtInPrimitiveIdentity state handle with
+            | Some id -> state, Some id
+            | None ->
+                // An enum is in the primitive category too, reporting the element type of its
+                // underlying integer. That underlying must itself be a built-in primitive — the
+                // CLR type loader will not admit an enum whose `value__` is anything else — so
+                // this resolves in exactly one step rather than recursing. Keeping it non-recursive
+                // means malformed metadata answers `None` instead of risking an unbounded walk.
+                let state, isEnum = isEnumValueType loggerFactory baseClassTypes state handle
+
+                if not isEnum then
+                    state, None
+                else
+                    match enumUnderlyingHandle loggerFactory baseClassTypes state handle with
+                    | None -> state, None
+                    | Some (state, underlying) -> state, builtInPrimitiveIdentity state underlying
+
+    /// CoreCLR `CastHelpers.Unbox_Helper`: `unbox` and the value-typed form of `unbox.any` accept a
+    /// boxed operand when the two handles are identical, or when both types are in the primitive
+    /// category and report the *same* primitive element type. That second clause is what lets a
+    /// boxed enum unbox to its underlying integer and back.
+    ///
+    /// It is narrower than it first looks, and deliberately so:
+    ///   - ECMA-335's verification types collapse signedness (`int32` and `uint32` share one), but
+    ///     this does not: `(uint)(object)1` raises InvalidCastException on a real runtime;
+    ///   - the array-element rule (`CanCastParam`, via `valueElementNormalisedIdentity` below)
+    ///     *does* collapse signedness, which is why `(uint[])(object)new int[1]` succeeds while the
+    ///     scalar cast fails. Do not reach for that helper here — the two rules genuinely differ.
+    ///
+    /// `Nullable\`1` never reaches this predicate: it matches its argument by exact equivalence
+    /// (`Nullable::IsNullableForTypeHelper`), so a boxed enum is not a `T?` of its underlying type.
+    let unboxPermitted
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (boxedType : ConcreteTypeHandle)
+        (targetType : ConcreteTypeHandle)
+        : IlMachineState * bool
+        =
+        if boxedType = targetType then
+            state, true
+        else
+
+        let state, boxedPrimitive =
+            primitiveElementIdentity loggerFactory baseClassTypes state boxedType
+
+        match boxedPrimitive with
+        | None -> state, false
+        | Some boxedPrimitive ->
+            let state, targetPrimitive =
+                primitiveElementIdentity loggerFactory baseClassTypes state targetType
+
+            match targetPrimitive with
+            | None -> state, false
+            | Some targetPrimitive -> state, boxedPrimitive = targetPrimitive
+
     /// Does this handle denote a reference type (as opposed to a value type)?
     ///
     /// The structural handles answer without any metadata: arrays of every rank are reference
@@ -1491,65 +1675,6 @@ module IlMachineRuntimeMetadata =
 
             loop state 0
 
-        // Returns true if `handle` is a CLR enum value type — a nominal type whose
-        // immediate runtime base is `System.Enum`. Used by the array-element
-        // assignability rule below to detect cases where ECMA-335 / CoreCLR
-        // enum-underlying-type equivalence (e.g. `MyEnum : int` ↔ `int`, or two
-        // enums sharing an underlying integer) might permit a store.
-        let isEnumValueType (state : IlMachineState) (handle : ConcreteTypeHandle) : IlMachineState * bool =
-            match handle with
-            | ConcreteTypeHandle.OneDimArrayZero _
-            | ConcreteTypeHandle.Array _
-            | ConcreteTypeHandle.Byref _
-            | ConcreteTypeHandle.Pointer _
-            | ConcreteTypeHandle.FunctionPointer _ -> state, false
-            | ConcreteTypeHandle.Concrete _ ->
-                let state, baseHandle =
-                    resolveBaseConcreteType loggerFactory baseClassTypes state handle
-
-                match baseHandle with
-                | None -> state, false
-                | Some bh ->
-                    match AllConcreteTypes.lookup bh state.ConcreteTypes with
-                    | Some baseTy -> state, baseTy.Identity = baseClassTypes.Enum.Identity
-                    | None -> state, false
-
-        // For an enum `ConcreteTypeHandle`, return the `ConcreteTypeHandle` of its
-        // underlying integer type by concretising the signature of its sole instance
-        // field (`value__`, the CLR-reserved name for the integer slot of an enum;
-        // ECMA-335 §II.14.3). Returns `None` if `handle` is not an enum, has no TypeDef
-        // row, or — defensively — has a malformed Fields list. The caller is expected
-        // to have first verified enum-ness via `isEnumValueType`; this helper does the
-        // metadata read.
-        let enumUnderlyingHandle
-            (state : IlMachineState)
-            (handle : ConcreteTypeHandle)
-            : (IlMachineState * ConcreteTypeHandle) option
-            =
-            match tryGetConcreteTypeInfo state handle with
-            | None -> None
-            | Some (ct, typeInfo) ->
-                let instanceFields =
-                    typeInfo.Fields
-                    |> List.filter (fun f -> not (f.Attributes.HasFlag FieldAttributes.Static))
-
-                match instanceFields with
-                | [ valueField ] when valueField.Name = "value__" ->
-                    let assy = state._LoadedAssemblies.[ct.Identity.AssemblyFullName]
-
-                    let state, underlying =
-                        IlMachineTypeResolution.concretizeType
-                            loggerFactory
-                            baseClassTypes
-                            state
-                            assy.Name
-                            ct.Generics
-                            ImmutableArray.Empty
-                            valueField.Signature
-
-                    Some (state, underlying)
-                | _ -> None
-
         // ECMA-335 III.8.7 / CoreCLR `GetNormalizedIntegralArrayElementType`:
         // signed and unsigned primitive integers of equal width are interchangeable
         // as array element types (`int[]` ↔ `uint[]`, `short[]` ↔ `ushort[]`, etc.).
@@ -1588,10 +1713,10 @@ module IlMachineRuntimeMetadata =
             (handle : ConcreteTypeHandle)
             : IlMachineState * ResolvedTypeIdentity option
             =
-            let state, isEnum = isEnumValueType state handle
+            let state, isEnum = isEnumValueType loggerFactory baseClassTypes state handle
 
             if isEnum then
-                match enumUnderlyingHandle state handle with
+                match enumUnderlyingHandle loggerFactory baseClassTypes state handle with
                 | None -> state, None
                 | Some (state, underlying) -> state, normalizedPrimitiveIntegerIdentity underlying
             else

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -221,6 +221,14 @@ module IlMachineState =
 
     let isReferenceTypeHandle = IlMachineRuntimeMetadata.isReferenceTypeHandle
 
+    let isEnumValueType = IlMachineRuntimeMetadata.isEnumValueType
+
+    let enumUnderlyingHandle = IlMachineRuntimeMetadata.enumUnderlyingHandle
+
+    let primitiveElementIdentity = IlMachineRuntimeMetadata.primitiveElementIdentity
+
+    let unboxPermitted = IlMachineRuntimeMetadata.unboxPermitted
+
     let requiredOwnInstanceFieldId = IlMachineRuntimeMetadata.requiredOwnInstanceFieldId
 
     let isConcreteTypeAssignableTo = IlMachineRuntimeMetadata.isConcreteTypeAssignableTo

--- a/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
@@ -894,13 +894,25 @@ module internal UnaryMetadataObjectOps =
                         state
                 | Some boxed ->
 
-                // Exact-type match per ECMA-335 III.4.33, not assignability.
-                // TODO: relax to underlying-type equivalence so a boxed enum can be unboxed to its
-                // underlying integral type (spec's "same type-verifier type"). Needs a generic-method
-                // test to exercise; not in scope for this PR.
-                if boxed.ConcreteType = targetConcreteTypeHandle then
+                // Handle identity, or same-primitive-element-type per CoreCLR
+                // `CastHelpers.Unbox_Helper` — the clause that lets a boxed enum unbox to its
+                // underlying integer and back. Not assignability, and narrower than ECMA-335's
+                // verification types: see `unboxPermitted`.
+                let state, permitted =
+                    IlMachineState.unboxPermitted
+                        loggerFactory
+                        baseClassTypes
+                        state
+                        boxed.ConcreteType
+                        targetConcreteTypeHandle
+
+                if permitted then
+                    // Materialise using the *boxed object's* handle, not the target's: that is the
+                    // handle its `Contents` were built with, which is the precondition
+                    // `unboxedContents` documents. Under the enum relaxation the two can differ,
+                    // and it is the push/store path that reconciles the result with the target.
                     let toPush, state =
-                        unboxedContents baseClassTypes targetConcreteTypeHandle boxed.Contents state
+                        unboxedContents baseClassTypes boxed.ConcreteType boxed.Contents state
 
                     state
                     |> IlMachineState.pushToEvalStack toPush thread


### PR DESCRIPTION
Resolves the standing TODO in `executeUnboxAny` (last of the `unbox.any` series, after #670, #672, #675).

`(int)(object)someEnum` raised InvalidCastException where a real runtime returns the value.

Interestingly, verification types collapse signedness — `int32` and `uint32` share one — but the runtime does not: `(uint)(object)1` throws.

Simplest test: `(int)(object)someEnum` emits `unbox.any int32` directly.

## The actual rule

CoreCLR `CastHelpers.Unbox_Helper`: accept when the handles are identical, **or** when both types are in the primitive-value-type category and report the *same* primitive element type. Enums are in that category (`// Enum is included`, RuntimeHelpers.CoreCLR.cs) and report their underlying integer's element type.

Checked against the real runtime across ~30 cases. That one rule explains every result:

| | |
|---|---|
| enum ↔ its exact underlying, both directions | **allowed** (I4 = I4) |
| two *distinct* enums sharing an underlying element type | **allowed** — falls out of the rule, no special case |
| every signedness pair (`int`/`uint`, `byte`/`sbyte`, `long`/`ulong`, `IntPtr`/`UIntPtr`) | rejected |
| `char`/`ushort`, `bool`/`byte`, `float`/`double`, `IntPtr`/`long` | rejected (distinct element types) |
| all widening/narrowing | rejected |
| anything via `Nullable`1` | rejected (exact equivalence, unchanged) |

## Not the array-element rule

Deliberately narrower than `CanCastParam`, already in this file, which *does* collapse signedness. The two genuinely diverge:

- `(uint[])(object)new int[1]` → **OK**;  `(uint)(object)1` → **InvalidCastException**
- `(UIntPtr[])(object)new IntPtr[1]` → **OK**;  `(UIntPtr)(object)(IntPtr)1` → **InvalidCastException**

So `unboxPermitted` is a new predicate, not a reuse of `valueElementNormalisedIdentity`. Both now carry comments pointing at each other so the distinction isn't lost.

## Storage-invariant guard

ECMA-335 II.14.3 permits `bool`-, `char`- and `nint`-backed enums, and the CLR does load them (C# can't declare one; Reflection.Emit can — verified). CoreCLR would permit unboxing those to their underlying, but `CliValueType.IsEnumStructural` covers only the fixed-width integers, so PawPrint stores them wrapped. The interpreter fails loudly in that case.

Relatedly, the two `*HandleInternal` structs *are* in CoreCLR's primitive category as `ELEMENT_TYPE_I` (`methodtablebuilder.cpp`), and PawPrint already flattens them, so they now map to `IntPtr`'s element identity. `RuntimeArgumentHandle` is in that same CoreCLR list but is left unclassified, because PawPrint has no `PrimitiveLikeKind` for it — commented in place.

## Supporting changes

Hoists `isEnumValueType` and `enumUnderlyingHandle` to module level (they were locals of `isConcreteTypeAssignableTo`), mirroring the #672 consolidation. `unboxPermitted` is module-level and named rather than inlined because the `unbox` opcode will need the identical rule when implemented — `Unsafe.Unbox<int>(boxedEnum)` goes through the same helper.

Materialisation now uses the boxed object's handle rather than the target's: under the relaxation the two differ, and the boxed handle is the one `unboxedContents` documents as its precondition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)