### PR TITLE
Let intrinsics raise guest exceptions, so an uncaught one kills the guest and not the interpreter

### DIFF
--- a/WoofWare.PawPrint.Test/TestFaultHandlers.fs
+++ b/WoofWare.PawPrint.Test/TestFaultHandlers.fs
@@ -136,7 +136,7 @@ module TestFaultHandlers =
                 WasInitialisingType = None
                 Constructing = ConstructionState.NotConstructing
                 CallSiteIlOpIndex = threadState.MethodState.IlOpIndex
-                DispatchAsExceptionOnReturn = false
+                ConstructedObjectDisposition = ConstructedObjectDisposition.PushToCaller
                 WrapExceptionInTargetInvocation = false
             }
 

--- a/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
+++ b/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
@@ -3089,7 +3089,8 @@ public unsafe struct PointerWrapper
 
             match frame.ReturnState with
             | Some returnState ->
-                returnState.DispatchAsExceptionOnReturn |> shouldEqual true
+                returnState.ConstructedObjectDisposition
+                |> shouldEqual (ConstructedObjectDisposition.DispatchAsException None)
 
                 // NullReferenceException is a fixed-size type, so the exception object was
                 // allocated up front and handed to the ctor as `this`.

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -27,7 +27,14 @@ module TestPureCases =
         ]
         |> Set.ofList
 
-    let expectsUnhandledException = [ "UnhandledException.cs" ] |> Set.ofList
+    let expectsUnhandledException =
+        [
+            "UnhandledException.cs"
+            "EnumHasFlagMismatchUnhandled.cs"
+            "EnumHasFlagNullFlagUnhandled.cs"
+            "ArrayGetLengthOutOfRangeUnhandled.cs"
+        ]
+        |> Set.ofList
 
     let customExitCodes = [ "ExceptionWithNoOpFinally.cs", 3 ] |> Map.ofList
 

--- a/WoofWare.PawPrint.Test/sourcesPure/ArrayGetLengthOutOfRangeUnhandled.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/ArrayGetLengthOutOfRangeUnhandled.cs
@@ -1,0 +1,24 @@
+// `Array.GetLength` with an out-of-range dimension raises `IndexOutOfRangeException`.
+// `ArrayShapeQueries.cs` covers the caught case (including the message); this covers the
+// uncaught one, where the exception escapes `Main` and the guest process dies.
+//
+// The `Array.GetLength` intrinsic used to dispatch the exception itself and had nowhere to
+// report "no handler was found", so an uncaught one took the interpreter down rather than
+// being reported as a dead guest.
+
+using System;
+
+public class Program
+{
+    // Keep the dimension opaque so nothing can fold the call away.
+    private static int Dimension(int d)
+    {
+        return d;
+    }
+
+    public static int Main(string[] args)
+    {
+        int[,] grid = new int[2, 3];
+        return grid.GetLength(Dimension(5));
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/EnumHasFlagMismatchUnhandled.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/EnumHasFlagMismatchUnhandled.cs
@@ -1,0 +1,32 @@
+// `Enum.HasFlag` with mismatched enum types raises `ArgumentException`. This is the same
+// scenario as `BoxHasFlagTypeMismatch.cs`, but with nothing catching it, so the exception
+// escapes `Main` and the guest process dies.
+//
+// That distinction is the point of the test: PawPrint's intrinsic dispatch had no way to
+// report "this exception was unhandled", so it host-`failwith`ed and brought the
+// interpreter down instead of reporting a dead guest.
+
+using System;
+
+public class Program
+{
+    private enum EnumA
+    {
+        X = 1,
+    }
+
+    private enum EnumB
+    {
+        Y = 1,
+    }
+
+    private static bool HasFlagViaEnum(Enum value, Enum flag)
+    {
+        return value.HasFlag(flag);
+    }
+
+    public static int Main(string[] args)
+    {
+        return HasFlagViaEnum(EnumA.X, EnumB.Y) ? 1 : 2;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/EnumHasFlagNullFlagUnhandled.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/EnumHasFlagNullFlagUnhandled.cs
@@ -1,0 +1,26 @@
+// `Enum.HasFlag(null)` raises `ArgumentNullException` — the null check runs before the
+// type-equivalence check, so this is a distinct arm from
+// `EnumHasFlagMismatchUnhandled.cs`. Nothing catches it, so the guest process dies.
+//
+// As with the mismatch case, the interesting part is the *unhandled* path: intrinsic
+// dispatch previously had no way to say the exception found no handler.
+
+using System;
+
+public class Program
+{
+    private enum EnumA
+    {
+        X = 1,
+    }
+
+    private static bool HasFlagViaEnum(Enum value, Enum flag)
+    {
+        return value.HasFlag(flag);
+    }
+
+    public static int Main(string[] args)
+    {
+        return HasFlagViaEnum(EnumA.X, null) ? 1 : 2;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/GetArrayDataReferenceNull.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/GetArrayDataReferenceNull.cs
@@ -1,0 +1,45 @@
+// `MemoryMarshal.GetArrayDataReference<T>(null)` throws `NullReferenceException`. This is
+// documented on the method (`<exception cref="NullReferenceException">`) and the JIT emits an
+// explicit null check for it rather than relying on a fault, so it is a guaranteed throw
+// rather than an accident of the expansion.
+//
+// It is a static method, so `callvirt`'s own null check never sees the argument — the
+// intrinsic has to raise this itself.
+
+using System;
+using System.Runtime.InteropServices;
+
+public class Program
+{
+    // Opaque so the null cannot be constant-folded into the call.
+    private static int[] NullArray()
+    {
+        return null;
+    }
+
+    private static int[] RealArray()
+    {
+        return new int[] { 11, 22, 33 };
+    }
+
+    public static int Main(string[] args)
+    {
+        try
+        {
+            ref int r = ref MemoryMarshal.GetArrayDataReference(NullArray());
+            return 1;
+        }
+        catch (NullReferenceException)
+        {
+        }
+
+        // A non-null array must still produce a reference to element 0.
+        ref int first = ref MemoryMarshal.GetArrayDataReference(RealArray());
+        if (first != 11)
+        {
+            return 2;
+        }
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/InitializeArrayNullArgs.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/InitializeArrayNullArgs.cs
@@ -1,0 +1,62 @@
+// `RuntimeHelpers.InitializeArray` validates its two arguments in order, and the two failures
+// are *different* exceptions:
+//
+//     if (array is null) ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+//     if (fldHandle.IsNullHandle()) throw new ArgumentException(SR.Argument_InvalidHandle);
+//
+// so a null array is an `ArgumentNullException`, not the `NullReferenceException` you might
+// expect from the name. The JIT only expands this intrinsic when it recognises a `newarr`
+// plus a constant `ldtoken`, which neither call below matches, so the managed body — and
+// hence these checks — is what really runs.
+//
+// `ArgumentNullException` derives from `ArgumentException`, so the second test has to
+// discriminate on the exact type rather than relying on catch ordering alone.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public class Program
+{
+    private static Array NullArray()
+    {
+        return null;
+    }
+
+    public static int Main(string[] args)
+    {
+        // Null array: ArgumentNullException. Checked first, so the null handle here is not
+        // what is being reported.
+        //
+        // The message is deliberately not asserted. The CLR's is "Value cannot be null.
+        // (Parameter 'array')", where the suffix is synthesised by `ArgumentException.Message`
+        // from `_paramName`; PawPrint constructs this exception through its parameterless ctor
+        // and has no way to set `_paramName`, so it reports "Value cannot be null.". Asserting
+        // the CLR's string here would be asserting a divergence we know about.
+        try
+        {
+            RuntimeHelpers.InitializeArray(NullArray(), default);
+            return 1;
+        }
+        catch (ArgumentNullException)
+        {
+        }
+
+        // Null field handle with a real array: plain ArgumentException, whose message is a
+        // constant (`SR.Argument_InvalidHandle`) with nothing interpolated, so it can be — and
+        // is — asserted exactly.
+        try
+        {
+            RuntimeHelpers.InitializeArray(new int[4], default);
+            return 2;
+        }
+        catch (Exception e) when (e.GetType() == typeof(ArgumentException))
+        {
+            if (e.Message != "The handle is invalid.")
+            {
+                return 3;
+            }
+        }
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/NullReceiverGuards.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/NullReceiverGuards.cs
@@ -1,0 +1,74 @@
+// Instance methods that PawPrint implements as intrinsics still get `callvirt`'s own null
+// check first, so a null receiver raises `NullReferenceException` before the intrinsic body
+// is consulted at all.
+//
+// This is why the null-receiver arms inside those intrinsics (`Object.GetType`,
+// `Array.Clone`) are reachable only from hand-written IL that uses a non-virtual `call`,
+// which performs no null check. There is no ilasm in this repo, so those arms cannot be
+// covered end to end; this test pins the guard that makes them unreachable, so that if the
+// guard ever moves, something fails here rather than silently starting to route null
+// receivers into the intrinsics.
+
+using System;
+
+public class Program
+{
+    // Opaque, so the null is not visible to the compiler as a constant.
+    private static object NullObject()
+    {
+        return null;
+    }
+
+    private static Array NullArray()
+    {
+        return null;
+    }
+
+    public static int Main(string[] args)
+    {
+        try
+        {
+            Type t = NullObject().GetType();
+            return 1;
+        }
+        catch (NullReferenceException)
+        {
+        }
+
+        try
+        {
+            object clone = NullArray().Clone();
+            return 2;
+        }
+        catch (NullReferenceException)
+        {
+        }
+
+        // Through the interface, which is also a callvirt.
+        try
+        {
+            ICloneable c = NullArray();
+            object clone = c.Clone();
+            return 3;
+        }
+        catch (NullReferenceException)
+        {
+        }
+
+        // Non-null receivers still reach the intrinsics.
+        if (new int[] { 1, 2 }.GetType() != typeof(int[]))
+        {
+            return 4;
+        }
+
+        int[] source = new int[] { 7, 8, 9 };
+        int[] copied = (int[]) source.Clone();
+
+        if (copied.Length != 3 || copied[2] != 9)
+        {
+            return 5;
+        }
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/SpanIndexOutOfRange.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/SpanIndexOutOfRange.cs
@@ -1,0 +1,132 @@
+// `Span<T>`/`ReadOnlySpan<T>` indexers bounds-check with `(uint)index >= (uint)_length` and
+// call `ThrowHelper.ThrowIndexOutOfRangeException()`, which throws the parameterless
+// `IndexOutOfRangeException` — so the message is the type's default and PawPrint reproduces
+// it exactly.
+//
+// Note the unsigned comparison: a negative index is caught by the same branch, because it
+// reinterprets as a huge unsigned value. Both directions are covered below.
+
+using System;
+
+public class Program
+{
+    // Keep indices opaque so nothing can fold the bounds check away.
+    private static int Opaque(int i)
+    {
+        return i;
+    }
+
+    private static int TestSpan()
+    {
+        Span<int> s = new int[3];
+
+        try
+        {
+            int x = s[Opaque(7)];
+            return 1;
+        }
+        catch (IndexOutOfRangeException)
+        {
+        }
+
+        try
+        {
+            int x = s[Opaque(-1)];
+            return 2;
+        }
+        catch (IndexOutOfRangeException)
+        {
+        }
+
+        // The boundary index is one past the end.
+        try
+        {
+            int x = s[Opaque(3)];
+            return 3;
+        }
+        catch (IndexOutOfRangeException)
+        {
+        }
+
+        // In-range indices must still work.
+        s[Opaque(2)] = 42;
+        if (s[Opaque(2)] != 42)
+        {
+            return 4;
+        }
+
+        return 0;
+    }
+
+    private static int TestReadOnlySpan()
+    {
+        ReadOnlySpan<int> r = new int[2];
+
+        try
+        {
+            int y = r[Opaque(2)];
+            return 1;
+        }
+        catch (IndexOutOfRangeException)
+        {
+        }
+
+        try
+        {
+            int y = r[Opaque(-5)];
+            return 2;
+        }
+        catch (IndexOutOfRangeException)
+        {
+        }
+
+        if (r[Opaque(1)] != 0)
+        {
+            return 3;
+        }
+
+        return 0;
+    }
+
+    private static int TestEmptySpan()
+    {
+        // A zero-length span rejects every index, including 0.
+        Span<int> empty = new int[0];
+
+        try
+        {
+            int z = empty[Opaque(0)];
+            return 1;
+        }
+        catch (IndexOutOfRangeException)
+        {
+        }
+
+        return 0;
+    }
+
+    public static int Main(string[] args)
+    {
+        int result;
+
+        result = TestSpan();
+        if (result != 0)
+        {
+            return 10 + result;
+        }
+
+        result = TestReadOnlySpan();
+        if (result != 0)
+        {
+            return 20 + result;
+        }
+
+        result = TestEmptySpan();
+        if (result != 0)
+        {
+            return 30 + result;
+        }
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/UnsafeAsNullRef.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/UnsafeAsNullRef.cs
@@ -1,0 +1,47 @@
+// `Unsafe.As<TFrom, TTo>(ref TFrom)` on a null byref does not throw: its CoreLib body is
+// replaced by `ldarg.0; ret`, and the JIT expansion (NI_SRCS_UNSAFE_As) inserts no null
+// check. Reinterpreting a null reference is address-preserving, so null goes in and null
+// comes out.
+//
+// The `Unsafe.As<T>(object)` overload already round-trips null correctly in PawPrint; this
+// pins the byref overload, where the reinterpret used to be pushed through a projection
+// that rejects the null managed pointer.
+
+using System.Runtime.CompilerServices;
+
+public class Program
+{
+    public static int Main(string[] args)
+    {
+        // Differing TFrom/TTo: the reinterpreting path.
+        ref int widened = ref Unsafe.As<byte, int>(ref Unsafe.NullRef<byte>());
+        if (!Unsafe.IsNullRef(ref widened))
+        {
+            return 1;
+        }
+
+        // Identical TFrom/TTo: the no-op path, which already worked.
+        ref byte same = ref Unsafe.As<byte, byte>(ref Unsafe.NullRef<byte>());
+        if (!Unsafe.IsNullRef(ref same))
+        {
+            return 2;
+        }
+
+        // Reinterpreting twice must stay null rather than accumulating projections.
+        ref long twice = ref Unsafe.As<int, long>(ref Unsafe.As<byte, int>(ref Unsafe.NullRef<byte>()));
+        if (!Unsafe.IsNullRef(ref twice))
+        {
+            return 3;
+        }
+
+        // A non-null byref must still reinterpret normally.
+        int value = 0x2A;
+        ref byte firstByte = ref Unsafe.As<int, byte>(ref value);
+        if (Unsafe.IsNullRef(ref firstByte))
+        {
+            return 4;
+        }
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/UnsafeBitCast.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/UnsafeBitCast.cs
@@ -150,6 +150,87 @@ public class TestUnsafeBitCast
         return 0;
     }
 
+    // Test 9: mismatched sizes throw NotSupportedException.
+    //
+    // `Unsafe.BitCast` guards with `if (sizeof(TFrom) != sizeof(TTo) || !typeof(TFrom).IsValueType
+    // || !typeof(TTo).IsValueType) ThrowHelper.ThrowNotSupportedException();`, and the JIT
+    // deliberately declines to expand in exactly those cases ("Fallback to the software
+    // implementation to throw when sizes don't match"), so the managed body runs and throws.
+    // `ThrowNotSupportedException` uses the parameterless ctor, so the message is the default.
+    public static int Test9()
+    {
+        try
+        {
+            long widened = Unsafe.BitCast<int, long>(5);
+            return 1;
+        }
+        catch (NotSupportedException)
+        {
+        }
+
+        try
+        {
+            byte narrowed = Unsafe.BitCast<int, byte>(0x12345678);
+            return 2;
+        }
+        catch (NotSupportedException)
+        {
+        }
+
+        // Struct sizes are compared too, not just primitive ones.
+        try
+        {
+            FourBytes fb = Unsafe.BitCast<EightBytes, FourBytes>(default);
+            return 3;
+        }
+        catch (NotSupportedException)
+        {
+        }
+
+        // The guard is a single `if` with three clauses, so a *reference* type is rejected
+        // too, even though both sides are pointer-sized and the sizes therefore agree:
+        //
+        //   if (sizeof(TFrom) != sizeof(TTo) || !typeof(TFrom).IsValueType || !typeof(TTo).IsValueType)
+        //
+        // The JIT declines to expand for reference types for exactly this reason ("Fallback to
+        // the software implementation to throw for reference types").
+        try
+        {
+            object o = Unsafe.BitCast<string, object>("x");
+            return 4;
+        }
+        catch (NotSupportedException)
+        {
+        }
+
+        // ...in either position.
+        try
+        {
+            string s = Unsafe.BitCast<object, string>(new object());
+            return 5;
+        }
+        catch (NotSupportedException)
+        {
+        }
+
+        // `ThrowHelper.ThrowNotSupportedException` uses the parameterless ctor, so HResult is
+        // COR_E_NOTSUPPORTED rather than the generic COR_E_EXCEPTION.
+        try
+        {
+            long widened = Unsafe.BitCast<int, long>(5);
+            return 6;
+        }
+        catch (NotSupportedException e)
+        {
+            if (e.HResult != unchecked((int) 0x80131515))
+            {
+                return 7;
+            }
+        }
+
+        return 0;
+    }
+
     public static int Main(string[] argv)
     {
         var result = Test1();
@@ -175,6 +256,9 @@ public class TestUnsafeBitCast
 
         result = Test8();
         if (result != 0) return result;
+
+        result = Test9();
+        if (result != 0) return 90 + result;
 
         return 0;
     }

--- a/WoofWare.PawPrint.Test/sourcesPure/UnsafeUnalignedNullRef.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/UnsafeUnalignedNullRef.cs
@@ -1,0 +1,46 @@
+// `Unsafe.ReadUnaligned`/`WriteUnaligned` through a null byref throw `NullReferenceException`.
+// Their CoreLib bodies are replaced by `ldarg.0; unaligned. 1; ldobj !!T; ret` and the
+// symmetric `stobj`, with no explicit null check — the access at address 0 faults and the
+// runtime translates it into `NullReferenceException`.
+//
+// The write is the load-bearing half: a store cannot be elided, whereas a read whose result
+// is unused could in principle be. The read below therefore parks its result in a static.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public class Program
+{
+    private static int Sink;
+
+    public static int Main(string[] args)
+    {
+        try
+        {
+            Unsafe.WriteUnaligned<int>(ref Unsafe.NullRef<byte>(), 42);
+            return 1;
+        }
+        catch (NullReferenceException)
+        {
+        }
+
+        try
+        {
+            Sink = Unsafe.ReadUnaligned<int>(ref Unsafe.NullRef<byte>());
+            return 2;
+        }
+        catch (NullReferenceException)
+        {
+        }
+
+        // Non-null byrefs must still round-trip.
+        byte[] buffer = new byte[8];
+        Unsafe.WriteUnaligned<int>(ref buffer[1], 0x12345678);
+        if (Unsafe.ReadUnaligned<int>(ref buffer[1]) != 0x12345678)
+        {
+            return 3;
+        }
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/AbstractMachine.fs
+++ b/WoofWare.PawPrint/AbstractMachine.fs
@@ -183,7 +183,7 @@ module AbstractMachine =
                     thread
                     currentThreadState
                     originalCallSitePC
-                    false
+                    ConstructedObjectDisposition.PushToCaller
                     false // wrapExceptionInTargetInvocation
                     state
 

--- a/WoofWare.PawPrint/ExceptionDispatching.fs
+++ b/WoofWare.PawPrint/ExceptionDispatching.fs
@@ -836,6 +836,8 @@ module ExceptionDispatching =
             ExceptionHResults.lookup "System.ArgumentException"
         elif id = baseClassTypes.ArgumentNullException.Identity then
             ExceptionHResults.lookup "System.ArgumentNullException"
+        elif id = baseClassTypes.NotSupportedException.Identity then
+            ExceptionHResults.lookup "System.NotSupportedException"
         else
             ExceptionHResults.corEException
 

--- a/WoofWare.PawPrint/Exceptions.fs
+++ b/WoofWare.PawPrint/Exceptions.fs
@@ -79,6 +79,7 @@ module internal ExceptionHResults =
             "System.MissingMethodException", int 0x80131513u // COR_E_MISSINGMETHOD
             "System.ArgumentException", int 0x80070057u // COR_E_ARGUMENT
             "System.ArgumentNullException", 0x80004003 // E_POINTER (ArgumentNullException maps to E_POINTER in the CLR)
+            "System.NotSupportedException", int 0x80131515u // COR_E_NOTSUPPORTED
             "System.Reflection.TargetInvocationException", int 0x80131604u // COR_E_TARGETINVOCATION
         ]
 

--- a/WoofWare.PawPrint/IlMachineStateExecution.fs
+++ b/WoofWare.PawPrint/IlMachineStateExecution.fs
@@ -997,7 +997,7 @@ module IlMachineStateExecution =
         (thread : ThreadId)
         (threadState : ThreadState)
         (callSiteIlOpIndexOverride : int option)
-        (dispatchAsExceptionOnReturn : bool)
+        (constructedObjectDisposition : ConstructedObjectDisposition)
         (wrapExceptionInTargetInvocation : bool)
         (state : IlMachineState)
         : IlMachineState
@@ -1362,7 +1362,7 @@ module IlMachineStateExecution =
                         thread
                         threadState
                         None
-                        false
+                        ConstructedObjectDisposition.PushToCaller
                         true // wrapExceptionInTargetInvocation: mirror CreateInstanceOfT
                         state
                     |> Some
@@ -1407,8 +1407,20 @@ module IlMachineStateExecution =
                 | None ->
 
                 match Intrinsics.call loggerFactory baseClassTypes wasConstructing methodToCall thread state with
-                | Some result -> Some result
-                | None ->
+                | IntrinsicResult.Completed result -> Some result
+                | IntrinsicResult.RaiseException (state, exnType, message) ->
+                    // The intrinsic described an exception rather than raising it, because it
+                    // cannot see `raiseRuntimeException` (compile order) and because raising it
+                    // here is what makes an *unhandled* one expressible: `raiseRuntimeException`
+                    // defers dispatch to the ctor's `Ret`, which can report
+                    // `ExecutionResult.UnhandledException`. The intrinsic has deliberately not
+                    // advanced the PC, so dispatch sees the faulting instruction's offset.
+                    // `WhatWeDid` is always `Executed` here — the ctor frame is now the active
+                    // frame, exactly as for an opcode-manufactured exception.
+                    raiseRuntimeExceptionWithMessage loggerFactory baseClassTypes exnType message thread state
+                    |> fst
+                    |> Some
+                | IntrinsicResult.Unrecognised ->
                     failwith
                         $"TODO: implement JIT intrinsic %s{Intrinsics.formatMethodKey intrinsicKey}, or add it to safeIntrinsics after reviewing its IL"
             else
@@ -1548,7 +1560,7 @@ module IlMachineStateExecution =
                         WasInitialisingType = wasInitialising
                         Constructing = wasConstructing
                         CallSiteIlOpIndex = callSiteIlOpIndexOverride |> Option.defaultValue afterPop.IlOpIndex
-                        DispatchAsExceptionOnReturn = dispatchAsExceptionOnReturn
+                        ConstructedObjectDisposition = constructedObjectDisposition
                         WrapExceptionInTargetInvocation = wrapExceptionInTargetInvocation
                     }
 
@@ -1758,7 +1770,7 @@ module IlMachineStateExecution =
                     currentThread
                     currentThreadState
                     None
-                    false
+                    ConstructedObjectDisposition.PushToCaller
                     false // wrapExceptionInTargetInvocation
                     state
                 |> FirstLoadThis
@@ -1827,10 +1839,20 @@ module IlMachineStateExecution =
     /// EEException::CreateThrowable path: allocate the object directly, call the default
     /// instance ctor, then overwrite HResult.
     /// See: https://github.com/dotnet/dotnet/blob/10060d128e3f470e77265f8490f5e4f72dae738e/src/runtime/src/coreclr/vm/clrex.cpp#L972-L1019
-    let raiseRuntimeException
+    ///
+    /// `message` overrides `_message` once the ctor has run, for the cases where the CLR
+    /// would have used a message-taking ctor overload. Most callers want `None` — the CLR
+    /// throws the great majority of these with no argument — and should use
+    /// `raiseRuntimeException` below, which is this function with `None` supplied.
+    ///
+    /// This is part of the `callMethod` recursion group only because it needs to call
+    /// `callMethod` to run the ctor, and `callMethod` needs to call it to service
+    /// `IntrinsicResult.RaiseException`.
+    and raiseRuntimeExceptionWithMessage
         (loggerFactory : ILoggerFactory)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (exceptionTypeInfo : TypeInfo<GenericParamFromMetadata, TypeDefn>)
+        (message : string option)
         (currentThread : ThreadId)
         (state : IlMachineState)
         : IlMachineState * WhatWeDid
@@ -1898,10 +1920,24 @@ module IlMachineStateExecution =
             currentThread
             threadState
             None
-            true // dispatchAsExceptionOnReturn
+            (ConstructedObjectDisposition.DispatchAsException message)
             false // wrapExceptionInTargetInvocation
             state,
         WhatWeDid.Executed
+
+    /// `raiseRuntimeExceptionWithMessage` with no message override, i.e. the exception is
+    /// constructed exactly as `new SomeException()` would construct it. This is the right
+    /// entry point wherever the CLR throws the exception with no argument, which is almost
+    /// everywhere the runtime manufactures one.
+    and raiseRuntimeException
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (exceptionTypeInfo : TypeInfo<GenericParamFromMetadata, TypeDefn>)
+        (currentThread : ThreadId)
+        (state : IlMachineState)
+        : IlMachineState * WhatWeDid
+        =
+        raiseRuntimeExceptionWithMessage loggerFactory baseClassTypes exceptionTypeInfo None currentThread state
 
     /// Result of the ECMA-335 III.4.x runtime array-store variance gate.
     [<RequireQualifiedAccess>]

--- a/WoofWare.PawPrint/IlMachineStateModel.fs
+++ b/WoofWare.PawPrint/IlMachineStateModel.fs
@@ -287,6 +287,48 @@ type ExecutionResult =
         terminatingThread : ThreadId *
         CliException<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>
 
+/// Outcome of invoking a hand-written JIT intrinsic (`Intrinsics.call`). This is the
+/// intrinsic analogue of `NativeHandlerResult` below, and exists for the same reason:
+/// an intrinsic must be able to say "raise a guest exception" without being able to
+/// perform the raise itself.
+///
+/// `Intrinsics.fs` compiles before `IlMachineStateExecution.fs`, so it cannot call
+/// `raiseRuntimeException`. Rather than duplicate exception machinery on the wrong side of
+/// that boundary, an intrinsic returns a *description* of the exception it wants and
+/// `IlMachineStateExecution.callMethod` performs it.
+///
+/// That indirection is not merely a compile-order workaround: it is what makes an unhandled
+/// guest exception expressible at all. `raiseRuntimeException` defers dispatch — it pushes
+/// the exception type's ctor frame and arms `ConstructedObjectDisposition.DispatchAsException`,
+/// so the handler
+/// search happens later, on the ctor's `Ret` in `NullaryIlOp`, which returns
+/// `ExecutionResult` and can therefore report `ExecutionResult.UnhandledException`. An
+/// intrinsic that dispatched inline would have to confront `ExceptionUnhandled` from a
+/// context with no way to report it, which is exactly how `Enum.HasFlag` used to
+/// host-`failwith` on a guest that legitimately died.
+type IntrinsicResult =
+    /// There is no hand-written implementation for this intrinsic key. The caller reports
+    /// this as an unimplemented intrinsic; it is NOT an instruction to interpret the
+    /// method's own IL (that decision is `Intrinsics.isSafeIntrinsic`, taken earlier).
+    | Unrecognised
+    /// The intrinsic ran to completion, and has already advanced the caller's program
+    /// counter itself.
+    | Completed of IlMachineState
+    /// The intrinsic wants `exnType` raised at the current instruction. The intrinsic must
+    /// NOT have advanced the program counter: exception dispatch keys both the handler
+    /// search and the stack trace on the faulting instruction's offset. `exnType` must be a
+    /// non-generic BCL exception type with a parameterless constructor — see
+    /// `IlMachineStateExecution.raiseRuntimeException`, which the caller invokes on the
+    /// intrinsic's behalf.
+    ///
+    /// `message` names the string the CLR would have passed to a message-taking ctor
+    /// overload; `None` accepts the parameterless ctor's default resource string, which is
+    /// correct wherever the CLR itself throws with no argument.
+    | RaiseException of
+        IlMachineState *
+        exnType : TypeInfo<GenericParamFromMetadata, TypeDefn> *
+        message : string option
+
 /// Outcome of invoking a native handler (QCall, P/Invoke shim, or other host-provided
 /// primitive registered under `WoofWare.PawPrint.Native`). Each variant names a single
 /// dispatcher decision, so the dispatcher's pattern match is total and the convention
@@ -358,8 +400,14 @@ type ReturnFrameResult =
     /// The caller should dispatch this object as a managed exception instead of pushing it
     /// onto the eval stack.  Before dispatching, the caller MUST call
     /// ExceptionDispatching.overwriteHResultPostCtor to apply the CLR's post-ctor
-    /// SetHResult(GetHR()) step.
-    | DispatchException of IlMachineState * exceptionAddr : ManagedHeapAddress * exceptionType : ConcreteTypeHandle
+    /// SetHResult(GetHR()) step, and then, when `message` is `Some`, overwrite `_message`
+    /// with it (see `ConstructedObjectDisposition.DispatchAsException` for why that has to
+    /// happen after the ctor rather than before it).
+    | DispatchException of
+        IlMachineState *
+        exceptionAddr : ManagedHeapAddress *
+        exceptionType : ConcreteTypeHandle *
+        message : string option
 
 /// Result of a complete program run (the pump loop having finished).
 type RunOutcome =
@@ -522,7 +570,8 @@ module NativeHandlerResult =
     /// Any `Stepped` value with a `WhatWeDid` other than `Executed` is rejected as a logic
     /// error: ExternImpls are not authorised to drive cctor / managed-call / exception
     /// re-entry directly, because those decisions require structural support (re-entry
-    /// markers, `dispatchAsExceptionOnReturn` arming) that ExternImpls don't have access to.
+    /// markers, `ConstructedObjectDisposition.DispatchAsException` arming) that ExternImpls don't
+    /// have access to.
     /// `VoluntaryYield` is rejected here for the same structural-boundary reason: the yield
     /// signal is produced at the native-handler return shape via `NativeHandlerResult.Yielded`,
     /// not threaded back through `ExecutionResult`. If an ExternImpl ever needs to yield, the

--- a/WoofWare.PawPrint/IlMachineStateModel.fs
+++ b/WoofWare.PawPrint/IlMachineStateModel.fs
@@ -291,21 +291,6 @@ type ExecutionResult =
 /// intrinsic analogue of `NativeHandlerResult` below, and exists for the same reason:
 /// an intrinsic must be able to say "raise a guest exception" without being able to
 /// perform the raise itself.
-///
-/// `Intrinsics.fs` compiles before `IlMachineStateExecution.fs`, so it cannot call
-/// `raiseRuntimeException`. Rather than duplicate exception machinery on the wrong side of
-/// that boundary, an intrinsic returns a *description* of the exception it wants and
-/// `IlMachineStateExecution.callMethod` performs it.
-///
-/// That indirection is not merely a compile-order workaround: it is what makes an unhandled
-/// guest exception expressible at all. `raiseRuntimeException` defers dispatch — it pushes
-/// the exception type's ctor frame and arms `ConstructedObjectDisposition.DispatchAsException`,
-/// so the handler
-/// search happens later, on the ctor's `Ret` in `NullaryIlOp`, which returns
-/// `ExecutionResult` and can therefore report `ExecutionResult.UnhandledException`. An
-/// intrinsic that dispatched inline would have to confront `ExceptionUnhandled` from a
-/// context with no way to report it, which is exactly how `Enum.HasFlag` used to
-/// host-`failwith` on a guest that legitimately died.
 type IntrinsicResult =
     /// There is no hand-written implementation for this intrinsic key. The caller reports
     /// this as an unimplemented intrinsic; it is NOT an instruction to interpret the

--- a/WoofWare.PawPrint/IlMachineThreadState.fs
+++ b/WoofWare.PawPrint/IlMachineThreadState.fs
@@ -200,7 +200,9 @@ module IlMachineThreadState =
                 failwith
                     $"Synthetic stack frame %s{threadStateWithSyntheticFrame.MethodState.ExecutingMethod.Name} unexpectedly represented object construction"
             | ConstructionState.NotConstructing ->
-                if returnState.DispatchAsExceptionOnReturn then
+                match returnState.ConstructedObjectDisposition with
+                | ConstructedObjectDisposition.PushToCaller -> ()
+                | ConstructedObjectDisposition.DispatchAsException _ ->
                     failwith
                         $"Synthetic stack frame %s{threadStateWithSyntheticFrame.MethodState.ExecutingMethod.Name} unexpectedly requested exception dispatch on return"
 
@@ -273,13 +275,14 @@ module IlMachineThreadState =
             failwith
                 $"Variable-size constructor %s{returningMethodState.ExecutingMethod.Name} returned without supplying a constructed object; it must call IlMachineState.withSuppliedConstructedObject before returning"
         | ConstructionState.Constructing constructing ->
-            if returnState.DispatchAsExceptionOnReturn then
+            match returnState.ConstructedObjectDisposition with
+            | ConstructedObjectDisposition.DispatchAsException message ->
                 // This ctor was constructing a runtime-synthesised exception object.
                 // Don't push it onto the eval stack; signal to the caller that exception
                 // dispatch should occur.
                 let constructed = state.ManagedHeap.NonArrayObjects.[constructing]
-                ReturnFrameResult.DispatchException (state, constructing, constructed.ConcreteType)
-            else
+                ReturnFrameResult.DispatchException (state, constructing, constructed.ConcreteType, message)
+            | ConstructedObjectDisposition.PushToCaller ->
 
             // Assumption: a constructor can't also return a value.
             // If we were constructing a reference type, we push a reference to it.

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -1530,7 +1530,20 @@ module Intrinsics =
                     | EvalStackValue.Int64 _
                     | EvalStackValue.Float _ -> failwith "expected pointer type"
                     | EvalStackValue.NativeInt nativeIntSource -> failwith "todo"
-                    | EvalStackValue.NullObjectRef -> failwith "todo: Unsafe.As on null"
+                    | EvalStackValue.NullObjectRef ->
+                        // A null byref spelled as an object reference, which is what hand-written
+                        // IL produces; `reinterpretAs` below handles the
+                        // `ManagedPointer ManagedPointerSource.Null` spelling that guest C#
+                        // produces, but it takes a `ManagedPointerSource` and so cannot see this
+                        // one. Same answer either way: `Unsafe.As` does not null-check (its CoreLib
+                        // body is `ldarg.0; ret`, and the JIT's `NI_SRCS_UNSAFE_As` expansion is a
+                        // bare `impPopStack().val`), and reinterpreting is address-preserving, so
+                        // null in means null out.
+                        //
+                        // Normalising to the managed-pointer spelling matches how `Unsafe.NullRef`
+                        // and `Unsafe.AsRef(void*)` above represent a null byref, so that
+                        // `Unsafe.IsNullRef` recognises the result.
+                        EvalStackValue.ManagedPointer ManagedPointerSource.Null
                     | EvalStackValue.ManagedPointer src when from = to_ ->
                         // Unsafe.As<T,T> is a no-op: same address and same type view.
                         // Skipping the projection keeps the representation canonical so

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -28,7 +28,7 @@ module Intrinsics =
         (methodToCall : WoofWare.PawPrint.MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>)
         (currentThread : ThreadId)
         (state : IlMachineState)
-        : IlMachineState option
+        : IntrinsicResult
         =
         let intrinsicKey = methodKey state methodToCall
 
@@ -77,7 +77,7 @@ module Intrinsics =
             state
             |> IlMachineState.pushToEvalStack (CliType.ofBool false) currentThread
             |> IlMachineState.advanceProgramCounter currentThread
-            |> Some
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", ("ReadOnlySpan`1" | "Span`1"), ".ctor" when
             intrinsicKey.ParameterShapes = [ "*" ; "System.Int32" ]
             && (intrinsicKey.DeclaringTypeFullName = "System.ReadOnlySpan`1"
@@ -90,16 +90,18 @@ module Intrinsics =
                 wasConstructing
                 methodToCall
                 state
-            |> Some
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", ("ReadOnlySpan`1" | "Span`1"), "ToString" ->
             spanToString loggerFactory baseClassTypes currentThread methodToCall state
-            |> Some
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "MemoryExtensions", "Equals" ->
-            memoryExtensionsEquals baseClassTypes currentThread methodToCall state |> Some
+            memoryExtensionsEquals baseClassTypes currentThread methodToCall state
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "SpanHelpers", "SequenceEqual" when
             isSpanHelpersByteSequenceEqual state methodToCall
             ->
-            spanHelpersSequenceEqual baseClassTypes currentThread methodToCall state |> Some
+            spanHelpersSequenceEqual baseClassTypes currentThread methodToCall state
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", ("Vector128" | "Vector256" | "Vector512"), "get_IsHardwareAccelerated"
         | "System.Private.CoreLib", "Vector", "get_IsHardwareAccelerated" when
             // System.Runtime.Intrinsics.Vector{128,256,512}.IsHardwareAccelerated and
@@ -122,7 +124,7 @@ module Intrinsics =
 
             IlMachineState.pushToEvalStack (CliType.ofBool isAccelerated) currentThread state
             |> IlMachineState.advanceProgramCounter currentThread
-            |> Some
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "Object", "GetType" ->
             match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
             | [],
@@ -162,7 +164,7 @@ module Intrinsics =
             state
             |> IlMachineState.pushToEvalStack (CliType.ObjectRef (Some runtimeTypeAddr)) currentThread
             |> IlMachineState.advanceProgramCounter currentThread
-            |> Some
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "RuntimeHelpers", "GetMethodTable" ->
             match methodToCall.Signature.ParameterTypes with
             | [ ConcretePrimitive state.ConcreteTypes PrimitiveType.Object ] -> ()
@@ -193,7 +195,7 @@ module Intrinsics =
                 (EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed concreteType)))
                 currentThread
             |> IlMachineState.advanceProgramCounter currentThread
-            |> Some
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "Type", "get_IsValueType" ->
             match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
             | [], MethodReturnType.Returns (ConcreteBool state.ConcreteTypes) -> ()
@@ -271,7 +273,7 @@ module Intrinsics =
 
             IlMachineState.pushToEvalStack (CliType.ofBool isValueType) currentThread state
             |> IlMachineState.advanceProgramCounter currentThread
-            |> Some
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "Unsafe", "AsPointer" ->
             // Method signature: 1 generic parameter, we take a Byref of that parameter, and return a TypeDefn.Pointer(Void)
             let arg, state = IlMachineState.popEvalStack currentThread state
@@ -283,7 +285,7 @@ module Intrinsics =
 
             IlMachineState.pushToEvalStack (CliType.RuntimePointer toPush) currentThread state
             |> IlMachineState.advanceProgramCounter currentThread
-            |> Some
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "Unsafe", "SkipInit" ->
             // `SkipInit<T>(out T)` is a JIT intrinsic that deliberately leaves
             // the byref target untouched. PawPrint's storage is already
@@ -304,7 +306,9 @@ module Intrinsics =
             | EvalStackValue.ManagedPointer _ -> ()
             | other -> failwith $"Unsafe.SkipInit: expected managed byref argument, got %O{other}"
 
-            state |> IlMachineState.advanceProgramCounter currentThread |> Some
+            state
+            |> IlMachineState.advanceProgramCounter currentThread
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "Unsafe", "AsRef" ->
             // `AsRef<T>(ref readonly T)` and `AsRef<T>(void* source)` are JIT
             // intrinsics. The CoreLib bodies in this runtime throw
@@ -359,7 +363,7 @@ module Intrinsics =
             state
             |> IlMachineState.pushToEvalStack' toPush currentThread
             |> IlMachineState.advanceProgramCounter currentThread
-            |> Some
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "Unsafe", "NullRef" ->
             // CoreCLR's UNSAFE__BYREF_NULLREF intrinsic replaces the CoreLib
             // body with a null managed byref (`ldc.i4.0; conv.u; ret`).
@@ -379,7 +383,7 @@ module Intrinsics =
             state
             |> IlMachineState.pushToEvalStack' (EvalStackValue.ManagedPointer ManagedPointerSource.Null) currentThread
             |> IlMachineState.advanceProgramCounter currentThread
-            |> Some
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "Unsafe", "IsNullRef" ->
             // The JIT intrinsic compares the byref argument against the null
             // managed byref.
@@ -408,7 +412,7 @@ module Intrinsics =
             state
             |> IlMachineState.pushToEvalStack (CliType.ofBool isNullRef) currentThread
             |> IlMachineState.advanceProgramCounter currentThread
-            |> Some
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "Interlocked", ("Add" | "ExchangeAdd") ->
             // `Add` returns the newly-stored sum; the private `ExchangeAdd`
             // primitive returns the original value. The read-modify-write
@@ -499,13 +503,13 @@ module Intrinsics =
               MethodReturnType.Returns (ConcreteInt32 state.ConcreteTypes)
             | [ ConcreteByref (ConcreteUInt32 state.ConcreteTypes) ; ConcreteUInt32 state.ConcreteTypes ],
               MethodReturnType.Returns (ConcreteUInt32 state.ConcreteTypes) ->
-                executeInt32 methodToCall.Name state |> Some
+                executeInt32 methodToCall.Name state |> IntrinsicResult.Completed
             | [ ConcreteByref (ConcreteInt64 state.ConcreteTypes) ; ConcreteInt64 state.ConcreteTypes ],
               MethodReturnType.Returns (ConcreteInt64 state.ConcreteTypes)
             | [ ConcreteByref (ConcreteUInt64 state.ConcreteTypes) ; ConcreteUInt64 state.ConcreteTypes ],
               MethodReturnType.Returns (ConcreteUInt64 state.ConcreteTypes) ->
-                executeInt64 methodToCall.Name state |> Some
-            | _ -> None
+                executeInt64 methodToCall.Name state |> IntrinsicResult.Completed
+            | _ -> IntrinsicResult.Unrecognised
 
         | "System.Private.CoreLib", "Interlocked", "MemoryBarrier" ->
             // [Intrinsic] public static void MemoryBarrier() => MemoryBarrier();
@@ -521,7 +525,9 @@ module Intrinsics =
             | [], MethodReturnType.Void -> ()
             | _ -> failwith $"Interlocked.MemoryBarrier: unexpected signature %A{methodToCall.Signature}"
 
-            state |> IlMachineState.advanceProgramCounter currentThread |> Some
+            state
+            |> IlMachineState.advanceProgramCounter currentThread
+            |> IntrinsicResult.Completed
 
         | "System.Private.CoreLib", "Interlocked", "CompareExchange" ->
             // The native-int-shaped overloads need their own path: the shipped IL wrappers do
@@ -615,7 +621,7 @@ module Intrinsics =
                 state
                 |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt currentSrc) currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
-                |> Some
+                |> IntrinsicResult.Completed
             | [ ConcreteByref (ConcretePrimitive state.ConcreteTypes locationPrimitive)
                 ConcretePrimitive state.ConcreteTypes valuePrimitive
                 ConcretePrimitive state.ConcreteTypes comparandPrimitive ],
@@ -625,7 +631,8 @@ module Intrinsics =
                 && locationPrimitive = comparandPrimitive
                 && locationPrimitive = returnPrimitive
                 ->
-                executeScalarInteger "Interlocked.CompareExchange" state |> Some
+                executeScalarInteger "Interlocked.CompareExchange" state
+                |> IntrinsicResult.Completed
             | [ ConcreteByref locationType ; valueType ; comparandType ], MethodReturnType.Returns returnType when
                 locationType = valueType
                 && locationType = comparandType
@@ -667,13 +674,13 @@ module Intrinsics =
                 state
                 |> IlMachineState.pushToEvalStack currentValue currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
-                |> Some
+                |> IntrinsicResult.Completed
             | _ ->
                 // The float/double overloads are not yet intrinsified. Their shipped IL bodies
                 // reinterpret-cast to integer overloads, so falling through would either re-enter
                 // this intrinsic path or lose the bit-level shape of the floating-point value.
                 // When a caller needs one of these, add a dedicated intrinsic arm.
-                None
+                IntrinsicResult.Unrecognised
         | "System.Private.CoreLib", "Interlocked", "Exchange" ->
             // Same intrinsic-boundary motivation as CompareExchange: the shipped CoreLib
             // bodies for Exchange ride Unsafe.As / InternalCall paths that would either
@@ -752,7 +759,7 @@ module Intrinsics =
                 state
                 |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt currentSrc) currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
-                |> Some
+                |> IntrinsicResult.Completed
             | [ ConcreteByref (ConcretePrimitive state.ConcreteTypes locationPrimitive)
                 ConcretePrimitive state.ConcreteTypes valuePrimitive ],
               MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes returnPrimitive) when
@@ -760,7 +767,8 @@ module Intrinsics =
                 && locationPrimitive = valuePrimitive
                 && locationPrimitive = returnPrimitive
                 ->
-                executeScalarIntegerExchange "Interlocked.Exchange" state |> Some
+                executeScalarIntegerExchange "Interlocked.Exchange" state
+                |> IntrinsicResult.Completed
             | [ ConcreteByref locationType ; valueType ], MethodReturnType.Returns returnType when
                 locationType = valueType
                 && locationType = returnType
@@ -784,11 +792,11 @@ module Intrinsics =
                 state
                 |> IlMachineState.pushToEvalStack currentValue currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
-                |> Some
+                |> IntrinsicResult.Completed
             | _ ->
                 // The float/double overloads are not yet intrinsified, matching the
                 // CompareExchange precedent above. Add a dedicated arm when first needed.
-                None
+                IntrinsicResult.Unrecognised
         | "System.Private.CoreLib", "Thread", "FastPollGC" ->
             // [Intrinsic] internal static void Thread.FastPollGC() => Thread.FastPollGC();
             // The managed IL body is an infinite self-recursive call; the JIT replaces
@@ -800,7 +808,9 @@ module Intrinsics =
             | [], MethodReturnType.Void -> ()
             | _ -> failwith $"Thread.FastPollGC: unexpected signature %A{methodToCall.Signature}"
 
-            state |> IlMachineState.advanceProgramCounter currentThread |> Some
+            state
+            |> IlMachineState.advanceProgramCounter currentThread
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "Volatile", ("ReadBarrier" | "WriteBarrier") ->
             // [Intrinsic] public static void Volatile.{Read,Write}Barrier() => Volatile.{Read,Write}Barrier();
             // Same shape as Thread.FastPollGC: the managed body is infinite self-recursion
@@ -814,7 +824,9 @@ module Intrinsics =
             | [], MethodReturnType.Void -> ()
             | _ -> failwith $"Volatile.%s{methodToCall.Name}: unexpected signature %A{methodToCall.Signature}"
 
-            state |> IlMachineState.advanceProgramCounter currentThread |> Some
+            state
+            |> IlMachineState.advanceProgramCounter currentThread
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "BitConverter", "SingleToInt32Bits" ->
             match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
             | [ ConcreteSingle state.ConcreteTypes ], MethodReturnType.Returns (ConcreteInt32 state.ConcreteTypes) -> ()
@@ -830,7 +842,7 @@ module Intrinsics =
             state
             |> IlMachineState.pushToEvalStack' result currentThread
             |> IlMachineState.advanceProgramCounter currentThread
-            |> Some
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "BitConverter", "Int32BitsToSingle" ->
             match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
             | [ ConcreteInt32 state.ConcreteTypes ], MethodReturnType.Returns (ConcreteSingle state.ConcreteTypes) -> ()
@@ -849,7 +861,7 @@ module Intrinsics =
             state
             |> IlMachineState.pushToEvalStack result currentThread
             |> IlMachineState.advanceProgramCounter currentThread
-            |> Some
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "BitConverter", "DoubleToUInt64Bits" ->
             match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
             | [ ConcreteDouble state.ConcreteTypes ], MethodReturnType.Returns (ConcreteUInt64 state.ConcreteTypes) ->
@@ -873,7 +885,7 @@ module Intrinsics =
             state
             |> IlMachineState.pushToEvalStack result currentThread
             |> IlMachineState.advanceProgramCounter currentThread
-            |> Some
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "BitConverter", "UInt64BitsToDouble" ->
             match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
             | [ ConcreteUInt64 state.ConcreteTypes ], MethodReturnType.Returns (ConcreteDouble state.ConcreteTypes) ->
@@ -893,7 +905,7 @@ module Intrinsics =
             state
             |> IlMachineState.pushToEvalStack result currentThread
             |> IlMachineState.advanceProgramCounter currentThread
-            |> Some
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "BitConverter", "Int64BitsToDouble" ->
             match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
             | [ ConcreteInt64 state.ConcreteTypes ], MethodReturnType.Returns (ConcreteDouble state.ConcreteTypes) -> ()
@@ -912,7 +924,7 @@ module Intrinsics =
             state
             |> IlMachineState.pushToEvalStack result currentThread
             |> IlMachineState.advanceProgramCounter currentThread
-            |> Some
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "BitConverter", "DoubleToInt64Bits" ->
             match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
             | [ ConcreteDouble state.ConcreteTypes ], MethodReturnType.Returns (ConcreteInt64 state.ConcreteTypes) -> ()
@@ -929,7 +941,7 @@ module Intrinsics =
             state
             |> IlMachineState.pushToEvalStack' result currentThread
             |> IlMachineState.advanceProgramCounter currentThread
-            |> Some
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "BitConverter", "SingleToUInt32Bits" ->
             match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
             | [ ConcreteSingle state.ConcreteTypes ], MethodReturnType.Returns (ConcreteUInt32 state.ConcreteTypes) ->
@@ -949,7 +961,7 @@ module Intrinsics =
             state
             |> IlMachineState.pushToEvalStack' result currentThread
             |> IlMachineState.advanceProgramCounter currentThread
-            |> Some
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "BitConverter", "UInt32BitsToSingle" ->
             match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
             | [ ConcreteUInt32 state.ConcreteTypes ], MethodReturnType.Returns (ConcreteSingle state.ConcreteTypes) ->
@@ -969,7 +981,7 @@ module Intrinsics =
             state
             |> IlMachineState.pushToEvalStack' result currentThread
             |> IlMachineState.advanceProgramCounter currentThread
-            |> Some
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "BitOperations", "Log2" ->
             // BitOperations.Log2 is a JIT intrinsic in the real CLR. The BCL IL body falls
             // through to a software fallback that reads from a De Bruijn lookup table backed
@@ -990,7 +1002,7 @@ module Intrinsics =
                 state
                 |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 result) currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
-                |> Some
+                |> IntrinsicResult.Completed
             | [ ConcreteUInt64 state.ConcreteTypes ], MethodReturnType.Returns (ConcreteInt32 state.ConcreteTypes) ->
                 let arg, state = IlMachineState.popEvalStack currentThread state
 
@@ -1004,7 +1016,7 @@ module Intrinsics =
                 state
                 |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 result) currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
-                |> Some
+                |> IntrinsicResult.Completed
             | [ ConcreteUIntPtr state.ConcreteTypes ], MethodReturnType.Returns (ConcreteInt32 state.ConcreteTypes) ->
                 let arg, state = IlMachineState.popEvalStack currentThread state
 
@@ -1021,7 +1033,7 @@ module Intrinsics =
                 state
                 |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 result) currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
-                |> Some
+                |> IntrinsicResult.Completed
             | _ -> failwith $"BitOperations.Log2: unexpected signature %s{formatMethodKey intrinsicKey}"
         | "System.Private.CoreLib", "String", "Equals" ->
             match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
@@ -1059,8 +1071,8 @@ module Intrinsics =
                 state
                 |> IlMachineState.pushToEvalStack (CliType.ofBool areEqual) currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
-                |> Some
-            | _ -> None
+                |> IntrinsicResult.Completed
+            | _ -> IntrinsicResult.Unrecognised
         | "System.Private.CoreLib", "Unsafe", "ReadUnaligned" ->
             // https://github.com/dotnet/runtime/blob/108fa7856efcfd39bc991c2d849eabbf7ba5989c/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/Unsafe.cs#L558
             // Semantically this returns the T that would be read by
@@ -1099,7 +1111,7 @@ module Intrinsics =
                     |> IlMachineState.pushToEvalStack v currentThread
                     |> IlMachineState.advanceProgramCounter currentThread
 
-                Some state
+                IntrinsicResult.Completed state
             | [ ConcretePointer _ ] ->
 
                 let t =
@@ -1120,8 +1132,8 @@ module Intrinsics =
                     |> IlMachineState.pushToEvalStack v currentThread
                     |> IlMachineState.advanceProgramCounter currentThread
 
-                Some state
-            | _ -> None
+                IntrinsicResult.Completed state
+            | _ -> IntrinsicResult.Unrecognised
         | "System.Private.CoreLib", "Unsafe", "WriteUnaligned" ->
             // https://github.com/dotnet/runtime/blob/108fa7856efcfd39bc991c2d849eabbf7ba5989c/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/Unsafe.cs#L609
             // Symmetric to ReadUnaligned: writes a T through a byte-level
@@ -1166,7 +1178,7 @@ module Intrinsics =
                     IlMachineState.writeManagedByrefBytesOrTypedCell baseClassTypes state src valueAsCli
 
                 let state = state |> IlMachineState.advanceProgramCounter currentThread
-                Some state
+                IntrinsicResult.Completed state
             | [ ConcretePointer _ ; _ ] ->
 
                 let t =
@@ -1196,8 +1208,8 @@ module Intrinsics =
                     IlMachineState.writeManagedByrefBytesOrTypedCell baseClassTypes state src valueAsCli
 
                 let state = state |> IlMachineState.advanceProgramCounter currentThread
-                Some state
-            | _ -> None
+                IntrinsicResult.Completed state
+            | _ -> IntrinsicResult.Unrecognised
         | "System.Private.CoreLib", "Unsafe", ("CopyBlock" | "CopyBlockUnaligned") ->
             // https://github.com/dotnet/runtime/blob/108fa7856efcfd39bc991c2d849eabbf7ba5989c/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/Unsafe.cs#L313
             // The CoreLib bodies throw PlatformNotSupportedException; the real JIT replaces
@@ -1210,8 +1222,10 @@ module Intrinsics =
               MethodReturnType.Void
             | [ ConcretePointer _ ; ConcretePointer _ ; ConcreteUInt32 state.ConcreteTypes ], MethodReturnType.Void ->
                 let operation = $"Unsafe.%s{methodToCall.Name}"
-                executeUnsafeCopyBlock baseClassTypes currentThread operation state |> Some
-            | _ -> None
+
+                executeUnsafeCopyBlock baseClassTypes currentThread operation state
+                |> IntrinsicResult.Completed
+            | _ -> IntrinsicResult.Unrecognised
         | "System.Private.CoreLib", "SpanHelpers", "Memmove" ->
             // `[Intrinsic] internal static void Memmove(ref byte dest, ref byte src, nuint len)`
             // (SpanHelpers.ByteMemOps.cs:37). The managed body executes the platform-tuned
@@ -1227,8 +1241,10 @@ module Intrinsics =
                 ConcreteUIntPtr state.ConcreteTypes ],
               MethodReturnType.Void ->
                 let operation = "SpanHelpers.Memmove"
-                executeSpanHelpersMemmove baseClassTypes currentThread operation state |> Some
-            | _ -> None
+
+                executeSpanHelpersMemmove baseClassTypes currentThread operation state
+                |> IntrinsicResult.Completed
+            | _ -> IntrinsicResult.Unrecognised
         | "System.Private.CoreLib", "String", "op_Implicit" ->
             match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
             | [ par ], MethodReturnType.Returns ret ->
@@ -1248,7 +1264,7 @@ module Intrinsics =
                         if gen.Namespace = "System" && gen.Name = "Char" then
                             // This is just an optimisation
                             // https://github.com/dotnet/runtime/blob/ab105b51f8b50ec5567d7cfe9001ca54dd6f64c3/src/libraries/System.Private.CoreLib/src/System/String.cs#L363-L366
-                            None
+                            IntrinsicResult.Unrecognised
                         else
                             failwith "TODO: unexpected params to String.op_Implicit"
                     | _ -> failwith "TODO: unexpected params to String.op_Implicit"
@@ -1293,7 +1309,7 @@ module Intrinsics =
                 |> IlMachineState.pushToEvalStack (CliType.ofBool result) currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
 
-            Some state
+            IntrinsicResult.Completed state
         | "System.Private.CoreLib", "RuntimeHelpers", "InitializeArray" ->
             // https://github.com/dotnet/runtime/blob/9e5e6aa7bc36aeb2a154709a9d1192030c30a2ef/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs#L18
             match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
@@ -1446,7 +1462,7 @@ module Intrinsics =
                     state
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread
-            Some state
+            IntrinsicResult.Completed state
         | "System.Private.CoreLib", "RuntimeHelpers", "IsBitwiseEquatable" ->
             match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
             | [], MethodReturnType.Returns (ConcreteBool state.ConcreteTypes) -> ()
@@ -1484,7 +1500,7 @@ module Intrinsics =
             state
             |> IlMachineState.pushToEvalStack (CliType.ofBool result) currentThread
             |> IlMachineState.advanceProgramCounter currentThread
-            |> Some
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "GC", "KeepAlive" ->
             match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
             | [ ConcretePrimitive state.ConcreteTypes PrimitiveType.Object ], MethodReturnType.Void -> ()
@@ -1492,7 +1508,9 @@ module Intrinsics =
 
             let _, state = IlMachineState.popEvalStack currentThread state
 
-            state |> IlMachineState.advanceProgramCounter currentThread |> Some
+            state
+            |> IlMachineState.advanceProgramCounter currentThread
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "Unsafe", "As" ->
             // https://github.com/dotnet/runtime/blob/721fdf6dcb032da1f883d30884e222e35e3d3c99/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/Unsafe.cs#L64
             let byrefAs () =
@@ -1563,7 +1581,7 @@ module Intrinsics =
                     |> IlMachineState.pushToEvalStack' ptr currentThread
                     |> IlMachineState.advanceProgramCounter currentThread
 
-                Some state
+                IntrinsicResult.Completed state
 
             match methodToCall.Signature.ParameterTypes, Seq.toList methodToCall.Generics with
             | [ ConcretePrimitive state.ConcreteTypes PrimitiveType.Object ], [ target ] ->
@@ -1578,7 +1596,7 @@ module Intrinsics =
                     state
                     |> IlMachineState.pushToEvalStack' obj currentThread
                     |> IlMachineState.advanceProgramCounter currentThread
-                    |> Some
+                    |> IntrinsicResult.Completed
                 | other -> failwith $"Unsafe.As<T>(object): expected object reference, got %O{other}"
             | _ -> byrefAs ()
         | "System.Private.CoreLib", "Unsafe", "BitCast" ->
@@ -1651,7 +1669,7 @@ module Intrinsics =
                 state
                 |> IlMachineState.pushToEvalStack result currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
-                |> Some
+                |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "Unsafe", "SizeOf" ->
             // https://github.com/dotnet/runtime/blob/721fdf6dcb032da1f883d30884e222e35e3d3c99/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/Unsafe.cs#L51
             match methodToCall.Signature.ParameterTypes, methodToCall.Signature.ReturnType with
@@ -1670,7 +1688,7 @@ module Intrinsics =
             state
             |> IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 size)) currentThread
             |> IlMachineState.advanceProgramCounter currentThread
-            |> Some
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "Unsafe", "AreSame" ->
             // https://github.com/dotnet/runtime/blob/108fa7856efcfd39bc991c2d849eabbf7ba5989c/src/coreclr/tools/Common/TypeSystem/IL/Stubs/UnsafeIntrinsics.cs#L55
             // The source-level IL body throws PlatformNotSupportedException; the JIT replaces it with ceq on two byrefs.
@@ -1718,7 +1736,7 @@ module Intrinsics =
             state
             |> IlMachineState.pushToEvalStack (CliType.ofBool areSame) currentThread
             |> IlMachineState.advanceProgramCounter currentThread
-            |> Some
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "Unsafe", "Add" ->
             // https://github.com/dotnet/runtime/blob/108fa7856efcfd39bc991c2d849eabbf7ba5989c/src/coreclr/tools/Common/TypeSystem/IL/Stubs/UnsafeIntrinsics.cs#L99
             // The source-level IL body throws PlatformNotSupportedException; the JIT replaces it with sizeof + conv.i + mul + add.
@@ -1766,7 +1784,7 @@ module Intrinsics =
             state
             |> IlMachineState.pushToEvalStack' ptr currentThread
             |> IlMachineState.advanceProgramCounter currentThread
-            |> Some
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "Unsafe", "AddByteOffset" ->
             // CoreCLR's managed body throws PlatformNotSupportedException; the JIT replaces
             // the call with raw byref + native-int addition. Both overloads (IntPtr and
@@ -1823,7 +1841,7 @@ module Intrinsics =
                 state
                 |> IlMachineState.pushToEvalStack' (EvalStackValue.ManagedPointer ptr) currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
-                |> Some
+                |> IntrinsicResult.Completed
             | ValueNone ->
 
             // `addByteOffsetUnderReinterpret` anchors the byte cursor under `ReinterpretAs T`
@@ -1913,7 +1931,7 @@ module Intrinsics =
             state
             |> IlMachineState.pushToEvalStack' (EvalStackValue.ManagedPointer ptr) currentThread
             |> IlMachineState.advanceProgramCounter currentThread
-            |> Some
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "Unsafe", "ByteOffset" ->
             // https://github.com/dotnet/runtime/blob/108fa7856efcfd39bc991c2d849eabbf7ba5989c/src/coreclr/tools/Common/TypeSystem/IL/Stubs/UnsafeIntrinsics.cs#L69
             // The source-level IL body throws PlatformNotSupportedException; the JIT replaces it with sub on two byrefs.
@@ -1952,7 +1970,7 @@ module Intrinsics =
                     (EvalStackValue.NativeInt (NativeIntSource.Verbatim byteOffset))
                     currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
-                |> Some
+                |> IntrinsicResult.Completed
             | _ ->
 
             // ByteOffset measures the byte distance between two byref address
@@ -2031,7 +2049,7 @@ module Intrinsics =
                     (EvalStackValue.NativeInt (NativeIntSource.Verbatim byteOffset))
                     currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
-                |> Some
+                |> IntrinsicResult.Completed
             else
                 let byteOffset =
                     NativeIntSource.syntheticCrossStorageByteOffset storage1 originOffset storage2 targetOffset
@@ -2039,7 +2057,7 @@ module Intrinsics =
                 state
                 |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt byteOffset) currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
-                |> Some
+                |> IntrinsicResult.Completed
         | "System.Private.CoreLib", ("ReadOnlySpan`1" | "Span`1"), "get_Item" ->
             // https://github.com/dotnet/runtime/blob/108fa7856efcfd39bc991c2d849eabbf7ba5989c/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs#L141
             // The source-level body returns `ref Unsafe.Add(ref _reference, index)`;
@@ -2109,7 +2127,7 @@ module Intrinsics =
             state
             |> IlMachineState.pushToEvalStack' ptr currentThread
             |> IlMachineState.advanceProgramCounter currentThread
-            |> Some
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "Span`1", "Clear" ->
             // https://github.com/dotnet/runtime/blob/108fa7856efcfd39bc991c2d849eabbf7ba5989c/src/libraries/System.Private.CoreLib/src/System/Span.cs#L280
             // Span<T>.Clear is a JIT intrinsic; the BCL IL falls through to
@@ -2177,10 +2195,12 @@ module Intrinsics =
                     IlMachineState.writeManagedByrefWithBase baseClassTypes state byrefSrc zero
                 )
 
-            state |> IlMachineState.advanceProgramCounter currentThread |> Some
+            state
+            |> IlMachineState.advanceProgramCounter currentThread
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "RuntimeHelpers", "CreateSpan" ->
             // https://github.com/dotnet/runtime/blob/9e5e6aa7bc36aeb2a154709a9d1192030c30a2ef/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs#L153
-            None
+            IntrinsicResult.Unrecognised
         | "System.Private.CoreLib", "MemoryMarshal", "GetArrayDataReference" ->
             // https://github.com/dotnet/runtime/blob/d258af50034c192bf7f0a18856bf83d2903d98ae/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.CoreCLR.cs#L20
             let generic = Seq.exactlyOne methodToCall.Generics
@@ -2214,7 +2234,7 @@ module Intrinsics =
             state
             |> IlMachineState.pushToEvalStack' toPush currentThread
             |> IlMachineState.advanceProgramCounter currentThread
-            |> Some
+            |> IntrinsicResult.Completed
         | "System.Private.CoreLib", "Array", "Clone" ->
             // https://github.com/dotnet/runtime/blob/7706f546bac1a99b3d891afe3591dc88c67f0cc4/src/libraries/System.Private.CoreLib/src/System/Array.cs#L1071-L1077
             // The managed body is `return MemberwiseClone();`, and CoreCLR's MemberwiseClone
@@ -2244,7 +2264,7 @@ module Intrinsics =
                 state
                 |> IlMachineState.pushToEvalStack' (EvalStackValue.ObjectRef clone) currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
-                |> Some
+                |> IntrinsicResult.Completed
             | EvalStackValue.NullObjectRef
             | EvalStackValue.ManagedPointer ManagedPointerSource.Null ->
                 // Unreachable from any C#-emitted call site: `Array.Clone` is an instance method,
@@ -2311,53 +2331,17 @@ module Intrinsics =
                         $"Array.%s{boundKind}: array at %O{addr} has concrete-type rank %d{declaredRank} but %d{arr.Lengths.Length} stored dimension length(s)"
 
                 if dimension < 0 || dimension >= arr.Lengths.Length then
-                    // Both arguments are already popped, so the eval stack is clean for dispatch.
-                    let exnAddr, exnTypeHandle, state =
-                        ExceptionDispatching.allocateRuntimeException
-                            loggerFactory
-                            baseClassTypes
-                            baseClassTypes.IndexOutOfRangeException
-                            state
-
-                    let state =
-                        ExceptionDispatching.overwriteHResultPostCtor baseClassTypes exnAddr exnTypeHandle state
-
-                    // `allocateRuntimeException` does not run a constructor, so populate `_message`
-                    // explicitly with the string the CLR would have passed
-                    // (`SR.IndexOutOfRange_ArrayRankIndex`); otherwise a guest that catches this and
-                    // reads `.Message` sees the generic "Exception of type X was thrown" fallback.
-                    let state =
-                        IlMachineState.setExceptionMessage
-                            loggerFactory
-                            baseClassTypes
-                            exnAddr
-                            "Array does not have that many dimensions."
-                            state
-
-                    match
-                        ExceptionDispatching.throwExceptionObject
-                            loggerFactory
-                            baseClassTypes
-                            state
-                            currentThread
-                            exnAddr
-                            exnTypeHandle
-                    with
-                    | ExceptionDispatchResult.HandlerFound state -> Some state
-                    | ExceptionDispatchResult.ExceptionUnhandled _ ->
-                        // KNOWN GAP, shared with the `Enum.HasFlag` arms below and the three
-                        // `ExceptionUnhandled` sites in `IlMachineStateExecution`: `Intrinsics.call`
-                        // returns `IlMachineState option`, which cannot express "the guest died of an
-                        // unhandled exception". Propagating it needs the effect-description return
-                        // type discussed in this commit's message, threaded through `callMethod` and
-                        // `UnaryMetadataIlOp.execute` up to `AbstractMachine.executeOneStep`. Until
-                        // then an uncaught out-of-range dimension takes down the interpreter instead
-                        // of being reported as a guest unhandled exception. This is deliberately not
-                        // pinned by a test: `TestPureCases`'s `unimplemented` category asserts the
-                        // real runtime exits normally, and there is no category for "PawPrint cannot
-                        // do this yet AND the real runtime throws".
-                        failwith
-                            $"TODO: Array.%s{boundKind} dimension %d{dimension} was out of range for rank %d{arr.Lengths.Length}, and the resulting IndexOutOfRangeException found no handler; PawPrint cannot yet surface an unhandled guest exception raised from an intrinsic"
+                    // Both arguments are already popped, so the eval stack is clean for dispatch,
+                    // and the PC has deliberately not been advanced.
+                    //
+                    // The message is the string the CLR would have passed
+                    // (`SR.IndexOutOfRange_ArrayRankIndex`); the parameterless ctor's default
+                    // ("Index was outside the bounds of the array.") is the wrong one here.
+                    IntrinsicResult.RaiseException (
+                        state,
+                        baseClassTypes.IndexOutOfRangeException,
+                        Some "Array does not have that many dimensions."
+                    )
                 else
 
                 let result =
@@ -2374,7 +2358,7 @@ module Intrinsics =
                 state
                 |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 result) currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
-                |> Some
+                |> IntrinsicResult.Completed
             | EvalStackValue.NullObjectRef
             | EvalStackValue.ManagedPointer ManagedPointerSource.Null ->
                 // Unreachable from C#-emitted code: these are instance methods, so callvirt's own
@@ -2400,34 +2384,18 @@ module Intrinsics =
                 let flagObj = ManagedHeap.get flagAddr state.ManagedHeap
 
                 if thisObj.ConcreteType <> flagObj.ConcreteType then
-                    // Type mismatch: raise ArgumentException.
+                    // Type mismatch: raise ArgumentException (Enum.cs:403-404).
                     // We must pop the two args before raising, so the eval stack is clean.
                     let _, state = IlMachineState.popEvalStack currentThread state
                     let _, state = IlMachineState.popEvalStack currentThread state
 
-                    let exnAddr, exnTypeHandle, state =
-                        ExceptionDispatching.allocateRuntimeException
-                            loggerFactory
-                            baseClassTypes
-                            baseClassTypes.ArgumentException
-                            state
-
-                    let state =
-                        ExceptionDispatching.overwriteHResultPostCtor baseClassTypes exnAddr exnTypeHandle state
-
-                    match
-                        ExceptionDispatching.throwExceptionObject
-                            loggerFactory
-                            baseClassTypes
-                            state
-                            currentThread
-                            exnAddr
-                            exnTypeHandle
-                    with
-                    | ExceptionDispatchResult.HandlerFound state -> Some state
-                    | ExceptionDispatchResult.ExceptionUnhandled _ ->
-                        failwith
-                            "Enum.HasFlag type mismatch: ArgumentException was unhandled (no catch handler in caller)"
+                    // No message: the CLR's is `SR.Argument_EnumTypeDoesNotMatch` formatted with
+                    // `flag.GetType()` and `GetType()`, and rendering those two the way
+                    // `Type.ToString()` would (nested types are `Outer+Inner`, generics are
+                    // backtick-arity) is a fidelity question of its own. A half-right string would
+                    // be worse than the parameterless ctor's honest default, which is already an
+                    // improvement on the null `_message` this arm used to leave behind.
+                    IntrinsicResult.RaiseException (state, baseClassTypes.ArgumentException, None)
                 else
                     let flag, state = IlMachineState.popEvalStack currentThread state
                     let thisVal, state = IlMachineState.popEvalStack currentThread state
@@ -2454,33 +2422,19 @@ module Intrinsics =
                     state
                     |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 (if result then 1 else 0)) currentThread
                     |> IlMachineState.advanceProgramCounter currentThread
-                    |> Some
+                    |> IntrinsicResult.Completed
             | Some _, Some EvalStackValue.NullObjectRef ->
-                // Null flag: raise ArgumentNullException.
+                // Null flag: `ArgumentNullException.ThrowIfNull(flag)` (Enum.cs:401), which runs
+                // before the type-equivalence check above.
                 let _, state = IlMachineState.popEvalStack currentThread state
                 let _, state = IlMachineState.popEvalStack currentThread state
 
-                let exnAddr, exnTypeHandle, state =
-                    ExceptionDispatching.allocateRuntimeException
-                        loggerFactory
-                        baseClassTypes
-                        baseClassTypes.ArgumentNullException
-                        state
-
-                let state =
-                    ExceptionDispatching.overwriteHResultPostCtor baseClassTypes exnAddr exnTypeHandle state
-
-                match
-                    ExceptionDispatching.throwExceptionObject
-                        loggerFactory
-                        baseClassTypes
-                        state
-                        currentThread
-                        exnAddr
-                        exnTypeHandle
-                with
-                | ExceptionDispatchResult.HandlerFound state -> Some state
-                | ExceptionDispatchResult.ExceptionUnhandled _ ->
-                    failwith "Enum.HasFlag null flag: ArgumentNullException was unhandled (no catch handler in caller)"
+                // No message: the CLR's `.Message` here is "Value cannot be null. (Parameter
+                // 'flag')", but that suffix is synthesised by `ArgumentException.Message` from
+                // `_paramName`, which this channel cannot set. Writing the suffix into `_message`
+                // would make `.Message` right while `.ParamName` stayed null — two fields
+                // disagreeing about whether a parameter name is known. The parameterless ctor's
+                // "Value cannot be null." is at least self-consistent.
+                IntrinsicResult.RaiseException (state, baseClassTypes.ArgumentNullException, None)
             | _ -> failwith $"Enum.HasFlag: expected two ObjectRefs on eval stack"
-        | _ -> None
+        | _ -> IntrinsicResult.Unrecognised

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -136,23 +136,38 @@ module Intrinsics =
 
             let arg, state = IlMachineState.popEvalStack currentThread state
 
-            let concreteType, state =
+            // A null receiver raises `NullReferenceException`: `Object.GetType`'s body starts
+            // `MethodTable* pMT = RuntimeHelpers.GetMethodTable(this)`, which the JIT expands to a
+            // bare indirection at offset 0, so the access faults and the runtime translates it.
+            //
+            // Not reachable from C#, which emits `callvirt` for `GetType()` — and
+            // `executeCallvirt`'s own null check fires before `callMethod` is entered, so the
+            // intrinsic never sees a null receiver. `constrained.callvirt` on a value type boxes
+            // first, so it cannot produce one either. Only hand-written
+            // `ldnull; call instance Object::GetType()` gets here, and there is no ilasm in this
+            // repo to write that with; `NullReceiverGuards.cs` pins the guard instead.
+            // `None` means the receiver was null.
+            let receiver : (ConcreteTypeHandle * IlMachineState) option =
                 // Normal Object.GetType dispatch arrives here with an ObjectRef. The managed-pointer
                 // arms are deliberately defensive for future receiver shapes and direct intrinsic use;
                 // constrained.callvirt on value types boxes before dispatching this intrinsic.
                 match arg with
-                | EvalStackValue.ObjectRef addr -> ManagedHeap.getObjectConcreteType addr state.ManagedHeap, state
+                | EvalStackValue.ObjectRef addr ->
+                    Some (ManagedHeap.getObjectConcreteType addr state.ManagedHeap, state)
                 | EvalStackValue.ManagedPointer ManagedPointerSource.Null
-                | EvalStackValue.NullObjectRef ->
-                    failwith "TODO: Object.GetType receiver was null; throw NullReferenceException"
+                | EvalStackValue.NullObjectRef -> None
                 | EvalStackValue.ManagedPointer ptr ->
                     match IlMachineState.readManagedByref baseClassTypes state ptr with
-                    | CliType.ObjectRef (Some addr) -> ManagedHeap.getObjectConcreteType addr state.ManagedHeap, state
-                    | CliType.ObjectRef None ->
-                        failwith "TODO: Object.GetType receiver was null; throw NullReferenceException"
-                    | CliType.ValueType valueType -> valueType.Declared, state
+                    | CliType.ObjectRef (Some addr) ->
+                        Some (ManagedHeap.getObjectConcreteType addr state.ManagedHeap, state)
+                    | CliType.ObjectRef None -> None
+                    | CliType.ValueType valueType -> Some (valueType.Declared, state)
                     | other -> failwith $"Object.GetType: expected object ref or value type receiver, got %O{other}"
                 | other -> failwith $"Object.GetType: expected object ref or managed pointer receiver, got %O{other}"
+
+            match receiver with
+            | None -> IntrinsicResult.RaiseException (state, baseClassTypes.NullReferenceException, None)
+            | Some (concreteType, state) ->
 
             let runtimeTypeAddr, state =
                 IlMachineState.getOrAllocateType
@@ -182,10 +197,24 @@ module Intrinsics =
 
             let arg, state = IlMachineState.popEvalStack currentThread state
 
+            match arg with
+            | EvalStackValue.NullObjectRef ->
+                // The JIT expands this to a bare load at offset 0 (`gtNewMethodTableLookup`, which
+                // asserts `VPTR_OFFS == 0`), so a null argument faults into
+                // `NullReferenceException`.
+                //
+                // Not reachable from C#: the method is `internal` to CoreLib and returns
+                // `MethodTable*`, an internal type, so it cannot be named from a test source — not
+                // even via `[UnsafeAccessor]`, whose signature match would need that return type.
+                // Every CoreLib caller null-guards first, except the non-generic
+                // `MemoryMarshal.GetArrayDataReference(Array)`, which PawPrint does not yet handle
+                // at all (its arm assumes a generic overload).
+                IntrinsicResult.RaiseException (state, baseClassTypes.NullReferenceException, None)
+            | _ ->
+
             let addr =
                 match arg with
                 | EvalStackValue.ObjectRef addr -> addr
-                | EvalStackValue.NullObjectRef -> failwith "TODO: throw NullReferenceException"
                 | other -> failwith $"RuntimeHelpers.GetMethodTable: expected ObjectRef, got %O{other}"
 
             let concreteType = ManagedHeap.getObjectConcreteType addr state.ManagedHeap
@@ -1379,9 +1408,11 @@ module Intrinsics =
             // RuntimeTypeHandle.GetFields returned, so we recover the FieldHandle by reading
             // the heap object's `m_fieldHandle` slot and resolving it against the id-keyed
             // index. Both RuntimeFieldInfoStub and RtFieldInfo declare a field with that name.
-            let fieldHandle : FieldHandle =
+            // `None` means `m_fieldHandle` was zero, i.e. the `RuntimeFieldHandle` points at a
+            // field info that names no field.
+            let fieldHandle : FieldHandle option =
                 match FieldHandleRegistry.resolveFieldFromAddress runtimeFieldInfoAddr state.FieldHandles with
-                | Some fh -> fh
+                | Some fh -> Some fh
                 | None ->
 
                 let heapObj = ManagedHeap.get runtimeFieldInfoAddr state.ManagedHeap
@@ -1408,21 +1439,52 @@ module Intrinsics =
                         AllocatedNonArrayObject.DereferenceFieldById fieldId heapObj
                         |> CliType.unwrapPrimitiveLikeDeep
                     with
-                    | CliType.RuntimePointer (CliRuntimePointer.FieldRegistryHandle id) -> id
-                    | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.FieldHandlePtr id)) -> id
+                    | CliType.RuntimePointer (CliRuntimePointer.FieldRegistryHandle id) -> Some id
+                    | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.FieldHandlePtr id)) -> Some id
+                    // All four spellings of a zero `IntPtr`. `ManagedPointerSource.Null` is the
+                    // canonical one — it is what `CliType.zeroOfPrimitive` plants for
+                    // `IntPtr.Zero`, and so what a zero-initialised `m_fieldHandle` actually holds
+                    // — so omitting it would send the very case this arm exists for into the
+                    // host-failure arm below. `Verbatim 0L` is the spelling that arrives from
+                    // integer arithmetic.
                     | CliType.RuntimePointer (CliRuntimePointer.Verbatim 0L)
-                    | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim 0L)) ->
-                        failwith
-                            "TODO: throw ArgumentException for InitializeArray with null field handle (m_fieldHandle was zero)"
+                    | CliType.RuntimePointer (CliRuntimePointer.Managed ManagedPointerSource.Null)
+                    | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim 0L))
+                    | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.ManagedPointer ManagedPointerSource.Null)) ->
+                        None
                     | other ->
                         failwith
                             $"InitializeArray: m_fieldHandle on %s{typeInfo.Namespace}.%s{typeInfo.Name} did not contain a field-registry handle, got %O{other}"
 
+                match fieldHandleId with
+                | None -> None
+                | Some fieldHandleId ->
+
                 match FieldHandleRegistry.resolveFieldFromId fieldHandleId state.FieldHandles with
-                | Some fh -> fh
+                | Some fh -> Some fh
                 | None ->
                     failwith
                         $"InitializeArray: m_fieldHandle id %d{fieldHandleId} on object at %O{runtimeFieldInfoAddr} (type %s{typeInfo.Namespace}.%s{typeInfo.Name}) was not present in the field handle registry"
+
+            match fieldHandle with
+            | None ->
+                // A zero `m_fieldHandle` is a *non-null* `RuntimeFieldHandle` (`m_ptr` points at a
+                // real field info) whose field info names no field, so `IsNullHandle()` is false
+                // and the `Argument_InvalidHandle` branch above is not the one taken. CoreCLR
+                // instead reaches `if (!RuntimeFieldHandle.GetRVAFieldInfo(...)) throw new
+                // ArgumentException(SR.Argument_BadFieldForInitializeArray)`, and the QCall returns
+                // FALSE for a null `FieldDesc*` — a different message from the null-handle case.
+                //
+                // Defensive: PawPrint's `FieldHandleRegistry` only ever writes real ids, and
+                // reflection populates `m_fieldHandle` from real ids too, so
+                // `default(RuntimeFieldHandle)` lands on the `IsNullHandle` check above instead.
+                // No C# reaches here.
+                IntrinsicResult.RaiseException (
+                    state,
+                    baseClassTypes.ArgumentException,
+                    Some "The field is invalid for initializing array or span."
+                )
+            | Some fieldHandle ->
 
             // Get the assembly and field definition
             let assemblyFullName = fieldHandle.GetAssemblyFullName ()
@@ -2343,14 +2405,16 @@ module Intrinsics =
                 |> IntrinsicResult.Completed
             | EvalStackValue.NullObjectRef
             | EvalStackValue.ManagedPointer ManagedPointerSource.Null ->
+                // `Array.Clone`'s body is `return MemberwiseClone()`, whose first act is to touch
+                // `this` (`ref byte src = ref this.GetRawData()`), so a null receiver faults into
+                // `NullReferenceException`.
+                //
                 // Unreachable from any C#-emitted call site: `Array.Clone` is an instance method,
                 // so callvirt's own null check (UnaryMetadataCallOps.executeCallvirt) raises the
-                // NullReferenceException before we get here. Only hand-written IL using a
-                // non-virtual `call` could reach this, and Intrinsics.fs is compiled before
-                // IlMachineStateExecution.fs so it cannot use `raiseRuntimeException` to
-                // synthesise a properly-constructed NRE.
-                failwith
-                    "TODO: Array.Clone was reached by a non-virtual `call` on a null receiver; should raise NullReferenceException"
+                // NullReferenceException before we get here — `NullReceiverGuards.cs` pins that,
+                // for the direct and the `ICloneable` form. Only hand-written IL using a
+                // non-virtual `call` could reach this arm.
+                IntrinsicResult.RaiseException (state, baseClassTypes.NullReferenceException, None)
             | other -> failwith $"Array.Clone: expected an object reference receiver, got %O{other}"
         | "System.Private.CoreLib", "Array", (("GetLength" | "GetLowerBound" | "GetUpperBound") as boundKind) ->
             // https://github.com/dotnet/runtime/blob/7706f546bac1a99b3d891afe3591dc88c67f0cc4/src/libraries/System.Private.CoreLib/src/System/Array.cs#L763-L806
@@ -2440,8 +2504,7 @@ module Intrinsics =
                 // Unreachable from C#-emitted code: these are instance methods, so callvirt's own
                 // null check (UnaryMetadataCallOps.executeCallvirt) raises the NullReferenceException
                 // first. See the matching note on the Array.Clone arm above.
-                failwith
-                    $"TODO: Array.%s{boundKind} was reached by a non-virtual `call` on a null receiver; should raise NullReferenceException"
+                IntrinsicResult.RaiseException (state, baseClassTypes.NullReferenceException, None)
             | other -> failwith $"Array.%s{boundKind}: expected an object reference receiver, got %O{other}"
         | "System.Private.CoreLib", "Enum", "HasFlag" ->
             // https://github.com/dotnet/runtime/blob/dbd3e33df9ccf74b91045e095477726c2bf83916/src/libraries/System.Private.CoreLib/src/System/Enum.cs#L398

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -1098,20 +1098,27 @@ module Intrinsics =
 
                 let ptr, state = IlMachineState.popEvalStack currentThread state
 
-                let src =
-                    match ptr with
-                    | EvalStackValue.ManagedPointer src -> src
-                    | EvalStackValue.NullObjectRef -> failwith "TODO: Unsafe.ReadUnaligned on null should throw NRE"
-                    | _ -> failwith $"TODO: Unsafe.ReadUnaligned: expected ManagedPointer, got %O{ptr}"
+                match ptr with
+                // A null byref is `ManagedPointer ManagedPointerSource.Null` — that is what
+                // `Unsafe.NullRef` and `Unsafe.AsRef(void*)` produce — so it must be matched
+                // *before* the general `ManagedPointer` arm, which would otherwise carry it into
+                // the byref machinery. `NullObjectRef` is the same condition reached from
+                // hand-written IL.
+                //
+                // `ReadUnaligned`'s body is `ldarg.0; unaligned. 1; ldobj !!T; ret`: no explicit
+                // null check, so the load at address 0 faults and the runtime translates it into
+                // the ordinary parameterless `NullReferenceException`.
+                | EvalStackValue.ManagedPointer ManagedPointerSource.Null
+                | EvalStackValue.NullObjectRef ->
+                    IntrinsicResult.RaiseException (state, baseClassTypes.NullReferenceException, None)
+                | EvalStackValue.ManagedPointer src ->
+                    let v = IlMachineState.readManagedByrefBytesAs baseClassTypes state src tZero
 
-                let v = IlMachineState.readManagedByrefBytesAs baseClassTypes state src tZero
-
-                let state =
                     state
                     |> IlMachineState.pushToEvalStack v currentThread
                     |> IlMachineState.advanceProgramCounter currentThread
-
-                IntrinsicResult.Completed state
+                    |> IntrinsicResult.Completed
+                | _ -> failwith $"TODO: Unsafe.ReadUnaligned: expected ManagedPointer, got %O{ptr}"
             | [ ConcretePointer _ ] ->
 
                 let t =
@@ -1157,28 +1164,31 @@ module Intrinsics =
                 let value, state = IlMachineState.popEvalStack currentThread state
                 let ptr, state = IlMachineState.popEvalStack currentThread state
 
-                let src =
-                    match ptr with
-                    | EvalStackValue.ManagedPointer src -> src
-                    | EvalStackValue.NullObjectRef -> failwith "TODO: Unsafe.WriteUnaligned on null should throw NRE"
-                    | _ -> failwith $"TODO: Unsafe.WriteUnaligned: expected ManagedPointer, got %O{ptr}"
+                match ptr with
+                // As for `ReadUnaligned` above: the C#-reachable null byref is the
+                // `ManagedPointerSource.Null` spelling, so it must precede the general
+                // `ManagedPointer` arm. `WriteUnaligned`'s body is
+                // `ldarg.0; ldarg.1; unaligned. 1; stobj !!T; ret`, with no null check, so the
+                // store at address 0 faults into a parameterless `NullReferenceException`.
+                | EvalStackValue.ManagedPointer ManagedPointerSource.Null
+                | EvalStackValue.NullObjectRef ->
+                    IntrinsicResult.RaiseException (state, baseClassTypes.NullReferenceException, None)
+                | EvalStackValue.ManagedPointer src ->
+                    // Coerce the stack value to a CliType shaped like T: sub-int
+                    // primitives arrive as Int32 and must narrow back to their
+                    // CliType flavour before the byte helpers write it.
+                    let valueAsCli = EvalStackValue.toCliTypeCoerced tZero value
 
-                // Coerce the stack value to a CliType shaped like T: sub-int
-                // primitives arrive as Int32 and must narrow back to their
-                // CliType flavour before the byte helpers write it.
-                let valueAsCli = EvalStackValue.toCliTypeCoerced tZero value
+                    let valueSize = CliType.sizeOf valueAsCli
 
-                let valueSize = CliType.sizeOf valueAsCli
+                    if valueSize <> tSize then
+                        failwith
+                            $"Unsafe.WriteUnaligned: coerced value has size %d{valueSize}, expected %d{tSize} for %O{valueAsCli}"
 
-                if valueSize <> tSize then
-                    failwith
-                        $"Unsafe.WriteUnaligned: coerced value has size %d{valueSize}, expected %d{tSize} for %O{valueAsCli}"
-
-                let state =
                     IlMachineState.writeManagedByrefBytesOrTypedCell baseClassTypes state src valueAsCli
-
-                let state = state |> IlMachineState.advanceProgramCounter currentThread
-                IntrinsicResult.Completed state
+                    |> IlMachineState.advanceProgramCounter currentThread
+                    |> IntrinsicResult.Completed
+                | _ -> failwith $"TODO: Unsafe.WriteUnaligned: expected ManagedPointer, got %O{ptr}"
             | [ ConcretePointer _ ; _ ] ->
 
                 let t =
@@ -1321,11 +1331,33 @@ module Intrinsics =
             let fldHandle, state = IlMachineState.popEvalStack currentThread state
             let arrayRef, state = IlMachineState.popEvalStack currentThread state
 
+            // Argument validation, in the BCL's order:
+            //
+            //     if (array is null) ThrowHelper.ThrowArgumentNullException(ExceptionArgument.array);
+            //     if (fldHandle.IsNullHandle()) throw new ArgumentException(SR.Argument_InvalidHandle);
+            //
+            // Note the first is an `ArgumentNullException`, not the `NullReferenceException` the
+            // shape of the check suggests. The JIT only expands this intrinsic when it recognises
+            // a `newarr` plus a constant `ldtoken`, which a null argument never matches, so the
+            // managed body — and hence these checks — is what really runs.
+            //
+            // Both arguments are already popped and the PC has not advanced, as the raise needs.
+            match arrayRef, fldHandle with
+            | EvalStackValue.NullObjectRef, _ ->
+                // No message: the CLR's is "Value cannot be null. (Parameter 'array')", but that
+                // suffix comes from `_paramName` via `ArgumentException.Message`, and this channel
+                // cannot set `_paramName`. Writing the suffix into `_message` alone would leave
+                // `.Message` and `.ParamName` disagreeing about whether the name is known.
+                IntrinsicResult.RaiseException (state, baseClassTypes.ArgumentNullException, None)
+            | _, EvalStackValue.NullObjectRef ->
+                // `RuntimeFieldHandle.IsNullHandle()` is `m_ptr == null`, which is exactly this
+                // flattened `NullObjectRef` (see the primitive-like note below).
+                IntrinsicResult.RaiseException (state, baseClassTypes.ArgumentException, Some "The handle is invalid.")
+            | _ ->
+
             // Extract the array address
             let arrayAddr : ManagedHeapAddress =
                 match arrayRef with
-                | EvalStackValue.NullObjectRef ->
-                    failwith "TODO: throw NullReferenceException for InitializeArray on null array"
                 | EvalStackValue.ObjectRef addr -> addr
                 | other -> failwith $"InitializeArray: expected array object ref, got %O{other}"
 
@@ -1339,8 +1371,6 @@ module Intrinsics =
             let runtimeFieldInfoAddr : ManagedHeapAddress =
                 match fldHandle with
                 | EvalStackValue.ObjectRef addr -> addr
-                | EvalStackValue.NullObjectRef ->
-                    failwith "TODO: throw ArgumentException for InitializeArray with null field handle"
                 | other -> failwith $"InitializeArray: expected RuntimeFieldHandle ObjectRef, got %O{other}"
 
             // The address-keyed registry index is populated when PawPrint allocates a
@@ -1646,22 +1676,56 @@ module Intrinsics =
                 | CliByteAddressability.ByteAddressable -> true
                 | CliByteAddressability.Rejected _ -> false
 
-            if fromSize <> toSize || not inputAddressable || not targetAddressable then
-                // The BCL throws `NotSupportedException` for these cases. Raising guest exceptions
-                // from intrinsic dispatch is not yet wired (Intrinsics.fs compiles before
-                // IlMachineStateExecution.fs, so `raiseRuntimeException` is not in scope here).
-                // Host-fail for now with a precise diagnostic; mirrors the existing
-                // `Unsafe.ReadUnaligned` null-target TODO above.
+            // `!typeof(T).IsValueType` from the BCL guard. Reference types are pointer-sized on
+            // both sides, so the size clause does not catch them; without this they would reach
+            // PawPrint's byte model and be rejected as a host failure instead of the
+            // `NotSupportedException` the BCL raises. The JIT declines to expand for them for
+            // exactly this reason ("Fallback to the software implementation to throw for
+            // reference types").
+            //
+            // Byrefs, pointers, function pointers and arrays are TypeDescs, for which CoreCLR's
+            // `IsValueTypeImpl` resolves to `IsSubclassOf(typeof(ValueType))` — false for all of
+            // them. Same reasoning as `Type.get_IsValueType` above.
+            let isValueTypeHandle (handle : ConcreteTypeHandle) : bool =
+                match handle with
+                | ConcreteTypeHandle.Byref _
+                | ConcreteTypeHandle.Pointer _
+                | ConcreteTypeHandle.FunctionPointer _
+                | ConcreteTypeHandle.OneDimArrayZero _
+                | ConcreteTypeHandle.Array _ -> false
+                | ConcreteTypeHandle.Concrete _ ->
+                    match AllConcreteTypes.lookup handle state.ConcreteTypes with
+                    | Some ty ->
+                        state.LoadedAssembly(ty.Assembly).Value.TypeDefs.[ty.Definition.Get]
+                        |> DumpedAssembly.isValueType baseClassTypes state._LoadedAssemblies
+                    | None -> failwith $"Unsafe.BitCast: expected nominal concrete type handle, got %O{handle}"
+
+            // The BCL's guard is a single `if` with three clauses, all of which mean
+            // `NotSupportedException` via `ThrowHelper.ThrowNotSupportedException` — the
+            // parameterless ctor, hence no message override.
+            //
+            // The two addressability clauses below are PawPrint's own stricter rule, described
+            // above, and are NOT part of that guard: the BCL accepts those inputs
+            // (`Unsafe.BitCast<IntPtr, long>` is legal .NET). Raising a guest exception for them
+            // would make PawPrint throw where the real runtime succeeds, so they stay a host
+            // failure with a precise diagnostic. Because the value-type clause is checked first,
+            // what reaches them is only a *value* type whose provenance the byte model cannot
+            // render — the genuine PawPrint-only restriction.
+            if
+                fromSize <> toSize
+                || not (isValueTypeHandle fromHandle)
+                || not (isValueTypeHandle toHandle)
+            then
+                IntrinsicResult.RaiseException (state, baseClassTypes.NotSupportedException, None)
+            elif not inputAddressable || not targetAddressable then
                 let reason =
-                    if fromSize <> toSize then
-                        $"size mismatch (TFrom = %d{fromSize} bytes, TTo = %d{toSize} bytes)"
-                    elif not inputAddressable then
+                    if not inputAddressable then
                         $"input is not byte-addressable: %s{(CliType.ByteAddressability inputCli).Description}"
                     else
                         $"target is not byte-addressable: %s{(CliType.ByteAddressability toZero).Description}"
 
                 failwith
-                    $"TODO: Unsafe.BitCast<%O{fromHandle}, %O{toHandle}> should throw NotSupportedException (%s{reason})"
+                    $"TODO: Unsafe.BitCast<%O{fromHandle}, %O{toHandle}> is rejected by PawPrint's byte model, though the BCL would allow it (%s{reason})"
             else
                 let bytes = CliType.ToBytes inputCli
                 let result = CliType.OfBytesLike toZero bytes
@@ -2104,8 +2168,14 @@ module Intrinsics =
                 | other -> failwith $"%s{spanTypeName}.get_Item expected _length to be int32, got %O{other}"
 
             if uint32<int32> index >= uint32<int32> length then
-                failwith
-                    $"TODO: %s{spanTypeName}.get_Item index %d{index} outside length %d{length}; throw IndexOutOfRangeException"
+                // `ThrowHelper.ThrowIndexOutOfRangeException()`, i.e. the parameterless ctor, so
+                // no message override. Both arguments are already popped and the PC has not been
+                // advanced, which is what the raise needs.
+                //
+                // The unsigned comparison is the BCL's own: it folds the negative-index case into
+                // the same branch.
+                IntrinsicResult.RaiseException (state, baseClassTypes.IndexOutOfRangeException, None)
+            else
 
             let reference : EvalStackValue =
                 let referenceField =
@@ -2214,27 +2284,33 @@ module Intrinsics =
 
             let arr, state = IlMachineState.popEvalStack currentThread state
 
-            let toPush =
-                match arr with
-                | EvalStackValue.Int32 _
-                | EvalStackValue.Int64 _
-                | EvalStackValue.Float _ -> failwith "expected reference"
-                | EvalStackValue.NativeInt nativeIntSource -> failwith "todo"
-                | EvalStackValue.ObjectRef addr ->
-                    if not (state.ManagedHeap.Arrays.ContainsKey addr) then
-                        failwith "array not found"
+            match arr with
+            | EvalStackValue.Int32 _
+            | EvalStackValue.Int64 _
+            | EvalStackValue.Float _ -> failwith "expected reference"
+            | EvalStackValue.NativeInt nativeIntSource -> failwith "todo"
+            | EvalStackValue.ObjectRef addr ->
+                if not (state.ManagedHeap.Arrays.ContainsKey addr) then
+                    failwith "array not found"
 
+                let toPush =
                     ManagedPointerSource.Byref (ByrefRoot.ArrayElement (addr, 0), [])
                     |> EvalStackValue.ManagedPointer
-                | EvalStackValue.NullObjectRef
-                | EvalStackValue.ManagedPointer ManagedPointerSource.Null -> failwith "TODO: raise NRE"
-                | EvalStackValue.UserDefinedValueType evalStackValueUserType -> failwith "todo"
-                | EvalStackValue.ManagedPointer _ -> failwith "todo"
 
-            state
-            |> IlMachineState.pushToEvalStack' toPush currentThread
-            |> IlMachineState.advanceProgramCounter currentThread
-            |> IntrinsicResult.Completed
+                state
+                |> IlMachineState.pushToEvalStack' toPush currentThread
+                |> IlMachineState.advanceProgramCounter currentThread
+                |> IntrinsicResult.Completed
+            | EvalStackValue.NullObjectRef
+            | EvalStackValue.ManagedPointer ManagedPointerSource.Null ->
+                // The null case is a documented `NullReferenceException`
+                // (`<exception cref="NullReferenceException">` on the method), and the JIT emits
+                // an explicit `gtNewNullCheck` for it rather than relying on the load faulting,
+                // so it is guaranteed rather than incidental. The parameterless ctor's message is
+                // the one the runtime produces.
+                IntrinsicResult.RaiseException (state, baseClassTypes.NullReferenceException, None)
+            | EvalStackValue.UserDefinedValueType evalStackValueUserType -> failwith "todo"
+            | EvalStackValue.ManagedPointer _ -> failwith "todo"
         | "System.Private.CoreLib", "Array", "Clone" ->
             // https://github.com/dotnet/runtime/blob/7706f546bac1a99b3d891afe3591dc88c67f0cc4/src/libraries/System.Private.CoreLib/src/System/Array.cs#L1071-L1077
             // The managed body is `return MemberwiseClone();`, and CoreCLR's MemberwiseClone

--- a/WoofWare.PawPrint/MethodState.fs
+++ b/WoofWare.PawPrint/MethodState.fs
@@ -618,6 +618,26 @@ type ConstructionState =
     /// `returnStackFrame` fails loudly on a frame that returns still in this state.
     | ConstructingVariableSize
 
+/// What `returnStackFrame` should do with the object a constructor frame was constructing,
+/// once that constructor returns.
+[<RequireQualifiedAccess>]
+type ConstructedObjectDisposition =
+    /// The ordinary `newobj` convention: push the constructed object (or, for value types,
+    /// its now-complete contents) onto the caller's evaluation stack.
+    | PushToCaller
+    /// The runtime synthesised this exception and pushed its ctor frame itself (see
+    /// `IlMachineStateExecution.raiseRuntimeException`). Dispatch the constructed object as
+    /// a managed exception instead of pushing it.
+    ///
+    /// `message`, when present, overwrites `_message` *after* the ctor has run — it must be
+    /// applied post-ctor, because the parameterless ctor sets `_message` to the type's
+    /// default resource string and would otherwise clobber it. Use it where the CLR would
+    /// have called a message-taking ctor overload that PawPrint cannot yet invoke (e.g.
+    /// `IndexOutOfRangeException(SR.IndexOutOfRange_ArrayRankIndex)`); leave it `None` to
+    /// accept the parameterless ctor's default, which is what the CLR produces when it
+    /// throws the exception with no argument.
+    | DispatchAsException of message : string option
+
 type MethodReturnState =
     {
         /// Handle to the caller's frame
@@ -631,10 +651,10 @@ type MethodReturnState =
         /// so that handler lookup sees the call site inside the protected region, even when
         /// the advanced resume PC falls outside it.
         CallSiteIlOpIndex : int
-        /// When true, the constructed object (see `Constructing`) should be dispatched as a
-        /// managed exception on return instead of being pushed onto the caller's eval stack.
-        /// Used by raiseRuntimeException to run exception ctors via the dispatch loop.
-        DispatchAsExceptionOnReturn : bool
+        /// What to do with the constructed object (see `Constructing`) when this frame
+        /// returns. Anything other than `PushToCaller` is set by `raiseRuntimeException`,
+        /// which runs exception ctors via the dispatch loop.
+        ConstructedObjectDisposition : ConstructedObjectDisposition
         /// When true, an exception escaping this frame is wrapped in a fresh
         /// `System.Reflection.TargetInvocationException` whose `_innerException` points at the
         /// original exception object. Used by the `Activator.CreateInstance<T>()` intrinsic to

--- a/WoofWare.PawPrint/Native/NativeCustomAttribute.fs
+++ b/WoofWare.PawPrint/Native/NativeCustomAttribute.fs
@@ -434,7 +434,7 @@ module NativeCustomAttribute =
 
                 // wasConstructing = None: we drive the ctor as a regular instance call, since
                 // the constructed instance is already on the eval stack as the re-entry marker.
-                // dispatchAsExceptionOnReturn = false / advanceProgramCounterOfCaller = false:
+                // ConstructedObjectDisposition.PushToCaller / advanceProgramCounterOfCaller = false:
                 // the native QCall frame has no IL to advance.
                 let state =
                     IlMachineStateExecution.callMethod
@@ -450,7 +450,7 @@ module NativeCustomAttribute =
                         ctx.Thread
                         threadState
                         None
-                        false
+                        ConstructedObjectDisposition.PushToCaller
                         false // wrapExceptionInTargetInvocation
                         state
 

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
@@ -750,7 +750,7 @@ module NativeRuntimeTypeQCall =
                         ctx.Thread
                         threadState
                         None
-                        false
+                        ConstructedObjectDisposition.PushToCaller
                         false // wrapExceptionInTargetInvocation
                         state
 

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -1139,11 +1139,19 @@ module NullaryIlOp =
             match IlMachineState.returnStackFrame loggerFactory corelib currentThread state with
             | ReturnFrameResult.NoFrameToReturn -> ExecutionResult.Terminated (state, currentThread)
             | ReturnFrameResult.NormalReturn state -> (state, WhatWeDid.Executed) |> ExecutionResult.stepped
-            | ReturnFrameResult.DispatchException (state, exnAddr, exnType) ->
+            | ReturnFrameResult.DispatchException (state, exnAddr, exnType, message) ->
                 // The ctor has run; now overwrite _HResult with the CLR's mapped value,
                 // matching EEException::CreateThrowable's SetHResult(GetHR()) post-ctor step.
                 let state =
                     ExceptionDispatching.overwriteHResultPostCtor corelib exnAddr exnType state
+
+                // The raiser asked for a specific message, i.e. the CLR would have used a
+                // message-taking ctor overload here. This has to happen after the ctor, which
+                // has just written the type's default resource string into `_message`.
+                let state =
+                    match message with
+                    | None -> state
+                    | Some message -> IlMachineState.setExceptionMessage loggerFactory corelib exnAddr message state
 
                 match
                     ExceptionDispatching.throwExceptionObject loggerFactory corelib state currentThread exnAddr exnType

--- a/WoofWare.PawPrint/UnaryMetadataCallOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataCallOps.fs
@@ -650,7 +650,7 @@ module internal UnaryMetadataCallOps =
                 thread
                 threadState
                 None
-                false
+                ConstructedObjectDisposition.PushToCaller
                 false // wrapExceptionInTargetInvocation
                 state,
             WhatWeDid.Executed
@@ -1040,7 +1040,7 @@ module internal UnaryMetadataCallOps =
             thread
             threadState
             None
-            false
+            ConstructedObjectDisposition.PushToCaller
             false // wrapExceptionInTargetInvocation
             state,
         WhatWeDid.Executed

--- a/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
@@ -309,7 +309,7 @@ module internal UnaryMetadataObjectOps =
                 thread
                 threadState
                 None
-                false
+                ConstructedObjectDisposition.PushToCaller
                 false // wrapExceptionInTargetInvocation
                 state,
             WhatWeDid.Executed
@@ -365,7 +365,7 @@ module internal UnaryMetadataObjectOps =
             thread
             threadState
             None
-            false
+            ConstructedObjectDisposition.PushToCaller
             false // wrapExceptionInTargetInvocation
             state,
         WhatWeDid.Executed


### PR DESCRIPTION
`Intrinsics.call` returned `IlMachineState option`: `Some` meant "handled", `None` meant "no implementation for this key". There was no third outcome, so an intrinsic that needed to raise a managed exception had nowhere to put it. Two consequences, both live:

**The guest could not die.** The three sites that raised anyway open-coded dispatch — allocate, set `_HResult`, call `throwExceptionObject` — and then faced `ExceptionDispatchResult.ExceptionUnhandled` from a context with no way to report it. All three ended in a host `failwith`, so a guest that legitimately died of an uncaught exception took the interpreter down with it instead of being reported as `RunOutcome.GuestUnhandledException`.

**Thirteen sites could not raise at all**, `failwith "TODO: throw ..."` instead. Seven were reachable from ordinary C#: `span[7]` on a length-3 span and `MemoryMarshal.GetArrayDataReference(null)` were the easiest ways to bring the interpreter down from guest code.

`Intrinsics.call` now returns an `IntrinsicResult` — `Unrecognised` / `Completed` / `RaiseException of state * exnType * message` — leaving the raising to `callMethod`. This mirrors `NativeHandlerResult`, which solved the same problem for native handlers in #576: describe the effect, let the layer that can perform it perform it.

## Notable

`MethodReturnState.DispatchAsExceptionOnReturn : bool` became `ConstructedObjectDisposition`, a two-case DU whose `DispatchAsException` case carries the message. A bool plus a parallel message field would have made "message set, but not dispatching as an exception" representable. This is the highest-blast-radius part of the branch — a core record, and eleven `callMethod` call sites.

Two conversions were reclassifications rather than mechanisms:

- `InitializeArray(null, h)` throws `ArgumentNullException`, not the `NullReferenceException` the TODO claimed.
- A zero `m_fieldHandle` is a *non-null* `RuntimeFieldHandle`, so it takes CoreCLR's `Argument_BadFieldForInitializeArray` path, not `Argument_InvalidHandle`. The two differ in message, so `fieldHandle` became an option and the distinction is now made rather than collapsed.

`Unsafe.BitCast` needed its guard split rather than converted. PawPrint conflated the BCL's real `NotSupportedException` with its own stricter byte-model rule; converting both would have made PawPrint throw where real .NET succeeds (`Unsafe.BitCast<IntPtr, long>` is legal). Splitting them also surfaced a missing clause: the BCL rejects *reference* types, which are pointer-sized and so slip past the size check — `Unsafe.BitCast<string, object>("x")` is a legal call that terminated the interpreter.

`NotSupportedException` joins `ExceptionHResults.table`; without it `overwriteHResultPostCtor` clobbered the correct `COR_E_NOTSUPPORTED` with `COR_E_EXCEPTION`.

Messages are supplied only where reproducible exactly. Both `ArgumentNullException` sites and `Enum.HasFlag`'s type mismatch pass `None` rather than approximate — the "(Parameter 'x')" suffix is synthesised from `_paramName`, which this channel cannot set, so writing it into `_message` would leave `.Message` and `.ParamName` disagreeing. The commit messages record each such divergence at the assertion the test deliberately omits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
