### PR TITLE
Use signature arity, not Param-row count, for virtual dispatch and every other arity check

### DIFF
--- a/WoofWare.PawPrint.Domain/MethodInfo.fs
+++ b/WoofWare.PawPrint.Domain/MethodInfo.fs
@@ -272,8 +272,27 @@ type MethodInfo<'typeGenerics, 'methodGenerics, 'methodVars> =
         Body : MethodBody<'methodVars>
 
         /// <summary>
-        /// The parameters of this method.
+        /// The parameters of this method, as read from the metadata Param table.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The Param table only carries a row per parameter that has metadata worth recording
+        /// (a name, a default value, marshalling info) — <see cref="Parameter.readAll"/> also
+        /// drops any row with <c>SequenceNumber = 0</c> (an unnamed "ref return" row some
+        /// compilers emit). Consequently <c>Parameters.Length</c> is <b>not</b> a reliable
+        /// arity: it can be short, or entirely empty, for a method whose parameters carry no
+        /// metadata at all — the F# compiler emits abstract member declarations this way, with
+        /// zero Param rows regardless of declared arity.
+        /// </para>
+        /// <para>
+        /// Do not use this field, or its <c>Length</c>/<c>IsEmpty</c>, to answer "how many
+        /// parameters does this method take?" or "is this method parameterless?". Use
+        /// <see cref="MethodInfo.arity"/> instead, which is derived from
+        /// <see cref="MethodInfo.Signature"/> and is therefore always accurate. Reserve this
+        /// field for call sites that genuinely want per-parameter metadata (names, default
+        /// values).
+        /// </para>
+        /// </remarks>
         Parameters : Parameter ImmutableArray
 
         /// <summary>
@@ -322,6 +341,13 @@ module MethodInfo =
         && a.DeclaringType.Generics = b.DeclaringType.Generics
         && a.Handle = b.Handle
         && a.Generics = b.Generics
+
+    /// The true number of declared parameters (excluding `this`), independent of how many
+    /// Param-table rows the metadata happened to carry. See the doc comment on
+    /// <see cref="MethodInfo.Parameters"/> for why `Parameters.Length`/`IsEmpty` must not be
+    /// used for this: the Param table is metadata-only and can under-count, or be entirely
+    /// empty, relative to the method's real declared arity.
+    let arity (m : MethodInfo<'typeGenerics, 'methodGenerics, 'methodVars>) : int = m.Signature.ParameterTypes.Length
 
     let private isIntrinsicAttributeType (namespaceName : string) (typeName : string) : bool =
         namespaceName = "System.Runtime.CompilerServices"

--- a/WoofWare.PawPrint.Test.FSharpPureCases/AbstractDispatch.fs
+++ b/WoofWare.PawPrint.Test.FSharpPureCases/AbstractDispatch.fs
@@ -1,0 +1,18 @@
+module AbstractDispatch
+
+/// Reproduces GitHub issue #693: an abstract member *declaration* gets zero Param-table
+/// rows from FSC (it has no name/default-value/marshalling metadata to record), even
+/// though its signature has one declared parameter. Virtual dispatch that used
+/// `Parameters.Length` to find `this` on the eval stack would peek the wrong slot here
+/// and dispatch on the argument instead of the receiver.
+[<AbstractClass>]
+type Base () =
+    abstract member Combine : int -> int
+
+type Derived (seed : int) =
+    inherit Base ()
+    override _.Combine x = seed + x
+
+let main (_argv : string array) : int =
+    let b : Base = Derived 40
+    b.Combine 2

--- a/WoofWare.PawPrint.Test.FSharpPureCases/Main.fs
+++ b/WoofWare.PawPrint.Test.FSharpPureCases/Main.fs
@@ -6,4 +6,5 @@ let main (argv : string array) : int =
     | "Placeholder" -> Placeholder.main argv.[1..]
     | "CeqBranch" -> CeqBranch.main argv.[1..]
     | "TailCall" -> TailCall.main argv.[1..]
+    | "AbstractDispatch" -> AbstractDispatch.main argv.[1..]
     | name -> failwith $"Unknown test case: {name}"

--- a/WoofWare.PawPrint.Test.FSharpPureCases/WoofWare.PawPrint.Test.FSharpPureCases.fsproj
+++ b/WoofWare.PawPrint.Test.FSharpPureCases/WoofWare.PawPrint.Test.FSharpPureCases.fsproj
@@ -10,6 +10,7 @@
     <Compile Include="Placeholder.fs" />
     <Compile Include="CeqBranch.fs" />
     <Compile Include="TailCall.fs" />
+    <Compile Include="AbstractDispatch.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
 

--- a/WoofWare.PawPrint.Test/TestFSharpPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestFSharpPureCases.fs
@@ -97,7 +97,8 @@ module TestFSharpPureCases =
         publishOnce.Force ()
         File.ReadAllBytes dllPath
 
-    let testCases : string list = [ "Placeholder" ; "CeqBranch" ; "TailCall" ]
+    let testCases : string list =
+        [ "Placeholder" ; "CeqBranch" ; "TailCall" ; "AbstractDispatch" ]
 
     // PawPrint cannot yet allocate string argv (Program.allocateArgs is unimplemented),
     // so all F# test cases that require argv dispatch are unimplemented for now.
@@ -108,9 +109,19 @@ module TestFSharpPureCases =
     // mechanism. Add a case here only when the throw is the intended observable.
     let expectsUnhandledException : Set<string> = Set.empty
 
+    // F# test cases whose successful exit code is not 0 — same mechanism as
+    // `customExitCodes` in TestPureCases.fs. `AbstractDispatch` returns the sum computed by
+    // its `Combine` call (see issue #693: 40 + 2 = 42) rather than a boolean success/failure
+    // code, so a wrong dispatch is directly observable as a wrong number rather than being
+    // laundered through an if/else into 0-or-1.
+    let customExitCodes : Map<string, int> = [ "AbstractDispatch", 42 ] |> Map.ofList
+
     let private runTest (testCaseName : string) : unit =
         let image = loadImage ()
         let messages, loggerFactory = LoggerFactory.makeTest ()
+
+        let expectedExitCode =
+            customExitCodes |> Map.tryFind testCaseName |> Option.defaultValue 0
 
         let dotnetRuntimes =
             seq {
@@ -136,7 +147,7 @@ module TestFSharpPureCases =
 
             match realResult, pawPrintResult with
             | RealRuntimeResult.NormalExit exitCode, RunOutcome.NormalExit (terminalState, terminatingThread) ->
-                exitCode |> shouldEqual 0
+                exitCode |> shouldEqual expectedExitCode
 
                 let pawPrintExitCode =
                     match terminalState.ThreadState.[terminatingThread].MethodState.EvaluationStack.Values with
@@ -222,11 +233,49 @@ module TestFSharpPureCases =
         // reached from `TailCall.main`, so the end-to-end case really executes the prefix.
         tailPrefixed |> shouldEqual (Set.ofList [ "isEven" ; "isOdd" ; "applyTail" ])
 
+    /// The `AbstractDispatch` case only exercises issue #693 if FSC actually emits the
+    /// abstract `Combine` declaration with zero Param-table rows despite its signature
+    /// declaring one parameter. Without this guard, a compiler change that started emitting
+    /// a Param row for the abstract declaration would leave `F# pure tests(AbstractDispatch)`
+    /// silently passing while covering nothing — `Parameters.Length` would then agree with
+    /// the true arity, and the bug this test exists to catch could regress unnoticed.
+    /// If this fails, re-inspect the metadata (`dotnet run --project WoofWare.PawPrint.IlDump
+    /// -- <published dll> Base Combine`) and reshape AbstractDispatch.fs until the shape
+    /// comes back.
+    [<Test>]
+    let ``AbstractDispatch's abstract Combine really does have zero Param rows`` () : unit =
+        let image = loadImage ()
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+        use peImage = new MemoryStream (image)
+
+        let assy = Assembly.read loggerFactory (Some dllPath) peImage
+
+        let combine =
+            assy.TypeDefs.Values
+            |> Seq.collect (fun typeInfo -> typeInfo.Methods)
+            |> Seq.filter (fun methodInfo -> methodInfo.DeclaringType.Name = "Base" && methodInfo.Name = "Combine")
+            |> Seq.toList
+            |> function
+                | [ m ] -> m
+                | [] -> failwith "AbstractDispatch.Base::Combine not found in the published assembly"
+                | ms -> failwith $"expected exactly one AbstractDispatch.Base::Combine, found %d{List.length ms}"
+
+        (match combine.Body with
+         | MethodBody.Abstract -> ()
+         | other -> failwith $"expected AbstractDispatch.Base::Combine to be MethodBody.Abstract, got %O{other}")
+
+        combine.Parameters.IsEmpty |> shouldEqual true
+        MethodInfo.arity combine |> shouldEqual 1
+
     [<TestCaseSource(nameof unimplemented)>]
     let ``Unimplemented F# tests have correct real-runtime behaviour`` (testCaseName : string) =
         let image = loadImage ()
 
+        let expectedExitCode =
+            customExitCodes |> Map.tryFind testCaseName |> Option.defaultValue 0
+
         match RealRuntime.executeWithRealRuntime [| testCaseName |] image with
-        | RealRuntimeResult.NormalExit exitCode -> exitCode |> shouldEqual 0
+        | RealRuntimeResult.NormalExit exitCode -> exitCode |> shouldEqual expectedExitCode
         | RealRuntimeResult.UnhandledException exn ->
             failwith $"Real runtime threw unhandled %s{exn.GetType().Name} for %s{testCaseName}: %s{exn.Message}"

--- a/WoofWare.PawPrint/IlMachineStateExecution.fs
+++ b/WoofWare.PawPrint/IlMachineStateExecution.fs
@@ -1024,7 +1024,7 @@ module IlMachineStateExecution =
                 let callingObj =
                     match
                         activeMethodState.EvaluationStack
-                        |> EvalStack.PeekNthFromTop methodToCall.Parameters.Length
+                        |> EvalStack.PeekNthFromTop (MethodInfo.arity methodToCall)
                     with
                     | None -> failwith "unexpectedly no `this` on the eval stack of instance method"
                     | Some this -> this
@@ -1189,7 +1189,7 @@ module IlMachineStateExecution =
                     | Some typeDef ->
                         let hasExplicitParameterlessCtor =
                             typeDef.Methods
-                            |> List.exists (fun m -> m.Name = ".ctor" && not m.IsStatic && m.Parameters.IsEmpty)
+                            |> List.exists (fun m -> m.Name = ".ctor" && not m.IsStatic && MethodInfo.arity m = 0)
 
                         if hasExplicitParameterlessCtor then
                             failwith
@@ -1242,7 +1242,9 @@ module IlMachineStateExecution =
 
                 let ctor =
                     typeDef.Methods
-                    |> List.tryFind (fun m -> m.Name = ".ctor" && not m.IsStatic && m.Parameters.IsEmpty && isPublic m)
+                    |> List.tryFind (fun m ->
+                        m.Name = ".ctor" && not m.IsStatic && MethodInfo.arity m = 0 && isPublic m
+                    )
 
                 match ctor with
                 | None ->
@@ -1251,7 +1253,7 @@ module IlMachineStateExecution =
                     let hasNonPublicParameterless =
                         typeDef.Methods
                         |> List.exists (fun m ->
-                            m.Name = ".ctor" && not m.IsStatic && m.Parameters.IsEmpty && not (isPublic m)
+                            m.Name = ".ctor" && not m.IsStatic && MethodInfo.arity m = 0 && not (isPublic m)
                         )
 
                     let reason =
@@ -1459,10 +1461,10 @@ module IlMachineStateExecution =
         // variable-size constructors, which CoreCLR calls with no `this` at all (see
         // `ConstructionState.ConstructingVariableSize`).
         let popDeclaredParametersOnly () =
-            let args = ImmutableArray.CreateBuilder methodToCall.Parameters.Length
+            let args = ImmutableArray.CreateBuilder (MethodInfo.arity methodToCall)
             let mutable currentState = activeMethodState
 
-            for i = methodToCall.Parameters.Length - 1 downto 0 do
+            for i = MethodInfo.arity methodToCall - 1 downto 0 do
                 let arg, newState = popAndCoerceArg argZeroObjects.[i] currentState
                 args.Add arg
                 currentState <- newState
@@ -1485,7 +1487,7 @@ module IlMachineStateExecution =
                 popDeclaredParametersOnly ()
             | ConstructionState.Constructing _ ->
                 // Instance method: handle `this` pointer
-                let argCount = methodToCall.Parameters.Length
+                let argCount = MethodInfo.arity methodToCall
                 let args = ImmutableArray.CreateBuilder (argCount + 1)
                 let mutable currentState = activeMethodState
                 let thisArgTarget = thisArgCoercionTarget methodToCall
@@ -1507,7 +1509,7 @@ module IlMachineStateExecution =
                 args.ToImmutable (), currentState
             | ConstructionState.NotConstructing ->
                 // Instance method: handle `this` pointer
-                let argCount = methodToCall.Parameters.Length
+                let argCount = MethodInfo.arity methodToCall
                 let args = ImmutableArray.CreateBuilder (argCount + 1)
                 let mutable currentState = activeMethodState
                 let thisArgTarget = thisArgCoercionTarget methodToCall
@@ -1669,7 +1671,7 @@ module IlMachineStateExecution =
             // Find the class constructor (.cctor) if it exists
             let cctor =
                 typeDef.Methods
-                |> List.tryFind (fun method -> method.Name = ".cctor" && method.IsStatic && method.Parameters.IsEmpty)
+                |> List.tryFind (fun method -> method.Name = ".cctor" && method.IsStatic && MethodInfo.arity method = 0)
 
             match cctor with
             | Some cctorMethod ->
@@ -1851,7 +1853,7 @@ module IlMachineStateExecution =
 
         let ctor =
             typeDef.Methods
-            |> List.tryFind (fun method -> method.Name = ".ctor" && not method.IsStatic && method.Parameters.IsEmpty)
+            |> List.tryFind (fun method -> method.Name = ".ctor" && not method.IsStatic && MethodInfo.arity method = 0)
             |> Option.defaultWith (fun () ->
                 failwith
                     $"raiseRuntimeException: no parameterless .ctor found on %s{exceptionTypeInfo.Namespace}.%s{exceptionTypeInfo.Name}"

--- a/WoofWare.PawPrint/MethodState.fs
+++ b/WoofWare.PawPrint/MethodState.fs
@@ -863,7 +863,7 @@ and MethodState =
 
             let expectsThis = not method.IsStatic && not isVariableSizeCtorFrame
 
-            let expected = method.Parameters.Length + (if expectsThis then 1 else 0)
+            let expected = MethodInfo.arity method + (if expectsThis then 1 else 0)
 
             if args.Length <> expected then
                 let shape =

--- a/WoofWare.PawPrint/Native/NativeCustomAttribute.fs
+++ b/WoofWare.PawPrint/Native/NativeCustomAttribute.fs
@@ -407,9 +407,9 @@ module NativeCustomAttribute =
                         (methodHandle.GetMethodGenerics () |> ImmutableArray.CreateRange)
                         state
 
-                if concretizedCtor.Parameters.Length <> List.length fixedArgs then
+                if MethodInfo.arity concretizedCtor <> List.length fixedArgs then
                     failwith
-                        $"%s{operation}: ctor expects %d{concretizedCtor.Parameters.Length} fixed argument(s) but the blob produced %d{List.length fixedArgs}"
+                        $"%s{operation}: ctor expects %d{MethodInfo.arity concretizedCtor} fixed argument(s) but the blob produced %d{List.length fixedArgs}"
 
                 // Push the re-entry marker first so it survives the ctor call below: `callMethod`
                 // pops `this` plus the ctor args, leaving exactly one ObjectRef beneath the new

--- a/WoofWare.PawPrint/Native/NativeRuntimeMethodHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeMethodHandle.fs
@@ -224,7 +224,7 @@ module NativeRuntimeMethodHandle =
                     // not static, no parameters" predicate used elsewhere
                     // (IlMachineStateExecution.fs activator paths).
                     attrTypeInfo.Methods
-                    |> List.tryFind (fun m -> m.Name = ".ctor" && not m.IsStatic && m.Parameters.IsEmpty)
+                    |> List.tryFind (fun m -> m.Name = ".ctor" && not m.IsStatic && MethodInfo.arity m = 0)
 
             let attrCtorAttrs : MethodAttributes =
                 match attrCtorMethodOpt with

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
@@ -354,7 +354,7 @@ module NativeRuntimeTypeHelpers =
         baseClassTypes.ValueType.Methods
         |> List.filter (fun methodInfo ->
             methodInfo.Name = name
-            && methodInfo.Parameters.Length = parameterCount
+            && MethodInfo.arity methodInfo = parameterCount
             && not methodInfo.IsStatic
         )
         |> function
@@ -363,7 +363,7 @@ module NativeRuntimeTypeHelpers =
             | methods ->
                 let signatures =
                     methods
-                    |> List.map (fun methodInfo -> $"%s{methodInfo.Name}/%i{methodInfo.Parameters.Length}")
+                    |> List.map (fun methodInfo -> $"%s{methodInfo.Name}/%i{MethodInfo.arity methodInfo}")
                     |> String.concat ", "
 
                 failwith $"%s{operation}: ambiguous System.ValueType::%s{name} candidates: %s{signatures}"
@@ -1337,7 +1337,7 @@ module NativeRuntimeTypeHelpers =
                 |> List.exists (fun m ->
                     m.Name = ".ctor"
                     && not m.IsStatic
-                    && m.Parameters.IsEmpty
+                    && MethodInfo.arity m = 0
                     && (m.MethodAttributes &&& System.Reflection.MethodAttributes.MemberAccessMask) = System.Reflection.MethodAttributes.Public
                 )
 

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
@@ -706,7 +706,7 @@ module NativeRuntimeTypeQCall =
 
                 let ctor =
                     typeInfo.Methods
-                    |> List.tryFind (fun m -> m.Name = ".ctor" && not m.IsStatic && m.Parameters.IsEmpty)
+                    |> List.tryFind (fun m -> m.Name = ".ctor" && not m.IsStatic && MethodInfo.arity m = 0)
                     |> Option.defaultWith (fun () ->
                         failwith
                             $"%s{operation}: no parameterless .ctor found on %s{typeInfo.Namespace}.%s{typeInfo.Name}"

--- a/WoofWare.PawPrint/SignalDispatch.fs
+++ b/WoofWare.PawPrint/SignalDispatch.fs
@@ -131,9 +131,9 @@ module SignalDispatch =
         (mi : MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>)
         : unit
         =
-        if mi.Parameters.Length <> 2 then
+        if MethodInfo.arity mi <> 2 then
             failwith
-                $"SignalDispatch.trySpawnHandler: registered handler %s{mi.Name} on type %s{mi.DeclaringType.Name} declares %d{mi.Parameters.Length} parameters; expected exactly 2 ((int signo, PosixSignal signal) -> int)."
+                $"SignalDispatch.trySpawnHandler: registered handler %s{mi.Name} on type %s{mi.DeclaringType.Name} declares %d{MethodInfo.arity mi} parameters; expected exactly 2 ((int signo, PosixSignal signal) -> int)."
 
         match mi.Signature.ReturnType with
         | MethodReturnType.Void ->
@@ -215,7 +215,7 @@ module SignalDispatch =
         let args = buildArgs entry.Signal
 
         // `MethodState.Empty` enforces an arity check against
-        // `mi.Parameters.Length` (plus 1 if non-static). The handler is
+        // `MethodInfo.arity mi` (plus 1 if non-static). The handler is
         // expected to be the static `OnPosixSignal`; if a test installs an
         // instance stand-in, that's a configuration error in the test, not
         // something this seam should silently paper over.

--- a/WoofWare.PawPrint/UnaryMetadataCallOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataCallOps.fs
@@ -838,7 +838,7 @@ module internal UnaryMetadataCallOps =
             | None -> state, concretizedMethod, true
             | Some tHandle ->
 
-            let nArgs = methodToCall.Parameters.Length
+            let nArgs = MethodInfo.arity methodToCall
 
             let state, argsBottomToTop =
                 let rec loop (state : IlMachineState) (acc : EvalStackValue list) (remaining : int) =
@@ -1011,7 +1011,7 @@ module internal UnaryMetadataCallOps =
             && (
                 match
                     state.ThreadState.[thread].MethodState.EvaluationStack
-                    |> EvalStack.PeekNthFromTop concretizedMethod.Parameters.Length
+                    |> EvalStack.PeekNthFromTop (MethodInfo.arity concretizedMethod)
                 with
                 | Some EvalStackValue.NullObjectRef -> true
                 | _ -> false


### PR DESCRIPTION
Closes #693.

`MethodInfo.Parameters` is built by `Parameter.readAll` from the metadata **Param table**, and additionally drops rows with `SequenceNumber = 0`. The Param table only carries a row per parameter that has metadata worth recording (a name, a default value, marshalling info), so `Parameters.Length` is not a reliable arity — it can be short, or zero, for a method whose parameters carry no metadata. The F# compiler emits abstract member *declarations* exactly that way.

Virtual-dispatch resolution located `this` on the eval stack by skipping `Parameters.Length` slots, so for such a method it peeked an argument instead of the receiver and dispatched on the wrong value.

### This was wider than the issue described

`Parameters.Length` was used as an arity in nine places, and `Parameters.IsEmpty` as a "is this parameterless?" predicate in eight more — including argument *popping* (`popDeclaredParametersOnly`, `argCount`), the frame-arity assertion in `MethodState`, reflection overload matching, the custom-attribute ctor arg-count check, and every "find the parameterless .ctor/.cctor" lookup. `IlMachineStateExecution.fs:1429` was already inconsistent with itself: it built `argZeroObjects` from `Signature.ParameterTypes` and then indexed it with a loop bounded by `Parameters.Length`.

So rather than patching the one dispatch site, this adds `MethodInfo.arity` (from `Signature.ParameterTypes`) and routes every arity/nullary question through it, leaving `Parameters` to the call sites that genuinely want per-parameter *metadata*. The `Parameters` field now carries a doc comment saying it must not be used for this — the field's contract was a trap, and a comment there is what stops the next person re-introducing the bug.

### Evidence this is real, not theoretical

Parsing Param tables straight out of built assemblies:

- **FSharp.Core**: 43 of 9694 methods have signature-arity ≠ Param-row count, several of them abstract — `ITypeProvider::add_Invalidate` (arity 1, 0 rows), `IQueryMethods::Execute` (arity 1, 0 rows), `PrintfEnv\`3::Write` (arity 1, 0 rows) — plus delegate `Invoke` methods, which are virtual (`EventWrapper\`2::Invoke`, arity 3, 0 rows). `EventWrapper\`2::BeginInvoke` has arity 5 with only 2 Param rows, so the omission is **per-parameter**, not all-or-nothing.
- **169 .NET framework assemblies** (128,184 C#-compiled methods): 24 mismatches, but **zero on virtual methods** — all are Roslyn-lowered local-function closure parameters. Hence the regression test must be F#; C# cannot produce this shape on a virtual method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)