### PR TITLE
Add regression test for #692 (getTypeOfObj on a ManagedPointer receiver)

### DIFF
--- a/WoofWare.PawPrint.Test.FSharpPureCases/ByrefDispatch.fs
+++ b/WoofWare.PawPrint.Test.FSharpPureCases/ByrefDispatch.fs
@@ -1,0 +1,28 @@
+module ByrefDispatch
+
+/// Regression test for GitHub issue #692 ("getTypeOfObj on a ManagedPointer receiver").
+///
+/// #692 was reported against FSharp.Core's `MapEnumerator`1::DoMoveNext(byref<T>)` — an
+/// abstract method with a *byref* parameter, dispatched virtually. The hypothesis (see the
+/// issue thread) is that #692 was never a distinct bug: it was a symptom of #693 (virtual
+/// dispatch using `Parameters.Length`, which can undercount an abstract declaration's true
+/// arity, to find `this` on the eval stack). When the resolver peeks too few slots, it grabs
+/// an *argument* instead of the receiver. `AbstractDispatch.fs` (the #693 regression test)
+/// uses a plain `int` parameter, so a mis-peek there just silently dispatches on the wrong
+/// operand -- `Int32` still satisfies `getTypeOfObj`, so the bug is invisible without manual
+/// inspection. A *byref* argument is different: `getTypeOfObj` has no case for
+/// `EvalStackValue.ManagedPointer`, so mis-peeking a byref argument as `this` fails loudly
+/// with exactly #692's error rather than quietly dispatching wrong. This file exists to pin
+/// that byref-specific shape, which `AbstractDispatch.fs` does not cover.
+[<AbstractClass>]
+type Base () =
+    abstract member Bump : byref<int> -> int
+
+type Derived (seed : int) =
+    inherit Base ()
+    override _.Bump (x : byref<int>) = seed + x
+
+let main (_argv : string array) : int =
+    let b : Base = Derived 40
+    let mutable v = 2
+    b.Bump &v

--- a/WoofWare.PawPrint.Test.FSharpPureCases/Main.fs
+++ b/WoofWare.PawPrint.Test.FSharpPureCases/Main.fs
@@ -7,4 +7,5 @@ let main (argv : string array) : int =
     | "CeqBranch" -> CeqBranch.main argv.[1..]
     | "TailCall" -> TailCall.main argv.[1..]
     | "AbstractDispatch" -> AbstractDispatch.main argv.[1..]
+    | "ByrefDispatch" -> ByrefDispatch.main argv.[1..]
     | name -> failwith $"Unknown test case: {name}"

--- a/WoofWare.PawPrint.Test.FSharpPureCases/WoofWare.PawPrint.Test.FSharpPureCases.fsproj
+++ b/WoofWare.PawPrint.Test.FSharpPureCases/WoofWare.PawPrint.Test.FSharpPureCases.fsproj
@@ -11,6 +11,7 @@
     <Compile Include="CeqBranch.fs" />
     <Compile Include="TailCall.fs" />
     <Compile Include="AbstractDispatch.fs" />
+    <Compile Include="ByrefDispatch.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
 

--- a/WoofWare.PawPrint.Test/TestFSharpPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestFSharpPureCases.fs
@@ -98,7 +98,13 @@ module TestFSharpPureCases =
         File.ReadAllBytes dllPath
 
     let testCases : string list =
-        [ "Placeholder" ; "CeqBranch" ; "TailCall" ; "AbstractDispatch" ]
+        [
+            "Placeholder"
+            "CeqBranch"
+            "TailCall"
+            "AbstractDispatch"
+            "ByrefDispatch"
+        ]
 
     // PawPrint cannot yet allocate string argv (Program.allocateArgs is unimplemented),
     // so all F# test cases that require argv dispatch are unimplemented for now.
@@ -114,7 +120,8 @@ module TestFSharpPureCases =
     // its `Combine` call (see issue #693: 40 + 2 = 42) rather than a boolean success/failure
     // code, so a wrong dispatch is directly observable as a wrong number rather than being
     // laundered through an if/else into 0-or-1.
-    let customExitCodes : Map<string, int> = [ "AbstractDispatch", 42 ] |> Map.ofList
+    let customExitCodes : Map<string, int> =
+        [ "AbstractDispatch", 42 ; "ByrefDispatch", 42 ] |> Map.ofList
 
     let private runTest (testCaseName : string) : unit =
         let image = loadImage ()
@@ -267,6 +274,43 @@ module TestFSharpPureCases =
 
         combine.Parameters.IsEmpty |> shouldEqual true
         MethodInfo.arity combine |> shouldEqual 1
+
+    /// Regression guard for issue #692, mirroring the `AbstractDispatch` guard above. #692's
+    /// real-world trigger (FSharp.Core's `MapEnumerator`1::DoMoveNext(byref<T>)`) is an
+    /// abstract method with a *byref* parameter; this asserts `ByrefDispatch.fs` reproduces
+    /// that same zero-Param-rows-but-nonzero-arity shape, and specifically that the one
+    /// parameter is a byref. Without this guard, a compiler change that started emitting a
+    /// Param row for the abstract declaration (or stopped modelling the parameter as a byref)
+    /// would leave `F# pure tests(ByrefDispatch)` silently passing while covering nothing.
+    [<Test>]
+    let ``ByrefDispatch's abstract Bump really does have zero Param rows and a byref parameter`` () : unit =
+        let image = loadImage ()
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+        use peImage = new MemoryStream (image)
+
+        let assy = Assembly.read loggerFactory (Some dllPath) peImage
+
+        let bump =
+            assy.TypeDefs.Values
+            |> Seq.collect (fun typeInfo -> typeInfo.Methods)
+            |> Seq.filter (fun methodInfo -> methodInfo.DeclaringType.Name = "Base" && methodInfo.Name = "Bump")
+            |> Seq.toList
+            |> function
+                | [ m ] -> m
+                | [] -> failwith "ByrefDispatch.Base::Bump not found in the published assembly"
+                | ms -> failwith $"expected exactly one ByrefDispatch.Base::Bump, found %d{List.length ms}"
+
+        (match bump.Body with
+         | MethodBody.Abstract -> ()
+         | other -> failwith $"expected ByrefDispatch.Base::Bump to be MethodBody.Abstract, got %O{other}")
+
+        bump.Parameters.IsEmpty |> shouldEqual true
+        MethodInfo.arity bump |> shouldEqual 1
+
+        (match bump.Signature.ParameterTypes.[0] with
+         | TypeDefn.Byref _ -> ()
+         | other -> failwith $"expected ByrefDispatch.Base::Bump's sole parameter to be a byref, got %O{other}")
 
     [<TestCaseSource(nameof unimplemented)>]
     let ``Unimplemented F# tests have correct real-runtime behaviour`` (testCaseName : string) =


### PR DESCRIPTION
Closes #692. Test-only PR.

Stacked on #719 — review only the top commit. **No production code changes**: this is a test-only PR.

#692 reported `getTypeOfObj` failing with `cannot get type of managed pointer target` on a `callvirt` with a byref `this`. It turns out to be a *symptom* of #693 (now fixed), not a separate bug, so the right resolution is a regression test pinning the specific shape, not a change to `getTypeOfObj`.

### Why it's the same bug

#693's virtual-dispatch resolver located `this` by skipping `Parameters.Length` eval-stack slots. When that count is too small it peeks an *argument* instead of the receiver. #693's own issue text names the real-world trigger as FSharp.Core's `MapEnumerator\`1::DoMoveNext(byref<T>)` — a method whose parameter is a **byref**. Peeking that argument puts an `EvalStackValue.ManagedPointer` where `getTypeOfObj` expects an object reference, which is exactly #692's error.

That also explains why the two issues look different despite one cause: `AbstractDispatch.fs` (the #693 repro, parameter type `int`) mis-peeks *silently*, because an `Int32` still satisfies `getTypeOfObj` and dispatch just proceeds on the wrong value. A byref argument surfaces *loudly*, because `getTypeOfObj` has no `ManagedPointer` case at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)