### PR TITLE
Teach ldind.ref the native-int address form

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/LdindRefNativeInt.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/LdindRefNativeInt.cs
@@ -1,0 +1,63 @@
+using System;
+
+// Regression test for issue #711: `ldind.ref` through a managed pointer that
+// has been widened to `native int` on the eval stack.
+//
+// ECMA-335 III.3.44 allows the address operand of `ldind.*` to be `native
+// int` as well as `&`. Real CoreLib exploits this in
+// `System.Threading.Tasks.Task.FromResult<TResult>` to reinterpret a
+// concretely-typed cached task as `Task<TResult>` without paying for a real
+// type check: it takes the address of a local of concrete type `Task<bool>`,
+// widens that address to `native int` via an explicit unsafe pointer cast
+// (`Task<TResult>*`), then reads back through it. Because the cast target is
+// a *closed generic reference type* (`Task<TResult>` is a class for every
+// TResult) rather than a bare type parameter, the compiler knows the
+// dereference is reference-shaped and so emits `ldind.ref`, not `ldobj`.
+//
+// `Reinterpret<T>` below reproduces that exact IL shape
+// (`ldloca.s; conv.u; ldind.ref`) without going anywhere near Task, using an
+// ordinary generic reference-type wrapper instead of Task<T>. Verified with
+// IlDump against the compiled test assembly to actually emit
+// `ldloca.s 0 / conv.u / ldind.ref`, not `ldobj`.
+unsafe class LdindRefNativeInt
+{
+    sealed class Box<T>
+    {
+        public T Value;
+
+        public Box (T value)
+        {
+            Value = value;
+        }
+    }
+
+    static Box<T> Reinterpret<T> (Box<bool> source)
+    {
+        Box<bool> local = source;
+
+        // `&local` is `Box<bool>&`; the cast to `Box<T>*` forces a `conv.u`
+        // before the address is dereferenced, so by the time `ldind.ref`
+        // executes, the address is native-int-typed on the eval stack, not
+        // `&`-typed.
+        return *(Box<T>*) &local;
+    }
+
+    static int Main (string[] args)
+    {
+        var box = new Box<bool> (true);
+
+        Box<bool> result = Reinterpret<bool> (box);
+
+        if (!ReferenceEquals (box, result))
+        {
+            return 1;
+        }
+
+        if (result.Value != true)
+        {
+            return 2;
+        }
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/TaskWhenAnyTwoResults.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/TaskWhenAnyTwoResults.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Threading.Tasks;
+
+// End-to-end motivation for issue #711: `Task.WhenAny` on two already-completed
+// `Task<int>`s. `Task.FromResult<TResult>` reinterprets a cached `Task<int>`
+// as `Task<TResult>` via `ldloca.s; conv.u; ldind.ref` (see
+// LdindRefNativeInt.cs for the isolated repro of that IL shape), so this is
+// the first thing WhenAny trips over. Whether the rest of WhenAny works is a
+// separate question tracked by wherever this test lands (unimplemented, if
+// it doesn't).
+public static class TaskWhenAnyTwoResults
+{
+    public static int Main (string[] args)
+    {
+        Task<int> x = Task.FromResult (1);
+        Task<int> y = Task.FromResult (2);
+        Task<int> done = Task.WhenAny (x, y).Result;
+        return (done == x || done == y) ? 0 : 1;
+    }
+}

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -2421,11 +2421,43 @@ module NullaryIlOp =
 
             let referenced =
                 match addr with
-                | EvalStackValue.ManagedPointer src -> IlMachineState.readManagedByref corelib state src
+                | EvalStackValue.ManagedPointer src
+                | EvalStackValue.NativeInt (NativeIntSource.ManagedPointer src) ->
+                    // ECMA-335 III.3.44 allows `ldind.ref`'s address operand to
+                    // be `native int` as well as `&`: a byref widened by
+                    // `conv.i`/`conv.u` (e.g. real CoreLib's
+                    // `Task.FromResult<TResult>`, which reinterprets a cached
+                    // `Task<bool>`/`Task<int>` as `Task<TResult>` via
+                    // `ldloca.s; conv.u; ldind.ref`) is still logically the
+                    // same address, so it must dereference identically to the
+                    // `&`-typed spelling. `Stind_ref` immediately below
+                    // already treats both spellings identically for exactly
+                    // this reason; this mirrors it.
+                    //
+                    // Both spellings route through `readManagedByref` rather
+                    // than the byte-view `readManagedByrefBytesAs` that the
+                    // generic `ldind` uses for primitives. That split is
+                    // deliberate, not an oversight: `readManagedByref` already
+                    // contains the correct byte-view-vs-structural dispatch
+                    // for object references (including the `ReinterpretAs`
+                    // zero-offset elision that the Task<T> pattern above
+                    // exercises when a projection chain is present), and
+                    // object references are not byte-addressable in
+                    // PawPrint's value model (`CliType.OfBytesLike` has no
+                    // case for `CliType.ObjectRef`). Pointers that are purely
+                    // byte-addressable storage (stack-allocated or native
+                    // memory with no typed cell at the target offset) have no
+                    // way to hold a real object reference in this model
+                    // either, and `readManagedByref` already fails loudly and
+                    // specifically for that shape (e.g. "has no typed cell
+                    // here; needs a byte-view byref shape") rather than
+                    // routing through a byte reconstruction that would
+                    // silently do the wrong thing.
+                    IlMachineState.readManagedByref corelib state src
                 | EvalStackValue.NativeInt (NativeIntSource.GcHandlePtr handle) ->
                     GcHandleRegistry.target handle state.GcHandles |> CliType.ObjectRef
                 | EvalStackValue.NullObjectRef -> failwith "unreachable: NullObjectRef handled above"
-                | a -> failwith $"TODO: {a}"
+                | a -> failwith $"TODO: Ldind_ref on unsupported eval stack value {a}"
 
             let state =
                 match referenced with


### PR DESCRIPTION
### The gap

`Ldind_ref` accepted `EvalStackValue.ManagedPointer src` and `NativeInt (NativeIntSource.GcHandlePtr _)`, but fell through to `failwith` for `NativeInt (NativeIntSource.ManagedPointer src)` — a managed pointer widened to native-int type on the eval stack.

ECMA-335 III.3.44 allows the address operand of `ldind.*` to be `native int` as well as `&`. The generic `ldind` helper in the same file already handled that spelling, and so did `stind` and `stind.ref`. `Ldind_ref` lives in a separate arm and was simply never taught it — an inconsistency with its own siblings, not a missing capability.

Found by scanning real System.Private.CoreLib for `conv.i`/`conv.u` immediately followed by `ldind.ref`: `Task.FromResult<TResult>` reinterprets a cached `Task<bool>`/`Task<int>` as `Task<TResult>` via `*(Task<TResult>*)&task`, compiling to `ldloca.s; conv.u; ldind.ref`. The cast target is a *closed generic reference type* (`Task<X>` is a class for every X), so Roslyn emits `ldind.ref` rather than `ldobj` — but the `conv.u` leaves the address as native int.

### Per-pointer-flavour behaviour

Both spellings route through `readManagedByref`, never the byte-view `readManagedByrefBytesAs` that the generic `ldind` uses for primitives. That split is deliberate: object references are not byte-addressable in PawPrint's value model (`CliType.OfBytesLike` has no `CliType.ObjectRef` case), whereas primitives are — which is why the generic `ldind` correctly *does* send stack/native-memory pointers down the byte path. `readManagedByref` already contains the right internal dispatch for references, including the `ReinterpretAs` zero-offset elision the `Task<T>` pattern exercises, and for byte-only storage roots with no typed cell — the one shape that genuinely cannot hold an object reference — it already fails loudly with a named condition rather than attempting a reconstruction that doesn't exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)