### PR TITLE
Preserve local-variable order when concretising a .cctor

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/CctorLocalOrdering.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/CctorLocalOrdering.cs
@@ -1,0 +1,72 @@
+using System;
+
+// The static constructor below has locals that interleave differently-shaped types:
+// a mutable generic value type, a reference, a primitive, and a non-generic value type.
+// `.locals init` must zero each slot according to *that* slot's declared type, so the
+// concretized per-slot type array has to preserve the declaration order of the method's
+// local signature.
+//
+// There are four declared locals rather than three on purpose. The failure this pins is a
+// reversal of the per-slot type array, and reversing an odd-length list leaves the middle
+// element at its own index; with three locals the middle slot would be typed correctly even
+// under the bug. Four locals means no slot maps to itself, so every one of them is load-bearing.
+// Don't reduce the count.
+public struct Accumulator<T>
+{
+    public object Payload;
+    public int Count;
+
+    // Reads Payload through the `this` byref before any store, so a default (all-zero)
+    // instance must present as a value type rather than as a null object reference.
+    public void Add(T item)
+    {
+        if (Payload == null)
+        {
+            Payload = new object();
+        }
+
+        Count = Count + 1;
+    }
+}
+
+public struct Offset
+{
+    public int Value;
+
+    public void Bump()
+    {
+        Value = Value + 3;
+    }
+}
+
+public static class CctorLocalOrdering
+{
+    static readonly int Result;
+
+    // An explicit static constructor, so this body *is* the type's `.cctor` and its locals
+    // go through the cctor local-variable concretization path.
+    static CctorLocalOrdering()
+    {
+        Accumulator<char> acc = default;
+        string refLocal = "x";
+        int intLocal = 7;
+        Offset offset = default;
+
+        acc.Add('a');
+        acc.Add('b');
+        offset.Bump();
+
+        Result = acc.Count + intLocal + refLocal.Length + offset.Value;
+    }
+
+    public static int Main(string[] argv)
+    {
+        // 2 (acc.Count) + 7 (intLocal) + 1 (refLocal.Length) + 3 (offset.Value) = 13.
+        if (Result != 13)
+        {
+            return 1;
+        }
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/IlMachineStateExecution.fs
+++ b/WoofWare.PawPrint/IlMachineStateExecution.fs
@@ -1712,9 +1712,11 @@ module IlMachineStateExecution =
                             match methodInstr.LocalVars with
                             | None -> state, None
                             | Some localVars ->
-                                // Concretize each local variable type
+                                // Concretize each local variable type. The result is indexed by
+                                // local-variable slot, so it must preserve the declaration order
+                                // of `localVars`.
                                 let state, convertedVars =
-                                    ((state, []), localVars)
+                                    ((state, ImmutableArray.CreateBuilder<ConcreteTypeHandle> ()), localVars)
                                     ||> Seq.fold (fun (state, acc) typeDefn ->
                                         let state, handle =
                                             IlMachineState.concretizeType
@@ -1726,9 +1728,10 @@ module IlMachineStateExecution =
                                                 ImmutableArray.Empty // no method generics for cctor
                                                 typeDefn
 
-                                        state, handle :: acc
+                                        acc.Add handle
+                                        state, acc
                                     )
-                                    |> Tuple.rmap ImmutableArray.CreateRange
+                                    |> Tuple.rmap (fun builder -> builder.ToImmutable ())
 
                                 state, Some convertedVars
 


### PR DESCRIPTION
Closes #689.

`loadClass` concretises a static constructor's locals by hand rather than going through `Concretization.concretizeMethod`, because it is already in the middle of loading the class and must not re-enter class loading. That hand-rolled fold accumulated with `handle :: acc` and finished with `ImmutableArray.CreateRange`, with no reversal, so the per-slot type array came out backwards.

`MethodState.Empty` zeroes each local by walking that array in slot order, so every `.cctor` whose locals interleave differently-shaped types got its slots initialised to the zero of some other slot's type. The new test fails on `stloc` of the `int` local into a slot the interpreter believes is a struct (`TODO: Int32(7) into value type ValueType`).

### Why a builder rather than adding the missing `List.rev`

The sibling folds that concretise method-generic arguments (`UnaryMetadataTokenOps.fs`, `UnaryMetadataCallOps.fs` — three of them) do remember the trailing `List.rev`, which is precisely the discipline that lapsed here. Switching to an `ImmutableArray` builder makes order preservation structural rather than something a later edit can silently drop again. It also matches the two existing order-preserving concretisation helpers: `concretizeTypeArgs` in this same file and `concretizeTypeArray` in `TypeConcretisation.fs`.

I deliberately did *not* try to unify this with the general `Concretization.concretizeMethod` path. That is not accidental duplication: `loadClass` hand-rolls it specifically to avoid re-entering class loading while already inside it, and unifying the four-ish "concretize a `TypeDefn` array in order" idioms is a separate cross-cutting refactor.

### Test

`CctorLocalOrdering.cs` declares **four** locals, not three: reversing an odd-length list fixes the middle element, so a three-local repro would leave one slot correct by accident. There is a comment saying so, because reducing the count would silently weaken the test.

Verified failing before the fix and passing after; full suite green (1589 passed).

A sweep of every `x :: acc` fold in `WoofWare.PawPrint`, `WoofWare.PawPrint.Domain` and the test project found no other instance of this bug — the other unreversed accumulations feed order-insensitive consumers (cardinality checks, an OR-reduction) or are deliberate pop-then-prepend double reversals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)