### PR TITLE
Split the assembly binder from the assembly load context

### DIFF
--- a/WoofWare.PawPrint.App/DebuggerServer.fs
+++ b/WoofWare.PawPrint.App/DebuggerServer.fs
@@ -475,7 +475,7 @@ module DebuggerServer =
         writeValueArray
             writer
             "loadedAssemblies"
-            state._LoadedAssemblies.Keys
+            state._LoadedAssemblies.DefinitionNames
             (fun writer assemblyName -> writer.WriteStringValue assemblyName)
 
         writeValueArray
@@ -688,7 +688,7 @@ module DebuggerServer =
             let frame = threadState.MethodState
 
             let assembly =
-                state._LoadedAssemblies.[frame.ExecutingMethod.DeclaringType.Assembly.FullName]
+                state._LoadedAssemblies.[frame.ExecutingMethod.DeclaringType.Assembly]
 
             let qualifiedTypeName = qualifiedTypeNameForMethod assembly frame.ExecutingMethod
 

--- a/WoofWare.PawPrint.Domain/Assembly.fs
+++ b/WoofWare.PawPrint.Domain/Assembly.fs
@@ -353,6 +353,181 @@ type DumpedAssembly =
             if this.OwnsPeReader then
                 this.PeReader.Dispose ()
 
+/// <summary>
+/// The assemblies the interpreter has loaded, together with the record of which
+/// AssemblyReferences have already been bound to which of them. This is the CLR's split
+/// between a *binder* (which reference identity resolves to which assembly) and a *load
+/// context* (which assembly has which identity).
+/// </summary>
+/// <remarks>
+/// Two kinds of identity are in play, and they are NOT interchangeable:
+///
+/// <para>
+/// A <em>definition</em> identity is an assembly's own <c>AssemblyDefinition</c> FullName. It is
+/// what <c>DumpedAssembly.Name</c>, <c>ConcreteType.Assembly</c> and
+/// <c>ResolvedTypeIdentity.AssemblyFullName</c> all carry, and it is the load context's key.
+/// </para>
+///
+/// <para>
+/// A <em>reference</em> identity is the FullName recorded in an <c>AssemblyReference</c> row of
+/// some other assembly. It need not equal the definition identity of whatever it binds to:
+/// in the .NET shared framework the .NET Framework compatibility facades (mscorlib, System,
+/// System.Core, ...) reference their implementation assemblies with <c>Version=0.0.0.0</c>,
+/// and any assembly built for an older target framework references the BCL by the version
+/// that framework shipped rather than the version on disk.
+/// </para>
+///
+/// Consequently the only way to ask about a reference identity is <c>TryResolveReference</c>,
+/// which takes an <c>AssemblyReference</c> — you cannot reach the binder with a bare
+/// <c>AssemblyName</c>, and every other member consumes a definition identity.
+/// </remarks>
+[<NoEquality ; NoComparison>]
+type LoadedAssemblies =
+    private
+        {
+            /// AssemblyDefinition FullName -> the assembly bearing that identity.
+            ByDefinition : ImmutableDictionary<string, DumpedAssembly>
+            /// AssemblyReference FullName -> the AssemblyDefinition FullName it bound to.
+            Bindings : ImmutableDictionary<string, string>
+        }
+
+    /// Every definition identity currently loaded. For diagnostics only.
+    member this.DefinitionNames : string seq = this.ByDefinition.Keys
+
+    /// Look an assembly up by its definition identity.
+    member this.TryByDefinitionName (fullName : string) : DumpedAssembly option =
+        match this.ByDefinition.TryGetValue fullName with
+        | false, _ -> None
+        | true, v -> Some v
+
+    /// Look an assembly up by its definition identity.
+    member this.TryByDefinition (name : AssemblyName) : DumpedAssembly option = this.TryByDefinitionName name.FullName
+
+    /// Look an assembly up by its definition identity, failing loudly if it is not loaded.
+    member this.ByDefinitionName (fullName : string) : DumpedAssembly =
+        match this.ByDefinition.TryGetValue fullName with
+        | true, v -> v
+        | false, _ ->
+            failwithf
+                "Assembly %s is not loaded. Loaded assemblies: %s"
+                fullName
+                (this.ByDefinition.Keys |> Seq.sort |> String.concat " ; ")
+
+    /// Look an assembly up by its definition identity, failing loudly if it is not loaded.
+    member this.Item
+        with get (name : AssemblyName) : DumpedAssembly = this.ByDefinitionName name.FullName
+
+    /// True if an assembly with this definition identity is loaded.
+    member this.ContainsDefinition (name : AssemblyName) : bool =
+        this.ByDefinition.ContainsKey name.FullName
+
+    /// <summary>
+    /// Resolve an AssemblyReference to the assembly it names, if we have already bound it.
+    /// </summary>
+    /// <remarks>
+    /// A reference with no recorded binding may still name an assembly we hold, if its
+    /// reference identity happens to equal that assembly's definition identity — the CLR's
+    /// exact-identity match. That is how an assembly registered directly (the entry assembly,
+    /// or a fixture that exists only in memory) is found the first time some other assembly
+    /// references it; without this fallback we would go to disk for an assembly we already
+    /// have, and fail outright for one that was never written to disk.
+    /// </remarks>
+    member this.TryResolveReference (reference : WoofWare.PawPrint.AssemblyReference) : DumpedAssembly option =
+        let refFullName = reference.Name.FullName
+
+        match this.Bindings.TryGetValue refFullName with
+        | true, definitionName -> this.TryByDefinitionName definitionName
+        | false, _ -> this.TryByDefinitionName refFullName
+
+    /// <summary>
+    /// Register an assembly under its own definition identity. If an assembly with that
+    /// identity is already loaded, the existing instance wins and this is a no-op.
+    /// </summary>
+    member this.WithLoadedAssembly (assy : DumpedAssembly) : LoadedAssemblies =
+        if this.ByDefinition.ContainsKey assy.Name.FullName then
+            this
+        else
+            { this with
+                ByDefinition = this.ByDefinition.SetItem (assy.Name.FullName, assy)
+            }
+
+    /// <summary>
+    /// Record that <paramref name="reference"/> binds to <paramref name="assy"/>, registering
+    /// the assembly under its own definition identity if we do not already hold it. Returns the
+    /// canonical instance for that definition identity, which is the previously-loaded one if
+    /// there was one — so exactly one <c>DumpedAssembly</c> exists per definition identity.
+    /// </summary>
+    member this.WithBoundReference
+        (reference : WoofWare.PawPrint.AssemblyReference)
+        (assy : DumpedAssembly)
+        : LoadedAssemblies * DumpedAssembly
+        =
+        let definitionName = assy.Name.FullName
+
+        let canonical =
+            match this.ByDefinition.TryGetValue definitionName with
+            | false, _ -> assy
+            | true, existing ->
+                // Two distinct assemblies claiming one definition identity means we would be
+                // silently picking one of two different sets of metadata. Crash instead.
+                if not (Object.ReferenceEquals (existing, assy)) then
+                    if existing.TypeDefs.Count <> assy.TypeDefs.Count then
+                        failwithf
+                            "Two different assemblies both claim definition identity %s (%d type definitions vs %d). Refusing to guess which one %s refers to."
+                            definitionName
+                            existing.TypeDefs.Count
+                            assy.TypeDefs.Count
+                            reference.Name.FullName
+
+                existing
+
+        let result =
+            {
+                ByDefinition = this.ByDefinition.SetItem (definitionName, canonical)
+                Bindings = this.Bindings.SetItem (reference.Name.FullName, definitionName)
+            }
+
+        result, canonical
+
+[<RequireQualifiedAccess>]
+module LoadedAssemblies =
+    let empty : LoadedAssemblies =
+        {
+            ByDefinition = ImmutableDictionary.Empty
+            Bindings = ImmutableDictionary.Empty
+        }
+
+    /// Build a load context from assemblies indexed by their own definition identities, with no
+    /// reference bindings recorded yet.
+    let ofAssemblies (assemblies : DumpedAssembly seq) : LoadedAssemblies =
+        assemblies
+        |> Seq.fold (fun (acc : LoadedAssemblies) assy -> acc.WithLoadedAssembly assy) empty
+
+    /// <summary>
+    /// Assert that the load prompted by a <c>TypeResolutionResult.FirstLoadAssy</c> achieved what
+    /// the caller is about to retry on: the reference now resolves.
+    /// </summary>
+    /// <remarks>
+    /// Every resolution loop responds to <c>FirstLoadAssy</c> by loading and then re-running the
+    /// identical resolution. If the load leaves the reference still unbound, that re-run takes the
+    /// identical branch and the loop spins forever. A livelock is far worse to diagnose than a
+    /// crash — and, since the only way to leave a reference unbound after loading it is to have
+    /// mis-filed it, the crash names the real fault.
+    /// </remarks>
+    let assertReferenceBound
+        (context : string)
+        (reference : WoofWare.PawPrint.AssemblyReference)
+        (assemblies : LoadedAssemblies)
+        : LoadedAssemblies
+        =
+        match assemblies.TryResolveReference reference with
+        | Some _ -> assemblies
+        | None ->
+            failwithf
+                "While resolving %s: loaded %s (referenced by %s), but it is still not bound afterwards. Retrying would loop forever; the load context has probably filed it under the wrong identity."
+                context
+                reference.Name.FullName
+                (snd reference.Handle).FullName
 
 type TypeResolutionResult =
     | FirstLoadAssy of WoofWare.PawPrint.AssemblyReference
@@ -884,7 +1059,7 @@ module Assembly =
         |> TypeInfo.fullName (fun h -> assy.TypeDefs.[h])
 
     let rec private resolveTopLevelTypeInAssembly
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (genericArgs : ImmutableArray<TypeDefn>)
         (assy : DumpedAssembly)
         (ns : string option)
@@ -913,7 +1088,7 @@ module Assembly =
     // Nested *forwarded* types (ExportedTypeData.ParentExportedType) are handled by a
     // separate code path: resolveTypeFromExport -> resolveExportedTypeByChain.
     and private resolveNestedTypeInAssembly
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (genericArgs : ImmutableArray<TypeDefn>)
         (assy : DumpedAssembly)
         (declaringType : ResolvedTypeIdentity)
@@ -930,7 +1105,7 @@ module Assembly =
                 assy.Name.FullName
 
     and private resolveTypeRefInAssembly
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (genericArgs : ImmutableArray<TypeDefn>)
         (referencedInAssembly : DumpedAssembly)
         (typeRefHandle : TypeReferenceHandle)
@@ -969,7 +1144,7 @@ module Assembly =
 
     and resolveTypeFromExport
         (fromAssembly : DumpedAssembly)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (genericArgs : ImmutableArray<TypeDefn>)
         (ty : WoofWare.PawPrint.ExportedType)
         : TypeResolutionResult
@@ -978,9 +1153,9 @@ module Assembly =
         | ExportedTypeData.ForwardsTo assyRef ->
             let assyRef = fromAssembly.AssemblyReferences.[assyRef]
 
-            match assemblies.TryGetValue assyRef.Name.FullName with
-            | false, _ -> TypeResolutionResult.FirstLoadAssy assyRef
-            | true, toAssy -> resolveTopLevelTypeInAssembly assemblies genericArgs toAssy ty.Namespace ty.Name
+            match assemblies.TryResolveReference assyRef with
+            | None -> TypeResolutionResult.FirstLoadAssy assyRef
+            | Some toAssy -> resolveTopLevelTypeInAssembly assemblies genericArgs toAssy ty.Namespace ty.Name
         | ExportedTypeData.ParentExportedType parentExport ->
             let parent = fromAssembly.ExportedTypes.[parentExport]
 
@@ -997,7 +1172,7 @@ module Assembly =
                 fromAssembly.Name.FullName
 
     and resolveTypeRef
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (referencedInAssembly : DumpedAssembly)
         (genericArgs : ImmutableArray<TypeDefn>)
         (target : TypeRef)
@@ -1014,12 +1189,9 @@ module Assembly =
                     (referencedInAssembly.AssemblyReferences.Keys |> Seq.toList)
             | true, assemblyRef ->
 
-            let assemblyName = assemblyRef.Name
-
-            match assemblies.TryGetValue assemblyName.FullName with
-            | false, _ -> TypeResolutionResult.FirstLoadAssy assemblyRef
-            | true, assy ->
-                resolveTopLevelTypeInAssembly assemblies genericArgs assy (Some target.Namespace) target.Name
+            match assemblies.TryResolveReference assemblyRef with
+            | None -> TypeResolutionResult.FirstLoadAssy assemblyRef
+            | Some assy -> resolveTopLevelTypeInAssembly assemblies genericArgs assy (Some target.Namespace) target.Name
         | TypeRefResolutionScope.TypeRef parent ->
             match resolveTypeRefInAssembly assemblies genericArgs referencedInAssembly parent with
             | TypeResolutionResult.FirstLoadAssy assyRef -> TypeResolutionResult.FirstLoadAssy assyRef
@@ -1043,7 +1215,7 @@ module Assembly =
 
     and resolveTopLevelTypeFromName
         (assy : DumpedAssembly)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (ns : string option)
         (name : string)
         (genericArgs : ImmutableArray<TypeDefn>)
@@ -1060,7 +1232,7 @@ module DumpedAssembly =
         |> TypeInfo.mapGeneric (fun (par, _) -> TypeDefn.GenericTypeParameter par.SequenceNumber)
 
     let private getTypeRef
-        (loadedAssemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (loadedAssemblies : LoadedAssemblies)
         (a : DumpedAssembly)
         (h : TypeReferenceHandle)
         : DumpedAssembly * TypeInfo<TypeDefn, TypeDefn>
@@ -1071,7 +1243,7 @@ module DumpedAssembly =
             failwith "seems pretty unlikely that we could have constructed this object without loading its base type"
 
     let private getTypeSpec
-        (loadedAssemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (loadedAssemblies : LoadedAssemblies)
         (a : DumpedAssembly)
         (h : TypeSpecificationHandle)
         : DumpedAssembly * TypeDefinitionHandle
@@ -1083,7 +1255,7 @@ module DumpedAssembly =
             | TypeDefn.GenericInstantiation (generic, _) -> go currentAssembly generic
             | TypeDefn.Modified (_, afterMod, _) -> go currentAssembly afterMod
             | TypeDefn.FromDefinition (identity, _) ->
-                let resolvedAssembly = loadedAssemblies.[identity.AssemblyFullName]
+                let resolvedAssembly = loadedAssemblies.ByDefinitionName identity.AssemblyFullName
                 let resolvedType = resolvedAssembly.TypeDefs.[identity.TypeDefinition.Get]
                 resolvedAssembly, resolvedType.TypeDefHandle
             | TypeDefn.FromReference (typeRef, _) ->
@@ -1105,18 +1277,14 @@ module DumpedAssembly =
 
         go a signature
 
-    let private assemblies
-        (loadedAssemblies : ImmutableDictionary<string, DumpedAssembly>)
-        (n : AssemblyName)
-        : DumpedAssembly
-        =
-        loadedAssemblies.[n.FullName]
+    let private assemblies (loadedAssemblies : LoadedAssemblies) (n : AssemblyName) : DumpedAssembly =
+        loadedAssemblies.[n]
 
     /// ECMA "value type": transitively inherits from System.ValueType (possibly via System.Enum),
     /// but is NOT exactly System.ValueType or System.Enum themselves.
     let isValueType
         (bct : BaseClassTypes<DumpedAssembly>)
-        (loadedAssemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (loadedAssemblies : LoadedAssemblies)
         (ty : TypeInfo<'generic, 'field>)
         : bool
         =
@@ -1132,7 +1300,7 @@ module DumpedAssembly =
     /// Convenience: not a value type.
     let isReferenceType
         (bct : BaseClassTypes<DumpedAssembly>)
-        (loadedAssemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (loadedAssemblies : LoadedAssemblies)
         (ty : TypeInfo<'generic, 'field>)
         : bool
         =
@@ -1149,7 +1317,7 @@ module DumpedAssembly =
     /// System.ValueType themselves encode as Class, matching real CLR signature encoding.
     let signatureTypeKind
         (bct : BaseClassTypes<DumpedAssembly>)
-        (loadedAssemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (loadedAssemblies : LoadedAssemblies)
         (ty : TypeInfo<'generic, 'field>)
         : SignatureTypeKind
         =
@@ -1164,7 +1332,7 @@ module DumpedAssembly =
 
     let typeInfoToTypeDefn
         (bct : BaseClassTypes<DumpedAssembly>)
-        (loadedAssemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (loadedAssemblies : LoadedAssemblies)
         (ti : TypeInfo<TypeDefn, TypeDefn>)
         : TypeDefn
         =
@@ -1179,7 +1347,7 @@ module DumpedAssembly =
 
     let typeInfoToTypeDefn'
         (bct : BaseClassTypes<DumpedAssembly>)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (ti : TypeInfo<GenericParamFromMetadata, TypeDefn>)
         =
         ti

--- a/WoofWare.PawPrint.Domain/Assembly.fs
+++ b/WoofWare.PawPrint.Domain/Assembly.fs
@@ -157,6 +157,17 @@ type DumpedAssembly =
         OwnsPeReader : bool
 
         /// <summary>
+        /// SHA-256 of the entire PE image: the identity of this assembly's <em>content</em>, as
+        /// opposed to the identity it declares for itself. See <c>HasSameContentAs</c>.
+        /// </summary>
+        /// <remarks>
+        /// Computed while the backing stream is known to be open, because it cannot be computed
+        /// later: <c>PEReader</c> reads lazily, and callers of <c>Assembly.read</c> own the stream
+        /// they pass and may close it as soon as the parse returns.
+        /// </remarks>
+        ContentHash : ImmutableArray<byte>
+
+        /// <summary>
         /// Dictionary of all custom attributes in this assembly, keyed by their handle.
         /// </summary>
         Attributes : ImmutableDictionary<CustomAttributeHandle, WoofWare.PawPrint.CustomAttribute>
@@ -305,6 +316,50 @@ type DumpedAssembly =
 
     member this.Name = this.ThisAssemblyDefinition.Name
 
+    /// <summary>
+    /// The module version ID: a GUID the compiler stamps afresh on every build. Useful for
+    /// reporting, but it is metadata like any other — see <c>HasSameContentAs</c>.
+    /// </summary>
+    member this.ModuleVersionId : Guid =
+        let metadata = this.PeReader.GetMetadataReader ()
+        metadata.GetGuid (metadata.GetModuleDefinition().Mvid)
+
+    /// <summary>
+    /// Whether this and <paramref name="other"/> are byte-identical PE images, i.e. the same
+    /// assembly by every observation this interpreter can make of it.
+    /// </summary>
+    /// <remarks>
+    /// This is how to ask "are these two <c>DumpedAssembly</c> values the same assembly?" when they
+    /// are not reference-equal. Weaker proxies do not hold:
+    ///
+    /// <para>
+    /// The declared identity (name, version, culture, public key) is a <em>claim</em>, not a
+    /// fingerprint — two different builds can make the identical claim, most obviously for unsigned
+    /// assemblies whose whole identity is
+    /// "Foo, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null".
+    /// </para>
+    ///
+    /// <para>
+    /// The MVID is likewise only an assertion of sameness stamped into the image, not a digest of
+    /// it: an IL rewriter that preserves the MVID, or hand-crafted metadata, yields differing
+    /// images that claim to be one build.
+    /// </para>
+    ///
+    /// <para>
+    /// Even the metadata block is not enough. It excludes IL method bodies and manifest-resource
+    /// payloads, which live elsewhere in the image and which we read through
+    /// <c>PEReader.GetMethodBody</c> and <c>PEReader.GetSectionData</c> — so two images agreeing on
+    /// metadata can still execute differently.
+    /// </para>
+    ///
+    /// Hence the whole image. Comparing more than we strictly consume can only ever cost us a
+    /// spurious crash on two images we would have treated alike, which is the safe direction to
+    /// err: correctness over availability.
+    /// </remarks>
+    member this.HasSameContentAs (other : DumpedAssembly) : bool =
+        Object.ReferenceEquals (this, other)
+        || this.ContentHash.AsSpan().SequenceEqual (other.ContentHash.AsSpan ())
+
     member this.TryGetTopLevelTypeDef
         (``namespace`` : string)
         (name : string)
@@ -440,16 +495,47 @@ type LoadedAssemblies =
         | false, _ -> this.TryByDefinitionName refFullName
 
     /// <summary>
-    /// Register an assembly under its own definition identity. If an assembly with that
-    /// identity is already loaded, the existing instance wins and this is a no-op.
+    /// The canonical instance for <paramref name="assy"/>'s definition identity: whatever we
+    /// already hold under that identity, or <paramref name="assy"/> itself if we hold nothing.
+    /// </summary>
+    /// <remarks>
+    /// Every route into the load context goes through here, so that none of them can register a
+    /// second, conflicting build under an identity already spoken for. Two distinct assemblies
+    /// claiming one definition identity means silently picking one of two different sets of
+    /// metadata to resolve and execute against; there is no safe choice, so crash.
+    ///
+    /// Sameness is decided by comparing metadata content, not by trusting any identifier the image
+    /// carries — see <c>DumpedAssembly.HasSameContentAs</c>. The comparison only runs when two
+    /// non-reference-equal instances collide, which is rare.
+    /// </remarks>
+    member private this.Canonicalise (assy : DumpedAssembly) (describeRequester : unit -> string) : DumpedAssembly =
+        match this.ByDefinition.TryGetValue assy.Name.FullName with
+        | false, _ -> assy
+        | true, existing ->
+            if not (existing.HasSameContentAs assy) then
+                failwithf
+                    "Two different assemblies both claim definition identity %s (module version IDs %O and %O, and their metadata differs). Refusing to guess which one %s refers to."
+                    assy.Name.FullName
+                    existing.ModuleVersionId
+                    assy.ModuleVersionId
+                    (describeRequester ())
+
+            existing
+
+    /// <summary>
+    /// Register an assembly under its own definition identity. Idempotent for the same build: if
+    /// that identity is already loaded, the existing instance wins. Registering a *different*
+    /// build under an identity we already hold is an error — see <c>Canonicalise</c>.
     /// </summary>
     member this.WithLoadedAssembly (assy : DumpedAssembly) : LoadedAssemblies =
-        if this.ByDefinition.ContainsKey assy.Name.FullName then
-            this
-        else
+        let canonical = this.Canonicalise assy (fun () -> "this direct registration")
+
+        if Object.ReferenceEquals (canonical, assy) then
             { this with
                 ByDefinition = this.ByDefinition.SetItem (assy.Name.FullName, assy)
             }
+        else
+            this
 
     /// <summary>
     /// Record that <paramref name="reference"/> binds to <paramref name="assy"/>, registering
@@ -463,23 +549,7 @@ type LoadedAssemblies =
         : LoadedAssemblies * DumpedAssembly
         =
         let definitionName = assy.Name.FullName
-
-        let canonical =
-            match this.ByDefinition.TryGetValue definitionName with
-            | false, _ -> assy
-            | true, existing ->
-                // Two distinct assemblies claiming one definition identity means we would be
-                // silently picking one of two different sets of metadata. Crash instead.
-                if not (Object.ReferenceEquals (existing, assy)) then
-                    if existing.TypeDefs.Count <> assy.TypeDefs.Count then
-                        failwithf
-                            "Two different assemblies both claim definition identity %s (%d type definitions vs %d). Refusing to guess which one %s refers to."
-                            definitionName
-                            existing.TypeDefs.Count
-                            assy.TypeDefs.Count
-                            reference.Name.FullName
-
-                existing
+        let canonical = this.Canonicalise assy (fun () -> reference.Name.FullName)
 
         let result =
             {
@@ -561,6 +631,14 @@ module Assembly =
         =
         let peReader = new PEReader (dllBytes)
         let metadataReader = peReader.GetMetadataReader ()
+
+        // Must happen here, not on demand: PEReader reads lazily, and callers of `read` own the
+        // stream they handed us and are free to close it the moment this returns.
+        let contentHash =
+            let image = peReader.GetEntireImage ()
+
+            System.Security.Cryptography.SHA256.HashData (image.GetContent().AsSpan ())
+            |> ImmutableArray.Create<byte>
 
         let assy = metadataReader.GetAssemblyDefinition () |> AssemblyDefinition.make
 
@@ -736,6 +814,7 @@ module Assembly =
             NonRootNamespaces = nonRootNamespaces
             PeReader = peReader
             OwnsPeReader = true
+            ContentHash = contentHash
             Attributes = attrs
             CustomAttributesByParentToken = customAttributesByParentToken
             ExportedTypes = exportedTypes

--- a/WoofWare.PawPrint.Domain/TypeConcretisation.fs
+++ b/WoofWare.PawPrint.Domain/TypeConcretisation.fs
@@ -453,11 +453,38 @@ module ConcreteActivePatterns =
         | _ -> None
 
 type IAssemblyLoad =
+    /// <param name="referencedIn">
+    /// The <em>definition</em> identity of the assembly whose AssemblyReference table
+    /// <c>handle</c> indexes. AssemblyReferenceHandles are only meaningful relative to the
+    /// assembly that declares them.
+    /// </param>
     abstract LoadAssembly :
-        loadedAssemblies : ImmutableDictionary<string, DumpedAssembly> ->
+        loadedAssemblies : LoadedAssemblies ->
         referencedIn : AssemblyName ->
         handle : AssemblyReferenceHandle ->
-            ImmutableDictionary<string, DumpedAssembly> * DumpedAssembly
+            LoadedAssemblies * DumpedAssembly
+
+[<RequireQualifiedAccess>]
+module IAssemblyLoad =
+    /// <summary>
+    /// An <c>IAssemblyLoad</c> which refuses to go to disk: it binds an AssemblyReference only if
+    /// the load context already holds the assembly. Use it where everything that could possibly
+    /// be needed has provably been loaded already, so that a miss is a bug rather than a cue to
+    /// read a file.
+    /// </summary>
+    let alreadyLoadedOnly : IAssemblyLoad =
+        { new IAssemblyLoad with
+            member _.LoadAssembly loaded referencedIn handle =
+                let targetRef = loaded.[referencedIn].AssemblyReferences.[handle]
+
+                match loaded.TryResolveReference targetRef with
+                | Some target -> loaded, target
+                | None ->
+                    failwithf
+                        "Assembly %s, referenced by %s, is not loaded, and this context is not permitted to load it."
+                        targetRef.Name.FullName
+                        referencedIn.FullName
+        }
 
 [<RequireQualifiedAccess>]
 module TypeConcretization =
@@ -466,7 +493,7 @@ module TypeConcretization =
             /// All concrete types created so far
             ConcreteTypes : AllConcreteTypes
             /// For resolving type references
-            LoadedAssemblies : ImmutableDictionary<string, DumpedAssembly>
+            LoadedAssemblies : LoadedAssemblies
             BaseTypes : BaseClassTypes<'corelib>
         }
 
@@ -520,10 +547,7 @@ module TypeConcretization =
             : (DumpedAssembly * ResolvedTypeIdentity * WoofWare.PawPrint.TypeInfo<_, _>) *
               ConcretizationContext<'corelib>
             =
-            let currentAssy =
-                match ctx.LoadedAssemblies.TryGetValue currentAssembly.FullName with
-                | false, _ -> failwithf "Current assembly %s not loaded" currentAssembly.FullName
-                | true, assy -> assy
+            let currentAssy = ctx.LoadedAssemblies.[currentAssembly]
 
             match Assembly.resolveTypeRef ctx.LoadedAssemblies currentAssy ImmutableArray.Empty typeRef with
             | TypeResolutionResult.Resolved (targetAssy, identity, typeInfo) -> (targetAssy, identity, typeInfo), ctx
@@ -535,7 +559,11 @@ module TypeConcretization =
 
                 let newCtx =
                     { ctx with
-                        LoadedAssemblies = newAssemblies
+                        LoadedAssemblies =
+                            LoadedAssemblies.assertReferenceBound
+                                $"type reference %s{typeRef.Name}"
+                                assemblyRef
+                                newAssemblies
                     }
 
                 go newCtx
@@ -600,11 +628,7 @@ module TypeConcretization =
         : ConcreteTypeHandle * ConcretizationContext<'corelib>
         =
 
-        let assembly =
-            match ctx.LoadedAssemblies.TryGetValue identity.AssemblyFullName with
-            | false, _ ->
-                failwithf "Cannot concretize type definition - assembly %s not loaded" identity.AssemblyFullName
-            | true, assy -> assy
+        let assembly = ctx.LoadedAssemblies.ByDefinitionName identity.AssemblyFullName
 
         let typeInfo = Assembly.resolveTypeIdentityDefinition assembly identity
 
@@ -819,7 +843,9 @@ module TypeConcretization =
         let baseIdentity, baseNamespace, baseName, ctxAfterArgs =
             match genericDef with
             | FromDefinition (identity, _) ->
-                let currentAssy = ctxAfterArgs.LoadedAssemblies.[identity.AssemblyFullName]
+                let currentAssy =
+                    ctxAfterArgs.LoadedAssemblies.ByDefinitionName identity.AssemblyFullName
+
                 let typeDef = Assembly.resolveTypeIdentityDefinition currentAssy identity
                 identity, typeDef.Namespace, typeDef.Name, ctxAfterArgs
             | FromReference (typeRef, _) ->
@@ -888,14 +914,14 @@ module Concretization =
     /// Helper to ensure base type assembly is loaded
     let private loadAssemblyReferenceByName
         (loadAssembly : IAssemblyLoad)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (referencedInAssembly : DumpedAssembly)
         (targetAssemblyName : AssemblyName)
-        : ImmutableDictionary<string, DumpedAssembly>
+        : LoadedAssemblies
         =
-        match assemblies.TryGetValue targetAssemblyName.FullName with
-        | true, _ -> assemblies
-        | false, _ ->
+        if assemblies.ContainsDefinition targetAssemblyName then
+            assemblies
+        else
             let handle =
                 referencedInAssembly.AssemblyReferences
                 |> Seq.tryPick (fun (KeyValue (assemblyRefHandle, assemblyRef)) ->
@@ -918,10 +944,10 @@ module Concretization =
 
     let rec private ensureTypeRefResolved
         (loadAssembly : IAssemblyLoad)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (sourceAssembly : DumpedAssembly)
         (typeRef : TypeRef)
-        : ImmutableDictionary<string, DumpedAssembly> * DumpedAssembly * TypeDefinitionHandle
+        : LoadedAssemblies * DumpedAssembly * TypeDefinitionHandle
         =
         match Assembly.resolveTypeRef assemblies sourceAssembly ImmutableArray.Empty typeRef with
         | TypeResolutionResult.Resolved (resolvedAssembly, _, resolvedType) ->
@@ -929,22 +955,26 @@ module Concretization =
         | TypeResolutionResult.FirstLoadAssy assemblyRef ->
             let handle, referencedIn = assemblyRef.Handle
             let newAssemblies, _ = loadAssembly.LoadAssembly assemblies referencedIn handle
-            let refreshedSourceAssembly = newAssemblies.[sourceAssembly.Name.FullName]
+
+            let newAssemblies =
+                LoadedAssemblies.assertReferenceBound $"base type reference %s{typeRef.Name}" assemblyRef newAssemblies
+
+            let refreshedSourceAssembly = newAssemblies.[sourceAssembly.Name]
             ensureTypeRefResolved loadAssembly newAssemblies refreshedSourceAssembly typeRef
 
     let rec private ensureTypeDefnResolved
         (loadAssembly : IAssemblyLoad)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (sourceAssembly : DumpedAssembly)
         (ty : TypeDefn)
-        : ImmutableDictionary<string, DumpedAssembly> * DumpedAssembly * TypeDefinitionHandle
+        : LoadedAssemblies * DumpedAssembly * TypeDefinitionHandle
         =
         match ty with
         | TypeDefn.GenericInstantiation (generic, _) ->
             ensureTypeDefnResolved loadAssembly assemblies sourceAssembly generic
         | TypeDefn.Modified (_, afterMod, _) -> ensureTypeDefnResolved loadAssembly assemblies sourceAssembly afterMod
         | TypeDefn.FromDefinition (identity, _) ->
-            let resolvedAssembly = assemblies.[identity.AssemblyFullName]
+            let resolvedAssembly = assemblies.ByDefinitionName identity.AssemblyFullName
             assemblies, resolvedAssembly, identity.TypeDefinition.Get
         | TypeDefn.FromReference (typeRef, _) -> ensureTypeRefResolved loadAssembly assemblies sourceAssembly typeRef
         | unexpected ->
@@ -955,19 +985,19 @@ module Concretization =
 
     let rec private ensureBaseTypeAssembliesLoaded
         (loadAssembly : IAssemblyLoad)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (assyName : AssemblyName)
         (baseTypeInfo : BaseTypeInfo option)
-        : ImmutableDictionary<string, DumpedAssembly>
+        : LoadedAssemblies
         =
         match baseTypeInfo with
         | None -> assemblies
         | Some (BaseTypeInfo.TypeDef handle) ->
-            let assy = assemblies.[assyName.FullName]
+            let assy = assemblies.[assyName]
             let baseType = assy.TypeDefs.[handle]
             ensureBaseTypeAssembliesLoaded loadAssembly assemblies assy.Name baseType.BaseType
         | Some (BaseTypeInfo.TypeRef handle) ->
-            let assy = assemblies.[assyName.FullName]
+            let assy = assemblies.[assyName]
             let typeRef = assy.TypeRefs.[handle]
 
             let newAssemblies, resolvedAssembly, resolvedHandle =
@@ -976,16 +1006,16 @@ module Concretization =
             let resolvedType = resolvedAssembly.TypeDefs.[resolvedHandle]
             ensureBaseTypeAssembliesLoaded loadAssembly newAssemblies resolvedAssembly.Name resolvedType.BaseType
         | Some (BaseTypeInfo.ForeignAssemblyType (assemblyName, handle)) ->
-            let assy = assemblies.[assyName.FullName]
+            let assy = assemblies.[assyName]
 
             let newAssemblies =
                 loadAssemblyReferenceByName loadAssembly assemblies assy assemblyName
 
-            let targetAssembly = newAssemblies.[assemblyName.FullName]
+            let targetAssembly = newAssemblies.[assemblyName]
             let targetType = targetAssembly.TypeDefs.[handle]
             ensureBaseTypeAssembliesLoaded loadAssembly newAssemblies targetAssembly.Name targetType.BaseType
         | Some (BaseTypeInfo.TypeSpec handle) ->
-            let assy = assemblies.[assyName.FullName]
+            let assy = assemblies.[assyName]
             let typeSpec = assy.TypeSpecs.[handle].Signature
 
             let newAssemblies, resolvedAssembly, resolvedHandle =
@@ -996,12 +1026,12 @@ module Concretization =
 
     let ensureTypeDefinitionBaseAssembliesLoaded
         (loadAssembly : IAssemblyLoad)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (assemblyName : AssemblyName)
         (typeDefinitionHandle : TypeDefinitionHandle)
-        : ImmutableDictionary<string, DumpedAssembly>
+        : LoadedAssemblies
         =
-        let assy = assemblies.[assemblyName.FullName]
+        let assy = assemblies.[assemblyName]
         let typeDef = assy.TypeDefs.[typeDefinitionHandle]
         ensureBaseTypeAssembliesLoaded loadAssembly assemblies assy.Name typeDef.BaseType
 
@@ -1040,10 +1070,10 @@ module Concretization =
         (loadAssembly : IAssemblyLoad)
         (baseTypes : BaseClassTypes<DumpedAssembly>)
         (visited : System.Collections.Generic.HashSet<ConcreteTypeHandle>)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (concreteTypes : AllConcreteTypes)
         (handle : ConcreteTypeHandle)
-        : ImmutableDictionary<string, DumpedAssembly> * AllConcreteTypes
+        : LoadedAssemblies * AllConcreteTypes
         =
         if not (visited.Add handle) then
             assemblies, concreteTypes
@@ -1067,7 +1097,7 @@ module Concretization =
                             concreteType.Assembly
                             concreteType.Definition.Get
 
-                    let outerAssembly = assemblies.[concreteType.Assembly.FullName]
+                    let outerAssembly = assemblies.[concreteType.Assembly]
                     let outerTypeDef = outerAssembly.TypeDefs.[concreteType.Definition.Get]
 
                     // Reference types terminate in zeroOf as null; fields (and,
@@ -1122,14 +1152,14 @@ module Concretization =
     let concretizeMethod
         (ctx : AllConcreteTypes)
         (loadAssembly : IAssemblyLoad)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (baseTypes : BaseClassTypes<DumpedAssembly>)
         (method : WoofWare.PawPrint.MethodInfo<'ty, GenericParamFromMetadata, TypeDefn>)
         (typeArgs : ImmutableArray<ConcreteTypeHandle>)
         (methodArgs : ImmutableArray<ConcreteTypeHandle>)
         : WoofWare.PawPrint.MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle> *
           AllConcreteTypes *
-          ImmutableDictionary<string, DumpedAssembly>
+          LoadedAssemblies
         =
 
         // Ensure base type assemblies are loaded for the declaring type
@@ -1151,7 +1181,7 @@ module Concretization =
         let declaringTypeDefn =
             if method.DeclaringType._Generics.IsEmpty then
                 // Non-generic type - determine the SignatureTypeKind
-                let assy = concCtx.LoadedAssemblies.[method.DeclaringType.Assembly.FullName]
+                let assy = concCtx.LoadedAssemblies.[method.DeclaringType.Assembly]
                 let arg = assy.TypeDefs.[method.DeclaringType.Definition.Get]
 
                 let signatureTypeKind =
@@ -1160,7 +1190,7 @@ module Concretization =
                 TypeDefn.FromDefinition (method.DeclaringType.Identity, signatureTypeKind)
             else
                 // Generic type - create a GenericInstantiation
-                let assy = concCtx.LoadedAssemblies.[method.DeclaringType.Assembly.FullName]
+                let assy = concCtx.LoadedAssemblies.[method.DeclaringType.Assembly]
                 let arg = assy.TypeDefs.[method.DeclaringType.Definition.Get]
 
                 let signatureTypeKind =
@@ -1309,7 +1339,7 @@ module Concretization =
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (handle : ConcreteTypeHandle)
         (concreteTypes : AllConcreteTypes)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         : TypeDefn
         =
         match handle with
@@ -1347,7 +1377,7 @@ module Concretization =
             | Some concreteType ->
 
             // Determine SignatureTypeKind
-            let assy = assemblies.[concreteType.Assembly.FullName]
+            let assy = assemblies.[concreteType.Assembly]
             let typeDef = assy.TypeDefs.[concreteType.Definition.Get]
 
             let signatureTypeKind =

--- a/WoofWare.PawPrint.Domain/TypeConcretisation.fs
+++ b/WoofWare.PawPrint.Domain/TypeConcretisation.fs
@@ -911,36 +911,64 @@ module Concretization =
         =
         TypeConcretization.concretizeMethodSignature ctx loadAssembly assembly typeArgs methodArgs signature
 
-    /// Helper to ensure base type assembly is loaded
+    /// <summary>
+    /// Get the assembly whose <em>definition</em> identity is
+    /// <paramref name="targetAssemblyName"/>, loading it via
+    /// <paramref name="referencedInAssembly"/>'s AssemblyReference table if we do not hold it yet.
+    /// Returns the assembly itself, not a name for the caller to look up again.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="targetAssemblyName"/> comes from <c>BaseTypeInfo.ForeignAssemblyType</c>,
+    /// whose payload is a definition identity — see the doc comment on that case. Every other
+    /// consumer of it reads it that way too (<c>Program.handleBaseTypeInfo</c>,
+    /// <c>TypeInfo.resolveBaseType</c>), so this must not accept a reference identity: doing so
+    /// would leave those consumers unable to find what it loaded, since the load context is keyed
+    /// by definition identity.
+    ///
+    /// Loading, though, can only go through an AssemblyReference, and a reference whose identity
+    /// differs from its referent's cannot be found from the definition identity alone. That case
+    /// fails loudly rather than guessing.
+    /// </remarks>
     let private loadAssemblyReferenceByName
         (loadAssembly : IAssemblyLoad)
         (assemblies : LoadedAssemblies)
         (referencedInAssembly : DumpedAssembly)
         (targetAssemblyName : AssemblyName)
-        : LoadedAssemblies
+        : LoadedAssemblies * DumpedAssembly
         =
-        if assemblies.ContainsDefinition targetAssemblyName then
-            assemblies
-        else
-            let handle =
-                referencedInAssembly.AssemblyReferences
-                |> Seq.tryPick (fun (KeyValue (assemblyRefHandle, assemblyRef)) ->
-                    if assemblyRef.Name.FullName = targetAssemblyName.FullName then
-                        Some assemblyRefHandle
-                    else
-                        None
-                )
-                |> Option.defaultWith (fun () ->
-                    failwithf
-                        "Assembly %s references base assembly %s, but no AssemblyReferenceHandle was found"
-                        referencedInAssembly.Name.FullName
-                        targetAssemblyName.FullName
-                )
+        match assemblies.TryByDefinition targetAssemblyName with
+        | Some assy -> assemblies, assy
+        | None ->
 
-            let newAssemblies, _ =
-                loadAssembly.LoadAssembly assemblies referencedInAssembly.Name handle
+        let handle =
+            referencedInAssembly.AssemblyReferences
+            |> Seq.tryPick (fun (KeyValue (assemblyRefHandle, assemblyRef)) ->
+                if assemblyRef.Name.FullName = targetAssemblyName.FullName then
+                    Some assemblyRefHandle
+                else
+                    None
+            )
+            |> Option.defaultWith (fun () ->
+                failwithf
+                    "Assembly %s needs base assembly %s, which is not loaded and is not named by any of its AssemblyReferences."
+                    referencedInAssembly.Name.FullName
+                    targetAssemblyName.FullName
+            )
 
-            newAssemblies
+        let assemblies, loaded =
+            loadAssembly.LoadAssembly assemblies referencedInAssembly.Name handle
+
+        // The reference we followed named the target by its definition identity, so this is what
+        // every downstream definition-identity lookup will ask for. If it is not, the DU's
+        // contract has been violated upstream and later lookups would fail confusingly.
+        if loaded.Name.FullName <> targetAssemblyName.FullName then
+            failwithf
+                "Loading base assembly %s via %s produced %s instead; BaseTypeInfo.ForeignAssemblyType must carry a definition identity."
+                targetAssemblyName.FullName
+                referencedInAssembly.Name.FullName
+                loaded.Name.FullName
+
+        assemblies, loaded
 
     let rec private ensureTypeRefResolved
         (loadAssembly : IAssemblyLoad)
@@ -1008,10 +1036,9 @@ module Concretization =
         | Some (BaseTypeInfo.ForeignAssemblyType (assemblyName, handle)) ->
             let assy = assemblies.[assyName]
 
-            let newAssemblies =
+            let newAssemblies, targetAssembly =
                 loadAssemblyReferenceByName loadAssembly assemblies assy assemblyName
 
-            let targetAssembly = newAssemblies.[assemblyName]
             let targetType = targetAssembly.TypeDefs.[handle]
             ensureBaseTypeAssembliesLoaded loadAssembly newAssemblies targetAssembly.Name targetType.BaseType
         | Some (BaseTypeInfo.TypeSpec handle) ->

--- a/WoofWare.PawPrint.Domain/TypeInfo.fs
+++ b/WoofWare.PawPrint.Domain/TypeInfo.fs
@@ -28,6 +28,19 @@ type BaseTypeInfo =
     | TypeDef of TypeDefinitionHandle
     | TypeRef of TypeReferenceHandle
     | TypeSpec of TypeSpecificationHandle
+    /// <summary>
+    /// A base type living in another assembly, already resolved to that assembly and a TypeDef
+    /// within it.
+    /// </summary>
+    /// <remarks>
+    /// <c>assemblyName</c> is the target's <em>definition</em> identity — the identity it declares
+    /// for itself — not the reference identity by which some other assembly names it. The two
+    /// routinely differ (the .NET Framework compatibility facades reference their implementation
+    /// assemblies as <c>Version=0.0.0.0</c>), and every consumer of this case looks the assembly up
+    /// by definition identity, so a reference identity here would not be found.
+    ///
+    /// Nothing currently constructs this case; whatever first does must honour that contract.
+    /// </remarks>
     | ForeignAssemblyType of assemblyName : AssemblyName * TypeDefinitionHandle
 
 type MethodImplParsed =

--- a/WoofWare.PawPrint.Test/TestAssemblyDictionaryKeying.fs
+++ b/WoofWare.PawPrint.Test/TestAssemblyDictionaryKeying.fs
@@ -1,0 +1,186 @@
+namespace WoofWare.PawPrint.Test
+
+open System
+open System.Collections.Immutable
+open System.IO
+open System.Reflection
+open System.Reflection.Metadata
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+/// The loaded-assemblies dictionary is populated by two different keying conventions.
+///
+///   * `IlMachineState.WithLoadedAssembly` (and `IlMachineState.initial`) key by the
+///     assembly's own *AssemblyDefinition* identity.
+///   * `TypeResolution.loadAssembly` keys by the *AssemblyReference* that triggered the
+///     load: `assemblies.SetItem (assemblyRef.Name.FullName, assy)`.
+///
+/// Every consumer, however, looks an assembly up by its definition identity:
+/// `Concretization.ensureTypeDefinitionBaseAssembliesLoaded` indexes
+/// `assemblies.[assemblyName.FullName]`, where `assemblyName` is a `DumpedAssembly.Name`
+/// or a `ConcreteType.Assembly`, both of which come from
+/// `ResolvedTypeIdentity.ofTypeDefinition` and are therefore definition identities.
+///
+/// A reference identity need not equal the referent's definition identity. In the .NET 10
+/// shared framework the .NET Framework compatibility facades (mscorlib, System,
+/// System.Core, System.Xml, ...) reference their implementation assemblies with
+/// `Version=0.0.0.0`; six assemblies there — including
+/// `System.IO.FileSystem.AccessControl` — are referenced *only* that way, so they can
+/// never be found again once loaded.
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestAssemblyDictionaryKeying =
+
+    let private corelibPath : string = typeof<obj>.Assembly.Location
+    let private runtimeDir : string = Path.GetDirectoryName corelibPath
+
+    let private readAssembly (path : string) : DumpedAssembly =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        Assembly.readFile loggerFactory path
+
+    let private requireFile (name : string) : string =
+        let candidate = Path.Combine (runtimeDir, name)
+
+        if not (File.Exists candidate) then
+            Assert.Ignore $"%s{name} not found next to corelib at %s{candidate}"
+
+        candidate
+
+    /// Byte-for-byte the keying production uses: `TypeResolution.loadAssembly` inserts the
+    /// freshly-read assembly under the FullName taken from the AssemblyReference that
+    /// caused the load, *not* under the assembly's own definition name.
+    type private ProductionKeyedAssemblyLoad (searchDirs : string list) =
+        interface IAssemblyLoad with
+            member _.LoadAssembly
+                (loadedAssemblies : ImmutableDictionary<string, DumpedAssembly>)
+                (referencedIn : AssemblyName)
+                (handle : AssemblyReferenceHandle)
+                : ImmutableDictionary<string, DumpedAssembly> * DumpedAssembly
+                =
+                let referencedInAssembly =
+                    match loadedAssemblies.TryGetValue referencedIn.FullName with
+                    | false, _ -> failwithf $"Missing loaded assembly %s{referencedIn.FullName}"
+                    | true, assy -> assy
+
+                let assemblyRef = referencedInAssembly.AssemblyReferences.[handle]
+
+                match loadedAssemblies.TryGetValue assemblyRef.Name.FullName with
+                | true, assy -> loadedAssemblies, assy
+                | false, _ ->
+                    let path =
+                        searchDirs
+                        |> List.tryPick (fun dir ->
+                            let candidate = Path.Combine (dir, assemblyRef.Name.Name + ".dll")
+                            if File.Exists candidate then Some candidate else None
+                        )
+                        |> Option.defaultWith (fun () ->
+                            failwithf $"Test setup could not locate assembly %s{assemblyRef.Name.FullName} on disk"
+                        )
+
+                    let dumped = readAssembly path
+                    // The production keying: the *reference's* FullName, not `dumped.Name.FullName`.
+                    loadedAssemblies.SetItem (assemblyRef.Name.FullName, dumped), dumped
+
+    /// Resolve a top-level type by name out of `fromAssembly`, loading referenced
+    /// assemblies on demand exactly as production does.
+    let private resolveWithLoads
+        (loadAssembly : IAssemblyLoad)
+        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (fromAssembly : DumpedAssembly)
+        (ns : string)
+        (name : string)
+        : ImmutableDictionary<string, DumpedAssembly> * DumpedAssembly * ResolvedTypeIdentity
+        =
+        let rec go
+            (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+            : ImmutableDictionary<string, DumpedAssembly> * DumpedAssembly * ResolvedTypeIdentity
+            =
+            match Assembly.resolveTopLevelTypeFromName fromAssembly assemblies (Some ns) name ImmutableArray.Empty with
+            | TypeResolutionResult.Resolved (assy, identity, _) -> assemblies, assy, identity
+            | TypeResolutionResult.FirstLoadAssy assyRef ->
+                let handle, referencedIn = assyRef.Handle
+                let assemblies, _ = loadAssembly.LoadAssembly assemblies referencedIn handle
+                go assemblies
+
+        go assemblies
+
+    /// Set up the reported scenario: `mscorlib` forwards
+    /// `System.Security.AccessControl.FileSystemRights` to
+    /// `System.IO.FileSystem.AccessControl` through an AssemblyReference whose Version is
+    /// 0.0.0.0, while the real DLL's AssemblyDefinition Version is the shared framework's.
+    /// No other assembly in the shared framework references it at all, so this is the only
+    /// way the interpreter can ever come to load it.
+    let private loadForwardedAccessControlType
+        ()
+        : IAssemblyLoad *
+          ImmutableDictionary<string, DumpedAssembly> *
+          DumpedAssembly *
+          DumpedAssembly *
+          ResolvedTypeIdentity
+        =
+        let mscorlibPath = requireFile "mscorlib.dll"
+        requireFile "System.IO.FileSystem.AccessControl.dll" |> ignore
+
+        let corelib = readAssembly corelibPath
+        let mscorlib = readAssembly mscorlibPath
+
+        let loaded : ImmutableDictionary<string, DumpedAssembly> =
+            [ corelib ; mscorlib ]
+            |> Seq.map (fun a -> System.Collections.Generic.KeyValuePair (a.Name.FullName, a))
+            |> ImmutableDictionary.CreateRange
+
+        let loadAssembly = ProductionKeyedAssemblyLoad [ runtimeDir ] :> IAssemblyLoad
+
+        let loaded, targetAssembly, identity =
+            resolveWithLoads loadAssembly loaded mscorlib "System.Security.AccessControl" "FileSystemRights"
+
+        // Sanity: we really did land in the forwarded-to assembly, via a reference whose
+        // identity differs from that assembly's own definition identity.
+        targetAssembly.Name.Name |> shouldEqual "System.IO.FileSystem.AccessControl"
+
+        let referenceKey =
+            loaded.Keys
+            |> Seq.filter (fun k -> k.StartsWith ("System.IO.FileSystem.AccessControl,", StringComparison.Ordinal))
+            |> Seq.exactlyOne
+
+        referenceKey |> shouldNotEqual targetAssembly.Name.FullName
+        identity.AssemblyFullName |> shouldEqual targetAssembly.Name.FullName
+
+        loadAssembly, loaded, corelib, targetAssembly, identity
+
+    /// An assembly that has been loaded must be findable by its definition identity,
+    /// which is the only identity `ConcreteType.Assembly`, `DumpedAssembly.Name` and
+    /// `ResolvedTypeIdentity.AssemblyFullName` ever carry.
+    [<Test>]
+    let ``a loaded assembly is keyed by its definition identity`` () : unit =
+        let _, loaded, _, targetAssembly, _ = loadForwardedAccessControlType ()
+
+        loaded.ContainsKey targetAssembly.Name.FullName |> shouldEqual true
+
+    [<Test>]
+    let ``ensureTypeDefinitionBaseAssembliesLoaded succeeds for a type reached through a forwarding facade`` () : unit =
+        let loadAssembly, loaded, _, targetAssembly, identity =
+            loadForwardedAccessControlType ()
+
+        Concretization.ensureTypeDefinitionBaseAssembliesLoaded
+            loadAssembly
+            loaded
+            targetAssembly.Name
+            identity.TypeDefinition.Get
+        |> ignore
+
+    [<Test>]
+    let ``concretizeTypeDefinition succeeds for a type reached through a forwarding facade`` () : unit =
+        let _, loaded, corelib, _, identity = loadForwardedAccessControlType ()
+
+        let baseTypes = Corelib.getBaseTypes corelib
+
+        let ctx : TypeConcretization.ConcretizationContext<DumpedAssembly> =
+            {
+                ConcreteTypes = Corelib.concretizeAll loaded baseTypes AllConcreteTypes.Empty
+                LoadedAssemblies = loaded
+                BaseTypes = baseTypes
+            }
+
+        TypeConcretization.concretizeTypeDefinition ctx identity |> ignore

--- a/WoofWare.PawPrint.Test/TestAssemblyDictionaryKeying.fs
+++ b/WoofWare.PawPrint.Test/TestAssemblyDictionaryKeying.fs
@@ -159,27 +159,68 @@ module TestAssemblyDictionaryKeying =
 
         loaded.TryResolveReference reference |> Option.isSome |> shouldEqual false
 
-    /// A reference whose identity happens to equal an already-loaded assembly's definition
-    /// identity must resolve to it without going to disk — the CLR's exact-identity match. This is
-    /// how an assembly registered directly (the entry assembly, or a fixture that exists only in
+    /// A reference whose identity *genuinely* equals an already-loaded assembly's definition
+    /// identity must resolve to it with no recorded binding — the CLR's exact-identity match. This
+    /// is how an assembly registered directly (the entry assembly, or a fixture that exists only in
     /// memory, never written to a runtime dir) is found the first time something references it.
+    ///
+    /// Finding such a pair takes searching: the facades are precisely the assemblies whose
+    /// references do NOT match, so we scan for a (reference, referent) pair whose FullNames agree.
     [<Test>]
     let ``an exact identity match resolves with no recorded binding`` () : unit =
-        let mscorlibPath = requireFile "mscorlib.dll"
-        let mscorlib = readAssembly mscorlibPath
-        let reference = forwardingReference mscorlib
+        let matchingPair =
+            Directory.EnumerateFiles (runtimeDir, "*.dll")
+            |> Seq.sort
+            |> Seq.truncate 40
+            |> Seq.collect (fun path ->
+                (readAssembly path).AssemblyReferences.Values
+                |> Seq.choose (fun reference ->
+                    let candidate = Path.Combine (runtimeDir, reference.Name.Name + ".dll")
 
-        // Stand in for "an assembly registered directly whose definition identity is exactly what
-        // some reference names": load the referent and register it under the reference's identity.
+                    if not (File.Exists candidate) then
+                        None
+                    else
+
+                    let referent = readAssembly candidate
+
+                    if referent.Name.FullName = reference.Name.FullName then
+                        Some (reference, referent)
+                    else
+                        None
+                )
+            )
+            |> Seq.tryHead
+
+        match matchingPair with
+        | None ->
+            Assert.Ignore
+                "No assembly reference in the shared framework exactly matches its referent's definition identity; cannot exercise the exact-identity fallback."
+        | Some (reference, referent) ->
+            // No binding has ever been recorded for this reference.
+            let loaded = LoadedAssemblies.ofAssemblies [ referent ]
+
+            match loaded.TryResolveReference reference with
+            | None ->
+                Assert.Fail
+                    $"Expected reference %s{reference.Name.FullName} to resolve by exact identity match against the loaded definition of the same name"
+            | Some resolved -> resolved.Name.FullName |> shouldEqual referent.Name.FullName
+
+    /// The exact-identity fallback must not fire on a *mismatched* reference, or the binder would
+    /// be inventing bindings it never made.
+    [<Test>]
+    let ``the exact identity fallback does not fire on a mismatched reference`` () : unit =
+        let mscorlib = readAssembly (requireFile "mscorlib.dll")
+        let reference = forwardingReference mscorlib
         let target = readAssembly (requireFile "System.IO.FileSystem.AccessControl.dll")
 
-        let loaded =
-            (LoadedAssemblies.empty.WithBoundReference reference target |> fst).WithLoadedAssembly target
+        // The reference names this very assembly, but with a different version, so it must not
+        // resolve until a binding is recorded.
+        reference.Name.Name |> shouldEqual target.Name.Name
+        reference.Name.FullName |> shouldNotEqual target.Name.FullName
 
-        // Now build a fresh context holding only an assembly whose definition identity equals the
-        // reference's identity, with no binding recorded at all.
         let bindingFree = LoadedAssemblies.ofAssemblies [ target ]
         bindingFree.TryResolveReference reference |> Option.isSome |> shouldEqual false
 
-        // ...whereas the recorded binding does resolve.
-        loaded.TryResolveReference reference |> Option.isSome |> shouldEqual true
+        // ...and once bound, it does.
+        let bound, _ = bindingFree.WithBoundReference reference target
+        bound.TryResolveReference reference |> Option.isSome |> shouldEqual true

--- a/WoofWare.PawPrint.Test/TestAssemblyDictionaryKeying.fs
+++ b/WoofWare.PawPrint.Test/TestAssemblyDictionaryKeying.fs
@@ -1,33 +1,22 @@
 namespace WoofWare.PawPrint.Test
 
-open System
 open System.Collections.Immutable
 open System.IO
-open System.Reflection
-open System.Reflection.Metadata
 open FsUnitTyped
 open NUnit.Framework
 open WoofWare.PawPrint
 
-/// The loaded-assemblies dictionary is populated by two different keying conventions.
+/// An assembly has two identities and they are not interchangeable: the *definition* identity it
+/// declares for itself, and the *reference* identity by which some other assembly names it.
+/// Everything downstream of type resolution — `DumpedAssembly.Name`, `ConcreteType.Assembly`,
+/// `ResolvedTypeIdentity.AssemblyFullName` — carries a definition identity, so an assembly must be
+/// findable by that identity no matter which reference caused it to be loaded.
 ///
-///   * `IlMachineState.WithLoadedAssembly` (and `IlMachineState.initial`) key by the
-///     assembly's own *AssemblyDefinition* identity.
-///   * `TypeResolution.loadAssembly` keys by the *AssemblyReference* that triggered the
-///     load: `assemblies.SetItem (assemblyRef.Name.FullName, assy)`.
-///
-/// Every consumer, however, looks an assembly up by its definition identity:
-/// `Concretization.ensureTypeDefinitionBaseAssembliesLoaded` indexes
-/// `assemblies.[assemblyName.FullName]`, where `assemblyName` is a `DumpedAssembly.Name`
-/// or a `ConcreteType.Assembly`, both of which come from
-/// `ResolvedTypeIdentity.ofTypeDefinition` and are therefore definition identities.
-///
-/// A reference identity need not equal the referent's definition identity. In the .NET 10
-/// shared framework the .NET Framework compatibility facades (mscorlib, System,
-/// System.Core, System.Xml, ...) reference their implementation assemblies with
-/// `Version=0.0.0.0`; six assemblies there — including
-/// `System.IO.FileSystem.AccessControl` — are referenced *only* that way, so they can
-/// never be found again once loaded.
+/// This used to fail: the load context was keyed by whichever AssemblyReference triggered the
+/// load. In the .NET shared framework the .NET Framework compatibility facades reference their
+/// implementation assemblies with `Version=0.0.0.0`, and six assemblies there — including
+/// `System.IO.FileSystem.AccessControl` — are referenced *only* that way, so they could never be
+/// found again once loaded.
 [<TestFixture>]
 [<Parallelizable(ParallelScope.All)>]
 module TestAssemblyDictionaryKeying =
@@ -47,124 +36,96 @@ module TestAssemblyDictionaryKeying =
 
         candidate
 
-    /// Byte-for-byte the keying production uses: `TypeResolution.loadAssembly` inserts the
-    /// freshly-read assembly under the FullName taken from the AssemblyReference that
-    /// caused the load, *not* under the assembly's own definition name.
-    type private ProductionKeyedAssemblyLoad (searchDirs : string list) =
-        interface IAssemblyLoad with
-            member _.LoadAssembly
-                (loadedAssemblies : ImmutableDictionary<string, DumpedAssembly>)
-                (referencedIn : AssemblyName)
-                (handle : AssemblyReferenceHandle)
-                : ImmutableDictionary<string, DumpedAssembly> * DumpedAssembly
-                =
-                let referencedInAssembly =
-                    match loadedAssemblies.TryGetValue referencedIn.FullName with
-                    | false, _ -> failwithf $"Missing loaded assembly %s{referencedIn.FullName}"
-                    | true, assy -> assy
+    /// The production loader. Tests must not hand-roll an `IAssemblyLoad`: this bug was invisible
+    /// to the suite for exactly as long as the test fakes keyed their dictionaries differently
+    /// from production.
+    let private loader () : IAssemblyLoad =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        TypeResolution.directoryLoader loggerFactory [ runtimeDir ]
 
-                let assemblyRef = referencedInAssembly.AssemblyReferences.[handle]
-
-                match loadedAssemblies.TryGetValue assemblyRef.Name.FullName with
-                | true, assy -> loadedAssemblies, assy
-                | false, _ ->
-                    let path =
-                        searchDirs
-                        |> List.tryPick (fun dir ->
-                            let candidate = Path.Combine (dir, assemblyRef.Name.Name + ".dll")
-                            if File.Exists candidate then Some candidate else None
-                        )
-                        |> Option.defaultWith (fun () ->
-                            failwithf $"Test setup could not locate assembly %s{assemblyRef.Name.FullName} on disk"
-                        )
-
-                    let dumped = readAssembly path
-                    // The production keying: the *reference's* FullName, not `dumped.Name.FullName`.
-                    loadedAssemblies.SetItem (assemblyRef.Name.FullName, dumped), dumped
-
-    /// Resolve a top-level type by name out of `fromAssembly`, loading referenced
-    /// assemblies on demand exactly as production does.
+    /// Resolve a top-level type by name out of `fromAssembly`, loading referenced assemblies on
+    /// demand through the production loader.
     let private resolveWithLoads
         (loadAssembly : IAssemblyLoad)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (fromAssembly : DumpedAssembly)
         (ns : string)
         (name : string)
-        : ImmutableDictionary<string, DumpedAssembly> * DumpedAssembly * ResolvedTypeIdentity
+        : LoadedAssemblies * DumpedAssembly * ResolvedTypeIdentity
         =
-        let rec go
-            (assemblies : ImmutableDictionary<string, DumpedAssembly>)
-            : ImmutableDictionary<string, DumpedAssembly> * DumpedAssembly * ResolvedTypeIdentity
-            =
+        let rec go (assemblies : LoadedAssemblies) : LoadedAssemblies * DumpedAssembly * ResolvedTypeIdentity =
             match Assembly.resolveTopLevelTypeFromName fromAssembly assemblies (Some ns) name ImmutableArray.Empty with
             | TypeResolutionResult.Resolved (assy, identity, _) -> assemblies, assy, identity
             | TypeResolutionResult.FirstLoadAssy assyRef ->
                 let handle, referencedIn = assyRef.Handle
                 let assemblies, _ = loadAssembly.LoadAssembly assemblies referencedIn handle
-                go assemblies
+
+                // Same guard production uses: a load that leaves the reference unbound would make
+                // this retry spin forever, so fail with a diagnosis instead of hanging.
+                go (LoadedAssemblies.assertReferenceBound $"%s{ns}.%s{name}" assyRef assemblies)
 
         go assemblies
 
-    /// Set up the reported scenario: `mscorlib` forwards
-    /// `System.Security.AccessControl.FileSystemRights` to
-    /// `System.IO.FileSystem.AccessControl` through an AssemblyReference whose Version is
-    /// 0.0.0.0, while the real DLL's AssemblyDefinition Version is the shared framework's.
-    /// No other assembly in the shared framework references it at all, so this is the only
-    /// way the interpreter can ever come to load it.
+    /// The one reference in `mscorlib` that names `System.IO.FileSystem.AccessControl`.
+    let private forwardingReference (mscorlib : DumpedAssembly) : AssemblyReference =
+        mscorlib.AssemblyReferences.Values
+        |> Seq.filter (fun r -> r.Name.Name = "System.IO.FileSystem.AccessControl")
+        |> Seq.exactlyOne
+
+    /// The reported scenario: `mscorlib` forwards `System.Security.AccessControl.FileSystemRights`
+    /// to `System.IO.FileSystem.AccessControl` through an AssemblyReference whose Version is
+    /// 0.0.0.0, while the real DLL's AssemblyDefinition Version is the shared framework's. No other
+    /// assembly in the shared framework references it at all, so this is the only way the
+    /// interpreter can ever come to load it.
     let private loadForwardedAccessControlType
         ()
-        : IAssemblyLoad *
-          ImmutableDictionary<string, DumpedAssembly> *
-          DumpedAssembly *
-          DumpedAssembly *
-          ResolvedTypeIdentity
+        : LoadedAssemblies * DumpedAssembly * DumpedAssembly * DumpedAssembly * ResolvedTypeIdentity
         =
         let mscorlibPath = requireFile "mscorlib.dll"
         requireFile "System.IO.FileSystem.AccessControl.dll" |> ignore
 
         let corelib = readAssembly corelibPath
         let mscorlib = readAssembly mscorlibPath
-
-        let loaded : ImmutableDictionary<string, DumpedAssembly> =
-            [ corelib ; mscorlib ]
-            |> Seq.map (fun a -> System.Collections.Generic.KeyValuePair (a.Name.FullName, a))
-            |> ImmutableDictionary.CreateRange
-
-        let loadAssembly = ProductionKeyedAssemblyLoad [ runtimeDir ] :> IAssemblyLoad
+        let loaded = LoadedAssemblies.ofAssemblies [ corelib ; mscorlib ]
 
         let loaded, targetAssembly, identity =
-            resolveWithLoads loadAssembly loaded mscorlib "System.Security.AccessControl" "FileSystemRights"
+            resolveWithLoads (loader ()) loaded mscorlib "System.Security.AccessControl" "FileSystemRights"
 
-        // Sanity: we really did land in the forwarded-to assembly, via a reference whose
-        // identity differs from that assembly's own definition identity.
+        // Sanity: we really did land in the forwarded-to assembly, and this really is the
+        // ref-identity-differs-from-def-identity case the fix is about.
         targetAssembly.Name.Name |> shouldEqual "System.IO.FileSystem.AccessControl"
 
-        let referenceKey =
-            loaded.Keys
-            |> Seq.filter (fun k -> k.StartsWith ("System.IO.FileSystem.AccessControl,", StringComparison.Ordinal))
-            |> Seq.exactlyOne
+        (forwardingReference mscorlib).Name.FullName
+        |> shouldNotEqual targetAssembly.Name.FullName
 
-        referenceKey |> shouldNotEqual targetAssembly.Name.FullName
         identity.AssemblyFullName |> shouldEqual targetAssembly.Name.FullName
 
-        loadAssembly, loaded, corelib, targetAssembly, identity
+        loaded, corelib, mscorlib, targetAssembly, identity
 
-    /// An assembly that has been loaded must be findable by its definition identity,
-    /// which is the only identity `ConcreteType.Assembly`, `DumpedAssembly.Name` and
-    /// `ResolvedTypeIdentity.AssemblyFullName` ever carry.
+    /// The invariant the whole design rests on: whatever route got an assembly into the load
+    /// context, it is findable by the only identity its consumers ever hold.
     [<Test>]
-    let ``a loaded assembly is keyed by its definition identity`` () : unit =
-        let _, loaded, _, targetAssembly, _ = loadForwardedAccessControlType ()
+    let ``a loaded assembly is findable by its definition identity`` () : unit =
+        let loaded, _, _, targetAssembly, _ = loadForwardedAccessControlType ()
 
-        loaded.ContainsKey targetAssembly.Name.FullName |> shouldEqual true
+        loaded.ContainsDefinition targetAssembly.Name |> shouldEqual true
+        loaded.TryByDefinition targetAssembly.Name |> Option.isSome |> shouldEqual true
+
+    /// ...and the reference that got us there still resolves, so we do not go back to disk.
+    [<Test>]
+    let ``the reference that triggered the load still resolves to the same assembly`` () : unit =
+        let loaded, _, mscorlib, targetAssembly, _ = loadForwardedAccessControlType ()
+
+        match loaded.TryResolveReference (forwardingReference mscorlib) with
+        | None -> Assert.Fail "Expected the recorded binding to resolve the forwarding reference"
+        | Some resolved -> resolved.Name.FullName |> shouldEqual targetAssembly.Name.FullName
 
     [<Test>]
     let ``ensureTypeDefinitionBaseAssembliesLoaded succeeds for a type reached through a forwarding facade`` () : unit =
-        let loadAssembly, loaded, _, targetAssembly, identity =
-            loadForwardedAccessControlType ()
+        let loaded, _, _, targetAssembly, identity = loadForwardedAccessControlType ()
 
         Concretization.ensureTypeDefinitionBaseAssembliesLoaded
-            loadAssembly
+            (loader ())
             loaded
             targetAssembly.Name
             identity.TypeDefinition.Get
@@ -172,7 +133,7 @@ module TestAssemblyDictionaryKeying =
 
     [<Test>]
     let ``concretizeTypeDefinition succeeds for a type reached through a forwarding facade`` () : unit =
-        let _, loaded, corelib, _, identity = loadForwardedAccessControlType ()
+        let loaded, corelib, _, _, identity = loadForwardedAccessControlType ()
 
         let baseTypes = Corelib.getBaseTypes corelib
 
@@ -184,3 +145,41 @@ module TestAssemblyDictionaryKeying =
             }
 
         TypeConcretization.concretizeTypeDefinition ctx identity |> ignore
+
+    /// A reference whose identity differs from every loaded assembly's definition identity must
+    /// NOT resolve — otherwise the binder would be inventing bindings it has not made.
+    [<Test>]
+    let ``a mismatched reference does not resolve against an unbound load context`` () : unit =
+        let mscorlibPath = requireFile "mscorlib.dll"
+        let corelib = readAssembly corelibPath
+        let mscorlib = readAssembly mscorlibPath
+        let loaded = LoadedAssemblies.ofAssemblies [ corelib ; mscorlib ]
+
+        let reference = forwardingReference mscorlib
+
+        loaded.TryResolveReference reference |> Option.isSome |> shouldEqual false
+
+    /// A reference whose identity happens to equal an already-loaded assembly's definition
+    /// identity must resolve to it without going to disk — the CLR's exact-identity match. This is
+    /// how an assembly registered directly (the entry assembly, or a fixture that exists only in
+    /// memory, never written to a runtime dir) is found the first time something references it.
+    [<Test>]
+    let ``an exact identity match resolves with no recorded binding`` () : unit =
+        let mscorlibPath = requireFile "mscorlib.dll"
+        let mscorlib = readAssembly mscorlibPath
+        let reference = forwardingReference mscorlib
+
+        // Stand in for "an assembly registered directly whose definition identity is exactly what
+        // some reference names": load the referent and register it under the reference's identity.
+        let target = readAssembly (requireFile "System.IO.FileSystem.AccessControl.dll")
+
+        let loaded =
+            (LoadedAssemblies.empty.WithBoundReference reference target |> fst).WithLoadedAssembly target
+
+        // Now build a fresh context holding only an assembly whose definition identity equals the
+        // reference's identity, with no binding recorded at all.
+        let bindingFree = LoadedAssemblies.ofAssemblies [ target ]
+        bindingFree.TryResolveReference reference |> Option.isSome |> shouldEqual false
+
+        // ...whereas the recorded binding does resolve.
+        loaded.TryResolveReference reference |> Option.isSome |> shouldEqual true

--- a/WoofWare.PawPrint.Test/TestBinaryArithmetic.fs
+++ b/WoofWare.PawPrint.Test/TestBinaryArithmetic.fs
@@ -22,8 +22,8 @@ module TestBinaryArithmetic =
     let private baseClassTypes : BaseClassTypes<DumpedAssembly> =
         Corelib.getBaseTypes corelib
 
-    let private loadedAssemblies : ImmutableDictionary<string, DumpedAssembly> =
-        ImmutableDictionary<string, DumpedAssembly>.Empty.Add (corelib.Name.FullName, corelib)
+    let private loadedAssemblies : LoadedAssemblies =
+        LoadedAssemblies.ofAssemblies [ corelib ]
 
     let private concreteTypes : AllConcreteTypes =
         Corelib.concretizeAll loadedAssemblies baseClassTypes AllConcreteTypes.Empty

--- a/WoofWare.PawPrint.Test/TestCliTypeBytes.fs
+++ b/WoofWare.PawPrint.Test/TestCliTypeBytes.fs
@@ -26,8 +26,7 @@ module TestCliTypeBytes =
 
     let private bct : BaseClassTypes<DumpedAssembly> = Corelib.getBaseTypes corelib
 
-    let private loaded : ImmutableDictionary<string, DumpedAssembly> =
-        ImmutableDictionary.CreateRange [ KeyValuePair (corelib.Name.FullName, corelib) ]
+    let private loaded : LoadedAssemblies = LoadedAssemblies.ofAssemblies [ corelib ]
 
     let private allCt : AllConcreteTypes =
         Corelib.concretizeAll loaded bct AllConcreteTypes.Empty

--- a/WoofWare.PawPrint.Test/TestCliValueTypeCoerceFrom.fs
+++ b/WoofWare.PawPrint.Test/TestCliValueTypeCoerceFrom.fs
@@ -24,8 +24,7 @@ module TestCliValueTypeCoerceFrom =
 
     let private bct : BaseClassTypes<DumpedAssembly> = Corelib.getBaseTypes corelib
 
-    let private loaded : ImmutableDictionary<string, DumpedAssembly> =
-        ImmutableDictionary.CreateRange [ KeyValuePair (corelib.Name.FullName, corelib) ]
+    let private loaded : LoadedAssemblies = LoadedAssemblies.ofAssemblies [ corelib ]
 
     let private allCt : AllConcreteTypes =
         Corelib.concretizeAll loaded bct AllConcreteTypes.Empty

--- a/WoofWare.PawPrint.Test/TestCustomAttribValueLowering.fs
+++ b/WoofWare.PawPrint.Test/TestCustomAttribValueLowering.fs
@@ -22,8 +22,7 @@ module TestCustomAttribValueLowering =
 
     let private bct : BaseClassTypes<DumpedAssembly> = Corelib.getBaseTypes corelib
 
-    let private loaded : ImmutableDictionary<string, DumpedAssembly> =
-        ImmutableDictionary.CreateRange [ KeyValuePair (corelib.Name.FullName, corelib) ]
+    let private loaded : LoadedAssemblies = LoadedAssemblies.ofAssemblies [ corelib ]
 
     let private concreteTypes : AllConcreteTypes =
         Corelib.concretizeAll loaded bct AllConcreteTypes.Empty

--- a/WoofWare.PawPrint.Test/TestEvalStackPrimitiveLikeBoundary.fs
+++ b/WoofWare.PawPrint.Test/TestEvalStackPrimitiveLikeBoundary.fs
@@ -22,8 +22,7 @@ module TestEvalStackPrimitiveLikeBoundary =
 
     let private bct : BaseClassTypes<DumpedAssembly> = Corelib.getBaseTypes corelib
 
-    let private loaded : ImmutableDictionary<string, DumpedAssembly> =
-        ImmutableDictionary.CreateRange [ KeyValuePair (corelib.Name.FullName, corelib) ]
+    let private loaded : LoadedAssemblies = LoadedAssemblies.ofAssemblies [ corelib ]
 
     let private allCt : AllConcreteTypes =
         let concreteTypes = Corelib.concretizeAll loaded bct AllConcreteTypes.Empty

--- a/WoofWare.PawPrint.Test/TestFaultHandlers.fs
+++ b/WoofWare.PawPrint.Test/TestFaultHandlers.fs
@@ -18,8 +18,7 @@ module TestFaultHandlers =
 
     let private bct : BaseClassTypes<DumpedAssembly> = Corelib.getBaseTypes corelib
 
-    let private loaded : ImmutableDictionary<string, DumpedAssembly> =
-        ImmutableDictionary.CreateRange [ KeyValuePair (corelib.Name.FullName, corelib) ]
+    let private loaded : LoadedAssemblies = LoadedAssemblies.ofAssemblies [ corelib ]
 
     let private concreteTypes : AllConcreteTypes =
         Corelib.concretizeAll loaded bct AllConcreteTypes.Empty

--- a/WoofWare.PawPrint.Test/TestFieldHandleRegistry.fs
+++ b/WoofWare.PawPrint.Test/TestFieldHandleRegistry.fs
@@ -89,7 +89,7 @@ public class GenericHolder<T>
             let initialState =
                 IlMachineState.initial loggerFactory ImmutableArray.Empty assembly
 
-            initialState.WithLoadedAssembly corelib.Name corelib
+            initialState.WithLoadedAssembly corelib
 
         let state : IlMachineState =
             (state,
@@ -1049,7 +1049,7 @@ public static class HasRvaData
             let initialState =
                 IlMachineState.initial loggerFactory ImmutableArray.Empty assembly
 
-            initialState.WithLoadedAssembly corelib.Name corelib
+            initialState.WithLoadedAssembly corelib
 
         let state, peByteRange =
             IlMachineState.peByteRangeForFieldRva

--- a/WoofWare.PawPrint.Test/TestFunctionPointerConcretization.fs
+++ b/WoofWare.PawPrint.Test/TestFunctionPointerConcretization.fs
@@ -18,8 +18,8 @@ module TestFunctionPointerConcretization =
     let private baseClassTypes : BaseClassTypes<DumpedAssembly> =
         Corelib.getBaseTypes corelib
 
-    let private loadedAssemblies : ImmutableDictionary<string, DumpedAssembly> =
-        ImmutableDictionary<string, DumpedAssembly>.Empty.Add (corelib.Name.FullName, corelib)
+    let private loadedAssemblies : LoadedAssemblies =
+        LoadedAssemblies.ofAssemblies [ corelib ]
 
     let private concreteTypes : AllConcreteTypes =
         Corelib.concretizeAll loadedAssemblies baseClassTypes AllConcreteTypes.Empty

--- a/WoofWare.PawPrint.Test/TestLoadedAssemblies.fs
+++ b/WoofWare.PawPrint.Test/TestLoadedAssemblies.fs
@@ -239,3 +239,201 @@ module TestLoadedAssemblies =
         match third.TryByDefinition assy.Name with
         | None -> Assert.Fail "Expected the assembly to remain findable by its definition identity"
         | Some held -> Object.ReferenceEquals (held, assy) |> shouldEqual true
+
+    /// Two *different* builds can make the identical identity claim — trivially so for unsigned
+    /// assemblies, whose entire identity is `Foo, Version=0.0.0.0, Culture=neutral,
+    /// PublicKeyToken=null`. Silently keeping one and discarding the other would mean resolving
+    /// and executing metadata the caller did not ask for, so this must crash.
+    ///
+    /// A coarser fingerprint than the module version ID (type counts, say) would let exactly this
+    /// case through: both assemblies below define one type.
+    /// Two single-type assemblies with one name and different contents. Both would pass a
+    /// type-count check, which is why the guard fingerprints on MVID.
+    let private conflictingBuildBytes () : (DumpedAssembly * byte[]) * (DumpedAssembly * byte[]) =
+        let corelibReference =
+            TypeIdentityTestHelpers.metadataReferenceFromImage (File.ReadAllBytes corelibPath)
+
+        let compile (source : string) : DumpedAssembly * byte[] =
+            let bytes =
+                TypeIdentityTestHelpers.compileLibrary "Ambiguous" [ corelibReference ] [ source ]
+
+            TypeIdentityTestHelpers.dumpedAssembly None bytes, bytes
+
+        let first = compile "namespace N { public class OnlyType { public int A; } }"
+        let second = compile "namespace N { public class OnlyType { public string B; } }"
+
+        // Same declared identity, same type count, genuinely different builds.
+        (fst second).Name.FullName |> shouldEqual (fst first).Name.FullName
+        (fst second).TypeDefs.Count |> shouldEqual (fst first).TypeDefs.Count
+        (fst second).ModuleVersionId |> shouldNotEqual (fst first).ModuleVersionId
+
+        first, second
+
+    let private conflictingBuilds () : DumpedAssembly * DumpedAssembly =
+        let first, second = conflictingBuildBytes ()
+        fst first, fst second
+
+    let private expectCollisionRejected (act : unit -> unit) : unit =
+        let thrown =
+            try
+                act ()
+                None
+            with e ->
+                Some e.Message
+
+        match thrown with
+        | None -> Assert.Fail "Expected two different builds claiming one identity to be rejected"
+        | Some msg -> msg |> shouldContainText "module version IDs"
+
+    [<Test>]
+    let ``two different builds claiming one identity is a hard error when binding a reference`` () : unit =
+        if references.Value.Length = 0 then
+            Assert.Ignore "No shared-framework assemblies found next to corelib"
+
+        let first, second = conflictingBuilds ()
+        let _, reference = references.Value.[0]
+        let loaded, _ = LoadedAssemblies.empty.WithBoundReference reference first
+
+        expectCollisionRejected (fun () -> loaded.WithBoundReference reference second |> ignore)
+
+    /// Direct registration must enforce the same rule, or it is a way around the guard.
+    [<Test>]
+    let ``two different builds claiming one identity is a hard error when registering directly`` () : unit =
+        let first, second = conflictingBuilds ()
+        let loaded = LoadedAssemblies.empty.WithLoadedAssembly first
+
+        expectCollisionRejected (fun () -> loaded.WithLoadedAssembly second |> ignore)
+        expectCollisionRejected (fun () -> LoadedAssemblies.ofAssemblies [ first ; second ] |> ignore)
+
+    /// ...while staying idempotent for the same build, which is the common case: the entry
+    /// assembly is registered directly and is also discoverable on disk.
+    [<Test>]
+    let ``registering the same build twice is idempotent`` () : unit =
+        let first, _ = conflictingBuilds ()
+
+        let once = LoadedAssemblies.empty.WithLoadedAssembly first
+        let twice = once.WithLoadedAssembly first
+
+        (twice.DefinitionNames |> Seq.length)
+        |> shouldEqual (once.DefinitionNames |> Seq.length)
+
+        match twice.TryByDefinition first.Name with
+        | None -> Assert.Fail "Expected the assembly to remain findable by its definition identity"
+        | Some held -> Object.ReferenceEquals (held, first) |> shouldEqual true
+
+    /// Two distinct reads of one file are byte-identical, so they must be accepted as the same
+    /// assembly — otherwise every entry assembly that is also discoverable on disk would crash.
+    [<Test>]
+    let ``distinct instances of one image compare as the same assembly`` () : unit =
+        if pool.Value.Length = 0 then
+            Assert.Ignore "No shared-framework assemblies found next to corelib"
+
+        let assy = pool.Value.[0]
+        let reread = readUncached assy.OriginalPath.Value
+
+        Object.ReferenceEquals (reread, assy) |> shouldEqual false
+        assy.HasSameContentAs reread |> shouldEqual true
+
+    /// The MVID is an assertion stamped into the image, not a digest of it: an IL rewriter that
+    /// preserves it, or crafted metadata, gives two different images claiming to be one build.
+    /// Sameness must therefore be decided on content, so that such a pair is still rejected.
+    [<Test>]
+    let ``images sharing an MVID but differing in content are not the same assembly`` () : unit =
+        let (first, _), (second, originalSecondBytes) = conflictingBuildBytes ()
+
+        // Splice `first`'s MVID GUID bytes over `second`'s, leaving the rest of its metadata
+        // alone, to synthesise the MVID collision an equality-on-MVID check would wave through.
+        let secondBytes = Array.copy originalSecondBytes
+        let firstMvid = first.ModuleVersionId.ToByteArray ()
+        let secondMvid = second.ModuleVersionId.ToByteArray ()
+
+        let mvidOffset =
+            let rec find (i : int) =
+                if i + secondMvid.Length > secondBytes.Length then
+                    None
+                elif Span(secondBytes, i, secondMvid.Length).SequenceEqual (Span secondMvid) then
+                    Some i
+                else
+                    find (i + 1)
+
+            find 0
+
+        match mvidOffset with
+        | None -> Assert.Ignore "Could not locate the MVID bytes in the compiled image"
+        | Some offset ->
+            Array.blit firstMvid 0 secondBytes offset firstMvid.Length
+            let spliced = TypeIdentityTestHelpers.dumpedAssembly None secondBytes
+
+            // Same declared identity, and now the same MVID — but different metadata.
+            spliced.Name.FullName |> shouldEqual first.Name.FullName
+            spliced.ModuleVersionId |> shouldEqual first.ModuleVersionId
+            first.HasSameContentAs spliced |> shouldEqual false
+
+            let loaded = LoadedAssemblies.empty.WithLoadedAssembly first
+            expectCollisionRejected (fun () -> loaded.WithLoadedAssembly spliced |> ignore)
+
+    /// IL method bodies live outside the metadata block, and PawPrint reads them through
+    /// `PEReader.GetMethodBody`. Two images can therefore agree on every byte of metadata — same
+    /// MVID, same type and method rows, same signatures — and still execute differently. Comparing
+    /// only metadata would call such a pair the same assembly and silently run the wrong one.
+    [<Test>]
+    let ``images differing only in an IL method body are not the same assembly`` () : unit =
+        let corelibReference =
+            TypeIdentityTestHelpers.metadataReferenceFromImage (File.ReadAllBytes corelibPath)
+
+        // Two constants of equal encoded width, so the two `ldc.i4` bodies are the same length and
+        // the metadata — which records only the body's RVA and size — is unaffected.
+        let compile (returned : string) : byte[] =
+            let source =
+                $"namespace N {{ public static class C {{ public static int M() {{ return %s{returned}; }} }} }}"
+
+            TypeIdentityTestHelpers.compileLibrary "SameMetadata" [ corelibReference ] [ source ]
+
+        let firstBytes = compile "1122867"
+        let secondBytes = compile "1146447" |> Array.copy
+
+        firstBytes.Length |> shouldEqual secondBytes.Length
+
+        let first = TypeIdentityTestHelpers.dumpedAssembly None firstBytes
+        let unspliced = TypeIdentityTestHelpers.dumpedAssembly None secondBytes
+
+        // Roslyn stamps a fresh MVID per build and the MVID lives in metadata, so splice it across
+        // to leave the IL bodies as the only difference between the two images.
+        let firstMvid = first.ModuleVersionId.ToByteArray ()
+        let secondMvid = unspliced.ModuleVersionId.ToByteArray ()
+
+        let mvidOffset =
+            let rec find (i : int) =
+                if i + secondMvid.Length > secondBytes.Length then
+                    None
+                elif Span(secondBytes, i, secondMvid.Length).SequenceEqual (Span secondMvid) then
+                    Some i
+                else
+                    find (i + 1)
+
+            find 0
+
+        match mvidOffset with
+        | None -> Assert.Ignore "Could not locate the MVID bytes in the compiled image"
+        | Some offset ->
+
+        Array.blit firstMvid 0 secondBytes offset firstMvid.Length
+        let second = TypeIdentityTestHelpers.dumpedAssembly None secondBytes
+
+        let metadataOf (assy : DumpedAssembly) : byte array =
+            assy.PeReader.GetMetadata().GetContent () |> Seq.toArray
+
+        // If the compiler varied metadata beyond the MVID, this pair does not isolate an
+        // IL-body-only difference and so cannot make the point.
+        if metadataOf first <> metadataOf second then
+            Assert.Ignore
+                "Compiler produced metadata differing beyond the MVID; cannot isolate an IL-body-only difference."
+
+        // Byte-identical metadata — so a metadata-only comparison would call these the same
+        // assembly — yet the images differ, and they differ precisely in the IL.
+        first.ModuleVersionId |> shouldEqual second.ModuleVersionId
+        firstBytes |> shouldNotEqual secondBytes
+        first.HasSameContentAs second |> shouldEqual false
+
+        let loaded = LoadedAssemblies.empty.WithLoadedAssembly first
+        expectCollisionRejected (fun () -> loaded.WithLoadedAssembly second |> ignore)

--- a/WoofWare.PawPrint.Test/TestLoadedAssemblies.fs
+++ b/WoofWare.PawPrint.Test/TestLoadedAssemblies.fs
@@ -1,5 +1,6 @@
 namespace WoofWare.PawPrint.Test
 
+open System
 open System.IO
 open System.Reflection
 open FsCheck
@@ -20,6 +21,12 @@ module TestLoadedAssemblies =
     let private readAssembly (path : string) : DumpedAssembly =
         let _, loggerFactory = LoggerFactory.makeTest ()
         Assembly.readFile loggerFactory path
+
+    /// Bypasses the process-lifetime parse cache, so this really does produce a fresh instance.
+    let private readUncached (path : string) : DumpedAssembly =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use stream = new MemoryStream (File.ReadAllBytes path)
+        AssemblyApi.read loggerFactory (Some path) stream
 
     /// Real assemblies from the pinned shared framework, which is where genuinely mismatching
     /// (reference, definition) identity pairs actually occur. Synthesising `DumpedAssembly`
@@ -214,10 +221,21 @@ module TestLoadedAssemblies =
         (second.DefinitionNames |> Seq.length)
         |> shouldEqual (first.DefinitionNames |> Seq.length)
 
-        // A freshly-read copy of the same assembly must not displace the instance already held.
-        let reread = readAssembly assy.OriginalPath.Value
+        // A genuinely distinct instance of the same assembly must not displace the one already
+        // held. `Assembly.readFile` memoises by path, so it would hand back a reference-equal
+        // value and never exercise the branch; read uncached to get a real second instance.
+        let reread = readUncached assy.OriginalPath.Value
+        Object.ReferenceEquals (reread, assy) |> shouldEqual false
+        reread.Name.FullName |> shouldEqual assy.Name.FullName
+
         let third, canonicalThird = second.WithBoundReference reference reread
-        canonicalThird.Name.FullName |> shouldEqual assy.Name.FullName
+
+        // The instance already held wins: exactly one DumpedAssembly per definition identity.
+        Object.ReferenceEquals (canonicalThird, assy) |> shouldEqual true
 
         (third.DefinitionNames |> Seq.length)
         |> shouldEqual (second.DefinitionNames |> Seq.length)
+
+        match third.TryByDefinition assy.Name with
+        | None -> Assert.Fail "Expected the assembly to remain findable by its definition identity"
+        | Some held -> Object.ReferenceEquals (held, assy) |> shouldEqual true

--- a/WoofWare.PawPrint.Test/TestLoadedAssemblies.fs
+++ b/WoofWare.PawPrint.Test/TestLoadedAssemblies.fs
@@ -1,0 +1,223 @@
+namespace WoofWare.PawPrint.Test
+
+open System.IO
+open System.Reflection
+open FsCheck
+open FsCheck.FSharp
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+/// `LoadedAssemblies` is the one place that knows an assembly's definition identity is not its
+/// reference identity. These tests pin its laws directly, so the whole class of ref/def confusion
+/// is covered rather than the single facade chain that happened to be reported.
+[<TestFixture>]
+module TestLoadedAssemblies =
+
+    let private corelibPath : string = typeof<obj>.Assembly.Location
+    let private runtimeDir : string = Path.GetDirectoryName corelibPath
+
+    let private readAssembly (path : string) : DumpedAssembly =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        Assembly.readFile loggerFactory path
+
+    /// Real assemblies from the pinned shared framework, which is where genuinely mismatching
+    /// (reference, definition) identity pairs actually occur. Synthesising `DumpedAssembly`
+    /// values is not practical, so the generator draws from this pool.
+    let private pool : DumpedAssembly array Lazy =
+        System.Lazy<_>
+            .Create (fun () ->
+                [|
+                    "System.Private.CoreLib"
+                    "mscorlib"
+                    "System"
+                    "System.Runtime"
+                    "netstandard"
+                    "System.Console"
+                    "System.Collections"
+                |]
+                |> Array.choose (fun name ->
+                    let path = Path.Combine (runtimeDir, name + ".dll")
+                    if File.Exists path then Some (readAssembly path) else None
+                )
+            )
+
+    /// Every AssemblyReference declared by anything in the pool. This is the only honest source of
+    /// reference identities: half of these disagree with their referent's definition identity.
+    let private references : (DumpedAssembly * AssemblyReference) array Lazy =
+        System.Lazy<_>
+            .Create (fun () ->
+                pool.Value
+                |> Array.collect (fun assy ->
+                    assy.AssemblyReferences.Values |> Seq.map (fun r -> assy, r) |> Seq.toArray
+                )
+            )
+
+    /// The operations that can be performed on a load context.
+    type private Op =
+        /// Register this pool assembly under its own definition identity.
+        | Load of int
+        /// Bind reference `refIndex` to pool assembly `assyIndex`.
+        | Bind of refIndex : int * assyIndex : int
+
+    /// Reference implementation: an association list of definition identity -> assembly (first
+    /// write wins), and one of reference identity -> definition identity (last write wins). Kept
+    /// deliberately naive so it is obviously correct by inspection.
+    type private Model =
+        {
+            ByDefinition : (string * DumpedAssembly) list
+            Bindings : (string * string) list
+        }
+
+    let private modelEmpty =
+        {
+            ByDefinition = []
+            Bindings = []
+        }
+
+    let private modelLoad (assy : DumpedAssembly) (m : Model) : Model =
+        if m.ByDefinition |> List.exists (fun (k, _) -> k = assy.Name.FullName) then
+            m
+        else
+            { m with
+                ByDefinition = m.ByDefinition @ [ assy.Name.FullName, assy ]
+            }
+
+    let private modelBind (reference : AssemblyReference) (assy : DumpedAssembly) (m : Model) : Model =
+        let m = modelLoad assy m
+
+        { m with
+            Bindings =
+                (m.Bindings |> List.filter (fun (k, _) -> k <> reference.Name.FullName))
+                @ [ reference.Name.FullName, assy.Name.FullName ]
+        }
+
+    let private modelResolveReference (reference : AssemblyReference) (m : Model) : DumpedAssembly option =
+        let byDefinition (name : string) =
+            m.ByDefinition |> List.tryPick (fun (k, v) -> if k = name then Some v else None)
+
+        match
+            m.Bindings
+            |> List.tryPick (fun (k, v) -> if k = reference.Name.FullName then Some v else None)
+        with
+        | Some definitionName -> byDefinition definitionName
+        | None -> byDefinition reference.Name.FullName
+
+    let private opsGen : Gen<Op list> =
+        gen {
+            let assemblyCount = pool.Value.Length
+            let referenceCount = references.Value.Length
+
+            return!
+                Gen.listOf (
+                    Gen.oneof
+                        [
+                            Gen.choose (0, assemblyCount - 1) |> Gen.map Op.Load
+                            Gen.zip (Gen.choose (0, referenceCount - 1)) (Gen.choose (0, assemblyCount - 1))
+                            |> Gen.map Op.Bind
+                        ]
+                )
+        }
+
+    /// The invariant the fix exists to guarantee, checked after every single operation.
+    let private assertEveryAssemblyFindableByItsOwnName (real : LoadedAssemblies) (model : Model) : unit =
+        for _, assy in model.ByDefinition do
+            match real.TryByDefinition assy.Name with
+            | None ->
+                Assert.Fail
+                    $"Assembly %s{assy.Name.FullName} is in the load context but is not findable by its own definition identity"
+            | Some found -> found.Name.FullName |> shouldEqual assy.Name.FullName
+
+    [<Test>]
+    let ``LoadedAssemblies agrees with a naive reference implementation`` () : unit =
+        if pool.Value.Length = 0 then
+            Assert.Ignore "No shared-framework assemblies found next to corelib"
+
+        let property (ops : Op list) : bool =
+            let mutable real = LoadedAssemblies.empty
+            let mutable model = modelEmpty
+
+            for op in ops do
+                match op with
+                | Op.Load i ->
+                    let assy = pool.Value.[i]
+                    real <- real.WithLoadedAssembly assy
+                    model <- modelLoad assy model
+                | Op.Bind (refIndex, assyIndex) ->
+                    let _, reference = references.Value.[refIndex]
+                    let assy = pool.Value.[assyIndex]
+                    let next, canonical = real.WithBoundReference reference assy
+                    real <- next
+                    model <- modelBind reference assy model
+
+                    // WithBoundReference must hand back the instance the context actually holds.
+                    canonical.Name.FullName |> shouldEqual assy.Name.FullName
+
+                assertEveryAssemblyFindableByItsOwnName real model
+
+            // Definition-identity lookups agree.
+            for assy in pool.Value do
+                let expected =
+                    model.ByDefinition
+                    |> List.tryPick (fun (k, v) -> if k = assy.Name.FullName then Some v else None)
+
+                (real.TryByDefinition assy.Name |> Option.isSome)
+                |> shouldEqual (expected |> Option.isSome)
+
+            // Reference lookups agree, including the exact-identity fallback.
+            for _, reference in references.Value do
+                let expected = modelResolveReference reference model
+                let actual = real.TryResolveReference reference
+
+                match expected, actual with
+                | None, None -> ()
+                | Some e, Some a -> a.Name.FullName |> shouldEqual e.Name.FullName
+                | _ ->
+                    Assert.Fail
+                        $"Disagreement resolving reference %s{reference.Name.FullName}: model %b{expected.IsSome}, real %b{actual.IsSome}"
+
+            true
+
+        Prop.forAll (Arb.fromGen opsGen) property |> Check.QuickThrowOnFailure
+
+    /// Loading an assembly is idempotent, and never displaces what is already there.
+    [<Test>]
+    let ``WithLoadedAssembly is idempotent`` () : unit =
+        if pool.Value.Length = 0 then
+            Assert.Ignore "No shared-framework assemblies found next to corelib"
+
+        let assy = pool.Value.[0]
+        let once = LoadedAssemblies.empty.WithLoadedAssembly assy
+        let twice = once.WithLoadedAssembly assy
+
+        (twice.DefinitionNames |> Seq.length)
+        |> shouldEqual (once.DefinitionNames |> Seq.length)
+
+        twice.ContainsDefinition assy.Name |> shouldEqual true
+
+    /// Binding the same reference to the same assembly twice changes nothing, and a second
+    /// reference to an already-loaded assembly reuses the instance already held.
+    [<Test>]
+    let ``WithBoundReference is idempotent and preserves the canonical instance`` () : unit =
+        if references.Value.Length = 0 then
+            Assert.Ignore "No shared-framework assemblies found next to corelib"
+
+        let _, reference = references.Value.[0]
+        let assy = pool.Value.[0]
+
+        let first, canonicalFirst = LoadedAssemblies.empty.WithBoundReference reference assy
+        let second, canonicalSecond = first.WithBoundReference reference assy
+
+        canonicalFirst.Name.FullName |> shouldEqual assy.Name.FullName
+        canonicalSecond.Name.FullName |> shouldEqual assy.Name.FullName
+
+        (second.DefinitionNames |> Seq.length)
+        |> shouldEqual (first.DefinitionNames |> Seq.length)
+
+        // A freshly-read copy of the same assembly must not displace the instance already held.
+        let reread = readAssembly assy.OriginalPath.Value
+        let third, canonicalThird = second.WithBoundReference reference reread
+        canonicalThird.Name.FullName |> shouldEqual assy.Name.FullName
+
+        (third.DefinitionNames |> Seq.length)
+        |> shouldEqual (second.DefinitionNames |> Seq.length)

--- a/WoofWare.PawPrint.Test/TestLowLevelMonitor.fs
+++ b/WoofWare.PawPrint.Test/TestLowLevelMonitor.fs
@@ -92,8 +92,8 @@ module TestLowLevelMonitor =
     let private baseClassTypes : BaseClassTypes<DumpedAssembly> =
         Corelib.getBaseTypes corelib
 
-    let private loadedAssemblies : ImmutableDictionary<string, DumpedAssembly> =
-        ImmutableDictionary.CreateRange [ KeyValuePair (corelib.Name.FullName, corelib) ]
+    let private loadedAssemblies : LoadedAssemblies =
+        LoadedAssemblies.ofAssemblies [ corelib ]
 
     let private concreteTypes : AllConcreteTypes =
         Corelib.concretizeAll loadedAssemblies baseClassTypes AllConcreteTypes.Empty

--- a/WoofWare.PawPrint.Test/TestManagedHeap.fs
+++ b/WoofWare.PawPrint.Test/TestManagedHeap.fs
@@ -20,8 +20,8 @@ module TestManagedHeap =
     let private baseClassTypes : BaseClassTypes<DumpedAssembly> =
         Corelib.getBaseTypes corelib
 
-    let private loadedAssemblies : ImmutableDictionary<string, DumpedAssembly> =
-        ImmutableDictionary.CreateRange [ KeyValuePair (corelib.Name.FullName, corelib) ]
+    let private loadedAssemblies : LoadedAssemblies =
+        LoadedAssemblies.ofAssemblies [ corelib ]
 
     let private concreteTypes : AllConcreteTypes =
         Corelib.concretizeAll loadedAssemblies baseClassTypes AllConcreteTypes.Empty

--- a/WoofWare.PawPrint.Test/TestManifestResources.fs
+++ b/WoofWare.PawPrint.Test/TestManifestResources.fs
@@ -778,7 +778,7 @@ public static class Entry
 
         let state =
             IlMachineState.initial loggerFactory ImmutableArray.Empty assembly
-            |> fun state -> state.WithLoadedAssembly corelib.Name corelib
+            |> fun state -> state.WithLoadedAssembly corelib
 
         let state, ptr =
             IlMachineState.peByteRangePointer loggerFactory baseClassTypes peByteRange state
@@ -978,8 +978,7 @@ public static class Entry
         use forwardedAssembly =
             global.WoofWare.PawPrint.AssemblyApi.read loggerFactory None forwardedAssemblyStream
 
-        let state =
-            prepared.State.WithLoadedAssembly forwardedAssembly.Name forwardedAssembly
+        let state = prepared.State.WithLoadedAssembly forwardedAssembly
 
         expectFailureContaining
             "assembly-forwarded manifest resource"

--- a/WoofWare.PawPrint.Test/TestMethodHandleRegistry.fs
+++ b/WoofWare.PawPrint.Test/TestMethodHandleRegistry.fs
@@ -36,7 +36,7 @@ module TestMethodHandleRegistry =
             let initialState =
                 IlMachineState.initial loggerFactory ImmutableArray.Empty assembly
 
-            let state = initialState.WithLoadedAssembly corelib.Name corelib
+            let state = initialState.WithLoadedAssembly corelib
 
             { state with
                 ConcreteTypes = Corelib.concretizeAll state._LoadedAssemblies baseClassTypes state.ConcreteTypes

--- a/WoofWare.PawPrint.Test/TestMethodReturnType.fs
+++ b/WoofWare.PawPrint.Test/TestMethodReturnType.fs
@@ -34,7 +34,7 @@ module TestMethodReturnType =
             let initialState =
                 IlMachineState.initial loggerFactory ImmutableArray.Empty assembly
 
-            let state = initialState.WithLoadedAssembly corelib.Name corelib
+            let state = initialState.WithLoadedAssembly corelib
 
             { state with
                 ConcreteTypes = Corelib.concretizeAll state._LoadedAssemblies baseClassTypes state.ConcreteTypes

--- a/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
+++ b/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
@@ -23,8 +23,7 @@ module TestMethodTableProjection =
 
     let private bct : BaseClassTypes<DumpedAssembly> = Corelib.getBaseTypes corelib
 
-    let private loaded : ImmutableDictionary<string, DumpedAssembly> =
-        ImmutableDictionary.CreateRange [ KeyValuePair (corelib.Name.FullName, corelib) ]
+    let private loaded : LoadedAssemblies = LoadedAssemblies.ofAssemblies [ corelib ]
 
     let private concreteTypes : AllConcreteTypes =
         Corelib.concretizeAll loaded bct AllConcreteTypes.Empty
@@ -580,7 +579,7 @@ public unsafe struct PointerWrapper
         =
         let state =
             stateWithLogger loggerFactory
-            |> fun state -> state.WithLoadedAssembly reinterpretWriteAssembly.Name reinterpretWriteAssembly
+            |> fun state -> state.WithLoadedAssembly reinterpretWriteAssembly
 
         let int32Wrapper = reinterpretWriteType "Int32Wrapper"
         let fourBytes = reinterpretWriteType "FourBytes"
@@ -1087,9 +1086,7 @@ public unsafe struct PointerWrapper
         use _loggerFactoryResource = loggerFactory
 
         let state =
-            (stateWithLogger loggerFactory).WithLoadedAssembly
-                openGenericProjectionAssembly.Name
-                openGenericProjectionAssembly
+            (stateWithLogger loggerFactory).WithLoadedAssembly openGenericProjectionAssembly
 
         let target =
             openGenericProjectionType "OpenWithPlainValue`1"
@@ -1112,9 +1109,7 @@ public unsafe struct PointerWrapper
         use _loggerFactoryResource = loggerFactory
 
         let state =
-            (stateWithLogger loggerFactory).WithLoadedAssembly
-                openGenericProjectionAssembly.Name
-                openGenericProjectionAssembly
+            (stateWithLogger loggerFactory).WithLoadedAssembly openGenericProjectionAssembly
 
         let target =
             openGenericProjectionType "OpenWithGenericField`1"
@@ -1132,9 +1127,7 @@ public unsafe struct PointerWrapper
         use _loggerFactoryResource = loggerFactory
 
         let state =
-            (stateWithLogger loggerFactory).WithLoadedAssembly
-                openGenericProjectionAssembly.Name
-                openGenericProjectionAssembly
+            (stateWithLogger loggerFactory).WithLoadedAssembly openGenericProjectionAssembly
 
         let target =
             openGenericProjectionType "OpenDerivedFromBase`1"
@@ -1152,9 +1145,7 @@ public unsafe struct PointerWrapper
         use _loggerFactoryResource = loggerFactory
 
         let state =
-            (stateWithLogger loggerFactory).WithLoadedAssembly
-                openGenericProjectionAssembly.Name
-                openGenericProjectionAssembly
+            (stateWithLogger loggerFactory).WithLoadedAssembly openGenericProjectionAssembly
 
         let target =
             openGenericProjectionType "OpenStruct`1"
@@ -1177,9 +1168,7 @@ public unsafe struct PointerWrapper
         use _loggerFactoryResource = loggerFactory
 
         let state =
-            (stateWithLogger loggerFactory).WithLoadedAssembly
-                openGenericProjectionAssembly.Name
-                openGenericProjectionAssembly
+            (stateWithLogger loggerFactory).WithLoadedAssembly openGenericProjectionAssembly
 
         let target =
             openGenericProjectionType "IOpenInterface`1"

--- a/WoofWare.PawPrint.Test/TestNativeCustomAttribute.fs
+++ b/WoofWare.PawPrint.Test/TestNativeCustomAttribute.fs
@@ -292,7 +292,7 @@ public sealed class CctorAttribute : System.Attribute
             let initialState =
                 IlMachineState.initial loggerFactory ImmutableArray.Empty guestAssembly
 
-            let state = initialState.WithLoadedAssembly corelib.Name corelib
+            let state = initialState.WithLoadedAssembly corelib
 
             { state with
                 ConcreteTypes = Corelib.concretizeAll state._LoadedAssemblies baseClassTypes state.ConcreteTypes

--- a/WoofWare.PawPrint.Test/TestNativeMetadataImport.fs
+++ b/WoofWare.PawPrint.Test/TestNativeMetadataImport.fs
@@ -187,7 +187,7 @@ public class TypesWithMembers
             let initialState =
                 IlMachineState.initial loggerFactory ImmutableArray.Empty assembly
 
-            initialState.WithLoadedAssembly corelib.Name corelib
+            initialState.WithLoadedAssembly corelib
 
         let state =
             (state,

--- a/WoofWare.PawPrint.Test/TestNativeSignature.fs
+++ b/WoofWare.PawPrint.Test/TestNativeSignature.fs
@@ -93,7 +93,7 @@ public sealed class GenericFieldHost<T>
             let initialState =
                 IlMachineState.initial loggerFactory ImmutableArray.Empty assembly
 
-            initialState.WithLoadedAssembly corelib.Name corelib
+            initialState.WithLoadedAssembly corelib
 
         let state : IlMachineState =
             (state,

--- a/WoofWare.PawPrint.Test/TestNullaryIlOp.fs
+++ b/WoofWare.PawPrint.Test/TestNullaryIlOp.fs
@@ -23,8 +23,8 @@ module TestNullaryIlOp =
     let private baseClassTypes : BaseClassTypes<DumpedAssembly> =
         Corelib.getBaseTypes corelib
 
-    let private loadedAssemblies : ImmutableDictionary<string, DumpedAssembly> =
-        ImmutableDictionary.CreateRange [ KeyValuePair (corelib.Name.FullName, corelib) ]
+    let private loadedAssemblies : LoadedAssemblies =
+        LoadedAssemblies.ofAssemblies [ corelib ]
 
     let private concreteTypes : AllConcreteTypes =
         Corelib.concretizeAll loadedAssemblies baseClassTypes AllConcreteTypes.Empty

--- a/WoofWare.PawPrint.Test/TestSharedFrameworkForwardSweep.fs
+++ b/WoofWare.PawPrint.Test/TestSharedFrameworkForwardSweep.fs
@@ -1,0 +1,119 @@
+namespace WoofWare.PawPrint.Test
+
+open System
+open System.Collections.Immutable
+open System.IO
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+/// The reported crash was one hand-picked chain (`mscorlib` forwarding
+/// `System.Security.AccessControl.FileSystemRights` to `System.IO.FileSystem.AccessControl`).
+/// Hand-picking chains does not tell us whether the *class* of bug is gone, so this sweeps every
+/// type-forward declared by the .NET Framework compatibility facades in the real pinned shared
+/// framework and asserts that resolving it lands somewhere findable by its definition identity.
+///
+/// Those facades are where reference and definition identities actually disagree: they name their
+/// implementation assemblies as `Version=0.0.0.0`. If the load context is ever keyed by reference
+/// identity again, this fails in bulk rather than waiting for a user report.
+[<TestFixture>]
+module TestSharedFrameworkForwardSweep =
+
+    let private corelibPath : string = typeof<obj>.Assembly.Location
+    let private runtimeDir : string = Path.GetDirectoryName corelibPath
+
+    let private readAssembly (path : string) : DumpedAssembly =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        Assembly.readFile loggerFactory path
+
+    let private loader () : IAssemblyLoad =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        TypeResolution.directoryLoader loggerFactory [ runtimeDir ]
+
+    /// The .NET Framework compatibility facades. These are the assemblies whose AssemblyReferences
+    /// carry `Version=0.0.0.0`, and they are almost entirely type-forwards.
+    let private facadeNames =
+        [
+            "mscorlib"
+            "System"
+            "System.Core"
+            "System.Xml"
+            "System.Xml.Linq"
+            "System.Transactions"
+            "System.Web"
+        ]
+
+    let facades : string list =
+        facadeNames
+        |> List.filter (fun n -> File.Exists (Path.Combine (runtimeDir, n + ".dll")))
+
+    [<TestCaseSource(nameof facades)>]
+    let ``every type forwarded by a facade resolves to a findable assembly`` (facadeName : string) : unit =
+        let corelib = readAssembly corelibPath
+        let facade = readAssembly (Path.Combine (runtimeDir, facadeName + ".dll"))
+        let loadAssembly = loader ()
+
+        let mutable loaded = LoadedAssemblies.ofAssemblies [ corelib ; facade ]
+        let mutable resolvedCount = 0
+        let failures = ResizeArray<string> ()
+
+        // Only top-level forwards: nested ones are reached through their parent, which this
+        // already covers, and `TryGetTopLevelExportedType` is the entry point resolution uses.
+        let topLevelForwards =
+            facade.ExportedTypes.Values
+            |> Seq.filter (fun e ->
+                match e.Data with
+                | ExportedTypeData.ForwardsTo _ -> true
+                | ExportedTypeData.ParentExportedType _
+                | ExportedTypeData.AssemblyFile _ -> false
+            )
+            |> Seq.toList
+
+        if topLevelForwards.IsEmpty then
+            Assert.Ignore $"%s{facadeName} declares no top-level type forwards"
+
+        for exported in topLevelForwards do
+            let ns = exported.Namespace |> Option.defaultValue "<global>"
+            let describe = $"%s{ns}.%s{exported.Name} (forwarded by %s{facadeName})"
+
+            try
+                // Resolve exactly as production does, loading on demand.
+                let rec go (assemblies : LoadedAssemblies) (fuel : int) =
+                    if fuel <= 0 then
+                        failwith "resolution did not converge"
+                    else
+
+                    match Assembly.resolveTypeFromExport facade assemblies ImmutableArray.Empty exported with
+                    | TypeResolutionResult.FirstLoadAssy assyRef ->
+                        let handle, referencedIn = assyRef.Handle
+                        let assemblies, _ = loadAssembly.LoadAssembly assemblies referencedIn handle
+                        go (LoadedAssemblies.assertReferenceBound describe assyRef assemblies) (fuel - 1)
+                    | TypeResolutionResult.Resolved (targetAssembly, identity, _) ->
+                        assemblies, targetAssembly, identity
+
+                let next, targetAssembly, identity = go loaded 16
+                loaded <- next
+                resolvedCount <- resolvedCount + 1
+
+                // The load context must be able to find the assembly the identity names. This is
+                // precisely what `ensureTypeDefinitionBaseAssembliesLoaded` and
+                // `concretizeTypeDefinition` do, and precisely what used to throw.
+                if not (loaded.ContainsDefinition targetAssembly.Name) then
+                    failures.Add
+                        $"%s{describe}: resolved into %s{targetAssembly.Name.FullName}, which is not findable by its definition identity"
+                elif loaded.TryByDefinitionName identity.AssemblyFullName |> Option.isNone then
+                    failures.Add
+                        $"%s{describe}: identity names %s{identity.AssemblyFullName}, which is not in the load context"
+            with e ->
+                // Unimplemented corners of the metadata surface (e.g. AssemblyFile exports) are
+                // not what this test is about; only identity-lookup failures are.
+                if e.Message.Contains "not loaded" || e :? Collections.Generic.KeyNotFoundException then
+                    failures.Add $"%s{describe}: %s{e.Message}"
+
+        if failures.Count > 0 then
+            let sample = failures |> Seq.truncate 10 |> String.concat "\n  "
+
+            Assert.Fail
+                $"%d{failures.Count} of %d{topLevelForwards.Length} forwards from %s{facadeName} failed identity lookup:\n  %s{sample}"
+
+        resolvedCount |> shouldBeGreaterThan 0

--- a/WoofWare.PawPrint.Test/TestSharedFrameworkForwardSweep.fs
+++ b/WoofWare.PawPrint.Test/TestSharedFrameworkForwardSweep.fs
@@ -59,18 +59,35 @@ module TestSharedFrameworkForwardSweep =
 
         // Only top-level forwards: nested ones are reached through their parent, which this
         // already covers, and `TryGetTopLevelExportedType` is the entry point resolution uses.
-        let topLevelForwards =
+        //
+        // Some facades forward to assemblies that are not part of the shared framework at all
+        // (System.Transactions forwards two types to System.Security.Permissions, which ships as a
+        // separate NuGet package). "The target is not installed" is a different fact from "we
+        // loaded it and then could not find it", and only the latter is what this sweep is about.
+        // The split is made structurally, on whether the target DLL exists, rather than by matching
+        // exception text — a text filter here would hide the very regression we are looking for.
+        let allForwards, skippedForMissingTarget =
             facade.ExportedTypes.Values
-            |> Seq.filter (fun e ->
+            |> Seq.choose (fun e ->
                 match e.Data with
-                | ExportedTypeData.ForwardsTo _ -> true
+                | ExportedTypeData.ForwardsTo assyRefHandle ->
+                    let target = facade.AssemblyReferences.[assyRefHandle]
+                    Some (e, File.Exists (Path.Combine (runtimeDir, target.Name.Name + ".dll")))
                 | ExportedTypeData.ParentExportedType _
-                | ExportedTypeData.AssemblyFile _ -> false
+                | ExportedTypeData.AssemblyFile _ -> None
             )
             |> Seq.toList
+            |> List.partition snd
+            |> fun (present, absent) -> present |> List.map fst, absent |> List.map fst
+
+        if not skippedForMissingTarget.IsEmpty then
+            TestContext.Progress.WriteLine
+                $"%s{facadeName}: skipping %d{skippedForMissingTarget.Length} forwards whose target assembly is not present in the shared framework"
+
+        let topLevelForwards = allForwards
 
         if topLevelForwards.IsEmpty then
-            Assert.Ignore $"%s{facadeName} declares no top-level type forwards"
+            Assert.Ignore $"%s{facadeName} declares no top-level type forwards with a resolvable target"
 
         for exported in topLevelForwards do
             let ns = exported.Namespace |> Option.defaultValue "<global>"
@@ -105,10 +122,11 @@ module TestSharedFrameworkForwardSweep =
                     failures.Add
                         $"%s{describe}: identity names %s{identity.AssemblyFullName}, which is not in the load context"
             with e ->
-                // Unimplemented corners of the metadata surface (e.g. AssemblyFile exports) are
-                // not what this test is about; only identity-lookup failures are.
-                if e.Message.Contains "not loaded" || e :? Collections.Generic.KeyNotFoundException then
-                    failures.Add $"%s{describe}: %s{e.Message}"
+                // Every exception is a failure. An earlier version filtered on the message text,
+                // which silently swallowed the exact regression this sweep exists to catch:
+                // `assertReferenceBound` says "still not bound", not "not loaded". A filter here
+                // can only ever hide the thing we are looking for.
+                failures.Add $"%s{describe}: %s{e.GetType().Name}: %s{e.Message}"
 
         if failures.Count > 0 then
             let sample = failures |> Seq.truncate 10 |> String.concat "\n  "
@@ -116,4 +134,5 @@ module TestSharedFrameworkForwardSweep =
             Assert.Fail
                 $"%d{failures.Count} of %d{topLevelForwards.Length} forwards from %s{facadeName} failed identity lookup:\n  %s{sample}"
 
-        resolvedCount |> shouldBeGreaterThan 0
+        // Every forward must have resolved, not merely "at least one".
+        resolvedCount |> shouldEqual topLevelForwards.Length

--- a/WoofWare.PawPrint.Test/TestSignalDispatch.fs
+++ b/WoofWare.PawPrint.Test/TestSignalDispatch.fs
@@ -36,10 +36,7 @@ module TestSignalDispatch =
         Corelib.getBaseTypes corelib
 
     let private concreteTypes : AllConcreteTypes =
-        Corelib.concretizeAll
-            (ImmutableDictionary<string, DumpedAssembly>.Empty.Add (corelib.Name.FullName, corelib))
-            baseClassTypes
-            AllConcreteTypes.Empty
+        Corelib.concretizeAll (LoadedAssemblies.ofAssemblies [ corelib ]) baseClassTypes AllConcreteTypes.Empty
 
     let private baseState () : IlMachineState =
         let _, loggerFactory = LoggerFactory.makeTest ()

--- a/WoofWare.PawPrint.Test/TestSignalHandler.fs
+++ b/WoofWare.PawPrint.Test/TestSignalHandler.fs
@@ -29,8 +29,8 @@ module TestSignalHandler =
     let private baseClassTypes : BaseClassTypes<DumpedAssembly> =
         Corelib.getBaseTypes corelib
 
-    let private loadedAssemblies : ImmutableDictionary<string, DumpedAssembly> =
-        ImmutableDictionary<string, DumpedAssembly>.Empty.Add (corelib.Name.FullName, corelib)
+    let private loadedAssemblies : LoadedAssemblies =
+        LoadedAssemblies.ofAssemblies [ corelib ]
 
     let private concreteTypes : AllConcreteTypes =
         Corelib.concretizeAll loadedAssemblies baseClassTypes AllConcreteTypes.Empty

--- a/WoofWare.PawPrint.Test/TestSwitchIlOp.fs
+++ b/WoofWare.PawPrint.Test/TestSwitchIlOp.fs
@@ -21,8 +21,8 @@ module TestSwitchIlOp =
     let private baseClassTypes : BaseClassTypes<DumpedAssembly> =
         Corelib.getBaseTypes corelib
 
-    let private loadedAssemblies : ImmutableDictionary<string, DumpedAssembly> =
-        ImmutableDictionary.CreateRange [ KeyValuePair (corelib.Name.FullName, corelib) ]
+    let private loadedAssemblies : LoadedAssemblies =
+        LoadedAssemblies.ofAssemblies [ corelib ]
 
     let private concreteTypes : AllConcreteTypes =
         Corelib.concretizeAll loadedAssemblies baseClassTypes AllConcreteTypes.Empty

--- a/WoofWare.PawPrint.Test/TestSyncBlockMonitor.fs
+++ b/WoofWare.PawPrint.Test/TestSyncBlockMonitor.fs
@@ -161,8 +161,8 @@ module TestSyncBlockMonitor =
     let private baseClassTypes : BaseClassTypes<DumpedAssembly> =
         Corelib.getBaseTypes corelib
 
-    let private loadedAssemblies : ImmutableDictionary<string, DumpedAssembly> =
-        ImmutableDictionary.CreateRange [ KeyValuePair (corelib.Name.FullName, corelib) ]
+    let private loadedAssemblies : LoadedAssemblies =
+        LoadedAssemblies.ofAssemblies [ corelib ]
 
     let private concreteTypes : AllConcreteTypes =
         Corelib.concretizeAll loadedAssemblies baseClassTypes AllConcreteTypes.Empty

--- a/WoofWare.PawPrint.Test/TestSzArrayInterfaceDispatch.fs
+++ b/WoofWare.PawPrint.Test/TestSzArrayInterfaceDispatch.fs
@@ -29,8 +29,7 @@ module TestSzArrayInterfaceDispatch =
 
     let private bct : BaseClassTypes<DumpedAssembly> = Corelib.getBaseTypes corelib
 
-    let private loaded : ImmutableDictionary<string, DumpedAssembly> =
-        ImmutableDictionary.CreateRange [ KeyValuePair (corelib.Name.FullName, corelib) ]
+    let private loaded : LoadedAssemblies = LoadedAssemblies.ofAssemblies [ corelib ]
 
     let private concreteTypes : AllConcreteTypes =
         Corelib.concretizeAll loaded bct AllConcreteTypes.Empty

--- a/WoofWare.PawPrint.Test/TestTypeIdentityProperties.fs
+++ b/WoofWare.PawPrint.Test/TestTypeIdentityProperties.fs
@@ -17,7 +17,7 @@ module TestTypeIdentityProperties =
         {
             TargetAssembly : DumpedAssembly
             ConsumerAssembly : DumpedAssembly
-            LoadedAssemblies : ImmutableDictionary<string, DumpedAssembly>
+            LoadedAssemblies : LoadedAssemblies
             TargetRef : TypeRef
             TargetPath : TypePath
         }

--- a/WoofWare.PawPrint.Test/TestUnaryConstIlOp.fs
+++ b/WoofWare.PawPrint.Test/TestUnaryConstIlOp.fs
@@ -22,8 +22,8 @@ module TestUnaryConstIlOp =
     let private baseClassTypes : BaseClassTypes<DumpedAssembly> =
         Corelib.getBaseTypes corelib
 
-    let private loadedAssemblies : ImmutableDictionary<string, DumpedAssembly> =
-        ImmutableDictionary.CreateRange [ KeyValuePair (corelib.Name.FullName, corelib) ]
+    let private loadedAssemblies : LoadedAssemblies =
+        LoadedAssemblies.ofAssemblies [ corelib ]
 
     let private concreteTypes : AllConcreteTypes =
         Corelib.concretizeAll loadedAssemblies baseClassTypes AllConcreteTypes.Empty

--- a/WoofWare.PawPrint.Test/TestUnaryMetadataIlOp.fs
+++ b/WoofWare.PawPrint.Test/TestUnaryMetadataIlOp.fs
@@ -19,8 +19,8 @@ module TestUnaryMetadataIlOp =
     let private baseClassTypes : BaseClassTypes<DumpedAssembly> =
         Corelib.getBaseTypes corelib
 
-    let private loadedAssemblies : ImmutableDictionary<string, DumpedAssembly> =
-        ImmutableDictionary.CreateRange [ KeyValuePair (corelib.Name.FullName, corelib) ]
+    let private loadedAssemblies : LoadedAssemblies =
+        LoadedAssemblies.ofAssemblies [ corelib ]
 
     let private concreteTypes : AllConcreteTypes =
         Corelib.concretizeAll loadedAssemblies baseClassTypes AllConcreteTypes.Empty

--- a/WoofWare.PawPrint.Test/TestZeroOfBaseAssemblies.fs
+++ b/WoofWare.PawPrint.Test/TestZeroOfBaseAssemblies.fs
@@ -69,41 +69,12 @@ module TestZeroOfBaseAssemblies =
         let _, loggerFactory = LoggerFactory.makeTest ()
         Assembly.readFile loggerFactory path
 
-    /// An IAssemblyLoad that resolves references by searching a set of
-    /// directories on disk for a DLL matching the referenced assembly's
-    /// simple name (`Foo` → `Foo.dll`). All BCL/facade assemblies live next
-    /// to System.Private.CoreLib, so a single directory lookup suffices for
-    /// this test's needs.
-    type private OnDemandAssemblyLoad (searchDirs : string list) =
-        interface IAssemblyLoad with
-            member _.LoadAssembly
-                (loadedAssemblies : ImmutableDictionary<string, DumpedAssembly>)
-                (referencedIn : AssemblyName)
-                (handle : AssemblyReferenceHandle)
-                : ImmutableDictionary<string, DumpedAssembly> * DumpedAssembly
-                =
-                let referencedInAssembly =
-                    match loadedAssemblies.TryGetValue referencedIn.FullName with
-                    | false, _ -> failwithf $"Missing loaded assembly %s{referencedIn.FullName}"
-                    | true, assy -> assy
-
-                let assemblyRef = referencedInAssembly.AssemblyReferences.[handle]
-
-                match loadedAssemblies.TryGetValue assemblyRef.Name.FullName with
-                | true, assy -> loadedAssemblies, assy
-                | false, _ ->
-                    let path =
-                        searchDirs
-                        |> List.tryPick (fun dir ->
-                            let candidate = Path.Combine (dir, assemblyRef.Name.Name + ".dll")
-                            if File.Exists candidate then Some candidate else None
-                        )
-                        |> Option.defaultWith (fun () ->
-                            failwithf $"Test setup could not locate assembly %s{assemblyRef.Name.FullName} on disk"
-                        )
-
-                    let dumped = readAssembly path
-                    loadedAssemblies.SetItem (dumped.Name.FullName, dumped), dumped
+    /// The production loader, pointed at a set of directories on disk. Deliberately not a
+    /// hand-rolled fake: the ref-vs-def keying bug was invisible to this suite for exactly as
+    /// long as the test fake keyed its dictionary differently from production.
+    let private onDemandAssemblyLoad (searchDirs : string seq) : IAssemblyLoad =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        TypeResolution.directoryLoader loggerFactory searchDirs
 
     /// Look up FSharpValueOption`1 in the netstandard2.1 build of FSharp.Core.
     let private getValueOptionTypeDef (fsharpCore : DumpedAssembly) : TypeInfo<GenericParamFromMetadata, TypeDefn> =
@@ -128,16 +99,16 @@ module TestZeroOfBaseAssemblies =
         // Prime loadedAssemblies with corelib + FSharp.Core (netstandard2.1),
         // but NOT netstandard itself — that's the facade FSharp.Core's base
         // TypeRefs point at.
-        let loaded : ImmutableDictionary<string, DumpedAssembly> =
-            [ corelib ; fsharpCore ]
-            |> Seq.map (fun a -> System.Collections.Generic.KeyValuePair (a.Name.FullName, a))
-            |> ImmutableDictionary.CreateRange
+        let loaded : LoadedAssemblies =
+            LoadedAssemblies.ofAssemblies [ corelib ; fsharpCore ]
 
-        loaded.ContainsKey "netstandard, Version=2.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51"
+        loaded.ContainsDefinition (
+            AssemblyName "netstandard, Version=2.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51"
+        )
         |> shouldEqual false
 
         assertNetstandardAvailable ()
-        let loadAssembly = OnDemandAssemblyLoad [ runtimeDir ]
+        let loadAssembly = onDemandAssemblyLoad [ runtimeDir ]
 
         // Concretize FSharpValueOption<int>. Concretization itself does not walk
         // base types, so it should not trigger a netstandard load.
@@ -165,7 +136,7 @@ module TestZeroOfBaseAssemblies =
         let handle, concretizeCtx =
             TypeConcretization.concretizeType
                 concretizeCtx
-                (loadAssembly :> IAssemblyLoad)
+                loadAssembly
                 fsharpCore.Name
                 ImmutableArray.Empty
                 ImmutableArray.Empty
@@ -173,7 +144,7 @@ module TestZeroOfBaseAssemblies =
 
         // Sanity: concretization itself did not need netstandard.
         let netstandardLoadedAfterConcretize =
-            concretizeCtx.LoadedAssemblies.Keys
+            concretizeCtx.LoadedAssemblies.DefinitionNames
             |> Seq.exists (fun (n : string) -> n.StartsWith ("netstandard,", StringComparison.OrdinalIgnoreCase))
 
         netstandardLoadedAfterConcretize |> shouldEqual false
@@ -200,7 +171,7 @@ module TestZeroOfBaseAssemblies =
 
         let loadedAfterHelper, _ =
             Concretization.ensureBaseAssembliesLoadedForConcreteHandle
-                (loadAssembly :> IAssemblyLoad)
+                loadAssembly
                 baseTypes
                 visited
                 concretizeCtx.LoadedAssemblies
@@ -208,7 +179,7 @@ module TestZeroOfBaseAssemblies =
                 handle
 
         // netstandard is now loaded.
-        loadedAfterHelper.Keys
+        loadedAfterHelper.DefinitionNames
         |> Seq.exists (fun (n : string) -> n.StartsWith ("netstandard,", StringComparison.OrdinalIgnoreCase))
         |> shouldEqual true
 
@@ -222,13 +193,11 @@ module TestZeroOfBaseAssemblies =
         let fsharpCore = readAssembly fsharpCoreNetstandard21Path.Value
         let baseTypes = Corelib.getBaseTypes corelib
 
-        let loaded : ImmutableDictionary<string, DumpedAssembly> =
-            [ corelib ; fsharpCore ]
-            |> Seq.map (fun a -> System.Collections.Generic.KeyValuePair (a.Name.FullName, a))
-            |> ImmutableDictionary.CreateRange
+        let loaded : LoadedAssemblies =
+            LoadedAssemblies.ofAssemblies [ corelib ; fsharpCore ]
 
         assertNetstandardAvailable ()
-        let loadAssembly = OnDemandAssemblyLoad [ runtimeDir ]
+        let loadAssembly = onDemandAssemblyLoad [ runtimeDir ]
 
         let concretizeCtx : TypeConcretization.ConcretizationContext<DumpedAssembly> =
             {
@@ -248,7 +217,7 @@ module TestZeroOfBaseAssemblies =
         let handle, concretizeCtx =
             TypeConcretization.concretizeType
                 concretizeCtx
-                (loadAssembly :> IAssemblyLoad)
+                loadAssembly
                 fsharpCore.Name
                 ImmutableArray.Empty
                 ImmutableArray.Empty
@@ -262,7 +231,7 @@ module TestZeroOfBaseAssemblies =
         // idempotence guarantee.
         let firstRun, firstCtx =
             Concretization.ensureBaseAssembliesLoadedForConcreteHandle
-                (loadAssembly :> IAssemblyLoad)
+                loadAssembly
                 baseTypes
                 (System.Collections.Generic.HashSet ())
                 concretizeCtx.LoadedAssemblies
@@ -271,14 +240,15 @@ module TestZeroOfBaseAssemblies =
 
         let secondRun, _ =
             Concretization.ensureBaseAssembliesLoadedForConcreteHandle
-                (loadAssembly :> IAssemblyLoad)
+                loadAssembly
                 baseTypes
                 (System.Collections.Generic.HashSet ())
                 firstRun
                 firstCtx
                 handle
 
-        secondRun.Count |> shouldEqual firstRun.Count
+        (secondRun.DefinitionNames |> Seq.length)
+        |> shouldEqual (firstRun.DefinitionNames |> Seq.length)
 
     [<Test>]
     let ``helper recurses into instance fields of value types`` () : unit =
@@ -318,14 +288,12 @@ public struct Outer
             use stream = new MemoryStream (outerAssemblyBytes)
             AssemblyApi.read loggerFactory None stream
 
-        let loadAssembly = OnDemandAssemblyLoad [ runtimeDir ]
+        let loadAssembly = onDemandAssemblyLoad [ runtimeDir ]
 
         // Prime with corelib + FSharp.Core + the wrapper. Deliberately leave
         // netstandard out; the wrapper's own base chain doesn't need it.
-        let loaded : ImmutableDictionary<string, DumpedAssembly> =
-            [ corelib ; fsharpCore ; outerAssembly ]
-            |> Seq.map (fun a -> System.Collections.Generic.KeyValuePair (a.Name.FullName, a))
-            |> ImmutableDictionary.CreateRange
+        let loaded : LoadedAssemblies =
+            LoadedAssemblies.ofAssemblies [ corelib ; fsharpCore ; outerAssembly ]
 
         let outerTypeDef =
             outerAssembly.TryGetTopLevelTypeDef "" "Outer"
@@ -341,7 +309,7 @@ public struct Outer
         let outerHandle, concretizeCtx =
             TypeConcretization.concretizeType
                 concretizeCtx
-                (loadAssembly :> IAssemblyLoad)
+                loadAssembly
                 outerAssembly.Name
                 ImmutableArray.Empty
                 ImmutableArray.Empty
@@ -353,12 +321,12 @@ public struct Outer
         // still absent.
         let assembliesAfterOuterBaseChain =
             Concretization.ensureTypeDefinitionBaseAssembliesLoaded
-                (loadAssembly :> IAssemblyLoad)
+                loadAssembly
                 concretizeCtx.LoadedAssemblies
                 outerAssembly.Name
                 outerTypeDef.TypeDefHandle
 
-        assembliesAfterOuterBaseChain.Keys
+        assembliesAfterOuterBaseChain.DefinitionNames
         |> Seq.exists (fun (n : string) -> n.StartsWith ("netstandard,", StringComparison.OrdinalIgnoreCase))
         |> shouldEqual false
 
@@ -367,14 +335,14 @@ public struct Outer
         // finally load netstandard.
         let loadedAfterHelper, _ =
             Concretization.ensureBaseAssembliesLoadedForConcreteHandle
-                (loadAssembly :> IAssemblyLoad)
+                loadAssembly
                 baseTypes
                 (System.Collections.Generic.HashSet ())
                 assembliesAfterOuterBaseChain
                 concretizeCtx.ConcreteTypes
                 outerHandle
 
-        loadedAfterHelper.Keys
+        loadedAfterHelper.DefinitionNames
         |> Seq.exists (fun (n : string) -> n.StartsWith ("netstandard,", StringComparison.OrdinalIgnoreCase))
         |> shouldEqual true
 
@@ -422,12 +390,9 @@ public struct S<T>
             asm.TryGetTopLevelTypeDef "" "S`1"
             |> Option.defaultWith (fun () -> failwith "Failed to find compiled struct S<T>")
 
-        let loaded : ImmutableDictionary<string, DumpedAssembly> =
-            [ corelib ; asm ]
-            |> Seq.map (fun a -> System.Collections.Generic.KeyValuePair (a.Name.FullName, a))
-            |> ImmutableDictionary.CreateRange
+        let loaded : LoadedAssemblies = LoadedAssemblies.ofAssemblies [ corelib ; asm ]
 
-        let loadAssembly = OnDemandAssemblyLoad [ runtimeDir ]
+        let loadAssembly = onDemandAssemblyLoad [ runtimeDir ]
 
         let concretizeCtx : TypeConcretization.ConcretizationContext<DumpedAssembly> =
             {
@@ -445,7 +410,7 @@ public struct S<T>
         let handle, concretizeCtx =
             TypeConcretization.concretizeType
                 concretizeCtx
-                (loadAssembly :> IAssemblyLoad)
+                loadAssembly
                 asm.Name
                 ImmutableArray.Empty
                 ImmutableArray.Empty
@@ -453,7 +418,7 @@ public struct S<T>
 
         // The helper must terminate (i.e. not blow the stack or run forever).
         Concretization.ensureBaseAssembliesLoadedForConcreteHandle
-            (loadAssembly :> IAssemblyLoad)
+            loadAssembly
             baseTypes
             (System.Collections.Generic.HashSet ())
             concretizeCtx.LoadedAssemblies
@@ -487,12 +452,9 @@ public struct S<T>
             asm.TryGetTopLevelTypeDef "" "S`1"
             |> Option.defaultWith (fun () -> failwith "Failed to find compiled struct S<T>")
 
-        let loaded : ImmutableDictionary<string, DumpedAssembly> =
-            [ corelib ; asm ]
-            |> Seq.map (fun a -> System.Collections.Generic.KeyValuePair (a.Name.FullName, a))
-            |> ImmutableDictionary.CreateRange
+        let loaded : LoadedAssemblies = LoadedAssemblies.ofAssemblies [ corelib ; asm ]
 
-        let loadAssembly = OnDemandAssemblyLoad [ runtimeDir ]
+        let loadAssembly = onDemandAssemblyLoad [ runtimeDir ]
 
         let concretizeCtx : TypeConcretization.ConcretizationContext<DumpedAssembly> =
             {
@@ -510,7 +472,7 @@ public struct S<T>
         let handle, concretizeCtx =
             TypeConcretization.concretizeType
                 concretizeCtx
-                (loadAssembly :> IAssemblyLoad)
+                loadAssembly
                 asm.Name
                 ImmutableArray.Empty
                 ImmutableArray.Empty
@@ -518,7 +480,7 @@ public struct S<T>
 
         // Must terminate.
         Concretization.ensureBaseAssembliesLoadedForConcreteHandle
-            (loadAssembly :> IAssemblyLoad)
+            loadAssembly
             baseTypes
             (System.Collections.Generic.HashSet ())
             concretizeCtx.LoadedAssemblies
@@ -561,12 +523,10 @@ public static class C
             |> List.tryFind (fun m -> m.Name = "M")
             |> Option.defaultWith (fun () -> failwith "Failed to find method M<T>")
 
-        let loaded : ImmutableDictionary<string, DumpedAssembly> =
-            [ corelib ; fsharpCore ; asm ]
-            |> Seq.map (fun a -> System.Collections.Generic.KeyValuePair (a.Name.FullName, a))
-            |> ImmutableDictionary.CreateRange
+        let loaded : LoadedAssemblies =
+            LoadedAssemblies.ofAssemblies [ corelib ; fsharpCore ; asm ]
 
-        let loadAssembly = OnDemandAssemblyLoad [ runtimeDir ]
+        let loadAssembly = onDemandAssemblyLoad [ runtimeDir ]
 
         // Concretize FSharpValueOption<int> into the concreteTypes dictionary
         // (still with netstandard not yet loaded), so we can pass its handle as
@@ -590,21 +550,21 @@ public static class C
         let valueOptionHandle, concretizeCtx =
             TypeConcretization.concretizeType
                 concretizeCtx
-                (loadAssembly :> IAssemblyLoad)
+                loadAssembly
                 fsharpCore.Name
                 ImmutableArray.Empty
                 ImmutableArray.Empty
                 valueOptionInt
 
         // Sanity: concretization alone did not need netstandard.
-        concretizeCtx.LoadedAssemblies.Keys
+        concretizeCtx.LoadedAssemblies.DefinitionNames
         |> Seq.exists (fun (n : string) -> n.StartsWith ("netstandard,", StringComparison.OrdinalIgnoreCase))
         |> shouldEqual false
 
         let _, _, loadedAfter =
             Concretization.concretizeMethod
                 concretizeCtx.ConcreteTypes
-                (loadAssembly :> IAssemblyLoad)
+                loadAssembly
                 concretizeCtx.LoadedAssemblies
                 baseTypes
                 mMethod
@@ -614,6 +574,6 @@ public static class C
         // The sweep must have primed the method's generic argument, which
         // means walking FSharpValueOption<int>'s base chain, which means
         // netstandard is now loaded.
-        loadedAfter.Keys
+        loadedAfter.DefinitionNames
         |> Seq.exists (fun (n : string) -> n.StartsWith ("netstandard,", StringComparison.OrdinalIgnoreCase))
         |> shouldEqual true

--- a/WoofWare.PawPrint.Test/TypeIdentityTestHelpers.fs
+++ b/WoofWare.PawPrint.Test/TypeIdentityTestHelpers.fs
@@ -14,22 +14,22 @@ module TypeIdentityTestHelpers =
             member _.LoadAssembly _loadedAssemblies _referencedIn _handle =
                 failwith "Test unexpectedly attempted to load an assembly"
 
-    type RecordingAssemblyLoad (availableAssemblies : ImmutableDictionary<string, DumpedAssembly>) =
+    type RecordingAssemblyLoad (availableAssemblies : LoadedAssemblies) =
         let calls = ResizeArray<string * string> ()
 
         member _.Calls : (string * string) list = calls |> Seq.toList
 
         interface IAssemblyLoad with
             member _.LoadAssembly
-                (loadedAssemblies : ImmutableDictionary<string, DumpedAssembly>)
+                (loadedAssemblies : LoadedAssemblies)
                 (referencedIn : System.Reflection.AssemblyName)
                 (handle : AssemblyReferenceHandle)
-                : ImmutableDictionary<string, DumpedAssembly> * DumpedAssembly
+                : LoadedAssemblies * DumpedAssembly
                 =
                 let referencedInAssembly =
-                    match loadedAssemblies.TryGetValue referencedIn.FullName with
-                    | false, _ -> failwithf "Missing loaded assembly %s" referencedIn.FullName
-                    | true, assy -> assy
+                    match loadedAssemblies.TryByDefinition referencedIn with
+                    | None -> failwithf "Missing loaded assembly %s" referencedIn.FullName
+                    | Some assy -> assy
 
                 let assemblyRef =
                     match referencedInAssembly.AssemblyReferences.TryGetValue handle with
@@ -37,12 +37,14 @@ module TypeIdentityTestHelpers =
                     | true, assyRef -> assyRef
 
                 let targetAssembly =
-                    match availableAssemblies.TryGetValue assemblyRef.Name.FullName with
-                    | false, _ -> failwithf "Missing available assembly %s" assemblyRef.Name.FullName
-                    | true, assy -> assy
+                    match availableAssemblies.TryResolveReference assemblyRef with
+                    | None -> failwithf "Missing available assembly %s" assemblyRef.Name.FullName
+                    | Some assy -> assy
 
                 calls.Add (referencedIn.FullName, targetAssembly.Name.FullName)
-                loadedAssemblies.SetItem (targetAssembly.Name.FullName, targetAssembly), targetAssembly
+                // Same bookkeeping production does: register under the definition identity and
+                // record the binding that got us here.
+                loadedAssemblies.WithBoundReference assemblyRef targetAssembly
 
     // Factory intentionally undisposed: f's return value (e.g. a DumpedAssembly) may close over
     // the factory's sinks, so disposing here would silently drop later log events.
@@ -63,10 +65,8 @@ module TypeIdentityTestHelpers =
 
     let metadataReferenceFromImage (bytes : byte[]) : MetadataReference = MetadataReference.CreateFromImage bytes
 
-    let loadedAssemblies (assemblies : DumpedAssembly list) : ImmutableDictionary<string, DumpedAssembly> =
-        assemblies
-        |> Seq.map (fun assy -> KeyValuePair (assy.Name.FullName, assy))
-        |> ImmutableDictionary.CreateRange
+    let loadedAssemblies (assemblies : DumpedAssembly list) : LoadedAssemblies =
+        LoadedAssemblies.ofAssemblies assemblies
 
     let emptyConcretizationContext
         (assemblies : DumpedAssembly list)

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -56,6 +56,7 @@
     <Compile Include="TestMethodReturnType.fs" />
     <Compile Include="TestFunctionPointerConcretization.fs" />
     <Compile Include="TestZeroOfBaseAssemblies.fs" />
+    <Compile Include="TestAssemblyDictionaryKeying.fs" />
     <Compile Include="TestGenericParamConstraints.fs" />
     <Compile Include="TestGcHandleRegistry.fs" />
     <Compile Include="TestFileDescriptorRegistry.fs" />

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -57,6 +57,8 @@
     <Compile Include="TestFunctionPointerConcretization.fs" />
     <Compile Include="TestZeroOfBaseAssemblies.fs" />
     <Compile Include="TestAssemblyDictionaryKeying.fs" />
+    <Compile Include="TestLoadedAssemblies.fs" />
+    <Compile Include="TestSharedFrameworkForwardSweep.fs" />
     <Compile Include="TestGenericParamConstraints.fs" />
     <Compile Include="TestGcHandleRegistry.fs" />
     <Compile Include="TestFileDescriptorRegistry.fs" />

--- a/WoofWare.PawPrint/CliType.fs
+++ b/WoofWare.PawPrint/CliType.fs
@@ -230,7 +230,7 @@ type CliType =
     /// context is required so descriptors that depend on the field's nominal type can be validated.
     static member TryComputeMarshalSize
         (concreteTypes : AllConcreteTypes)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (corelib : BaseClassTypes<DumpedAssembly>)
         (t : CliType)
         : Result<SizeofResult, MarshalSizeError>
@@ -1169,7 +1169,7 @@ and CliValueType =
     /// `[MarshalAs(ByValTStr)]` on string-typed fields, so we use this as the shape guard.
     static member private IsStringFieldType
         (concreteTypes : AllConcreteTypes)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (corelib : BaseClassTypes<DumpedAssembly>)
         (handle : ConcreteTypeHandle)
         : bool
@@ -1184,7 +1184,7 @@ and CliValueType =
                     && concreteType.Generics.IsEmpty
                 then
                     let typeDef =
-                        assemblies.[concreteType.Assembly.FullName].TypeDefs.[concreteType.Definition.Get]
+                        assemblies.[concreteType.Assembly].TypeDefs.[concreteType.Definition.Get]
 
                     TypeInfo.NominallyEqual typeDef corelib.String
                 else
@@ -1205,7 +1205,7 @@ and CliValueType =
     /// of the OADate native form).
     static member IsHostKnownDateTime
         (concreteTypes : AllConcreteTypes)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (corelib : BaseClassTypes<DumpedAssembly>)
         (vt : CliValueType)
         : bool
@@ -1220,7 +1220,7 @@ and CliValueType =
                     && concreteType.Generics.IsEmpty
                 then
                     let typeDef =
-                        assemblies.[concreteType.Assembly.FullName].TypeDefs.[concreteType.Definition.Get]
+                        assemblies.[concreteType.Assembly].TypeDefs.[concreteType.Definition.Get]
 
                     TypeInfo.NominallyEqual typeDef corelib.DateTime
                 else
@@ -1246,7 +1246,7 @@ and CliValueType =
     /// `wReserved+scale+sign`).
     static member IsHostKnownDecimal
         (concreteTypes : AllConcreteTypes)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (corelib : BaseClassTypes<DumpedAssembly>)
         (vt : CliValueType)
         : bool
@@ -1261,7 +1261,7 @@ and CliValueType =
                     && concreteType.Generics.IsEmpty
                 then
                     let typeDef =
-                        assemblies.[concreteType.Assembly.FullName].TypeDefs.[concreteType.Definition.Get]
+                        assemblies.[concreteType.Assembly].TypeDefs.[concreteType.Definition.Get]
 
                     TypeInfo.NominallyEqual typeDef corelib.Decimal
                 else
@@ -1284,7 +1284,7 @@ and CliValueType =
     /// and callers must classify them through a different path.
     static member IsAutoLayoutHandle
         (concreteTypes : AllConcreteTypes)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (handle : ConcreteTypeHandle)
         : bool
         =
@@ -1293,9 +1293,9 @@ and CliValueType =
             match AllConcreteTypes.lookup handle concreteTypes with
             | None -> false
             | Some concreteType ->
-                match assemblies.TryGetValue concreteType.Assembly.FullName with
-                | false, _ -> false
-                | true, assy ->
+                match assemblies.TryByDefinition concreteType.Assembly with
+                | None -> false
+                | Some assy ->
                     match assy.TypeDefs.TryGetValue concreteType.Definition.Get with
                     | false, _ -> false
                     | true, typeDef ->
@@ -1314,7 +1314,7 @@ and CliValueType =
     /// their dedicated shortcut.
     static member private IsAutoLayout
         (concreteTypes : AllConcreteTypes)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (vt : CliValueType)
         : bool
         =
@@ -1328,7 +1328,7 @@ and CliValueType =
     /// descriptors against the declared field shape (CoreCLR rejects mismatches).
     static member TryFieldMarshalSize
         (concreteTypes : AllConcreteTypes)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (corelib : BaseClassTypes<DumpedAssembly>)
         (charSet : CharSet)
         (descriptor : FieldMarshalDescriptor option)
@@ -1450,7 +1450,7 @@ and CliValueType =
     /// `ByValTStr` requires `System.String`) can be validated.
     static member TryComputeMarshalSize
         (concreteTypes : AllConcreteTypes)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (corelib : BaseClassTypes<DumpedAssembly>)
         (vt : CliValueType)
         : Result<SizeofResult, MarshalSizeError>
@@ -1933,7 +1933,7 @@ module CliType =
 
     let rec zeroOf
         (concreteTypes : AllConcreteTypes)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (corelib : BaseClassTypes<DumpedAssembly>)
         (handle : ConcreteTypeHandle)
         : CliType * AllConcreteTypes
@@ -1942,7 +1942,7 @@ module CliType =
 
     and zeroOfWithVisited
         (concreteTypes : AllConcreteTypes)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (corelib : BaseClassTypes<DumpedAssembly>)
         (handle : ConcreteTypeHandle)
         (visited : Set<ConcreteTypeHandle>)
@@ -1978,7 +1978,7 @@ module CliType =
                 | None -> failwithf "ConcreteTypeHandle %A not found in AllConcreteTypes" handle
 
             // Get the type definition from the assembly
-            let assembly = assemblies.[concreteType.Assembly.FullName]
+            let assembly = assemblies.[concreteType.Assembly]
             let typeDef = assembly.TypeDefs.[concreteType.Definition.Get]
 
             // Check if it's a primitive type by comparing with corelib types FIRST
@@ -2062,7 +2062,7 @@ module CliType =
 
     and private determineZeroForCustomType
         (concreteTypes : AllConcreteTypes)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (corelib : BaseClassTypes<DumpedAssembly>)
         (handle : ConcreteTypeHandle)
         (concreteType : ConcreteType<ConcreteTypeHandle>)
@@ -2117,7 +2117,7 @@ module CliType =
 
     and private concretizeFieldType
         (concreteTypes : AllConcreteTypes)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (assemblies : LoadedAssemblies)
         (corelib : BaseClassTypes<DumpedAssembly>)
         (declaringType : ConcreteType<ConcreteTypeHandle>)
         (fieldType : TypeDefn)
@@ -2135,22 +2135,7 @@ module CliType =
         // The field type might reference generic parameters of the declaring type
         let methodGenerics = ImmutableArray.Empty // Fields don't have method generics
 
-        let loadAssembly =
-            { new IAssemblyLoad with
-                member _.LoadAssembly loaded assyName ref =
-                    match loaded.TryGetValue assyName.FullName with
-                    | true, currentAssy ->
-                        let targetAssyRef = currentAssy.AssemblyReferences.[ref]
-
-                        match loaded.TryGetValue targetAssyRef.Name.FullName with
-                        | true, targetAssy -> loaded, targetAssy
-                        | false, _ ->
-                            failwithf
-                                "Assembly %s not loaded when trying to resolve reference"
-                                targetAssyRef.Name.FullName
-                    | false, _ ->
-                        failwithf "Current assembly %s not loaded when trying to resolve reference" assyName.FullName
-            }
+        let loadAssembly = IAssemblyLoad.alreadyLoadedOnly
 
         let handle, newCtx =
             TypeConcretization.concretizeType

--- a/WoofWare.PawPrint/Corelib.fs
+++ b/WoofWare.PawPrint/Corelib.fs
@@ -205,7 +205,7 @@ module Corelib =
         }
 
     let concretizeAll
-        (loaded : ImmutableDictionary<string, DumpedAssembly>)
+        (loaded : LoadedAssemblies)
         (bct : BaseClassTypes<DumpedAssembly>)
         (t : AllConcreteTypes)
         : AllConcreteTypes
@@ -217,11 +217,7 @@ module Corelib =
                 TypeConcretization.ConcretizationContext.BaseTypes = bct
             }
 
-        let loader =
-            { new IAssemblyLoad with
-                member _.LoadAssembly _ _ _ =
-                    failwith "should have already loaded this assembly"
-            }
+        let loader = IAssemblyLoad.alreadyLoadedOnly
 
         let tys =
             [

--- a/WoofWare.PawPrint/ExceptionDispatching.fs
+++ b/WoofWare.PawPrint/ExceptionDispatching.fs
@@ -520,7 +520,7 @@ module ExceptionDispatching =
                 let typeFullName =
                     match AllConcreteTypes.lookup finishedInitialising state.ConcreteTypes with
                     | Some ct ->
-                        let assy = state._LoadedAssemblies.[ct.Identity.AssemblyFullName]
+                        let assy = state._LoadedAssemblies.ByDefinitionName ct.Identity.AssemblyFullName
                         Assembly.fullName assy ct.Identity
                     | None ->
                         failwith
@@ -927,7 +927,8 @@ module ExceptionDispatching =
             )
 
         let typeInfo =
-            state._LoadedAssemblies.[ct.Identity.AssemblyFullName].TypeDefs.[ct.Identity.TypeDefinition.Get]
+            (state._LoadedAssemblies.ByDefinitionName ct.Identity.AssemblyFullName)
+                .TypeDefs.[ct.Identity.TypeDefinition.Get]
 
         let hresult = hresultForExceptionType baseClassTypes typeInfo
 

--- a/WoofWare.PawPrint/ExecutionConcretization.fs
+++ b/WoofWare.PawPrint/ExecutionConcretization.fs
@@ -233,7 +233,7 @@ module ExecutionConcretization =
         let declaringTypeDefn =
             if field.DeclaringType.Generics.IsEmpty then
                 // Non-generic type - determine the SignatureTypeKind
-                let assy = state._LoadedAssemblies.[field.DeclaringType.Assembly.FullName]
+                let assy = state._LoadedAssemblies.[field.DeclaringType.Assembly]
                 let typeDef = assy.TypeDefs.[field.DeclaringType.Definition.Get]
 
                 let signatureTypeKind =
@@ -242,7 +242,7 @@ module ExecutionConcretization =
                 TypeDefn.FromDefinition (field.DeclaringType.Identity, signatureTypeKind)
             else
                 // Generic type - the field's declaring type already has the generic arguments
-                let assy = state._LoadedAssemblies.[field.DeclaringType.Assembly.FullName]
+                let assy = state._LoadedAssemblies.[field.DeclaringType.Assembly]
                 let typeDef = assy.TypeDefs.[field.DeclaringType.Definition.Get]
 
                 let signatureTypeKind =

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -352,7 +352,7 @@ module IlMachineRuntimeMetadata =
             match AllConcreteTypes.lookup concreteType state.ConcreteTypes with
             | None -> failwith $"ConcreteTypeHandle {concreteType} not found in AllConcreteTypes"
             | Some ct ->
-                let assy = state._LoadedAssemblies.[ct.Identity.AssemblyFullName]
+                let assy = state._LoadedAssemblies.ByDefinitionName ct.Identity.AssemblyFullName
                 let typeInfo = assy.TypeDefs.[ct.Identity.TypeDefinition.Get]
 
                 match typeInfo.BaseType with
@@ -491,7 +491,7 @@ module IlMachineRuntimeMetadata =
                 failwith $"collectAllInstanceFields: ConcreteTypeHandle %O{concreteType} not found in AllConcreteTypes"
             )
 
-        let assy = state._LoadedAssemblies.[ct.Identity.AssemblyFullName]
+        let assy = state._LoadedAssemblies.ByDefinitionName ct.Identity.AssemblyFullName
         let typeInfo = assy.TypeDefs.[ct.Identity.TypeDefinition.Get]
 
         // Get this type's own instance fields
@@ -1022,7 +1022,7 @@ module IlMachineRuntimeMetadata =
                 )
 
             let threadAssembly =
-                state._LoadedAssemblies.[threadConcreteType.Identity.AssemblyFullName]
+                state._LoadedAssemblies.ByDefinitionName threadConcreteType.Identity.AssemblyFullName
 
             let threadTypeInfo =
                 threadAssembly.TypeDefs.[threadConcreteType.Identity.TypeDefinition.Get]
@@ -1247,7 +1247,8 @@ module IlMachineRuntimeMetadata =
             match AllConcreteTypes.lookup concreteType state.ConcreteTypes with
             | None -> failwith $"ConcreteTypeHandle {concreteType} not found in AllConcreteTypes"
             | Some concreteType ->
-                let assembly = state._LoadedAssemblies.[concreteType.Identity.AssemblyFullName]
+                let assembly =
+                    state._LoadedAssemblies.ByDefinitionName concreteType.Identity.AssemblyFullName
 
                 Some (concreteType, assembly.TypeDefs.[concreteType.Identity.TypeDefinition.Get])
         | ConcreteTypeHandle.OneDimArrayZero _
@@ -1304,7 +1305,7 @@ module IlMachineRuntimeMetadata =
 
             match instanceFields with
             | [ valueField ] when valueField.Name = "value__" ->
-                let assy = state._LoadedAssemblies.[ct.Identity.AssemblyFullName]
+                let assy = state._LoadedAssemblies.ByDefinitionName ct.Identity.AssemblyFullName
 
                 let state, underlying =
                     IlMachineTypeResolution.concretizeType
@@ -1610,7 +1611,7 @@ module IlMachineRuntimeMetadata =
                 // This node has no metadata-declared interfaces. The caller decides whether to walk its base.
                 state, false
             | Some (ct, typeInfo) ->
-                let assy = state._LoadedAssemblies.[ct.Identity.AssemblyFullName]
+                let assy = state._LoadedAssemblies.ByDefinitionName ct.Identity.AssemblyFullName
 
                 ((state, false), typeInfo.ImplementedInterfaces)
                 ||> Seq.fold (fun (state, found) impl ->
@@ -1693,7 +1694,9 @@ module IlMachineRuntimeMetadata =
 
                 match sameDefnDifferentGenerics with
                 | Some targetCt ->
-                    let targetAssy = state._LoadedAssemblies.[targetCt.Identity.AssemblyFullName]
+                    let targetAssy =
+                        state._LoadedAssemblies.ByDefinitionName targetCt.Identity.AssemblyFullName
+
                     let targetTypeInfo = targetAssy.TypeDefs.[targetCt.Identity.TypeDefinition.Get]
 
                     let hasVariantGenericParams =
@@ -2164,7 +2167,9 @@ module IlMachineRuntimeMetadata =
             let targetIdentityWithVariance =
                 match AllConcreteTypes.lookup t state.ConcreteTypes with
                 | Some targetCt ->
-                    let targetAssy = state._LoadedAssemblies.[targetCt.Identity.AssemblyFullName]
+                    let targetAssy =
+                        state._LoadedAssemblies.ByDefinitionName targetCt.Identity.AssemblyFullName
+
                     let targetTypeInfo = targetAssy.TypeDefs.[targetCt.Identity.TypeDefinition.Get]
 
                     let hasVariantGenericParams =

--- a/WoofWare.PawPrint/IlMachineStateExecution.fs
+++ b/WoofWare.PawPrint/IlMachineStateExecution.fs
@@ -500,7 +500,8 @@ module IlMachineStateExecution =
             : IlMachineState *
               WoofWare.PawPrint.MethodInfo<GenericParamFromMetadata, GenericParamFromMetadata, TypeDefn> list
             =
-            let currentAssy = state._LoadedAssemblies.[currentTy.Identity.AssemblyFullName]
+            let currentAssy =
+                state._LoadedAssemblies.ByDefinitionName currentTy.Identity.AssemblyFullName
 
             ((state, []), currentTypeInfo.MethodImpls.Values)
             ||> Seq.fold (fun (state, acc) impl ->
@@ -715,7 +716,8 @@ module IlMachineStateExecution =
               ConcreteType<ConcreteTypeHandle> *
               TypeInfo<GenericParamFromMetadata, TypeDefn>
             =
-            let ownerAssy = state._LoadedAssemblies.[ownerTy.Identity.AssemblyFullName]
+            let ownerAssy =
+                state._LoadedAssemblies.ByDefinitionName ownerTy.Identity.AssemblyFullName
 
             let implAssy =
                 match state.LoadedAssembly impl.RelativeToAssembly with
@@ -1789,7 +1791,7 @@ module IlMachineStateExecution =
             ExceptionDispatching.allocateRuntimeException loggerFactory baseClassTypes exceptionTypeInfo state
 
         // 2. Find the parameterless .ctor on the exception type.
-        let assy = state._LoadedAssemblies.[exceptionTypeInfo.Assembly.FullName]
+        let assy = state._LoadedAssemblies.[exceptionTypeInfo.Assembly]
         let typeDef = assy.TypeDefs.[exceptionTypeInfo.Identity.TypeDefinition.Get]
 
         if not typeDef.Generics.IsEmpty then

--- a/WoofWare.PawPrint/IlMachineStateModel.fs
+++ b/WoofWare.PawPrint/IlMachineStateModel.fs
@@ -17,9 +17,12 @@ type IlMachineState =
         ManagedHeap : ManagedHeap
         ThreadState : Map<ThreadId, ThreadState>
         InternedStrings : ImmutableDictionary<string, ManagedHeapAddress>
-        /// Keyed by FullName. (Sometimes an assembly has a PublicKey when we read it from the disk, but we
-        /// only have a reference to it by an AssemblyName without a PublicKey.)
-        _LoadedAssemblies : ImmutableDictionary<string, DumpedAssembly>
+        /// The assemblies we have loaded, keyed by their own AssemblyDefinition identity, plus the
+        /// record of which AssemblyReferences have been bound to which of them. An assembly's
+        /// reference identity routinely differs from its definition identity (the .NET Framework
+        /// compatibility facades reference implementation assemblies as `Version=0.0.0.0`), so the
+        /// two must not be conflated; see `LoadedAssemblies`.
+        _LoadedAssemblies : LoadedAssemblies
         /// Tracks initialization state of types across assemblies
         TypeInitTable : TypeInitTable
         /// For each concrete type, a map of field definition handle to static value.
@@ -137,17 +140,18 @@ type IlMachineState =
             TypeInitTable = typeInitTable
         }
 
-    member this.WithLoadedAssembly (name : AssemblyName) (value : DumpedAssembly) =
+    /// Register an assembly under its own definition identity. Idempotent: if an assembly with
+    /// that identity is already loaded, the existing instance is kept.
+    member this.WithLoadedAssembly (value : DumpedAssembly) =
         { this with
-            _LoadedAssemblies = this._LoadedAssemblies.Add (name.FullName, value)
+            _LoadedAssemblies = this._LoadedAssemblies.WithLoadedAssembly value
         }
 
     member this.LoadedAssembly' (fullName : string) : DumpedAssembly option =
-        match this._LoadedAssemblies.TryGetValue fullName with
-        | false, _ -> None
-        | true, v -> Some v
+        this._LoadedAssemblies.TryByDefinitionName fullName
 
-    member this.LoadedAssembly (name : AssemblyName) : DumpedAssembly option = this.LoadedAssembly' name.FullName
+    member this.LoadedAssembly (name : AssemblyName) : DumpedAssembly option =
+        this._LoadedAssemblies.TryByDefinition name
 
     member this.ActiveAssembly (thread : ThreadId) =
         let active = this.ThreadState.[thread].ActiveAssembly
@@ -155,7 +159,7 @@ type IlMachineState =
         match this.LoadedAssembly active with
         | Some v -> v
         | None ->
-            let available = this._LoadedAssemblies.Keys |> String.concat " ; "
+            let available = this._LoadedAssemblies.DefinitionNames |> String.concat " ; "
 
             failwith
                 $"Somehow we believe the active assembly is {active}, but only had the following available: {available}"

--- a/WoofWare.PawPrint/IlMachineThreadState.fs
+++ b/WoofWare.PawPrint/IlMachineThreadState.fs
@@ -332,7 +332,6 @@ module IlMachineThreadState =
         (entryAssembly : DumpedAssembly)
         : IlMachineState
         =
-        let assyName = entryAssembly.ThisAssemblyDefinition.Name
         let logger = lf.CreateLogger "IlMachineState"
 
         let state =
@@ -344,7 +343,7 @@ module IlMachineThreadState =
                 ManagedHeap = ManagedHeap.empty
                 ThreadState = Map.empty
                 InternedStrings = ImmutableDictionary.Empty
-                _LoadedAssemblies = ImmutableDictionary.Empty
+                _LoadedAssemblies = LoadedAssemblies.empty
                 _Statics = ImmutableDictionary.Empty
                 TypeInitTable = ImmutableDictionary.Empty
                 DotnetRuntimeDirs = dotnetRuntimeDirs
@@ -363,7 +362,7 @@ module IlMachineThreadState =
                 Scheduling = SchedulerState.RoundRobin
             }
 
-        state.WithLoadedAssembly assyName entryAssembly
+        state.WithLoadedAssembly entryAssembly
 
     let addThread (newThreadState : MethodState) (state : IlMachineState) : IlMachineState * ThreadId =
         let thread = ThreadId state.NextThreadId

--- a/WoofWare.PawPrint/IlMachineTypeResolution.fs
+++ b/WoofWare.PawPrint/IlMachineTypeResolution.fs
@@ -41,18 +41,7 @@ module IlMachineTypeResolution =
         assyName
 
     let internal loader (loggerFactory : ILoggerFactory) (state : IlMachineState) : IAssemblyLoad =
-        { new IAssemblyLoad with
-            member _.LoadAssembly loaded assyName ref =
-                let assemblies, targetAssy, _name =
-                    TypeResolution.loadAssembly
-                        loggerFactory
-                        state.DotnetRuntimeDirs
-                        loaded.[assyName.FullName]
-                        ref
-                        loaded
-
-                assemblies, targetAssy
-        }
+        TypeResolution.directoryLoader loggerFactory state.DotnetRuntimeDirs
 
     let concretizeType
         (loggerFactory : ILoggerFactory)
@@ -592,11 +581,8 @@ module IlMachineTypeResolution =
 
         // First concretize the type
         // Make sure the current assembly is included in the state for concretization
-        let state =
-            if state.LoadedAssembly assy.Name |> Option.isSome then
-                state
-            else
-                state.WithLoadedAssembly assy.Name assy
+        // (WithLoadedAssembly keeps the existing instance if we already hold this identity).
+        let state = state.WithLoadedAssembly assy
 
         let state, handle =
             concretizeType loggerFactory baseClassTypes state assy.Name typeGenerics methodGenerics ty

--- a/WoofWare.PawPrint/MethodState.fs
+++ b/WoofWare.PawPrint/MethodState.fs
@@ -839,7 +839,7 @@ and MethodState =
     static member Empty
         (concreteTypes : AllConcreteTypes)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
-        (loadedAssemblies : ImmutableDictionary<string, DumpedAssembly>)
+        (loadedAssemblies : LoadedAssemblies)
         (containingAssembly : DumpedAssembly)
         (method : WoofWare.PawPrint.MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>)
         (methodGenerics : ImmutableArray<ConcreteTypeHandle>)

--- a/WoofWare.PawPrint/MethodTableProjection.fs
+++ b/WoofWare.PawPrint/MethodTableProjection.fs
@@ -100,7 +100,8 @@ module internal MethodTableProjection =
         match AllConcreteTypes.lookup handle state.ConcreteTypes with
         | None -> None
         | Some concreteType ->
-            let assembly = state._LoadedAssemblies.[concreteType.Identity.AssemblyFullName]
+            let assembly =
+                state._LoadedAssemblies.ByDefinitionName concreteType.Identity.AssemblyFullName
 
             Some (concreteType, assembly.TypeDefs.[concreteType.Identity.TypeDefinition.Get])
 

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -641,11 +641,7 @@ module Program =
                         let handle, definedIn = assyRef.Handle
 
                         let state, _, _ =
-                            IlMachineState.loadAssembly
-                                loggerFactory
-                                state._LoadedAssemblies.[definedIn.FullName]
-                                handle
-                                state
+                            IlMachineState.loadAssembly loggerFactory state._LoadedAssemblies.[definedIn] handle state
 
                         go state
                     | TypeResolutionResult.Resolved (resolvedAssembly, _, resolvedType) ->
@@ -659,11 +655,11 @@ module Program =
             | BaseTypeInfo.TypeSpec _ -> failwith "Type specs not yet supported in base type traversal"
             | BaseTypeInfo.ForeignAssemblyType (assemblyName, typeDefHandle) ->
                 // Base type is in a foreign assembly
-                match state._LoadedAssemblies.TryGetValue assemblyName.FullName with
-                | true, foreignAssembly ->
+                match state._LoadedAssemblies.TryByDefinition assemblyName with
+                | Some foreignAssembly ->
                     let baseType = foreignAssembly.TypeDefs.[typeDefHandle]
                     continueWithGeneric state baseType foreignAssembly
-                | false, _ -> failwith $"Foreign assembly {assemblyName.FullName} not loaded"
+                | None -> failwith $"Foreign assembly {assemblyName.FullName} not loaded"
 
         let rec findCoreLibraryAssemblyFromGeneric
             (state : IlMachineState)

--- a/WoofWare.PawPrint/TypeResolution.fs
+++ b/WoofWare.PawPrint/TypeResolution.fs
@@ -13,23 +13,33 @@ module TypeResolution =
 
     type private Dummy = class end
 
-    /// Load an assembly referenced by another assembly. Returns the updated assemblies dictionary,
-    /// the loaded assembly, and its name. If the assembly is already loaded, returns the dictionary
-    /// unchanged.
+    /// <summary>
+    /// Bind an AssemblyReference to an assembly, loading it from the runtime dirs if this is the
+    /// first time we have needed it. Returns the updated load context, the assembly, and the
+    /// assembly's own *definition* identity — which is in general NOT the reference's identity,
+    /// so callers must not assume the returned name is what they asked for.
+    /// </summary>
+    /// <remarks>
+    /// Binding is by simple name: we look for <c>&lt;SimpleName&gt;.dll</c> in each runtime dir in
+    /// turn. Version, culture and public key token in the reference are therefore not honoured,
+    /// which is exactly why the reference's identity so often disagrees with the definition
+    /// identity of what it binds to (the .NET Framework compatibility facades reference
+    /// implementation assemblies as <c>Version=0.0.0.0</c>).
+    /// </remarks>
     let internal loadAssembly
         (loggerFactory : ILoggerFactory)
         (dotnetRuntimeDirs : string seq)
         (referencedInAssembly : DumpedAssembly)
         (r : AssemblyReferenceHandle)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
-        : ImmutableDictionary<string, DumpedAssembly> * DumpedAssembly * AssemblyName
+        (assemblies : LoadedAssemblies)
+        : LoadedAssemblies * DumpedAssembly * AssemblyName
         =
         let assemblyRef = referencedInAssembly.AssemblyReferences.[r]
-        let assemblyName = assemblyRef.Name
 
-        match assemblies.TryGetValue assemblyName.FullName with
-        | true, v -> assemblies, v, assemblyName
-        | false, _ ->
+        match assemblies.TryResolveReference assemblyRef with
+        | Some v -> assemblies, v, v.Name
+        | None ->
+            let assemblyName = assemblyRef.Name
             let logger = loggerFactory.CreateLogger typeof<Dummy>.DeclaringType
 
             let assy =
@@ -48,8 +58,28 @@ module TypeResolution =
             match assy |> List.tryHead with
             | None -> failwith $"Could not find a readable DLL in any runtime dir with name %s{assemblyName.Name}.dll"
             | Some assy ->
-                let assemblies = assemblies.SetItem (assemblyName.FullName, assy)
-                assemblies, assy, assemblyName
+                // Record both the assembly (under its own definition identity) and the binding
+                // that got us here, so the next probe with this reference identity is a hit.
+                let assemblies, canonical = assemblies.WithBoundReference assemblyRef assy
+                assemblies, canonical, canonical.Name
+
+    /// <summary>
+    /// The interpreter's assembly loader: binds AssemblyReferences by simple name against
+    /// <paramref name="dotnetRuntimeDirs"/>, in order.
+    /// </summary>
+    /// <remarks>
+    /// This is the one loader. Tests must use it too rather than hand-rolling an
+    /// <c>IAssemblyLoad</c>: the bug this exists to prevent was invisible to the test suite for
+    /// precisely as long as the test fakes keyed their dictionaries differently from production.
+    /// </remarks>
+    let directoryLoader (loggerFactory : ILoggerFactory) (dotnetRuntimeDirs : string seq) : IAssemblyLoad =
+        { new IAssemblyLoad with
+            member _.LoadAssembly loaded referencedIn ref =
+                let assemblies, targetAssy, _name =
+                    loadAssembly loggerFactory dotnetRuntimeDirs loaded.[referencedIn] ref loaded
+
+                assemblies, targetAssy
+        }
 
     let rec internal resolveTopLevelTypeFromName
         (loggerFactory : ILoggerFactory)
@@ -58,8 +88,8 @@ module TypeResolution =
         (name : string)
         (genericArgs : ImmutableArray<TypeDefn>)
         (assy : DumpedAssembly)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
-        : ImmutableDictionary<string, DumpedAssembly> * DumpedAssembly * WoofWare.PawPrint.TypeInfo<TypeDefn, TypeDefn>
+        (assemblies : LoadedAssemblies)
+        : LoadedAssemblies * DumpedAssembly * WoofWare.PawPrint.TypeInfo<TypeDefn, TypeDefn>
         =
         match Assembly.resolveTopLevelTypeFromName assy assemblies ns name genericArgs with
         | TypeResolutionResult.Resolved (assy, _, typeDef) -> assemblies, assy, typeDef
@@ -68,9 +98,12 @@ module TypeResolution =
                 loadAssembly
                     loggerFactory
                     dotnetRuntimeDirs
-                    assemblies.[snd(loadFirst.Handle).FullName]
+                    assemblies.[snd loadFirst.Handle]
                     (fst loadFirst.Handle)
                     assemblies
+
+            let assemblies =
+                LoadedAssemblies.assertReferenceBound $"top-level type %s{name}" loadFirst assemblies
 
             resolveTopLevelTypeFromName loggerFactory dotnetRuntimeDirs ns name genericArgs assy assemblies
 
@@ -80,8 +113,8 @@ module TypeResolution =
         (fromAssembly : DumpedAssembly)
         (ty : WoofWare.PawPrint.ExportedType)
         (genericArgs : ImmutableArray<TypeDefn>)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
-        : ImmutableDictionary<string, DumpedAssembly> * DumpedAssembly * WoofWare.PawPrint.TypeInfo<TypeDefn, TypeDefn>
+        (assemblies : LoadedAssemblies)
+        : LoadedAssemblies * DumpedAssembly * WoofWare.PawPrint.TypeInfo<TypeDefn, TypeDefn>
         =
         match Assembly.resolveTypeFromExport fromAssembly assemblies genericArgs ty with
         | TypeResolutionResult.Resolved (assy, _, typeDef) -> assemblies, assy, typeDef
@@ -90,9 +123,12 @@ module TypeResolution =
                 loadAssembly
                     loggerFactory
                     dotnetRuntimeDirs
-                    assemblies.[snd(loadFirst.Handle).FullName]
+                    assemblies.[snd loadFirst.Handle]
                     (fst loadFirst.Handle)
                     assemblies
+
+            let assemblies =
+                LoadedAssemblies.assertReferenceBound $"exported type %s{ty.Name}" loadFirst assemblies
 
             resolveTypeFromExport loggerFactory dotnetRuntimeDirs fromAssembly ty genericArgs assemblies
 
@@ -102,8 +138,8 @@ module TypeResolution =
         (referencedInAssembly : DumpedAssembly)
         (target : TypeRef)
         (typeGenericArgs : ImmutableArray<TypeDefn>)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
-        : ImmutableDictionary<string, DumpedAssembly> * DumpedAssembly * WoofWare.PawPrint.TypeInfo<TypeDefn, TypeDefn>
+        (assemblies : LoadedAssemblies)
+        : LoadedAssemblies * DumpedAssembly * WoofWare.PawPrint.TypeInfo<TypeDefn, TypeDefn>
         =
         match Assembly.resolveTypeRef assemblies referencedInAssembly typeGenericArgs target with
         | TypeResolutionResult.Resolved (assy, _, typeDef) -> assemblies, assy, typeDef
@@ -112,9 +148,12 @@ module TypeResolution =
                 loadAssembly
                     loggerFactory
                     dotnetRuntimeDirs
-                    assemblies.[snd(loadFirst.Handle).FullName]
+                    assemblies.[snd loadFirst.Handle]
                     (fst loadFirst.Handle)
                     assemblies
+
+            let assemblies =
+                LoadedAssemblies.assertReferenceBound $"type reference %s{target.Name}" loadFirst assemblies
 
             resolveTypeFromRef loggerFactory dotnetRuntimeDirs referencedInAssembly target typeGenericArgs assemblies
 
@@ -124,8 +163,8 @@ module TypeResolution =
         (ty : TypeReferenceHandle)
         (genericArgs : ImmutableArray<TypeDefn>)
         (assy : DumpedAssembly)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
-        : ImmutableDictionary<string, DumpedAssembly> * DumpedAssembly * WoofWare.PawPrint.TypeInfo<TypeDefn, TypeDefn>
+        (assemblies : LoadedAssemblies)
+        : LoadedAssemblies * DumpedAssembly * WoofWare.PawPrint.TypeInfo<TypeDefn, TypeDefn>
         =
         let target = assy.TypeRefs.[ty]
         resolveTypeFromRef loggerFactory dotnetRuntimeDirs assy target genericArgs assemblies
@@ -144,8 +183,8 @@ module TypeResolution =
         (typeGenericArgs : ImmutableArray<TypeDefn>)
         (methodGenericArgs : ImmutableArray<TypeDefn>)
         (assy : DumpedAssembly)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
-        : ImmutableDictionary<string, DumpedAssembly> * TypeDefn
+        (assemblies : LoadedAssemblies)
+        : LoadedAssemblies * TypeDefn
         =
         match ty with
         | TypeDefn.GenericTypeParameter idx ->
@@ -311,8 +350,8 @@ module TypeResolution =
         (typeGenericArgs : ImmutableArray<TypeDefn>)
         (methodGenericArgs : ImmutableArray<TypeDefn>)
         (assy : DumpedAssembly)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
-        : ImmutableDictionary<string, DumpedAssembly> * DumpedAssembly * WoofWare.PawPrint.TypeInfo<TypeDefn, TypeDefn>
+        (assemblies : LoadedAssemblies)
+        : LoadedAssemblies * DumpedAssembly * WoofWare.PawPrint.TypeInfo<TypeDefn, TypeDefn>
         =
         match ty with
         | TypeDefn.GenericInstantiation (generic, args) ->
@@ -349,7 +388,7 @@ module TypeResolution =
                 assy
                 assemblies
         | TypeDefn.FromDefinition (identity, _typeKind) ->
-            let assy = assemblies.[identity.AssemblyFullName]
+            let assy = assemblies.ByDefinitionName identity.AssemblyFullName
 
             let defn =
                 assy.TypeDefs.[identity.TypeDefinition.Get]
@@ -433,8 +472,8 @@ module TypeResolution =
         (assy : DumpedAssembly)
         (typeGenericArgs : TypeDefn ImmutableArray)
         (methodGenericArgs : TypeDefn ImmutableArray)
-        (assemblies : ImmutableDictionary<string, DumpedAssembly>)
-        : ImmutableDictionary<string, DumpedAssembly> * DumpedAssembly * WoofWare.PawPrint.TypeInfo<TypeDefn, TypeDefn>
+        (assemblies : LoadedAssemblies)
+        : LoadedAssemblies * DumpedAssembly * WoofWare.PawPrint.TypeInfo<TypeDefn, TypeDefn>
         =
         let sign = assy.TypeSpecs.[ty].Signature
 

--- a/WoofWare.PawPrint/UnaryMetadataCallOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataCallOps.fs
@@ -577,8 +577,7 @@ module internal UnaryMetadataCallOps =
             match pendingConstrained with
             | None -> state, concretizedMethod, declaringTypeHandle
             | Some constrainedTypeHandle ->
-                let methodDeclAssy =
-                    state._LoadedAssemblies.[methodToCall.DeclaringType.Assembly.FullName]
+                let methodDeclAssy = state._LoadedAssemblies.[methodToCall.DeclaringType.Assembly]
 
                 let methodDeclType =
                     methodDeclAssy.TypeDefs.[methodToCall.DeclaringType.Definition.Get]
@@ -882,7 +881,7 @@ module internal UnaryMetadataCallOps =
 
                 let tConcrete = AllConcreteTypes.lookup tHandle state.ConcreteTypes |> Option.get
 
-                let tAssy = state._LoadedAssemblies.[tConcrete.Assembly.FullName]
+                let tAssy = state._LoadedAssemblies.[tConcrete.Assembly]
                 let tDefn = tAssy.TypeDefs.[tConcrete.Definition.Get]
 
                 let tIsValueType =

--- a/WoofWare.PawPrint/UnaryMetadataIlOp.fs
+++ b/WoofWare.PawPrint/UnaryMetadataIlOp.fs
@@ -18,7 +18,7 @@ module internal UnaryMetadataIlOp =
         let activeAssy =
             state.LoadedAssembly sourcedMetadataToken.SourceAssembly
             |> Option.defaultWith (fun () ->
-                let available = state._LoadedAssemblies.Keys |> String.concat " ; "
+                let available = state._LoadedAssemblies.DefinitionNames |> String.concat " ; "
 
                 failwith
                     $"Metadata token source assembly %O{sourcedMetadataToken.SourceAssembly} is not loaded; available assemblies: {available}"

--- a/WoofWare.PawPrint/UnaryMetadataMemoryOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataMemoryOps.fs
@@ -166,7 +166,7 @@ module internal UnaryMetadataMemoryOps =
             AllConcreteTypes.lookup typeHandle state.ConcreteTypes |> Option.get
 
         let defn =
-            state._LoadedAssemblies.[targetType.Assembly.FullName].TypeDefs.[targetType.Definition.Get]
+            state._LoadedAssemblies.[targetType.Assembly].TypeDefs.[targetType.Definition.Get]
 
         let toPush, state =
             if DumpedAssembly.isValueType baseClassTypes state._LoadedAssemblies defn then

--- a/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
@@ -428,7 +428,7 @@ module internal UnaryMetadataObjectOps =
             AllConcreteTypes.lookup typeHandle state.ConcreteTypes |> Option.get
 
         let defn =
-            state._LoadedAssemblies.[targetType.Assembly.FullName].TypeDefs.[targetType.Definition.Get]
+            state._LoadedAssemblies.[targetType.Assembly].TypeDefs.[targetType.Definition.Get]
 
         let isNullable =
             InternalTypeKind.kind baseClassTypes targetType = InternalTypeKind.Nullable
@@ -467,15 +467,14 @@ module internal UnaryMetadataObjectOps =
                                     AllConcreteTypes.lookup underlyingTypeHandle state.ConcreteTypes |> Option.get
 
                                 let underlyingDefn =
-                                    state._LoadedAssemblies.[underlyingConcreteType.Assembly.FullName].TypeDefs
+                                    state._LoadedAssemblies.[underlyingConcreteType.Assembly].TypeDefs
                                         .[underlyingConcreteType.Definition.Get]
 
                                 let underlyingInstanceFields =
                                     underlyingDefn.Fields
                                     |> List.filter (fun field -> not (field.Attributes.HasFlag FieldAttributes.Static))
 
-                                let underlyingAssembly =
-                                    state._LoadedAssemblies.[underlyingConcreteType.Assembly.FullName]
+                                let underlyingAssembly = state._LoadedAssemblies.[underlyingConcreteType.Assembly]
 
                                 let valueAsEval = EvalStackValue.ofCliType value
 
@@ -532,7 +531,7 @@ module internal UnaryMetadataObjectOps =
                     | _ ->
                         // Primitive value on the eval stack (Int32, Int64, Float, etc.)
                         // Construct a CliValueType from the type definition's instance fields
-                        let targetAssembly = state._LoadedAssemblies.[targetType.Assembly.FullName]
+                        let targetAssembly = state._LoadedAssemblies.[targetType.Assembly]
 
                         let instanceFields =
                             defn.Fields
@@ -753,7 +752,7 @@ module internal UnaryMetadataObjectOps =
             |> Option.get
 
         let targetDefn =
-            state._LoadedAssemblies.[targetConcreteType.Assembly.FullName].TypeDefs.[targetConcreteType.Definition.Get]
+            state._LoadedAssemblies.[targetConcreteType.Assembly].TypeDefs.[targetConcreteType.Definition.Get]
 
         let isNullable =
             InternalTypeKind.kind baseClassTypes targetConcreteType = InternalTypeKind.Nullable

--- a/WoofWare.PawPrint/UnaryStringTokenIlOp.fs
+++ b/WoofWare.PawPrint/UnaryStringTokenIlOp.fs
@@ -20,7 +20,7 @@ module internal UnaryStringTokenIlOp =
                 match state.LoadedAssembly sh.SourceAssembly with
                 | Some assy -> assy.Strings sh.Token
                 | None ->
-                    let available = state._LoadedAssemblies.Keys |> String.concat " ; "
+                    let available = state._LoadedAssemblies.DefinitionNames |> String.concat " ; "
 
                     failwith
                         $"Tried to resolve ldstr token %O{sh.Token} from assembly {sh.SourceAssembly.FullName}, but only had the following available: {available}"


### PR DESCRIPTION
`_LoadedAssemblies` had two incompatible keying conventions. Direct registration (`WithLoadedAssembly`) keyed an assembly by its own **definition** identity — the `FullName` in its `AssemblyDefinition` row. But `TypeResolution.loadAssembly` keyed the assembly it had just loaded by the **`AssemblyReference` FullName that triggered the load**. Every reader looks up by definition identity.

Those two identities are routinely different. In the .NET 10 shared framework the .NET Framework compatibility facades (`mscorlib`, `System`, `System.Core`, `System.Xml`, …) reference their implementation assemblies with `Version=0.0.0.0`: 121 mismatching `(reference, definition)` pairs, of which **6 assemblies are referenced *only* that way**. Those six were mis-keyed on every load — present in the dictionary, findable by nothing.

That is the reported crash. `System.IO.FileSystem.AccessControl` is one of the six:

```
Assembly System.IO.FileSystem.AccessControl, Version=10.0.0.0, ... is not loaded.
```

The message says "not loaded", but it *was* loaded — under the key `System.IO.FileSystem.AccessControl, Version=0.0.0.0, ...`. The guard added in #668 didn't cause this; it made a pre-existing mis-keying visible by being the first code to look these assemblies up.

## The fix

Adopt the CLR's own split between the **binder** (reference identity → assembly) and the **load context** (definition identity → assembly), as a `LoadedAssemblies` type with a private representation:

```fsharp
type LoadedAssemblies =
    private
        {
            /// AssemblyDefinition FullName -> the assembly bearing that identity.
            ByDefinition : ImmutableDictionary<string, DumpedAssembly>
            /// AssemblyReference FullName -> the AssemblyDefinition FullName it bound to.
            Bindings : ImmutableDictionary<string, string>
        }
```

The binder is reachable only through `TryResolveReference`, which takes an `AssemblyReference` — so conflating a reference identity with a definition identity is now a **type error** rather than a convention someone has to remember. `TryResolveReference` keeps the CLR's exact-identity fallback: an unbound reference still matches an assembly whose definition identity equals it, which is how a directly-registered assembly (the entry assembly, or an in-memory test fixture never written to disk) is found the first time something references it.

The two identity kinds were also conflated in `loadAssemblyReferenceByName` and in the foreign-base traversal; both are now definition-identity-only, and `BaseTypeInfo.ForeignAssemblyType`'s contract is documented as carrying a definition identity.

### Collision detection

Two distinct assemblies claiming one definition identity means silently choosing one of two different sets of metadata to execute against. There is no safe choice, so we crash. Every registration route funnels through one private `Canonicalise`, so no route can register a second, conflicting build under an identity already spoken for.

The fingerprint is a **SHA-256 of the whole PE image**, computed during parse and stored on `DumpedAssembly`. Weaker fingerprints were each defeated by a concrete counterexample: `TypeDefs.Count` (trivially collides), MVID (caller-controlled, and spliceable), and metadata-only hashing (`GetMetadata()` excludes IL method bodies and embedded-resource payloads, both of which PawPrint reads via `GetMethodBody`/`GetSectionData` — so an IL-rewritten assembly compared equal). It is computed eagerly because `Assembly.read` takes caller-owned streams that may be closed before the hash is needed. Suite runtime is unchanged.

### Livelock guard

The `FirstLoadAssy` retry loops were unbounded: a load that failed to make the reference resolvable spun forever instead of failing. When I reintroduced the original bug to check the new tests caught it, the suite **hung rather than failed**. `LoadedAssemblies.assertReferenceBound` now turns that into a loud error at all four retry sites.

## Why the suite never caught this

`TestZeroOfBaseAssemblies.fs` had a hand-rolled `OnDemandAssemblyLoad` that keyed the **opposite** way from production, so the tests exercised a keying convention no production code used. It — and two other hand-rolled no-disk loaders — now go through the single production loader `TypeResolution.directoryLoader` and a shared `IAssemblyLoad.alreadyLoadedOnly`.

## Tests

- `TestLoadedAssemblies.fs` — 9 tests, including a model-based FsCheck property test against a naive list-of-triples reference implementation, plus three collision tests: differing metadata, MVID-spliced, and IL-body-only difference (this last needs the MVID spliced across, since Roslyn stamps a fresh MVID per build).
- `TestAssemblyDictionaryKeying.fs` — 6 tests over the real framework covering the reported crash directly.
- `TestSharedFrameworkForwardSweep.fs` — sweeps every top-level type forward in every compatibility facade of the pinned framework, asserting `resolvedCount = topLevelForwards.Length`. Forwards whose target DLL is genuinely absent are partitioned out *structurally*, not by matching exception text.

Each guard test was verified by reverting the implementation to the weaker version and confirming that specific test fails — which is how I found that the sweep had only ever been failing via a `resolvedCount > 0` backstop, and that two other tests passed without testing anything.

1513 tests pass; build is clean with 0 warnings.

## Note for the reviewer

`BaseTypeInfo.ForeignAssemblyType` has **zero construction sites** — four match arms and the helper `IlMachineRuntimeMetadata.ensureAssemblyLoadedByName` are dead. I documented its contract rather than deleting it, since removal is out of scope here; worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
