### PR TITLE
Dump fields, properties and events in IlDump's default mode (#700)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,8 +58,10 @@ nix develop -c dotnet run --project WoofWare.PawPrint.App/WoofWare.PawPrint.App.
 
 **WoofWare.PawPrint.IlDump**
 - Small CLI tool for disassembling IL from .NET assemblies, using the same assembly-reading infrastructure as the interpreter
-- Usage: `nix develop -c dotnet run --project WoofWare.PawPrint.IlDump -- <dll-path> [TypeName] [MethodName]`
-- Filters are case-insensitive substring matches
+- Usage: `nix develop -c dotnet run --project WoofWare.PawPrint.IlDump -- <dll-path> [TypeName] [MemberName]`
+- Filters are case-insensitive substring matches; an empty filter argument means "no narrowing", so `-- <dll> "" Foo` searches every type for a member named `Foo`
+- Default mode dumps each matching type as a `// type` header, one line per field/property/event, then the full IL of each matching method. A type filter that matches a type but no member still prints the type header, so "no such member" is distinguishable from "no such type"
+- `--attrs-only` instead dumps custom attribute applications, and emits only those members which carry attributes
 
 ### Key Design Patterns
 

--- a/WoofWare.PawPrint.Domain/AttributeFormatting.fs
+++ b/WoofWare.PawPrint.Domain/AttributeFormatting.fs
@@ -409,9 +409,25 @@ module AttributeFormatting =
             paramTypes
             method.RawSignature.ReturnType
 
-    /// Comment-prefixed header for a FieldDef.
+    /// <summary>
+    /// Comment-prefixed header for a FieldDef. Static-ness is rendered in the
+    /// same position as <see cref="methodHeader"/> renders it. A trailing
+    /// <c>@ 0xNN</c> reports the field's offset for explicitly-laid-out types;
+    /// fields whose offset the runtime chooses carry no such suffix.
+    /// </summary>
     let fieldHeader (qualifiedTypeName : string) (field : FieldInfo<GenericParamFromMetadata, TypeDefn>) : string =
-        sprintf "// field %s::%s : %O" qualifiedTypeName field.Name field.Signature
+        let staticStr =
+            if field.Attributes.HasFlag System.Reflection.FieldAttributes.Static then
+                "static "
+            else
+                ""
+
+        let offsetStr =
+            match field.Offset with
+            | None -> ""
+            | Some offset -> sprintf " @ 0x%X" offset
+
+        sprintf "// field %s::%s%s : %O%s" qualifiedTypeName staticStr field.Name field.Signature offsetStr
 
     /// Comment-prefixed header for an EventDef.
     let eventHeader (qualifiedTypeName : string) (event : EventDefn) : string =

--- a/WoofWare.PawPrint.Domain/IlDumpRendering.fs
+++ b/WoofWare.PawPrint.Domain/IlDumpRendering.fs
@@ -1,0 +1,137 @@
+namespace WoofWare.PawPrint
+
+open System
+open System.Reflection.Metadata
+
+/// <summary>
+/// The pair of case-insensitive substring filters IlDump takes on its command
+/// line. <c>None</c> means "no filter given", which matches everything.
+/// </summary>
+type IlDumpFilter =
+    {
+        /// Matched against the fully-qualified type name.
+        Type : string option
+
+        /// Matched against member names: fields, properties, events, methods.
+        Member : string option
+    }
+
+[<RequireQualifiedAccess>]
+module IlDumpFilter =
+
+    /// <summary>
+    /// Build a filter from raw command-line arguments. An empty argument is
+    /// normalised to <c>None</c>: the only way to spell "every type, this member"
+    /// on the command line is to pass an empty type argument, and that must mean
+    /// "no type narrowing" rather than "a filter which happens to match all types"
+    /// — the two differ in whether unmatched types still report their existence.
+    /// </summary>
+    let make (typeFilter : string option) (memberFilter : string option) : IlDumpFilter =
+        let normalise (s : string option) : string option =
+            match s with
+            | Some "" -> None
+            | other -> other
+
+        {
+            Type = normalise typeFilter
+            Member = normalise memberFilter
+        }
+
+/// <summary>
+/// Rendering for IlDump's default mode: a whole type as a sequence of lines —
+/// the type header, a one-line summary of each field, property and event, and
+/// the full IL of each method.
+/// </summary>
+/// <remarks>
+/// This lives alongside <see cref="AttributeFormatting"/> rather than in the
+/// IlDump executable so that it is a pure <c>string list</c>-returning function
+/// the test suite can exercise directly against a real assembly.
+/// </remarks>
+[<RequireQualifiedAccess>]
+module IlDumpRendering =
+
+    /// Whether a name passes a filter. A filter of `None` (the user gave no such
+    /// argument) admits everything.
+    let matchesFilter (filter : string option) (name : string) : bool =
+        match filter with
+        | None -> true
+        | Some filter -> name.Contains (filter, StringComparison.OrdinalIgnoreCase)
+
+    /// Whether a type passes the filter's type component.
+    let typeMatches
+        (assembly : DumpedAssembly)
+        (filter : IlDumpFilter)
+        (typeInfo : TypeInfo<GenericParamFromMetadata, TypeDefn>)
+        : bool
+        =
+        matchesFilter filter.Type (IlFormatting.qualifyTypeName assembly.TypeDefs typeInfo)
+
+    /// <summary>
+    /// The lines IlDump's default mode emits for a single type which has already
+    /// passed <see cref="typeMatches"/>, or the empty list if the type should
+    /// contribute no output at all.
+    /// </summary>
+    /// <remarks>
+    /// The type header is emitted whenever the caller narrowed the dump by type,
+    /// even if no member matched: that is what makes "this type exists but has no
+    /// such member" distinguishable from "there is no such type". Without a type
+    /// filter the header is emitted only when some member matched, so that a bare
+    /// member search across an assembly does not emit a header for each of its
+    /// thousands of types.
+    /// </remarks>
+    let formatTypeLines
+        (assembly : DumpedAssembly)
+        (filter : IlDumpFilter)
+        (typeInfo : TypeInfo<GenericParamFromMetadata, TypeDefn>)
+        : string list
+        =
+        let qualified = IlFormatting.qualifyTypeName assembly.TypeDefs typeInfo
+
+        let fieldLines =
+            typeInfo.Fields
+            |> List.filter (fun f -> matchesFilter filter.Member f.Name)
+            |> List.map (AttributeFormatting.fieldHeader qualified)
+
+        // Properties live only in the metadata reader: there is no domain type.
+        let propertyLines =
+            let mr = assembly.PeReader.GetMetadataReader ()
+            let typeDef = mr.GetTypeDefinition typeInfo.TypeDefHandle
+
+            [
+                for propHandle in typeDef.GetProperties () do
+                    let name = mr.GetString ((mr.GetPropertyDefinition propHandle).Name)
+
+                    if matchesFilter filter.Member name then
+                        yield AttributeFormatting.propertyHeader qualified name
+            ]
+
+        let eventLines =
+            typeInfo.Events
+            |> Seq.filter (fun e -> matchesFilter filter.Member e.Name)
+            |> Seq.map (AttributeFormatting.eventHeader qualified)
+            |> List.ofSeq
+
+        // Methods are the only members with a body, so each becomes its own
+        // blank-line-separated block rather than a single summary line.
+        let methodBlocks =
+            typeInfo.Methods
+            |> List.filter (fun m -> matchesFilter filter.Member m.Name)
+            |> List.map (IlFormatting.formatMethodLines assembly qualified)
+
+        let summaryLines = fieldLines @ propertyLines @ eventLines
+
+        if
+            List.isEmpty summaryLines
+            && List.isEmpty methodBlocks
+            && Option.isNone filter.Type
+        then
+            []
+        else
+            [
+                yield AttributeFormatting.typeHeader assembly typeInfo
+                yield! summaryLines
+
+                for block in methodBlocks do
+                    yield ""
+                    yield! block
+            ]

--- a/WoofWare.PawPrint.Domain/WoofWare.PawPrint.Domain.fsproj
+++ b/WoofWare.PawPrint.Domain/WoofWare.PawPrint.Domain.fsproj
@@ -49,6 +49,7 @@
         <Compile Include="AccessCheck.fs" />
         <Compile Include="IlFormatting.fs" />
         <Compile Include="AttributeFormatting.fs" />
+        <Compile Include="IlDumpRendering.fs" />
         <Compile Include="TypeConcretisation.fs" />
         <EmbeddedResource Include="version.json" />
     </ItemGroup>

--- a/WoofWare.PawPrint.IlDump/Program.fs
+++ b/WoofWare.PawPrint.IlDump/Program.fs
@@ -1,7 +1,5 @@
 namespace WoofWare.PawPrint.IlDump
 
-open System
-open System.IO
 open System.Reflection.Metadata
 open System.Reflection.Metadata.Ecma335
 open Microsoft.Extensions.Logging
@@ -12,17 +10,6 @@ module Program =
     type private Mode =
         | Default
         | AttrsOnly
-
-    let private printMethod
-        (assembly : DumpedAssembly)
-        (qualifiedTypeName : string)
-        (method : MethodInfo<GenericParamFromMetadata, GenericParamFromMetadata, TypeDefn>)
-        : unit
-        =
-        for line in IlFormatting.formatMethodLines assembly qualifiedTypeName method do
-            printfn $"%s{line}"
-
-        printfn ""
 
     /// Emit attribute-only output for a single type: the type's own attribute
     /// lines (if any), followed by attribute lines for each filter-matching
@@ -49,10 +36,7 @@ module Program =
                 typeHeader
                 (MetadataToken.TypeDefinition typeInfo.TypeDefHandle)
 
-        let memberNameMatches (name : string) : bool =
-            match memberFilter with
-            | None -> true
-            | Some filter -> name.Contains (filter, StringComparison.OrdinalIgnoreCase)
+        let memberNameMatches : string -> bool = IlDumpRendering.matchesFilter memberFilter
 
         let methodGroups =
             typeInfo.Methods
@@ -135,11 +119,11 @@ module Program =
 
             1
         | dllPath :: rest ->
-            let typeFilter, memberFilter =
+            let filter =
                 match rest with
-                | [] -> None, None
-                | [ t ] -> Some t, None
-                | t :: m :: _ -> Some t, Some m
+                | [] -> IlDumpFilter.make None None
+                | [ t ] -> IlDumpFilter.make (Some t) None
+                | t :: m :: _ -> IlDumpFilter.make (Some t) (Some m)
 
             use loggerFactory =
                 LoggerFactory.Create (fun builder ->
@@ -151,24 +135,24 @@ module Program =
 
             match mode with
             | Mode.Default ->
+                let mutable anyEmitted = false
+
                 for kvp in assembly.TypeDefs do
                     let typeInfo = kvp.Value
-                    let qualifiedName = IlFormatting.qualifyTypeName assembly.TypeDefs typeInfo
 
-                    let typeMatches =
-                        match typeFilter with
-                        | None -> true
-                        | Some filter -> qualifiedName.Contains (filter, StringComparison.OrdinalIgnoreCase)
+                    if IlDumpRendering.typeMatches assembly filter typeInfo then
+                        let lines = IlDumpRendering.formatTypeLines assembly filter typeInfo
 
-                    if typeMatches then
-                        for method in typeInfo.Methods do
-                            let methodMatches =
-                                match memberFilter with
-                                | None -> true
-                                | Some filter -> method.Name.Contains (filter, StringComparison.OrdinalIgnoreCase)
+                        if not (List.isEmpty lines) then
+                            // Separate from the previous type only now that we know
+                            // there's something to emit.
+                            if anyEmitted then
+                                printfn ""
 
-                            if methodMatches then
-                                printMethod assembly qualifiedName method
+                            for line in lines do
+                                printfn $"%s{line}"
+
+                            anyEmitted <- true
 
             | Mode.AttrsOnly ->
                 let mutable anyEmitted = false
@@ -190,7 +174,7 @@ module Program =
                 // ModuleDefinition rows, not under any type. Emit them up front when the user
                 // hasn't narrowed the scope with a type filter; a type filter scopes the
                 // output to types and should suppress these.
-                if Option.isNone typeFilter then
+                if Option.isNone filter.Type then
                     printOwnerGroup
                         (AttributeFormatting.assemblyHeader assembly)
                         (MetadataToken.AssemblyDefinition EntityHandle.AssemblyDefinition)
@@ -206,15 +190,9 @@ module Program =
 
                 for kvp in assembly.TypeDefs do
                     let typeInfo = kvp.Value
-                    let qualifiedName = IlFormatting.qualifyTypeName assembly.TypeDefs typeInfo
 
-                    let typeMatches =
-                        match typeFilter with
-                        | None -> true
-                        | Some filter -> qualifiedName.Contains (filter, StringComparison.OrdinalIgnoreCase)
-
-                    if typeMatches then
-                        let emitted = printTypeAttrs assembly memberFilter (not anyEmitted) typeInfo
+                    if IlDumpRendering.typeMatches assembly filter typeInfo then
+                        let emitted = printTypeAttrs assembly filter.Member (not anyEmitted) typeInfo
 
                         if emitted then
                             anyEmitted <- true

--- a/WoofWare.PawPrint.Test/TestAttributeFormatting.fs
+++ b/WoofWare.PawPrint.Test/TestAttributeFormatting.fs
@@ -257,6 +257,52 @@ module TestAttributeFormatting =
         let header = AttributeFormatting.typeHeader corelib exn
         header |> shouldEqual "// type System.Exception"
 
+    // ----- field header: static-ness and explicit layout ---------------------
+
+    [<Test>]
+    let ``fieldHeader marks a static field static, mirroring methodHeader`` () : unit =
+        let str = findTypeByName "System.String"
+
+        let empty = str.Fields |> List.find (fun f -> f.Name = "Empty")
+
+        // The signature rendering is TypeDefn's business; assert only the prefix
+        // this header controls.
+        AttributeFormatting.fieldHeader "System.String" empty
+        |> fun h -> h.StartsWith "// field System.String::static Empty : " |> shouldEqual true
+
+    [<Test>]
+    let ``fieldHeader omits the static marker for an instance field`` () : unit =
+        let str = findTypeByName "System.String"
+
+        let length = str.Fields |> List.find (fun f -> f.Name = "_stringLength")
+
+        AttributeFormatting.fieldHeader "System.String" length
+        |> fun h -> h.StartsWith "// field System.String::_stringLength : " |> shouldEqual true
+
+    [<Test>]
+    let ``fieldHeader reports an explicit field offset`` () : unit =
+        // Search corelib for any explicitly-laid-out field rather than hard-coding a
+        // type whose layout may change between servicing releases.
+        let found =
+            corelib.TypeDefs.Values
+            |> Seq.collect (fun td ->
+                td.Fields
+                |> Seq.choose (fun f ->
+                    match f.Offset with
+                    | None -> None
+                    | Some offset -> Some (IlFormatting.qualifyTypeName corelib.TypeDefs td, f, offset)
+                )
+            )
+            |> Seq.sortBy (fun (qualified, f, _) -> qualified, f.Name)
+            |> Seq.tryHead
+
+        match found with
+        | None -> Assert.Inconclusive "corelib declares no explicitly-laid-out fields; nothing to exercise"
+        | Some (qualified, field, offset) ->
+
+        let header = AttributeFormatting.fieldHeader qualified field
+        header.EndsWith (sprintf " @ 0x%X" offset) |> shouldEqual true
+
     // ----- renderOwnerLines: skips empty owners ------------------------------
 
     [<Test>]

--- a/WoofWare.PawPrint.Test/TestIlDumpRendering.fs
+++ b/WoofWare.PawPrint.Test/TestIlDumpRendering.fs
@@ -1,0 +1,218 @@
+namespace WoofWare.PawPrint.Test
+
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+/// Tests for the default (non-`--attrs-only`) IlDump rendering: the whole-type
+/// dump that IlDump's Mode.Default prints for each type matching the filters.
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestIlDumpRendering =
+
+    // The factory is intentionally undisposed: the returned DumpedAssembly.Logger closes
+    // over its sinks, and disposing while the assembly is still live would silently drop
+    // events.
+    let private corelib : DumpedAssembly =
+        let corelibPath = typeof<obj>.Assembly.Location
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        Assembly.readFile loggerFactory corelibPath
+
+    let private findTypeByName (qualified : string) : TypeInfo<GenericParamFromMetadata, TypeDefn> =
+        corelib.TypeDefs.Values
+        |> Seq.find (fun td -> IlFormatting.qualifyTypeName corelib.TypeDefs td = qualified)
+
+    /// The filter shape IlDump builds when the user supplies both a type and a
+    /// member argument on the command line.
+    let private filterOn (typeName : string) (memberName : string option) : IlDumpFilter =
+        {
+            Type = Some typeName
+            Member = memberName
+        }
+
+    // ----- filter construction from command-line arguments -------------------
+
+    [<Test>]
+    let ``an empty filter argument means no narrowing`` () : unit =
+        // "ildump foo.dll '' SomeMember" is the only way to spell a member search
+        // across every type, so the empty type argument must not count as having
+        // narrowed by type.
+        IlDumpFilter.make (Some "") (Some "Foo")
+        |> shouldEqual
+            {
+                Type = None
+                Member = Some "Foo"
+            }
+
+        IlDumpFilter.make (Some "System") (Some "")
+        |> shouldEqual
+            {
+                Type = Some "System"
+                Member = None
+            }
+
+    // ----- the regression from issue #700 ------------------------------------
+
+    [<Test>]
+    let ``a field-name member filter finds the field`` () : unit =
+        // Before the fix, Mode.Default iterated only Methods, so filtering a type
+        // by one of its field names emitted nothing at all — making a data-only
+        // type look as though it did not exist.
+        let ty = findTypeByName "System.GCMemoryInfoData"
+
+        let lines =
+            IlDumpRendering.formatTypeLines corelib (filterOn "GCMemoryInfoData" (Some "_heapSizeBytes")) ty
+
+        lines
+        |> List.exists (fun l -> l.StartsWith ("// field ", System.StringComparison.Ordinal))
+        |> shouldEqual true
+
+        lines
+        |> List.exists (fun l -> l.Contains "System.GCMemoryInfoData::" && l.Contains "_heapSizeBytes")
+        |> shouldEqual true
+
+    [<Test>]
+    let ``every declared field is visible in an unfiltered type dump`` () : unit =
+        let ty = findTypeByName "System.GCMemoryInfoData"
+
+        // Guard the test itself: this fixture is worthless if the type has no fields.
+        ty.Fields |> List.isEmpty |> shouldEqual false
+
+        let lines =
+            IlDumpRendering.formatTypeLines corelib (filterOn "GCMemoryInfoData" None) ty
+
+        let rendered = String.concat "\n" lines
+
+        for field in ty.Fields do
+            if not (rendered.Contains field.Name) then
+                failwithf "field %s was not rendered in the type dump" field.Name
+
+    // ----- type header policy ------------------------------------------------
+
+    [<Test>]
+    let ``a type filter that matches no member still reports the type's existence`` () : unit =
+        let ty = findTypeByName "System.GCMemoryInfoData"
+
+        let lines =
+            IlDumpRendering.formatTypeLines corelib (filterOn "GCMemoryInfoData" (Some "NoSuchMemberName")) ty
+
+        // Exactly the type header: enough to distinguish "type exists, no such
+        // member" from "no such type".
+        lines |> shouldEqual [ "// type System.GCMemoryInfoData" ]
+
+    [<Test>]
+    let ``with no type filter, a type whose members all fail the filter emits nothing`` () : unit =
+        // A bare member search across a whole assembly must not emit a header for
+        // every one of the assembly's thousands of types.
+        let ty = findTypeByName "System.GCMemoryInfoData"
+
+        let filter =
+            {
+                Type = None
+                Member = Some "NoSuchMemberName"
+            }
+
+        IlDumpRendering.formatTypeLines corelib filter ty |> shouldEqual []
+
+    [<Test>]
+    let ``with no type filter, a type with a matching member is still headed`` () : unit =
+        let ty = findTypeByName "System.GCMemoryInfoData"
+
+        let filter =
+            {
+                Type = None
+                Member = Some "_heapSizeBytes"
+            }
+
+        let lines = IlDumpRendering.formatTypeLines corelib filter ty
+        lines |> List.isEmpty |> shouldEqual false
+        lines.Head |> shouldEqual "// type System.GCMemoryInfoData"
+
+    // ----- methods keep their IL bodies --------------------------------------
+
+    [<Test>]
+    let ``methods are still dumped with their IL`` () : unit =
+        let ty = findTypeByName "System.GCMemoryInfoData"
+
+        let lines =
+            IlDumpRendering.formatTypeLines corelib (filterOn "GCMemoryInfoData" (Some "get_GenerationInfoAsSpan")) ty
+
+        lines
+        |> List.exists (fun l -> l.Contains "get_GenerationInfoAsSpan")
+        |> shouldEqual true
+
+        lines |> List.exists (fun l -> l.Contains "IL_0000:") |> shouldEqual true
+
+    // ----- properties and events ---------------------------------------------
+
+    [<Test>]
+    let ``properties are listed`` () : unit =
+        // System.Exception has properties (Message, StackTrace, ...) but the
+        // property rows themselves are only reachable via the MetadataReader.
+        let ty = findTypeByName "System.Exception"
+
+        let lines =
+            IlDumpRendering.formatTypeLines corelib (filterOn "System.Exception" (Some "Message")) ty
+
+        lines
+        |> List.exists (fun l -> l = "// property System.Exception::Message")
+        |> shouldEqual true
+
+    [<Test>]
+    let ``events are listed`` () : unit =
+        let ty =
+            corelib.TypeDefs.Values
+            |> Seq.filter (fun td -> not (Seq.isEmpty td.Events))
+            |> Seq.sortBy (fun td -> IlFormatting.qualifyTypeName corelib.TypeDefs td)
+            |> Seq.tryHead
+
+        match ty with
+        | None -> Assert.Inconclusive "corelib declares no events; nothing to exercise"
+        | Some ty ->
+
+        let qualified = IlFormatting.qualifyTypeName corelib.TypeDefs ty
+        let evt = Seq.head ty.Events
+
+        let lines =
+            IlDumpRendering.formatTypeLines corelib (filterOn qualified (Some evt.Name)) ty
+
+        lines
+        |> List.exists (fun l -> l = sprintf "// event %s::%s" qualified evt.Name)
+        |> shouldEqual true
+
+    // ----- the invariant, over a deterministic sample of corelib -------------
+
+    [<Test>]
+    let ``no declared member of any sampled type is invisible`` () : unit =
+        // The property the fix is really asserting: for any type, an unfiltered
+        // dump mentions every field, method and event the type declares. Sampled
+        // with a fixed stride so the test is deterministic and doesn't format the
+        // IL of all of corelib.
+        let sample =
+            corelib.TypeDefs.Values
+            |> Seq.sortBy (fun td -> IlFormatting.qualifyTypeName corelib.TypeDefs td)
+            |> Seq.indexed
+            |> Seq.filter (fun (i, _) -> i % 250 = 0)
+            |> Seq.map snd
+            |> Seq.toList
+
+        sample |> List.isEmpty |> shouldEqual false
+
+        for ty in sample do
+            let qualified = IlFormatting.qualifyTypeName corelib.TypeDefs ty
+
+            let rendered =
+                IlDumpRendering.formatTypeLines corelib (filterOn qualified None) ty
+                |> String.concat "\n"
+
+            for field in ty.Fields do
+                if not (rendered.Contains field.Name) then
+                    failwithf "field %s::%s was not rendered" qualified field.Name
+
+            for method in ty.Methods do
+                if not (rendered.Contains method.Name) then
+                    failwithf "method %s::%s was not rendered" qualified method.Name
+
+            for evt in ty.Events do
+                if not (rendered.Contains evt.Name) then
+                    failwithf "event %s::%s was not rendered" qualified evt.Name

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="TestCustomAttributeBlob.fs" />
     <Compile Include="TestCustomAttribValueLowering.fs" />
     <Compile Include="TestAttributeFormatting.fs" />
+    <Compile Include="TestIlDumpRendering.fs" />
     <Compile Include="TestFriendAssemblies.fs" />
     <Compile Include="TestAccessCheck.fs" />
     <Compile Include="RealRuntime.fs" />


### PR DESCRIPTION
Fixes #700.

IlDump's default (non-`--attrs-only`) mode iterated only `typeInfo.Methods`, so a member filter naming a field matched nothing and the tool emitted nothing at all, making a data-only type look as though it did not exist.

Default mode now renders each matching type as a `// type` header, one line per field, property and event, then the full IL of each matching method.

```
$ ildump corelib.dll GCMemoryInfoData _heapSizeBytes
// type System.GCMemoryInfoData
// field System.GCMemoryInfoData::_heapSizeBytes : int64

$ ildump corelib.dll GCMemoryInfoData NoSuchMember
// type System.GCMemoryInfoData

$ ildump corelib.dll NoSuchType NoSuchMember
(nothing)
```

**Type header policy.** The header is emitted whenever the user narrowed by type even if no member matched, so "this type exists but has no such member" is distinguishable from "there is no such type". Without a type filter the header appears only when some member matched, so a bare member search across an assembly does not emit a header for each of its thousands of types — that search went from 5,530 lines of bare headers to 18 lines of actual results.

**Filter semantics.** Both modes now share one definition of the filtering rules, and an empty filter argument normalises to "no narrowing". `ildump <dll> "" Foo` is the only way to spell a member search across every type, and previously that empty type argument both defeated the header policy and suppressed assembly/module attributes under `--attrs-only`.

**Field detail.** `fieldHeader` now reports static-ness in the same position `methodHeader` does, and appends `@ 0xNN` for explicitly-laid-out fields — so `System.Guid/GuidResult`'s overlapping `_bc` and `_b`, both at `0x4`, are visible:

```
// field System.String::static Empty : string
// field System.Guid/GuidResult::_bc : uint32 @ 0x4
// field System.Guid/GuidResult::_b : uint16 @ 0x4
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)