### PR TITLE
Implement the `not` IL instruction on native ints

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/NativeIntBitwiseNot.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/NativeIntBitwiseNot.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace NativeIntBitwiseNotTest
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            // `not` on a native unsigned int. This is the shape the BCL's unrolled
+            // loops use to round a count down to a multiple of a power of two, e.g.
+            // SpanHelpers.Fill's `numElements & ~(nuint)7`.
+            nuint seven = 7;
+            nuint mask = ~seven;
+
+            if ((nuint)23 == (23 & mask))
+            {
+                return 1;
+            }
+
+            if ((23 & mask) != 16)
+            {
+                return 2;
+            }
+
+            if ((8 & mask) != 8)
+            {
+                return 3;
+            }
+
+            if ((7 & mask) != 0)
+            {
+                return 4;
+            }
+
+            // ~0 is all bits set, so masking with it is the identity.
+            nuint zero = 0;
+
+            if ((12345 & ~zero) != 12345)
+            {
+                return 5;
+            }
+
+            if (~(nuint)0 == 0)
+            {
+                return 6;
+            }
+
+            // Double complement is the identity.
+            if (~~seven != 7)
+            {
+                return 7;
+            }
+
+            // `not` on a signed native int: ~x == -x - 1.
+            nint five = 5;
+
+            if (~five != -6)
+            {
+                return 8;
+            }
+
+            nint negSix = -6;
+
+            if (~negSix != 5)
+            {
+                return 9;
+            }
+
+            nint minusOne = -1;
+
+            if (~minusOne != 0)
+            {
+                return 10;
+            }
+
+            // Wider than 32 bits, to confirm the operation is done at native width
+            // rather than being truncated to int.
+            nint big = (nint)(1L << 40);
+
+            if (~big != (nint)(-(1L << 40) - 1))
+            {
+                return 11;
+            }
+
+            nuint bigU = (nuint)(1UL << 40);
+
+            if ((~bigU & (nuint)(1UL << 40)) != 0)
+            {
+                return 12;
+            }
+
+            if ((~bigU & (nuint)(1UL << 41)) != (nuint)(1UL << 41))
+            {
+                return 13;
+            }
+
+            // `UIntPtr.Zero` reaches the eval stack as a null managed pointer rather than
+            // as a verbatim integer, but PawPrint models null as exactly the bit pattern 0,
+            // so complementing it is an ordinary all-ones integer and still composes with
+            // the masking arms below.
+            nuint zeroPtr = UIntPtr.Zero;
+
+            if (~zeroPtr == 0)
+            {
+                return 14;
+            }
+
+            if ((12345 & ~zeroPtr) != 12345)
+            {
+                return 15;
+            }
+
+            if (~~zeroPtr != 0)
+            {
+                return 16;
+            }
+
+            nint zeroIntPtr = IntPtr.Zero;
+
+            if (~zeroIntPtr != -1)
+            {
+                return 17;
+            }
+
+            // Synthesised pointer-hash bits. A `TypeHandle.Value` has no real address, so
+            // PawPrint gives it deterministic opaque bits; widening to ulong and narrowing
+            // back with `conv.u` is the established way to land those in the native-int
+            // slot (see XorNativeIntOpaqueHashBits.cs). `not` must keep them deterministic
+            // and stay inside the opaque domain rather than claiming a verbatim value.
+            IntPtr handle = typeof(int).TypeHandle.Value;
+            ulong widened = (ulong)handle;
+            nuint opaque = (nuint)((widened << 32) | (widened >> 32));
+
+            // Double complement is the identity.
+            if (~~opaque != opaque)
+            {
+                return 18;
+            }
+
+            // Complementing actually changes the bits.
+            if (~opaque == opaque)
+            {
+                return 19;
+            }
+
+            // x ^ ~x is all ones, whatever representation x has.
+            if ((opaque ^ ~opaque) != ~(nuint)0)
+            {
+                return 20;
+            }
+
+            // `x & ~x == 0` is deliberately not checked here: `and` between two
+            // NativeInt(OpaqueHashBits) operands is a separate unimplemented case
+            // ("refusing to do binary operation on ..."), unrelated to `not`. The
+            // xor above already pins that the complemented bits are the right ones.
+
+            // A bit-pattern placeholder byref, which is by construction nothing but the
+            // raw bits that produced it. `Unsafe.AsRef<T>((void*)bits)` is how the BCL
+            // makes one (see MemoryMarshal.GetNonNullPinnableReference); taking its
+            // address back out lands those bits in the native-int slot.
+            unsafe
+            {
+                ref int placeholderRef = ref Unsafe.AsRef<int>((void*)7);
+                nuint placeholderBits = (nuint)Unsafe.AsPointer(ref placeholderRef);
+
+                if (placeholderBits != 7)
+                {
+                    return 21;
+                }
+
+                if (~placeholderBits != ~(nuint)7)
+                {
+                    return 22;
+                }
+
+                if ((23 & ~placeholderBits) != 16)
+                {
+                    return 23;
+                }
+            }
+
+            return 0;
+        }
+    }
+}

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -132,6 +132,46 @@ module NullaryIlOp =
             let b, counters = PointerHashSynthesis.materialiseHashBits "Xor" i2 counters
             NativeIntSource.OpaqueHashBits (a ^^^ b), counters
 
+    /// Bitwise complement of a `NativeIntSource` in the native-int slot, for the
+    /// `not` IL instruction (ECMA-335 III.3.35). Mirrors `xorNativeIntSources`,
+    /// which is the same operation against an all-ones operand.
+    ///
+    /// `Verbatim` and the two bit-pattern pointer forms have exact, definitional
+    /// bit patterns — PawPrint models `Null` as the bit pattern 0 throughout, and
+    /// a `NativeIntPlaceholder` is by construction nothing but the raw bits that
+    /// produced it — so their complement is an honest `Verbatim`, which keeps
+    /// composing with the verbatim arms of `And` / `Or` / comparisons. (The
+    /// result is an integer, not a pointer, so the placeholder-to-`Null`
+    /// normalisation that applies when *constructing* byrefs is not needed
+    /// here.) Everything else routes
+    /// through `PointerHashSynthesis.materialiseHashBits` and is tagged
+    /// `OpaqueHashBits`, propagating the synthesised-bits contract: the result is
+    /// deterministic but MUST NOT be used as a real pointer. `materialiseHashBits`
+    /// fails loudly on any other `ManagedPointer` and on
+    /// `SyntheticCrossArrayOffset`, preserving byref / cross-storage provenance.
+    ///
+    /// Note that a handle-shaped source does not survive a double complement as
+    /// itself: `~~handle` comes back as `OpaqueHashBits`, so comparing that against
+    /// the original handle hits `equalsForCli`'s "synthesised hash bits vs handle
+    /// pointer" refusal (CEQ has no `PointerHashCounters` with which to materialise
+    /// the handle). That is a property of the hash-synthesis design rather than of
+    /// `not`: `xorNativeIntSources` loses handle provenance the same way, so
+    /// `(handle ^ 0) ^ 0 == handle` already fails identically. The failure is loud,
+    /// and the complemented bits themselves are correct and deterministic.
+    let private notNativeIntSource
+        (source : NativeIntSource)
+        (counters : PointerHashCounters)
+        : NativeIntSource * PointerHashCounters
+        =
+        match source with
+        | NativeIntSource.Verbatim i -> NativeIntSource.Verbatim ~~~i, counters
+        | NativeIntSource.ManagedPointer ManagedPointerSource.Null -> NativeIntSource.Verbatim ~~~0L, counters
+        | NativeIntSource.ManagedPointer (ManagedPointerSource.NativeIntPlaceholder bits) ->
+            NativeIntSource.Verbatim ~~~bits, counters
+        | _ ->
+            let bits, counters = PointerHashSynthesis.materialiseHashBits "Not" source counters
+            NativeIntSource.OpaqueHashBits ~~~bits, counters
+
     let private locallocSizeBytes (value : EvalStackValue) : int =
         let size =
             match value with
@@ -2334,10 +2374,21 @@ module NullaryIlOp =
                     { state with
                         PointerHashCounters = counters
                     }
+                | EvalStackValue.NativeInt src ->
+                    // ECMA-335 III.3.35: `not` is defined on native ints. The BCL reaches
+                    // this through the unrolled loops that round a count down to a multiple
+                    // of a power of two, e.g. `numElements & ~(nuint)7` in SpanHelpers.Fill.
+                    let r, counters = notNativeIntSource src state.PointerHashCounters
+
+                    EvalStackValue.NativeInt r,
+                    { state with
+                        PointerHashCounters = counters
+                    }
                 | EvalStackValue.ManagedPointer _
                 | EvalStackValue.NullObjectRef
                 | EvalStackValue.ObjectRef _ -> failwith "refusing to negate a pointer"
-                | _ -> failwith "TODO"
+                | EvalStackValue.Float f -> failwith $"Not is not defined on floating-point values; got %f{f}"
+                | EvalStackValue.UserDefinedValueType vt -> failwith $"TODO: Not on a user-defined value type: %O{vt}"
 
             state
             |> IlMachineState.pushToEvalStack' result currentThread


### PR DESCRIPTION
First of two PRs for `Span<T>.Fill`. This one lands the dependency; the follow-up allowlists `Span<T>.Fill` and `SpanHelpers.Fill<T>` so their IL runs.

ECMA-335 III.3.35 defines `not` on native ints, but PawPrint only handled the int32 and int64 cases — a native-int operand fell into a bare `failwith "TODO"`. The BCL reaches it through the unrolled loops that round a count down to a multiple of a power of two; `SpanHelpers.Fill`'s `numElements & ~(nuint)7` is the case that surfaced it.

## Approach

`notNativeIntSource` mirrors the existing `xorNativeIntSources`, which is the same operation against an all-ones operand.

**Exact bits stay exact.** `Verbatim`, and the two bit-pattern pointer forms, have definitional bit patterns — PawPrint models `Null` as the bit pattern 0 throughout, and a `NativeIntPlaceholder` is by construction nothing but the raw bits that produced it. Their complement is an honest `Verbatim`. That matters beyond tidiness: it keeps the result composing with the verbatim arms of `And`/`Or`/comparisons, which is exactly what `~UIntPtr.Zero`-as-a-mask needs. The result is an integer rather than a pointer, so the placeholder-to-`Null` normalisation that applies when *constructing* byrefs isn't needed.

**Everything else goes through the synthesis pipeline.** `PointerHashSynthesis.materialiseHashBits`, tagged `OpaqueHashBits`, propagating the synthesised-bits contract — covering already-opaque bits arriving via `conv.u`, and handle-shaped sources. `materialiseHashBits` fails loudly on any other `ManagedPointer` and on `SyntheticCrossArrayOffset`, so byref and cross-storage provenance is preserved rather than erased into a bit pattern.

The `Float` and `UserDefinedValueType` cases that shared the old catch-all get specific messages instead of the bare "TODO".

## Known limitation, documented not fixed

A handle-shaped source doesn't survive a double complement *as itself*: `~~handle` returns `OpaqueHashBits`, so comparing it against the original handle hits `equalsForCli`'s "synthesised hash bits vs handle pointer" refusal, because CEQ has no `PointerHashCounters` with which to materialise the handle.

This is a property of the hash-synthesis design, not of `not` — verified directly: with no `not` anywhere, `(handle ^ 0) ^ 0 == handle` already fails identically on `main`, because `xorNativeIntSources` loses handle provenance the same way. Preserving reversible provenance would mean changing the `NativeIntSource` representation, which is well beyond this change. The failure is loud and the complemented bits themselves are correct, so it's recorded in the doc comment.

Two smaller gaps noted while testing, both pre-existing and out of scope: `and` between two `NativeInt(OpaqueHashBits)` operands is unimplemented, and the same CEQ refusal above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
