### PR TITLE
Implement SystemNative_GetTimestamp

### DIFF
--- a/WoofWare.PawPrint.Test/TestMonotonicTimestamp.fs
+++ b/WoofWare.PawPrint.Test/TestMonotonicTimestamp.fs
@@ -1,0 +1,207 @@
+namespace WoofWare.PawPrint.Test
+
+open System
+open FsCheck
+open FsCheck.FSharp
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+/// `EmulatedKernel.monotonicTimestampNs` is the value
+/// `SystemNative_GetTimestamp` returns: nanoseconds on a monotonic clock with
+/// an arbitrary origin, which CoreLib surfaces unchanged as
+/// `Stopwatch.GetTimestamp()` (Stopwatch.Unix.cs). Unlike the wall clock there
+/// is no BCL type to bound the range, so the constraint this module has to
+/// establish is arithmetic: the derivation must never overflow int64, because
+/// the one thing a *monotonic* clock promises its callers is that it does not
+/// run backwards.
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestMonotonicTimestamp =
+
+    let private propertyConfig : Config = Config.QuickThrowOnFailure.WithMaxTest 500
+
+    let private maxClockMs : int64 = EmulatedKernel.maxMonotonicClockMs
+
+    /// Fold an arbitrary int64 into `[0, bound]`. Deliberately not `abs`, which
+    /// throws on `Int64.MinValue` — a value FsCheck does generate.
+    let private intoRange (bound : int64) (seed : int64) : int64 =
+        let modulus = bound + 1L
+        ((seed % modulus) + modulus) % modulus
+
+    /// A kernel whose virtual clock has advanced to `clockMs`. Set by
+    /// record-copy because the driver loop is its only production writer.
+    let private kernelAt (clockMs : int64) : EmulatedKernel =
+        { EmulatedKernel.initial with
+            VirtualClockMs = clockMs
+        }
+
+    let private int64s = ArbMap.defaults |> ArbMap.arbitrary<int64>
+    let private int64Pairs = ArbMap.defaults |> ArbMap.arbitrary<int64 * int64>
+
+    /// Did the thunk complete, rather than failing the way PawPrint reports a
+    /// violated kernel invariant?
+    let private succeeds (f : unit -> 'a) : bool =
+        try
+            f () |> ignore<'a>
+            true
+        with _ ->
+            false
+
+    [<Test>]
+    let ``the nanosecond scale is the one CoreLib fixes`` () =
+        // `Stopwatch` on Unix never asks the PAL for its frequency:
+        // `Stopwatch.Unix.cs`'s `GetFrequency()` returns the literal
+        // 1_000_000_000, so the unit of this PAL entry is nanoseconds whether we
+        // like it or not. Anchored on the BCL's own constants rather than on a
+        // repeated literal, so this fails if the scale factor is ever retyped.
+        EmulatedKernel.nanosecondsPerMillisecond
+        |> shouldEqual (TimeSpan.TicksPerMillisecond * int64 TimeSpan.NanosecondsPerTick)
+
+        EmulatedKernel.nanosecondsPerMillisecond |> shouldEqual 1_000_000L
+
+    [<Test>]
+    let ``maxMonotonicClockMs is the last reading that does not overflow`` () =
+        // Pinned against the arithmetic that defines it, so a mistyped literal
+        // is caught rather than merely being self-consistent.
+        maxClockMs
+        |> shouldEqual (Int64.MaxValue / EmulatedKernel.nanosecondsPerMillisecond)
+
+        // The boundary itself is representable...
+        maxClockMs * EmulatedKernel.nanosecondsPerMillisecond |> shouldBeGreaterThan 0L
+
+        // ...and one millisecond further is not, which is precisely why the
+        // bound exists: unchecked, this would wrap to a negative timestamp and
+        // hand the guest a monotonic clock that had run backwards.
+        (maxClockMs + 1L) * EmulatedKernel.nanosecondsPerMillisecond
+        |> shouldBeSmallerThan 0L
+
+    [<Test>]
+    let ``a default kernel boots at zero`` () =
+        // Part of the replay contract, and a deliberate choice: real
+        // `CLOCK_MONOTONIC` promises nothing about its origin, so a guest
+        // reading meaning into an absolute timestamp is broken upstream too.
+        EmulatedKernel.monotonicTimestampNs EmulatedKernel.initial |> shouldEqual 0L
+
+    [<Test>]
+    let ``the reading tracks the virtual clock strictly monotonically`` () =
+        // The defining property of the clock CoreLib thinks it is reading: it
+        // never runs backwards, and never stands still while time passes.
+        let property (firstSeed : int64, secondSeed : int64) : bool =
+            let first = intoRange maxClockMs firstSeed
+            let second = intoRange maxClockMs secondSeed
+
+            let firstNs = EmulatedKernel.monotonicTimestampNs (kernelAt first)
+            let secondNs = EmulatedKernel.monotonicTimestampNs (kernelAt second)
+
+            compare firstNs secondNs = compare first second
+
+        Check.One (propertyConfig, Prop.forAll int64Pairs property)
+
+    [<Test>]
+    let ``the reading is non-negative`` () =
+        let property (seed : int64) : bool =
+            EmulatedKernel.monotonicTimestampNs (kernelAt (intoRange maxClockMs seed)) >= 0L
+
+        Check.One (propertyConfig, Prop.forAll int64s property)
+
+    [<Test>]
+    let ``the wall-clock epoch cannot perturb the monotonic clock`` () =
+        // `CLOCK_MONOTONIC` is immune to wall-clock changes, and here that is
+        // structural rather than enforced: `WallClockEpochMs` does not appear in
+        // the derivation at all. Pinned anyway, because it is the property a
+        // future NTP-skew model would be at risk of quietly breaking.
+        let property (epochSeed : int64, clockSeed : int64) : bool =
+            let epochMs = intoRange EmulatedKernel.maxWallClockEpochMs epochSeed
+            let clockMs = intoRange maxClockMs clockSeed
+
+            let withEpoch =
+                { kernelAt clockMs with
+                    WallClockEpochMs = epochMs
+                }
+
+            EmulatedKernel.monotonicTimestampNs withEpoch = EmulatedKernel.monotonicTimestampNs (kernelAt clockMs)
+
+        Check.One (propertyConfig, Prop.forAll int64Pairs property)
+
+    [<Test>]
+    let ``the monotonic and wall clocks agree about elapsed time`` () =
+        // The point of deriving both from one field: a guest that times an
+        // interval with `Stopwatch` and one that times it with `DateTime.UtcNow`
+        // must get the same answer. Compared in 100ns ticks, the coarser of the
+        // two units, since that is exactly the conversion `Stopwatch` performs
+        // when it hands out a `TimeSpan`.
+        let nsPerTick : int64 = int64 TimeSpan.NanosecondsPerTick
+
+        let property (firstSeed : int64, secondSeed : int64) : bool =
+            // Constrained to the range legal for *both* clocks; the asymmetry
+            // between their bounds gets its own test below.
+            let bound = min maxClockMs EmulatedKernel.maxWallClockEpochMs
+            let first = intoRange bound firstSeed
+            let second = intoRange bound secondSeed
+
+            let elapsedNs =
+                EmulatedKernel.monotonicTimestampNs (kernelAt second)
+                - EmulatedKernel.monotonicTimestampNs (kernelAt first)
+
+            let elapsedTicks =
+                EmulatedKernel.systemTimeAsTicks (kernelAt second)
+                - EmulatedKernel.systemTimeAsTicks (kernelAt first)
+
+            elapsedNs / nsPerTick = elapsedTicks
+
+        Check.One (propertyConfig, Prop.forAll int64Pairs property)
+
+    [<Test>]
+    let ``the reading has millisecond granularity`` () =
+        // Documented consequence of deriving from a millisecond clock: the low
+        // six digits are always zero, so `Stopwatch` cannot resolve anything
+        // finer than one retired IL instruction. Not observable in a run — the
+        // scheduler advances the clock a whole millisecond per instruction, so
+        // no two reads separated by guest code collide — but it is the reason
+        // `Stopwatch.Frequency` overstates the real resolution by a factor of a
+        // million, and that is worth pinning rather than discovering.
+        let property (seed : int64) : bool =
+            let ns = EmulatedKernel.monotonicTimestampNs (kernelAt (intoRange maxClockMs seed))
+            ns % EmulatedKernel.nanosecondsPerMillisecond = 0L
+
+        Check.One (propertyConfig, Prop.forAll int64s property)
+
+    [<Test>]
+    let ``a kernel record-copied out of range is rejected at the point of use`` () =
+        // Nothing bounds `VirtualClockMs` at its writer, and record-copy bypasses
+        // any setter, so the derivation re-asserts: past the horizon the guest
+        // must get a loud failure and not a wrapped, negative timestamp.
+        let property (overshootSeed : int64) : bool =
+            let clockMs = maxClockMs + 1L + intoRange 1_000_000L overshootSeed
+            not (succeeds (fun () -> EmulatedKernel.monotonicTimestampNs (kernelAt clockMs)))
+
+        Check.One (propertyConfig, Prop.forAll int64s property)
+
+    [<Test>]
+    let ``a negative virtual clock is rejected`` () =
+        let property (seed : int64) : bool =
+            let clockMs = -1L - intoRange 1_000_000L seed
+            not (succeeds (fun () -> EmulatedKernel.monotonicTimestampNs (kernelAt clockMs)))
+
+        Check.One (propertyConfig, Prop.forAll int64s property)
+
+    [<Test>]
+    let ``the monotonic clock is bounded more tightly than the wall clock`` () =
+        // Pins a real asymmetry rather than asserting it is fine. There is a
+        // band of virtual-clock readings from which `DateTime.UtcNow` and
+        // `Environment.TickCount64` can still be derived but
+        // `Stopwatch.GetTimestamp` cannot, because nanoseconds run out of int64
+        // long before `DateTime` runs out of years. Nothing bounds the field
+        // centrally, so each clock enforces its own ceiling at the moment the
+        // guest reads it; if that is ever fixed at the scheduler, this test
+        // should start failing and be deleted along with the asymmetry.
+        maxClockMs |> shouldBeSmallerThan EmulatedKernel.maxWallClockEpochMs
+
+        let inBand = maxClockMs + 1L
+
+        succeeds (fun () -> EmulatedKernel.systemTimeAsTicks (kernelAt inBand))
+        |> shouldEqual true
+
+        succeeds (fun () -> EmulatedKernel.monotonicTimestampNs (kernelAt inBand))
+        |> shouldEqual false

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -85,6 +85,7 @@
     <Compile Include="TestSignalDispatch.fs" />
     <Compile Include="TestEffectiveProcessorCount.fs" />
     <Compile Include="TestSystemTimeAsTicks.fs" />
+    <Compile Include="TestMonotonicTimestamp.fs" />
     <Compile Include="TestSignalTermination.fs" />
     <Compile Include="TestWaitHandle.fs" />
     <Compile Include="TestSyncBlockMonitor.fs" />

--- a/WoofWare.PawPrint.Test/sourcesPure/StopwatchMonotonic.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/StopwatchMonotonic.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Diagnostics;
+
+// End-to-end coverage of SystemNative_GetTimestamp, the PAL entry behind
+// Stopwatch.GetTimestamp on Unix. PawPrint derives it from the same deterministic virtual
+// clock that backs Environment.TickCount64, so what is assertable here is the shape of a
+// monotonic clock -- ordering and non-negativity -- rather than any particular rate.
+//
+// Every assertion below is straight-line or bounded by a plain counter. Nothing loops on a
+// clock predicate: PawPrint's clock advances a millisecond per retired IL instruction, so
+// merely reading it twice burns milliseconds, and a clock-conditioned loop can be false on
+// its first evaluation. SpinWaitDelayLoop.cs was vacuous under PawPrint for exactly that
+// reason before it was restructured -- it ran zero iterations here and 28 on the real
+// runtime -- so a test in this area has to be readable as covering the handler *without*
+// depending on how fast the clock happens to move.
+public static class StopwatchMonotonic
+{
+    public static int Main (string[] args)
+    {
+        // Stopwatch.Frequency is not read from the PAL on Unix: Stopwatch.Unix.cs returns
+        // the literal 1e9 from GetFrequency(). Asserting it pins the *unit* of the handler
+        // end-to-end, which is the one thing about this primitive that would be silently
+        // wrong rather than loudly wrong if we picked it incorrectly.
+        if (Stopwatch.Frequency != 1_000_000_000L)
+        {
+            return 1;
+        }
+
+        if (!Stopwatch.IsHighResolution)
+        {
+            return 2;
+        }
+
+        long first = Stopwatch.GetTimestamp ();
+        long second = Stopwatch.GetTimestamp ();
+
+        // The defining property. Deliberately `<`, not `<=`: real hardware can return the
+        // same tick twice, so requiring strict progress would be a genuine race there.
+        if (second < first)
+        {
+            return 3;
+        }
+
+        if (Stopwatch.GetElapsedTime (first, second) < TimeSpan.Zero)
+        {
+            return 4;
+        }
+
+        // Bounded by the counter, never by the clock, so the body always runs.
+        long previous = second;
+        for (int i = 0; i < 32; i++)
+        {
+            long current = Stopwatch.GetTimestamp ();
+            if (current < previous)
+            {
+                return 5;
+            }
+
+            previous = current;
+        }
+
+        Stopwatch watch = Stopwatch.StartNew ();
+        int accumulator = 0;
+        for (int i = 0; i < 64; i++)
+        {
+            accumulator += i;
+        }
+
+        watch.Stop ();
+
+        if (accumulator != 2016)
+        {
+            return 6;
+        }
+
+        // No upper bound and no `> TimeSpan.Zero`: PawPrint bills this loop tens of
+        // milliseconds where real hardware bills it nanoseconds, so any assertion sharp
+        // enough to see a difference would have to fail on one runtime or the other, and
+        // the harness diffs exit codes between the two.
+        if (watch.Elapsed < TimeSpan.Zero || watch.ElapsedTicks < 0 || watch.ElapsedMilliseconds < 0)
+        {
+            return 7;
+        }
+
+        if (watch.IsRunning)
+        {
+            return 8;
+        }
+
+        // A stopped Stopwatch holds its reading still: Elapsed stops consulting the clock
+        // once IsRunning is false, so two reads agree even though the clock has moved
+        // between them (and under PawPrint it certainly has -- reading it once costs
+        // milliseconds).
+        TimeSpan held = watch.Elapsed;
+        if (watch.Elapsed != held)
+        {
+            return 9;
+        }
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/EmulatedKernel.fs
+++ b/WoofWare.PawPrint/EmulatedKernel.fs
@@ -435,11 +435,13 @@ type EmulatedKernel =
         /// `SystemNative_GetLowResolutionTimestamp` (the PAL backing
         /// `Environment.TickCount64` on Unix) and intended to be the single
         /// source of truth for every elapsed-time computation the guest
-        /// performs — `SystemNative_GetSystemTimeAsTicks` (the wall clock
-        /// behind `DateTime.UtcNow`) already derives from it via
-        /// `EmulatedKernel.systemTimeAsTicks`, and a future
-        /// `SystemNative_GetTimestamp` (nanoseconds) should too, rather than
-        /// maintaining a parallel clock.
+        /// performs. `SystemNative_GetSystemTimeAsTicks` (the wall clock
+        /// behind `DateTime.UtcNow`) derives from it via
+        /// `EmulatedKernel.systemTimeAsTicks`, and `SystemNative_GetTimestamp`
+        /// (the monotonic nanosecond source behind `Stopwatch.GetTimestamp`)
+        /// via `EmulatedKernel.monotonicTimestampNs`. Both are derivations
+        /// rather than parallel clocks, which is what makes the three
+        /// guest-visible time sources agree with each other by construction.
         ///
         /// The driver loop advances this by 1 ms each time it increments
         /// `StepCounter`, so the guest sees one wall-clock millisecond per
@@ -723,6 +725,44 @@ module EmulatedKernel =
     [<Literal>]
     let maxWallClockEpochMs : int64 = 253402300799999L
 
+    /// Nanoseconds per millisecond: the scale factor between
+    /// `EmulatedKernel.VirtualClockMs` and the monotonic timestamp
+    /// `SystemNative_GetTimestamp` hands the guest. Nanoseconds because
+    /// `Stopwatch.Frequency` on Unix is not queried from the PAL at all —
+    /// `Stopwatch.Unix.cs`'s `GetFrequency()` returns the literal
+    /// 1_000_000_000 — so the unit of the PAL entry is fixed by CoreLib
+    /// rather than negotiable here.
+    [<Literal>]
+    let nanosecondsPerMillisecond : int64 = 1_000_000L
+
+    /// Largest `EmulatedKernel.VirtualClockMs` from which a monotonic
+    /// nanosecond timestamp can be derived without overflowing int64:
+    /// `Int64.MaxValue / nanosecondsPerMillisecond`, about 292 years of
+    /// virtual time.
+    ///
+    /// Deliberately *tighter* than `maxWallClockEpochMs` (by a factor of
+    /// about 27), so there is a band of clock readings from which
+    /// `DateTime.UtcNow` and `Environment.TickCount64` are derivable but
+    /// `Stopwatch.GetTimestamp` is not. That asymmetry is real and is not
+    /// currently reconciled: neither driver write site bounds
+    /// `VirtualClockMs`, and no deadline computation caps it either, so
+    /// each clock-derived PAL entry enforces its own ceiling lazily, at the
+    /// moment the guest happens to read that particular clock. Bounding the
+    /// field centrally at the scheduler — its sole writer — would give one
+    /// coherent invariant and would fault at the wait that pushed time past
+    /// the horizon rather than at an arbitrary later read; that is worth
+    /// doing, and is deliberately not done here because it changes the
+    /// failure point of existing behaviour.
+    ///
+    /// The horizon is reachable by ordinary guest code, not merely in
+    /// principle: a `Thread.Sleep` deadline is `VirtualClockMs + timeout`
+    /// with no cap, and the driver's deadline jump moves the clock the whole
+    /// way, so `Thread.Sleep(Int32.MaxValue)` advances it about 2.1e9 ms per
+    /// call. Measured: eight such sleeps advance the clock by 17,179,869,451
+    /// ms, so roughly 4,300 of them cross this bound.
+    [<Literal>]
+    let maxMonotonicClockMs : int64 = 9_223_372_036_854L
+
     /// Unix platform identity a freshly-minted simulated process reports.
     /// Linux/x64 because that is the platform whose CoreLib actually routes
     /// `Environment.OSVersion` through `SystemNative_GetUnixRelease` (the
@@ -850,6 +890,51 @@ module EmulatedKernel =
                 $"simulated wall clock has reached %d{ms} ms since the Unix epoch, past the %d{maxWallClockEpochMs} ms that System.DateTime can represent; lower KernelConfig.WallClockEpochMs"
 
         ms * ticksPerMillisecond
+
+    /// Monotonic time the simulated process currently observes, in nanoseconds
+    /// since an arbitrary origin: exactly what `SystemNative_GetTimestamp`
+    /// returns, and hence what `Stopwatch.GetTimestamp` reports on Unix.
+    ///
+    /// Derived from `VirtualClockMs` rather than from a clock of its own, so
+    /// every elapsed-time computation the guest can perform is a view of one
+    /// underlying quantity. Three properties the real
+    /// `clock_gettime(CLOCK_MONOTONIC)` guarantees then hold structurally
+    /// rather than by separate enforcement: the result never runs backwards
+    /// (because `VirtualClockMs` never does), it agrees with
+    /// `Environment.TickCount64` about how much time has passed (they are the
+    /// same number in different units), and it is immune to the wall clock —
+    /// `WallClockEpochMs` does not appear in the derivation, so a host that
+    /// boots the guest at some other date cannot perturb it.
+    ///
+    /// The origin is the same zero as `VirtualClockMs`, not a synthetic
+    /// boot offset. Real `CLOCK_MONOTONIC` promises nothing about its origin,
+    /// so guest code that reads meaning into an absolute timestamp is broken
+    /// on the real runtime too.
+    ///
+    /// Resolution is one millisecond expressed in nanoseconds, so the low six
+    /// digits are always zero. That is coarse in absolute terms but not
+    /// observably so: the scheduler advances the clock a full millisecond per
+    /// retired IL instruction, so no two reads separated by any guest code at
+    /// all can land on the same value. What the guest cannot do is measure a
+    /// duration *finer* than one instruction, which is the same "very slow
+    /// computer" bargain `Environment.TickCount64` already makes.
+    ///
+    /// Pure, like every other clock observer here: reading never advances the
+    /// clock, so two threads reading on the same scheduler tick agree.
+    let monotonicTimestampNs (kernel : EmulatedKernel) : int64 =
+        // A kernel built by record-copy bypasses the driver entirely, and the
+        // driver does not bound this field in any case, so the invariant has
+        // to be re-asserted here. Establishing it also establishes that the
+        // multiplication below cannot overflow. Failing loudly rather than
+        // saturating: a saturated clock stops advancing, which breaks guest
+        // forward progress exactly as badly and does so silently, whereas a
+        // guest that observes a monotonic clock jumping backwards has had the
+        // one guarantee this primitive exists to provide taken away from it.
+        if kernel.VirtualClockMs < 0L || kernel.VirtualClockMs > maxMonotonicClockMs then
+            failwith
+                $"kernel VirtualClockMs is %d{kernel.VirtualClockMs}, which is outside the range [0, %d{maxMonotonicClockMs}] a monotonic nanosecond timestamp can be derived from without overflowing int64"
+
+        kernel.VirtualClockMs * nanosecondsPerMillisecond
 
     /// Largest value CoreCLR will accept from the processor-count
     /// configuration knob (`MAX_PROCESSOR_COUNT` in

--- a/WoofWare.PawPrint/Native/NativeSystemNative.fs
+++ b/WoofWare.PawPrint/Native/NativeSystemNative.fs
@@ -293,6 +293,32 @@ module NativeSystemNative =
                 ctx.Thread
             |> NativeHandlerResult.completed
             |> Some
+        | Some "SystemNative_GetTimestamp",
+          [],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int64) ->
+            // PAL entry behind `Stopwatch.GetTimestamp` on Unix, which is
+            // `clock_gettime(CLOCK_MONOTONIC)` in real CoreCLR. The unit is
+            // nanoseconds, and that is not a choice made here: `Stopwatch`
+            // on Unix never asks the PAL for its frequency, because
+            // `Stopwatch.Unix.cs`'s `GetFrequency()` returns the literal
+            // 1_000_000_000. PawPrint derives the value from the same
+            // deterministic virtual clock that backs `Environment.TickCount64`
+            // and `DateTime.UtcNow`, so the guest's three time sources cannot
+            // disagree about how much time has passed.
+            //
+            // Reaching this matters beyond `Stopwatch` itself: the thread
+            // pool's hill-climbing step calls it unconditionally
+            // (`PortableThreadPool.AdjustMaxWorkersActive`), so without it a
+            // guest dies partway into its first few blocking pool waits.
+            //
+            // Read-only, like every other clock observer: the scheduler is
+            // the sole writer of `VirtualClockMs`.
+            state
+            |> IlMachineState.pushToEvalStack'
+                (EvalStackValue.Int64 (Int64Source.Verbatim (EmulatedKernel.monotonicTimestampNs state.Kernel)))
+                ctx.Thread
+            |> NativeHandlerResult.completed
+            |> Some
         | Some "SystemNative_GetSystemTimeAsTicks",
           [],
           MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int64) ->


### PR DESCRIPTION
Closes #726.

The PAL entry behind `Stopwatch.GetTimestamp` on Unix. Without it a guest dies partway into its first few blocking thread-pool waits — the pool's hill-climbing step calls it unconditionally (`PortableThreadPool.AdjustMaxWorkersActive`, PortableThreadPool.cs:379), while everything before that point is gated on `Environment.TickCount`, which routes to the already-implemented `SystemNative_GetLowResolutionTimestamp`. That is exactly why the guest gets *some* distance before falling over; the "exactly three waits" boundary in the issue is an emergent artefact of the virtual clock's granularity, not a designed budget.

The unit is nanoseconds, and that is not a choice made here: `Stopwatch` on Unix never asks the PAL for its frequency, because `Stopwatch.Unix.cs`'s `GetFrequency()` returns the literal `1_000_000_000`.

### Design

Derived from `VirtualClockMs`, which is what the field's own doc comment already said should happen. Three properties of the real `clock_gettime(CLOCK_MONOTONIC)` then hold structurally rather than by separate enforcement: the result never runs backwards, it agrees with `Environment.TickCount64` and `DateTime.UtcNow` about how much time has passed, and it is immune to the wall clock, since `WallClockEpochMs` does not appear in the derivation.

Three alternatives were considered and rejected, in the commit message and in a plan reviewed before any code was written:

- **A parallel `VirtualClockNs` field** advanced alongside `VirtualClockMs` — the drift hazard the `WallClockEpochMs` doc already argues against: two fields that must agree, with more than one write path (the per-tick advance *and* the deadline jump).
- **Deriving from `StepCounter`** — worse than coarse. The deadline jump advances `VirtualClockMs` without advancing `StepCounter`, deliberately, so the two clocks would disagree about elapsed time — and `AdjustMaxWorkersActive` reads both in the same method.
- **Inverting primacy** (`VirtualClockNs` the sole field, `VirtualClockMs` a lossless view) — genuinely better information-preservation, and the migration to make if a finer clock is ever wanted. Not done speculatively: nothing can observe sub-millisecond resolution while the scheduler bills a whole millisecond per retired instruction.

### Overflow, and an asymmetry left in place

`maxMonotonicClockMs` is tighter than `maxWallClockEpochMs` by a factor of ~27, because nanoseconds run out of `int64` long before `DateTime` runs out of years. Unchecked, the multiplication wraps and hands the guest a monotonic clock that has run *backwards* — the one guarantee this primitive exists to provide. Enforced with a loud failure rather than by saturating, since a saturated clock stops advancing and breaks forward progress just as badly but silently.

The horizon is reachable by ordinary guest code, not only in principle. Measured: eight `Thread.Sleep(int.MaxValue)` calls advance the clock 17,179,869,451 ms, so roughly 4,300 of them cross it.

That leaves a real asymmetry, documented rather than glossed: **nothing bounds `VirtualClockMs` at its writer**, so each clock-derived PAL entry now enforces its own ceiling lazily, at the moment the guest reads that particular clock. Bounding centrally at the scheduler would give one coherent invariant and would fault at the wait that overshot rather than at an arbitrary later read. Deliberately not done here, because it changes the failure point of behaviour that already exists — it is pinned by a test that should be *deleted* when it is fixed. Happy to do it as a follow-up if you'd prefer it sooner.

### Tests

- `TestMonotonicTimestamp.fs` — FsCheck properties: strict monotonicity, non-negativity, immunity to `WallClockEpochMs`, agreement with `systemTimeAsTicks` about elapsed durations, millisecond granularity, both bounds rejected, and the bound asymmetry itself. Anchored on BCL constants (`TimeSpan.TicksPerMillisecond * NanosecondsPerTick`) rather than on repeated literals.
- `sourcesPure/StopwatchMonotonic.cs` — differential. **Verified non-vacuous** by deleting the handler and confirming it fails with precisely the unimplemented-native-method error from the issue. Every assertion is straight-line or bounded by a plain counter, never by a clock predicate: reading this clock twice already burns milliseconds, which is what made `SpinWaitDelayLoop.cs` vacuous before it was restructured.

Full suite green at 1648/1648. Reviewed by Fable (plan and implementation) and by Codex; both clean.

### Follow-up not done here

`sourcesPure/TaskMultipleBlockingWaits.cs` is sized to three waits and cites #726, and the issue asks for it to be raised once this lands. That file exists only on `wip-taskcoverage` (#728), not on `main`, so it is left for whoever lands that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)