### PR TITLE
Run the IL for MemoryExtensions.StartsWith(ROS<T>, ROS<T>)

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/IntSpanStartsWithBitwise.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/IntSpanStartsWithBitwise.cs
@@ -1,0 +1,189 @@
+using System;
+
+namespace IntSpanStartsWithBitwiseTest
+{
+    enum SmallEnum : short
+    {
+        First = 1,
+        Second = 2,
+        Third = -3,
+    }
+
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            int[] empty = new int[0];
+
+            // Every span starts with the empty span, including the empty span itself.
+            if (!((ReadOnlySpan<int>)empty).StartsWith((ReadOnlySpan<int>)new int[0]))
+            {
+                return 1;
+            }
+
+            int[] left = new int[3];
+            left[0] = 123456;
+            left[1] = -789;
+            left[2] = 42;
+
+            int[] prefix = new int[2];
+            prefix[0] = 123456;
+            prefix[1] = -789;
+
+            int[] notPrefix = new int[2];
+            notPrefix[0] = 123456;
+            notPrefix[1] = -790;
+
+            int[] suffix = new int[2];
+            suffix[0] = -789;
+            suffix[1] = 42;
+
+            int[] longer = new int[4];
+            longer[0] = 123456;
+            longer[1] = -789;
+            longer[2] = 42;
+            longer[3] = 7;
+
+            ReadOnlySpan<int> leftSpan = left;
+
+            if (!leftSpan.StartsWith((ReadOnlySpan<int>)prefix))
+            {
+                return 2;
+            }
+
+            // A span starts with itself.
+            if (!leftSpan.StartsWith(leftSpan))
+            {
+                return 3;
+            }
+
+            if (leftSpan.StartsWith((ReadOnlySpan<int>)notPrefix))
+            {
+                return 4;
+            }
+
+            // Matching elements, but not at the start.
+            if (leftSpan.StartsWith((ReadOnlySpan<int>)suffix))
+            {
+                return 5;
+            }
+
+            // A value longer than the span can never be a prefix.
+            if (leftSpan.StartsWith((ReadOnlySpan<int>)longer))
+            {
+                return 6;
+            }
+
+            // The empty span starts with nothing but the empty span.
+            if (((ReadOnlySpan<int>)empty).StartsWith((ReadOnlySpan<int>)prefix))
+            {
+                return 7;
+            }
+
+            // Slicing shifts which elements are compared.
+            if (!leftSpan.Slice(1).StartsWith((ReadOnlySpan<int>)suffix))
+            {
+                return 8;
+            }
+
+            if (leftSpan.Slice(1).StartsWith((ReadOnlySpan<int>)prefix))
+            {
+                return 9;
+            }
+
+            bool[] boolLeft = new bool[3];
+            boolLeft[0] = true;
+            boolLeft[1] = false;
+            boolLeft[2] = true;
+
+            bool[] boolPrefix = new bool[2];
+            boolPrefix[0] = true;
+            boolPrefix[1] = false;
+
+            bool[] boolNotPrefix = new bool[2];
+            boolNotPrefix[0] = true;
+            boolNotPrefix[1] = true;
+
+            if (!((ReadOnlySpan<bool>)boolLeft).StartsWith((ReadOnlySpan<bool>)boolPrefix))
+            {
+                return 10;
+            }
+
+            if (((ReadOnlySpan<bool>)boolLeft).StartsWith((ReadOnlySpan<bool>)boolNotPrefix))
+            {
+                return 11;
+            }
+
+            char[] charLeft = new char[3];
+            charLeft[0] = 'a';
+            charLeft[1] = '☃';
+            charLeft[2] = 'z';
+
+            char[] charPrefix = new char[2];
+            charPrefix[0] = 'a';
+            charPrefix[1] = '☃';
+
+            char[] charNotPrefix = new char[2];
+            charNotPrefix[0] = 'a';
+            charNotPrefix[1] = '☄';
+
+            if (!((ReadOnlySpan<char>)charLeft).StartsWith((ReadOnlySpan<char>)charPrefix))
+            {
+                return 12;
+            }
+
+            if (((ReadOnlySpan<char>)charLeft).StartsWith((ReadOnlySpan<char>)charNotPrefix))
+            {
+                return 13;
+            }
+
+            SmallEnum[] enumLeft = new SmallEnum[3];
+            enumLeft[0] = SmallEnum.First;
+            enumLeft[1] = SmallEnum.Second;
+            enumLeft[2] = SmallEnum.Third;
+
+            SmallEnum[] enumPrefix = new SmallEnum[2];
+            enumPrefix[0] = SmallEnum.First;
+            enumPrefix[1] = SmallEnum.Second;
+
+            SmallEnum[] enumNotPrefix = new SmallEnum[2];
+            enumNotPrefix[0] = SmallEnum.First;
+            enumNotPrefix[1] = SmallEnum.Third;
+
+            if (!((ReadOnlySpan<SmallEnum>)enumLeft).StartsWith((ReadOnlySpan<SmallEnum>)enumPrefix))
+            {
+                return 14;
+            }
+
+            if (((ReadOnlySpan<SmallEnum>)enumLeft).StartsWith((ReadOnlySpan<SmallEnum>)enumNotPrefix))
+            {
+                return 15;
+            }
+
+            long[] longLeft = new long[3];
+            longLeft[0] = 1L << 40;
+            longLeft[1] = -(1L << 33);
+            longLeft[2] = 5;
+
+            long[] longPrefix = new long[2];
+            longPrefix[0] = 1L << 40;
+            longPrefix[1] = -(1L << 33);
+
+            long[] longNotPrefix = new long[2];
+            longNotPrefix[0] = 1L << 40;
+            longNotPrefix[1] = -(1L << 34);
+
+            if (!((ReadOnlySpan<long>)longLeft).StartsWith((ReadOnlySpan<long>)longPrefix))
+            {
+                return 16;
+            }
+
+            if (((ReadOnlySpan<long>)longLeft).StartsWith((ReadOnlySpan<long>)longNotPrefix))
+            {
+                return 17;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/WoofWare.PawPrint/IntrinsicMethodKeys.fs
+++ b/WoofWare.PawPrint/IntrinsicMethodKeys.fs
@@ -151,6 +151,23 @@ module IntrinsicMethodKeys =
                     IntrinsicParameterPattern.Exact "System.ReadOnlySpan`1"
                     IntrinsicParameterPattern.Exact "System.ReadOnlySpan`1"
                 ]
+            // Same shape as SequenceEqual above, with `value.Length <= span.Length` in place of
+            // the equal-lengths check: the IL is `get_Length`, RuntimeHelpers.IsBitwiseEquatable<T>,
+            // MemoryMarshal.GetReference, Unsafe.As<T, byte>, `sizeof T`, then
+            // SpanHelpers.SequenceEqual(ref byte, ref byte, nuint) — all modelled boundaries.
+            // The `[Intrinsic]` marker is only so the JIT can unroll/vectorise half-constant input.
+            // As with SequenceEqual, the non-bitwise-equatable fallback bottoms out in the generic
+            // SpanHelpers.SequenceEqual<T>, which PawPrint does not yet implement; executing this
+            // IL for such a T therefore fails loudly there rather than silently misbehaving.
+            // https://github.com/dotnet/runtime/blob/HEAD/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs#L3561
+            pattern
+                "System.Private.CoreLib"
+                "System.MemoryExtensions"
+                "StartsWith"
+                [
+                    IntrinsicParameterPattern.Exact "System.ReadOnlySpan`1"
+                    IntrinsicParameterPattern.Exact "System.ReadOnlySpan`1"
+                ]
             // https://github.com/dotnet/runtime/blob/ec11903827fc28847d775ba17e0cd1ff56cfbc2e/src/libraries/System.Private.CoreLib/src/System/ArgumentNullException.cs#L54
             anyParams "System.Private.CoreLib" "System.ArgumentNullException" "ThrowIfNull"
             // https://github.com/dotnet/runtime/blob/ec11903827fc28847d775ba17e0cd1ff56cfbc2e/src/coreclr/System.Private.CoreLib/src/System/Type.CoreCLR.cs#L82


### PR DESCRIPTION
`MemoryExtensions.StartsWith<T>(ReadOnlySpan<T>, ReadOnlySpan<T>)` is marked `[Intrinsic]`, so PawPrint refused to execute it and failed with `TODO: implement JIT intrinsic ...`. The marker is only there so the JIT can unroll/vectorise half-constant input; the managed IL is perfectly executable here, so this adds the method to `safeIntrinsics` rather than hand-implementing it.

I dumped the actual IL with `WoofWare.PawPrint.IlDump` rather than trusting the C# source. The body is `get_Length`, `RuntimeHelpers.IsBitwiseEquatable<T>`, `MemoryMarshal.GetReference`, `Unsafe.As<T, byte>`, `sizeof T`/`conv.u`/`mul`, then `SpanHelpers.SequenceEqual(ref byte, ref byte, nuint)` — structurally identical to `SequenceEqual<T>(ROS<T>, ROS<T>)`, which is already allowlisted; only the length guard differs (`<=` vs `==`). Every callee is an already-modelled boundary, including the `SpanHelpers.SequenceEqual` interception that routes through `CellAwareCopy`-aware byte reads to preserve cell provenance.

The allowlist entry uses two `Exact "System.ReadOnlySpan`1"` shapes, so it deliberately does not match the sibling `StartsWith(Span<T>, ROS<T>)`, the 3-argument `IEqualityComparer` overload, or the single-`T`-value overloads.

## Not included

- The sibling `StartsWith<T>(this Span<T>, ROS<T>)` (IL: `op_Implicit` then a tail call into the overload enabled here) and `EndsWith` are still `[Intrinsic]` and still hit the TODO. One allowlist entry each; kept out to stay to one feature per change.
- For a `T` where `IsBitwiseEquatable` is false (user structs, reference types), the IL falls through to the generic `SpanHelpers.SequenceEqual<T>`, which PawPrint does not implement. That fails loudly rather than misbehaving silently. It is the same pre-existing gap `SequenceEqual` has, but note that `StartsWith` on e.g. a `string[]` now fails deeper in, at `SpanHelpers`, instead of at the intrinsic check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
