### PR TITLE
Implement the `unbox` IL instruction

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/UnboxFieldAccess.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/UnboxFieldAccess.cs
@@ -1,0 +1,162 @@
+// ECMA-335 III.4.32 (`unbox`), as distinct from III.4.33 (`unbox.any`): it pushes a managed
+// pointer *into* the boxed object rather than a copy of the object's contents.
+//
+// C# reaches this opcode by reading a field off a cast result: `((Point) o).X` compiles to
+// `unbox Point; ldfld Point::X`, because the field read needs an address. A *method* call on a
+// cast result does not reach it -- Roslyn spills through `unbox.any; stloc; ldloca` so that a
+// mutating method cannot write back into the box -- which is also why nothing here observes the
+// aliasing directly; see UnaryMetadataObjectOps.executeUnbox for why the pointer aliases anyway.
+//
+// The type test is shared with the value-type arm of `unbox.any` (CoreCLR routes both through
+// `CastHelpers.Unbox_Helper`), so the negatives below pin that `unbox` agrees with it.
+
+using System;
+
+public struct Point
+{
+    public int X;
+    public int Y;
+}
+
+public struct Outer
+{
+    public Point Inner;
+    public int Tag;
+}
+
+public readonly struct ReadOnlyPoint
+{
+    public readonly int X;
+
+    public ReadOnlyPoint(int x)
+    {
+        X = x;
+    }
+}
+
+public struct WithRef
+{
+    public string S;
+    public int N;
+}
+
+public struct Wrapper<T>
+{
+    public T Item;
+}
+
+public class TestUnboxFieldAccess
+{
+    public static int Main(string[] argv)
+    {
+        object boxedPoint = new Point
+        {
+            X = 3,
+            Y = 4,
+        };
+
+        if (((Point) boxedPoint).X != 3) return 1;
+        if (((Point) boxedPoint).Y != 4) return 2;
+
+        // Reading the same box twice through two separate `unbox` instructions agrees.
+        if (((Point) boxedPoint).X + ((Point) boxedPoint).Y != 7) return 3;
+
+        // A projection chain on top of the byref: `unbox Outer; ldflda Outer::Inner; ldfld Point::Y`.
+        object boxedOuter = new Outer
+        {
+            Inner = new Point
+            {
+                X = 10,
+                Y = 20,
+            },
+            Tag = 30,
+        };
+
+        if (((Outer) boxedOuter).Inner.X != 10) return 4;
+        if (((Outer) boxedOuter).Inner.Y != 20) return 5;
+        if (((Outer) boxedOuter).Tag != 30) return 6;
+
+        // readonly structs take the same path.
+        object boxedReadOnly = new ReadOnlyPoint(11);
+        if (((ReadOnlyPoint) boxedReadOnly).X != 11) return 7;
+
+        // A payload containing a GC reference reads back through the byref as an objref, not
+        // as bytes.
+        object boxedWithRef = new WithRef
+        {
+            S = "hello",
+            N = 12,
+        };
+
+        if (((WithRef) boxedWithRef).S != "hello") return 8;
+        if (((WithRef) boxedWithRef).N != 12) return 9;
+
+        // Generic value types: the token is a TypeSpec rather than a TypeDef.
+        object boxedWrapper = new Wrapper<int>
+        {
+            Item = 13,
+        };
+
+        if (((Wrapper<int>) boxedWrapper).Item != 13) return 10;
+
+        object boxedWrapperOfString = new Wrapper<string>
+        {
+            Item = "world",
+        };
+
+        if (((Wrapper<string>) boxedWrapperOfString).Item != "world") return 11;
+
+        // Wrong boxed type is an InvalidCastException, exactly as for `unbox.any`.
+        if (!ThrowsInvalidCast((object) new ReadOnlyPoint(1))) return 12;
+        if (!ThrowsInvalidCast((object) 1)) return 13;
+        if (!ThrowsInvalidCast("not a Point")) return 14;
+        if (!ThrowsInvalidCast(new int[1])) return 15;
+
+        // Null is a NullReferenceException, not an InvalidCastException: `unbox` has no
+        // Nullable-shaped escape hatch the way `unbox.any` does.
+        if (!ThrowsNullReference(null)) return 16;
+
+        // Mutating the box through a normal write is visible to a later `unbox`, so the
+        // pointer really is re-read each time rather than cached from the box's creation.
+        boxedPoint = new Point
+        {
+            X = 5,
+            Y = 6,
+        };
+
+        if (((Point) boxedPoint).X != 5) return 17;
+
+        return 0;
+    }
+
+    // The field read must be *used*, or Roslyn drops the `ldfld` and degrades the whole
+    // expression to `unbox.any; pop` -- which would leave these negatives testing the wrong
+    // instruction. Storing to a static keeps the read alive.
+    private static int sink;
+
+    private static bool ThrowsInvalidCast(object o)
+    {
+        try
+        {
+            sink = ((Point) o).X;
+            return false;
+        }
+        catch (InvalidCastException)
+        {
+            return true;
+        }
+    }
+
+    private static bool ThrowsNullReference(object o)
+    {
+        try
+        {
+            sink = ((Point) o).X;
+            return false;
+        }
+        catch (NullReferenceException)
+        {
+            return true;
+        }
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/UnboxFieldAccess.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/UnboxFieldAccess.cs
@@ -126,6 +126,18 @@ public class TestUnboxFieldAccess
 
         if (((Point) boxedPoint).X != 5) return 17;
 
+        // A real BCL user of the instruction, so this exercises it against CoreLib's own IL and
+        // not just against this assembly's: `System.Index.Equals(object)` is compiled as
+        // `isinst Index; unbox Index; ldfld Index::_value` (it is the only bare `unbox` in all of
+        // System.Private.CoreLib).
+        Index index = new Index(3);
+        if (!index.Equals((object) new Index(3))) return 18;
+        if (index.Equals((object) new Index(4))) return 19;
+
+        // The `isinst` guard means a non-Index never reaches the `unbox`.
+        if (index.Equals((object) "not an index")) return 20;
+        if (index.Equals((object) null)) return 21;
+
         return 0;
     }
 

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -369,12 +369,30 @@ module IlMachineManagedByref =
                     let pool = NativeMemoryPool.writeCell block byteOffset updated pool
                     IlMachineThreadState.setNativeMemoryPool pool state
         | ByrefRoot.HeapValue addr ->
+            let existing = ManagedHeap.get addr state.ManagedHeap
+
             let contents =
                 match updated with
                 | CliType.ValueType contents -> contents
-                | other -> failwith $"cannot write non-value-type {other} through heap value byref"
+                | bare ->
+                    // `box` of a *bare* primitive stores it inside a synthetic single-field
+                    // struct — the shape `UnaryMetadataObjectOps.unboxedContents` reads back
+                    // out — so a byref to the whole boxed value addresses that wrapper, not the
+                    // primitive directly. A typed write of the bare primitive (`unbox int32`
+                    // then `stobj int32`, say) must therefore be installed into the wrapper's
+                    // field; replacing the wrapper outright would destroy the boxed object's
+                    // shape. Requiring a unique field at offset 0 of the same size *and* CLI
+                    // constructor keeps an unrelated value of coincidentally equal width — an
+                    // object reference over a boxed `int64`, say — from being smuggled in.
+                    let candidates =
+                        CliValueType.TryFieldsAt 0 existing.Contents
+                        |> List.filter (fun f -> f.Size = CliType.sizeOf bare && sameCliConstructor f.Contents bare)
 
-            let existing = ManagedHeap.get addr state.ManagedHeap
+                    match candidates with
+                    | [ f ] -> CliValueType.WithFieldSetById f.Id bare existing.Contents
+                    | _ ->
+                        failwith
+                            $"cannot write non-value-type {bare} through heap value byref to %O{existing.ConcreteType}: its contents are not a single-field wrapper around a value of matching shape"
 
             if System.Object.ReferenceEquals (contents, existing.Contents) then
                 state

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -369,30 +369,12 @@ module IlMachineManagedByref =
                     let pool = NativeMemoryPool.writeCell block byteOffset updated pool
                     IlMachineThreadState.setNativeMemoryPool pool state
         | ByrefRoot.HeapValue addr ->
-            let existing = ManagedHeap.get addr state.ManagedHeap
-
             let contents =
                 match updated with
                 | CliType.ValueType contents -> contents
-                | bare ->
-                    // `box` of a *bare* primitive stores it inside a synthetic single-field
-                    // struct — the shape `UnaryMetadataObjectOps.unboxedContents` reads back
-                    // out — so a byref to the whole boxed value addresses that wrapper, not the
-                    // primitive directly. A typed write of the bare primitive (`unbox int32`
-                    // then `stobj int32`, say) must therefore be installed into the wrapper's
-                    // field; replacing the wrapper outright would destroy the boxed object's
-                    // shape. Requiring a unique field at offset 0 of the same size *and* CLI
-                    // constructor keeps an unrelated value of coincidentally equal width — an
-                    // object reference over a boxed `int64`, say — from being smuggled in.
-                    let candidates =
-                        CliValueType.TryFieldsAt 0 existing.Contents
-                        |> List.filter (fun f -> f.Size = CliType.sizeOf bare && sameCliConstructor f.Contents bare)
+                | other -> failwith $"cannot write non-value-type {other} through heap value byref"
 
-                    match candidates with
-                    | [ f ] -> CliValueType.WithFieldSetById f.Id bare existing.Contents
-                    | _ ->
-                        failwith
-                            $"cannot write non-value-type {bare} through heap value byref to %O{existing.ConcreteType}: its contents are not a single-field wrapper around a value of matching shape"
+            let existing = ManagedHeap.get addr state.ManagedHeap
 
             if System.Object.ReferenceEquals (contents, existing.Contents) then
                 state

--- a/WoofWare.PawPrint/UnaryMetadataIlOp.fs
+++ b/WoofWare.PawPrint/UnaryMetadataIlOp.fs
@@ -63,7 +63,7 @@ module internal UnaryMetadataIlOp =
         | UnaryMetadataTokenIlOp.Ldobj -> UnaryMetadataMemoryOps.executeLdobj ctx state
         | UnaryMetadataTokenIlOp.Sizeof -> UnaryMetadataMemoryOps.executeSizeof ctx state
         | UnaryMetadataTokenIlOp.Calli -> failwith "TODO: Calli unimplemented"
-        | UnaryMetadataTokenIlOp.Unbox -> failwith "TODO: Unbox unimplemented"
+        | UnaryMetadataTokenIlOp.Unbox -> UnaryMetadataObjectOps.executeUnbox ctx state
         | UnaryMetadataTokenIlOp.Ldvirtftn -> failwith "TODO: Ldvirtftn unimplemented"
         | UnaryMetadataTokenIlOp.Mkrefany -> failwith "TODO: Mkrefany unimplemented"
         | UnaryMetadataTokenIlOp.Refanyval -> failwith "TODO: Refanyval unimplemented"

--- a/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
@@ -690,6 +690,66 @@ module internal UnaryMetadataObjectOps =
                 let size = (CliType.SizeOf zero).Size
                 CliValueType.DereferenceFieldAt 0 size contents, state
 
+    /// The outcome of the type test that ECMA-335 III.4.32 (`unbox`) and the value-type arm of
+    /// III.4.33 (`unbox.any`) share; CoreCLR routes both through `CastHelpers.Unbox_Helper`.
+    [<RequireQualifiedAccess>]
+    type private UnboxTypeTest =
+        /// The operand is a boxed value whose type the token accepts. Materialise from
+        /// `boxed.ConcreteType` rather than from the token's handle: under the enum/underlying
+        /// relaxation in `unboxPermitted` the two differ, and `Contents` was built with the former.
+        | Accepted of addr : ManagedHeapAddress * boxed : AllocatedNonArrayObject
+        /// The operand is null. `unbox` and the non-Nullable arm of `unbox.any` both raise
+        /// NullReferenceException; only the `Nullable<T>` arm of `unbox.any` accepts null, and it
+        /// never reaches this test.
+        | NullOperand
+        /// InvalidCastException: the operand is not a boxed value type the token accepts.
+        | WrongType
+
+    /// Shared by `unbox` and the value-type arm of `unbox.any`, so the two cannot drift apart on
+    /// which operands they accept. `opName` appears only in diagnostics for shapes we do not model.
+    let private unboxTypeTest
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (opName : string)
+        (targetConcreteTypeHandle : ConcreteTypeHandle)
+        (actualObj : EvalStackValue)
+        (state : IlMachineState)
+        : IlMachineState * UnboxTypeTest
+        =
+        match actualObj with
+        | EvalStackValue.NullObjectRef -> state, UnboxTypeTest.NullOperand
+        | EvalStackValue.ObjectRef addr ->
+            let boxedOpt =
+                match state.ManagedHeap.NonArrayObjects.TryGetValue addr with
+                | true, v -> Some v
+                | false, _ ->
+                    match state.ManagedHeap.Arrays.TryGetValue addr with
+                    // An array is never a boxed value type, so per the CLR this is an ordinary
+                    // type mismatch rather than an interpreter abort.
+                    | true, _ -> None
+                    | false, _ -> failwith $"%s{opName}: could not find managed object with address {addr}"
+
+            match boxedOpt with
+            | None -> state, UnboxTypeTest.WrongType
+            | Some boxed ->
+                // Handle identity, or same-primitive-element-type per CoreCLR
+                // `CastHelpers.Unbox_Helper` — the clause that lets a boxed enum unbox to its
+                // underlying integer and back. Not assignability, and narrower than ECMA-335's
+                // verification types: see `unboxPermitted`.
+                let state, permitted =
+                    IlMachineState.unboxPermitted
+                        loggerFactory
+                        baseClassTypes
+                        state
+                        boxed.ConcreteType
+                        targetConcreteTypeHandle
+
+                if permitted then
+                    state, UnboxTypeTest.Accepted (addr, boxed)
+                else
+                    state, UnboxTypeTest.WrongType
+        | other -> failwith $"%s{opName}: unexpected eval stack value {other}"
+
     let executeUnboxAny (ctx : UnaryMetadataIlOpContext) (state : IlMachineState) : IlMachineState * WhatWeDid =
         let loggerFactory = ctx.LoggerFactory
         let baseClassTypes = ctx.BaseClassTypes
@@ -863,65 +923,158 @@ module internal UnaryMetadataObjectOps =
                 state
         else
             // Value-type target, non-Nullable.
-            match actualObj with
-            | EvalStackValue.NullObjectRef ->
+            let state, typeTest =
+                unboxTypeTest
+                    loggerFactory
+                    baseClassTypes
+                    "Unbox_Any (value-type target)"
+                    targetConcreteTypeHandle
+                    actualObj
+                    state
+
+            match typeTest with
+            | UnboxTypeTest.NullOperand ->
                 IlMachineStateExecution.raiseRuntimeException
                     loggerFactory
                     baseClassTypes
                     baseClassTypes.NullReferenceException
                     thread
                     state
-            | EvalStackValue.ObjectRef addr ->
-                let boxedOpt =
-                    match state.ManagedHeap.NonArrayObjects.TryGetValue addr with
-                    | true, v -> Some v
-                    | false, _ ->
-                        match state.ManagedHeap.Arrays.TryGetValue addr with
-                        | true, _ ->
-                            // Array object with non-array value-type target: wrong type, per CLR this
-                            // is an InvalidCastException, not an interpreter abort.
-                            None
-                        | false, _ -> failwith $"Unbox_Any: could not find managed object with address {addr}"
-
-                match boxedOpt with
-                | None ->
-                    IlMachineStateExecution.raiseRuntimeException
-                        loggerFactory
-                        baseClassTypes
-                        baseClassTypes.InvalidCastException
-                        thread
-                        state
-                | Some boxed ->
-
-                // Handle identity, or same-primitive-element-type per CoreCLR
-                // `CastHelpers.Unbox_Helper` — the clause that lets a boxed enum unbox to its
-                // underlying integer and back. Not assignability, and narrower than ECMA-335's
-                // verification types: see `unboxPermitted`.
-                let state, permitted =
-                    IlMachineState.unboxPermitted
-                        loggerFactory
-                        baseClassTypes
-                        state
-                        boxed.ConcreteType
-                        targetConcreteTypeHandle
-
-                if permitted then
-                    // Materialise using the *boxed object's* handle, not the target's: that is the
-                    // handle its `Contents` were built with, which is the precondition
-                    // `unboxedContents` documents. Under the enum relaxation the two can differ,
-                    // and it is the push/store path that reconciles the result with the target.
-                    let toPush, state =
-                        unboxedContents baseClassTypes boxed.ConcreteType boxed.Contents state
-
+            | UnboxTypeTest.WrongType ->
+                IlMachineStateExecution.raiseRuntimeException
+                    loggerFactory
+                    baseClassTypes
+                    baseClassTypes.InvalidCastException
+                    thread
                     state
-                    |> IlMachineState.pushToEvalStack toPush thread
-                    |> IlMachineState.advanceProgramCounter thread
-                    |> Tuple.withRight WhatWeDid.Executed
+            | UnboxTypeTest.Accepted (_addr, boxed) ->
+                // Materialise using the *boxed object's* handle, not the target's: that is the
+                // handle its `Contents` were built with, which is the precondition
+                // `unboxedContents` documents. Under the enum relaxation the two can differ,
+                // and it is the push/store path that reconciles the result with the target.
+                let toPush, state =
+                    unboxedContents baseClassTypes boxed.ConcreteType boxed.Contents state
+
+                state
+                |> IlMachineState.pushToEvalStack toPush thread
+                |> IlMachineState.advanceProgramCounter thread
+                |> Tuple.withRight WhatWeDid.Executed
+
+    /// ECMA-335 III.4.32 (`unbox`). The type test is shared with the value-type arm of
+    /// `unbox.any` — CoreCLR routes both through `CastHelpers.Unbox_Helper` — but the result
+    /// differs: `unbox` pushes a managed pointer *into* the boxed object rather than a copy of
+    /// its contents, so a `stobj`/`stfld` through the result is visible through the box.
+    ///
+    /// The `Nullable<T>` target is deliberately unimplemented; see the `failwith` below.
+    let executeUnbox (ctx : UnaryMetadataIlOpContext) (state : IlMachineState) : IlMachineState * WhatWeDid =
+        let loggerFactory = ctx.LoggerFactory
+        let baseClassTypes = ctx.BaseClassTypes
+        let activeAssy = ctx.ActiveAssembly
+        let metadataToken = ctx.MetadataToken
+        let currentMethod = ctx.CurrentMethod
+        let thread = ctx.Thread
+
+        let actualObj, state = IlMachineState.popEvalStack thread state
+
+        let state, targetType, _targetAssy =
+            IlMachineState.resolveTypeMetadataToken
+                loggerFactory
+                baseClassTypes
+                state
+                activeAssy
+                ImmutableArray.Empty
+                metadataToken
+
+        let state, targetConcreteTypeHandle =
+            IlMachineState.concretizeType
+                loggerFactory
+                baseClassTypes
+                state
+                activeAssy.Name
+                currentMethod.DeclaringType.Generics
+                currentMethod.Generics
+                targetType
+
+        // Unlike `unbox.any`, whose token may denote any boxable type, III.4.32 requires a value
+        // type. None of the structural handle shapes is one — arrays are reference types, and
+        // byrefs/pointers/function pointers are not boxable at all — so metadata that gets here
+        // is invalid IL that the real runtime would reject too. Dispatch on the shape before
+        // touching metadata, since these handles have no row in `AllConcreteTypes`.
+        match targetConcreteTypeHandle with
+        | ConcreteTypeHandle.OneDimArrayZero _
+        | ConcreteTypeHandle.Array _
+        | ConcreteTypeHandle.Byref _
+        | ConcreteTypeHandle.Pointer _
+        | ConcreteTypeHandle.FunctionPointer _ ->
+            failwith
+                $"Unbox: type token denotes %O{targetConcreteTypeHandle}, which is not a value type as ECMA-335 III.4.32 requires; this is invalid IL"
+        | ConcreteTypeHandle.Concrete _ ->
+
+        let targetConcreteType =
+            AllConcreteTypes.lookup targetConcreteTypeHandle state.ConcreteTypes
+            |> Option.get
+
+        let targetDefn =
+            state._LoadedAssemblies.[targetConcreteType.Assembly].TypeDefs.[targetConcreteType.Definition.Get]
+
+        // `Nullable<T>` is a value type, so test for it before the general value-type check.
+        if InternalTypeKind.kind baseClassTypes targetConcreteType = InternalTypeKind.Nullable then
+            // `box` of a `Nullable<T>` yields null or a boxed `T`, so there is no `Nullable<T>` in
+            // the heap for a pointer to point *into*. CoreCLR resolves that by materialising a
+            // fresh `Nullable<T>` into a JIT temp and pushing the temp's address
+            // (jit/importer.cpp, `CEE_UNBOX` with `CORINFO_HELP_UNBOX_NULLABLE`), which the JIT
+            // itself flags as non-compliant with ECMA-335: the result aliases a copy, so writes
+            // through it are lost. Modelling that needs a storage location for the temp, which
+            // this interpreter has no notion of at this point; rather than guess at one, refuse
+            // loudly. Roslyn never emits this shape — it compiles `(T?) o` to
+            // `unbox.any; stloc; ldloca` — so reaching this is a signal that some other IL
+            // producer needs the temp modelled properly.
+            failwith
+                $"TODO: Unbox with a System.Nullable`1 type token (%O{targetConcreteTypeHandle}) is unimplemented; CoreCLR would push the address of a materialised copy rather than a pointer into the box"
+
+        if not (DumpedAssembly.isValueType baseClassTypes state._LoadedAssemblies targetDefn) then
+            failwith
+                $"Unbox: type token denotes reference type %O{targetConcreteTypeHandle}, but ECMA-335 III.4.32 requires a value type; this is invalid IL"
+
+        let state, typeTest =
+            unboxTypeTest loggerFactory baseClassTypes "Unbox" targetConcreteTypeHandle actualObj state
+
+        match typeTest with
+        | UnboxTypeTest.NullOperand ->
+            IlMachineStateExecution.raiseRuntimeException
+                loggerFactory
+                baseClassTypes
+                baseClassTypes.NullReferenceException
+                thread
+                state
+        | UnboxTypeTest.WrongType ->
+            IlMachineStateExecution.raiseRuntimeException
+                loggerFactory
+                baseClassTypes
+                baseClassTypes.InvalidCastException
+                thread
+                state
+        | UnboxTypeTest.Accepted (addr, boxed) ->
+            // `HeapValue` denotes the whole boxed value (see `CellAwareCopy`), so the aliasing
+            // III.4.32 requires falls out: reads and writes through this pointer go to the box
+            // itself, not to a copy.
+            let projections =
+                if boxed.ConcreteType = targetConcreteTypeHandle then
+                    []
                 else
-                    IlMachineStateExecution.raiseRuntimeException
-                        loggerFactory
-                        baseClassTypes
-                        baseClassTypes.InvalidCastException
-                        thread
-                        state
-            | other -> failwith $"Unbox_Any (value-type target): unexpected eval stack value {other}"
+                    // Reachable only through the enum/underlying relaxation in `unboxPermitted`,
+                    // where the box holds e.g. an `IntEnum` while the token says `int32`. The
+                    // pointer must be typed as the token says, so view the storage as the target.
+                    // C# cannot emit this shape (an enum has no accessible field to read through
+                    // the pointer), so it is not covered by the differential tests.
+                    [ ByrefProjection.ReinterpretAs targetConcreteType ]
+
+            let ptr =
+                CliType.RuntimePointer (
+                    CliRuntimePointer.Managed (ManagedPointerSource.Byref (ByrefRoot.HeapValue addr, projections))
+                )
+
+            state
+            |> IlMachineState.pushToEvalStack ptr thread
+            |> IlMachineState.advanceProgramCounter thread
+            |> Tuple.withRight WhatWeDid.Executed

--- a/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
@@ -1080,34 +1080,40 @@ module internal UnaryMetadataObjectOps =
             // `HeapValue` denotes the whole boxed value (see `CellAwareCopy`), so the aliasing
             // III.4.32 requires falls out: reads and writes through this pointer go to the box
             // itself, not to a copy.
+            //
+            // What it does *not* carry is a static type. Every consumer — `ldind`, `ldobj`,
+            // `ldfld`, `ldflda`, `stobj`, `stfld` — resolves the pointee from whatever storage it
+            // finds at the root, which is right exactly when the box holds the target type's own
+            // fields. The two shapes below break that, and no projection list fixes them: a
+            // trailing byte view satisfies `ldind`/`ldobj` (they take the typed byte-view read for
+            // such a pointer) but then hides the storage's real fields from `ldfld`, and omitting
+            // it does the reverse. Serving them properly needs a byref that carries a static type
+            // — a change to the pointer representation itself, not to this instruction — so refuse
+            // loudly here instead of handing back a pointer that is wrong for half its consumers.
+            //
+            // Nothing exercises either today: C# emits `unbox` only for a field read, so only ever
+            // for a genuine value type, and the single bare `unbox` in all of
+            // System.Private.CoreLib (`System.Index.Equals`, covered by UnboxFieldAccess.cs) is
+            // one of those.
             let barePrimitive, state =
                 barePrimitiveBoxShape baseClassTypes boxed.ConcreteType boxed.Contents state
 
-            // A bare `HeapValue` byref denotes the box's storage *as stored*, and an untyped read
-            // of it (which is what `ldind`/`ldobj` do — `executeLdind` routes to the typed
-            // byte-view read only for a trailing-byte-view pointer) yields that storage verbatim.
-            // That is already right for everything except one shape:
-            //   - a genuine value type reads back as itself;
-            //   - a primitive-like one (IntPtr, the `*HandleInternal` structs, an enum) is
-            //     flattened to its underlying value on push, by the eval-stack invariant in
-            //     `EvalStack.Push'`. That preserves pointer provenance, which a byte
-            //     reinterpretation would destroy — and it covers the enum/underlying relaxation
-            //     in `unboxPermitted` without any help from us;
-            //   - but `box` of a *bare* primitive stores it inside a synthetic single-field
-            //     struct, which is not primitive-like and so is not flattened. Only here does the
-            //     pointer need to carry its static type, so that reads and writes go through the
-            //     byte-view path and see the payload rather than the wrapper.
-            // None of this is reachable from C#, which emits `unbox` only for a field read and so
-            // only ever for a genuine value type; it is not covered end-to-end by the
-            // differential tests.
-            let projections =
-                match barePrimitive with
-                | None -> []
-                | Some _ -> [ ByrefProjection.ReinterpretAs targetConcreteType ]
+            match barePrimitive with
+            | Some _ ->
+                failwith
+                    $"TODO: Unbox of a boxed bare primitive (%O{boxed.ConcreteType}) is unimplemented; `box` stores it inside a synthetic single-field struct, so a byref to the box addresses that wrapper rather than the value, and `HeapValue` cannot express the distinction"
+            | None ->
+
+            if boxed.ConcreteType <> targetConcreteTypeHandle then
+                // `unboxPermitted` also accepts same-primitive-element-type pairs, so the box's
+                // type and the token's can differ: a boxed enum unboxed as its underlying integer,
+                // or as another enum over the same integer.
+                failwith
+                    $"TODO: Unbox under the enum/underlying relaxation (box holds %O{boxed.ConcreteType}, token says %O{targetConcreteTypeHandle}) is unimplemented; the byref would have to present the box's storage as the token's type while leaving the box's own runtime type intact"
 
             let ptr =
                 CliType.RuntimePointer (
-                    CliRuntimePointer.Managed (ManagedPointerSource.Byref (ByrefRoot.HeapValue addr, projections))
+                    CliRuntimePointer.Managed (ManagedPointerSource.Byref (ByrefRoot.HeapValue addr, []))
                 )
 
             state

--- a/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
@@ -672,6 +672,31 @@ module internal UnaryMetadataObjectOps =
     ///   - a bare primitive (Int32, Float64, ...), which `box` stored in a synthetic single-field
     ///     struct: read field 0 back by offset and size. `box` guarantees that shape, so this is a
     ///     nominal dereference rather than a structural guess.
+    /// `Some zero` exactly when `executeBox` stored a *bare* primitive inside a synthetic
+    /// single-field struct, `zero` being the zero of that primitive (whose size is the field's
+    /// extent). `None` when the boxed storage is the value type's own fields — either because it
+    /// is primitive-like (IntPtr, RuntimeTypeHandle, an enum, ...) and stays wrapped, or because
+    /// it is a genuine value type.
+    ///
+    /// This distinction is what separates "a byref to the box addresses the value directly" from
+    /// "it addresses a wrapper around the value", so both `unboxedContents` and `executeUnbox`
+    /// hang off it.
+    let private barePrimitiveBoxShape
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (handle : ConcreteTypeHandle)
+        (contents : CliValueType)
+        (state : IlMachineState)
+        : CliType option * IlMachineState
+        =
+        if contents.PrimitiveLikeKind.IsSome then
+            None, state
+        else
+            let zero, state = IlMachineState.cliTypeZeroOfHandle state baseClassTypes handle
+
+            match zero with
+            | CliType.ValueType _ -> None, state
+            | bare -> Some bare, state
+
     let private unboxedContents
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (handle : ConcreteTypeHandle)
@@ -679,16 +704,13 @@ module internal UnaryMetadataObjectOps =
         (state : IlMachineState)
         : CliType * IlMachineState
         =
-        if contents.PrimitiveLikeKind.IsSome then
-            CliType.ValueType contents, state
-        else
-            let zero, state = IlMachineState.cliTypeZeroOfHandle state baseClassTypes handle
+        let shape, state = barePrimitiveBoxShape baseClassTypes handle contents state
 
-            match zero with
-            | CliType.ValueType _ -> CliType.ValueType contents, state
-            | _ ->
-                let size = (CliType.SizeOf zero).Size
-                CliValueType.DereferenceFieldAt 0 size contents, state
+        match shape with
+        | None -> CliType.ValueType contents, state
+        | Some zero ->
+            let size = (CliType.SizeOf zero).Size
+            CliValueType.DereferenceFieldAt 0 size contents, state
 
     /// The outcome of the type test that ECMA-335 III.4.32 (`unbox`) and the value-type arm of
     /// III.4.33 (`unbox.any`) share; CoreCLR routes both through `CastHelpers.Unbox_Helper`.
@@ -1058,15 +1080,25 @@ module internal UnaryMetadataObjectOps =
             // `HeapValue` denotes the whole boxed value (see `CellAwareCopy`), so the aliasing
             // III.4.32 requires falls out: reads and writes through this pointer go to the box
             // itself, not to a copy.
+            let barePrimitive, state =
+                barePrimitiveBoxShape baseClassTypes boxed.ConcreteType boxed.Contents state
+
+            // A bare `HeapValue` byref denotes the box's storage *as stored*, which is only the
+            // same thing as the token's type when the box holds the target type's own fields.
+            // Two cases break that, and both need the pointer to carry its static type:
+            //   - `box` of a bare primitive stores it inside a synthetic single-field struct, so
+            //     the storage is a wrapper around the value rather than the value. Without the
+            //     view, `ldind`/`ldobj` take the untyped read (`executeLdind` only routes to the
+            //     typed byte-view read for a trailing-byte-view pointer) and surface the wrapper;
+            //   - the enum/underlying relaxation in `unboxPermitted`, where the box holds e.g. an
+            //     `IntEnum` while the token says `int32`.
+            // Neither is reachable from C#, which emits `unbox` only for a field read and so only
+            // ever for a genuine multi-field struct; they are therefore not covered end-to-end by
+            // the differential tests.
             let projections =
-                if boxed.ConcreteType = targetConcreteTypeHandle then
+                if barePrimitive.IsNone && boxed.ConcreteType = targetConcreteTypeHandle then
                     []
                 else
-                    // Reachable only through the enum/underlying relaxation in `unboxPermitted`,
-                    // where the box holds e.g. an `IntEnum` while the token says `int32`. The
-                    // pointer must be typed as the token says, so view the storage as the target.
-                    // C# cannot emit this shape (an enum has no accessible field to read through
-                    // the pointer), so it is not covered by the differential tests.
                     [ ByrefProjection.ReinterpretAs targetConcreteType ]
 
             let ptr =

--- a/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
@@ -1083,23 +1083,27 @@ module internal UnaryMetadataObjectOps =
             let barePrimitive, state =
                 barePrimitiveBoxShape baseClassTypes boxed.ConcreteType boxed.Contents state
 
-            // A bare `HeapValue` byref denotes the box's storage *as stored*, which is only the
-            // same thing as the token's type when the box holds the target type's own fields.
-            // Two cases break that, and both need the pointer to carry its static type:
-            //   - `box` of a bare primitive stores it inside a synthetic single-field struct, so
-            //     the storage is a wrapper around the value rather than the value. Without the
-            //     view, `ldind`/`ldobj` take the untyped read (`executeLdind` only routes to the
-            //     typed byte-view read for a trailing-byte-view pointer) and surface the wrapper;
-            //   - the enum/underlying relaxation in `unboxPermitted`, where the box holds e.g. an
-            //     `IntEnum` while the token says `int32`.
-            // Neither is reachable from C#, which emits `unbox` only for a field read and so only
-            // ever for a genuine multi-field struct; they are therefore not covered end-to-end by
-            // the differential tests.
+            // A bare `HeapValue` byref denotes the box's storage *as stored*, and an untyped read
+            // of it (which is what `ldind`/`ldobj` do — `executeLdind` routes to the typed
+            // byte-view read only for a trailing-byte-view pointer) yields that storage verbatim.
+            // That is already right for everything except one shape:
+            //   - a genuine value type reads back as itself;
+            //   - a primitive-like one (IntPtr, the `*HandleInternal` structs, an enum) is
+            //     flattened to its underlying value on push, by the eval-stack invariant in
+            //     `EvalStack.Push'`. That preserves pointer provenance, which a byte
+            //     reinterpretation would destroy — and it covers the enum/underlying relaxation
+            //     in `unboxPermitted` without any help from us;
+            //   - but `box` of a *bare* primitive stores it inside a synthetic single-field
+            //     struct, which is not primitive-like and so is not flattened. Only here does the
+            //     pointer need to carry its static type, so that reads and writes go through the
+            //     byte-view path and see the payload rather than the wrapper.
+            // None of this is reachable from C#, which emits `unbox` only for a field read and so
+            // only ever for a genuine value type; it is not covered end-to-end by the
+            // differential tests.
             let projections =
-                if barePrimitive.IsNone && boxed.ConcreteType = targetConcreteTypeHandle then
-                    []
-                else
-                    [ ByrefProjection.ReinterpretAs targetConcreteType ]
+                match barePrimitive with
+                | None -> []
+                | Some _ -> [ ByrefProjection.ReinterpretAs targetConcreteType ]
 
             let ptr =
                 CliType.RuntimePointer (


### PR DESCRIPTION
`unbox` (ECMA-335 III.4.32) differs from `unbox.any` (III.4.33) in its *result*, not its type test: it pushes a managed pointer **into** the boxed object rather than a copy of the contents, so a write through the result is visible through the box. CoreCLR routes both instructions through `CastHelpers.Unbox_Helper`, so the accept/reject decision — including the enum/underlying relaxation from #679 — is shared, and this PR factors it out of `executeUnboxAny` into `unboxTypeTest` so the two cannot drift apart.

`ByrefRoot.HeapValue` already denotes "the whole boxed value" and has full read/write support, so the aliasing falls out with no new byref machinery.

### Scope

Implemented: a boxed value type unboxed by its own type. That is the whole of what C# can reach — `((Point) o).X` compiles to `unbox Point; ldfld Point::X`, because the field read needs an address, whereas a *method* call on a cast result spills through `unbox.any; stloc; ldloca` so it cannot observe the aliasing.

Three shapes fail loudly instead, each with a message naming the condition:

- **`Nullable<T>` token.** `box` of a `Nullable<T>` never produces a boxed Nullable, so there is nothing in the heap to point into. CoreCLR materialises a fresh `Nullable<T>` into a JIT temp and pushes the temp's address (`jit/importer.cpp`, `CEE_UNBOX` with `CORINFO_HELP_UNBOX_NULLABLE`) — which the JIT itself flags as non-compliant with ECMA-335, since the result aliases a copy and writes through it are lost. Modelling it needs a storage location for the temp.
- **A boxed bare primitive**, whose storage is `box`'s synthetic single-field wrapper rather than the value itself.
- **The enum/underlying relaxation**, where the box's runtime type and the token differ.

The last two are refused for the same underlying reason: `ByrefRoot.HeapValue` carries no static type, so every consumer (`ldind`, `ldobj`, `ldfld`, `stobj`, …) resolves the pointee from whatever storage it finds. That is right exactly when the box holds the target type's own fields, and **no projection list fixes it otherwise** — a trailing byte view satisfies `ldind`/`ldobj` but then hides the storage's real fields from `ldfld`, and omitting it does the reverse. Serving them needs a byref that carries a static type, which is a change to the pointer representation rather than to this instruction.

Nothing exercises any of the three today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)