### PR TITLE
Extract the heap-object field-write helper centrally

### DIFF
--- a/WoofWare.PawPrint/ExceptionDispatching.fs
+++ b/WoofWare.PawPrint/ExceptionDispatching.fs
@@ -896,18 +896,11 @@ module ExceptionDispatching =
         // the Ret handler's DispatchException path in NullaryIlOp.fs.
         let hresult = hresultForExceptionType baseClassTypes exceptionTypeInfo
 
-        let heapObj = ManagedHeap.get addr state.ManagedHeap
-
         let hresultField =
             FieldIdentity.requiredNonGenericInstanceFieldId state.ConcreteTypes baseClassTypes.Exception "_HResult"
 
-        let heapObj =
-            AllocatedNonArrayObject.SetFieldById hresultField (CliType.Numeric (CliNumericType.Int32 hresult)) heapObj
-
         let state =
-            { state with
-                ManagedHeap = ManagedHeap.set addr heapObj state.ManagedHeap
-            }
+            IlMachineState.setInstanceFieldById addr hresultField (CliType.Numeric (CliNumericType.Int32 hresult)) state
 
         addr, exnHandle, state
 
@@ -934,14 +927,7 @@ module ExceptionDispatching =
 
         let hresult = hresultForExceptionType baseClassTypes typeInfo
 
-        let heapObj = ManagedHeap.get exnAddr state.ManagedHeap
-
         let hresultField =
             FieldIdentity.requiredNonGenericInstanceFieldId state.ConcreteTypes baseClassTypes.Exception "_HResult"
 
-        let heapObj =
-            AllocatedNonArrayObject.SetFieldById hresultField (CliType.Numeric (CliNumericType.Int32 hresult)) heapObj
-
-        { state with
-            ManagedHeap = ManagedHeap.set exnAddr heapObj state.ManagedHeap
-        }
+        IlMachineState.setInstanceFieldById exnAddr hresultField (CliType.Numeric (CliNumericType.Int32 hresult)) state

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -840,7 +840,7 @@ module IlMachineRuntimeMetadata =
             state.ManagedHeap.NonArrayObjects |> Map.tryFind exceptionAddr,
             AllConcreteTypes.findExistingNonGenericConcreteType state.ConcreteTypes baseClassTypes.Exception.Identity
         with
-        | Some heapObj, Some exceptionHandle ->
+        | Some _, Some exceptionHandle ->
             let messageAddr, state =
                 allocateManagedString loggerFactory baseClassTypes message state
 
@@ -848,13 +848,11 @@ module IlMachineRuntimeMetadata =
                 FieldIdentity.requiredOwnInstanceField baseClassTypes.Exception "_message"
                 |> FieldIdentity.fieldId exceptionHandle
 
-            let heapObj =
-                heapObj
-                |> AllocatedNonArrayObject.SetFieldById messageField (CliType.ObjectRef (Some messageAddr))
-
-            { state with
-                ManagedHeap = ManagedHeap.set exceptionAddr heapObj state.ManagedHeap
-            }
+            IlMachineThreadState.setInstanceFieldById
+                exceptionAddr
+                messageField
+                (CliType.ObjectRef (Some messageAddr))
+                state
         // Mirrors `setExceptionStackTraceString`: skeletal states in low-level dispatch tests may
         // lack either piece, and there is nothing to project into in that case.
         | None, _
@@ -881,7 +879,7 @@ module IlMachineRuntimeMetadata =
                     state.ConcreteTypes
                     baseClassTypes.Exception.Identity
             with
-            | Some heapObj, Some exceptionHandle ->
+            | Some _, Some exceptionHandle ->
                 let trace = renderExceptionStackTrace state stackTrace
 
                 let traceAddr, state =
@@ -891,13 +889,11 @@ module IlMachineRuntimeMetadata =
                     FieldIdentity.requiredOwnInstanceField baseClassTypes.Exception "_stackTraceString"
                     |> FieldIdentity.fieldId exceptionHandle
 
-                let heapObj =
-                    heapObj
-                    |> AllocatedNonArrayObject.SetFieldById stackTraceStringField (CliType.ObjectRef (Some traceAddr))
-
-                { state with
-                    ManagedHeap = ManagedHeap.set exceptionAddr heapObj state.ManagedHeap
-                }
+                IlMachineThreadState.setInstanceFieldById
+                    exceptionAddr
+                    stackTraceStringField
+                    (CliType.ObjectRef (Some traceAddr))
+                    state
             | None, _
             | _, None -> state
 

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -233,6 +233,23 @@ module IlMachineState =
 
     let requiredOwnInstanceFieldId = IlMachineRuntimeMetadata.requiredOwnInstanceFieldId
 
+    let setInstanceFieldById = IlMachineThreadState.setInstanceFieldById
+
+    /// Overwrite the field named `fieldName` on the non-array heap object at `addr`, resolving
+    /// the field against the object's *own* concrete type. Fails loudly if that type does not
+    /// itself declare `fieldName`; an inherited field must be resolved against its declaring
+    /// type and written with `setInstanceFieldById`.
+    let setOwnInstanceField
+        (addr : ManagedHeapAddress)
+        (fieldName : string)
+        (value : CliType)
+        (state : IlMachineState)
+        : IlMachineState
+        =
+        let obj = ManagedHeap.get addr state.ManagedHeap
+        let field = requiredOwnInstanceFieldId state obj.ConcreteType fieldName
+        setInstanceFieldById addr field value state
+
     let isConcreteTypeAssignableTo = IlMachineRuntimeMetadata.isConcreteTypeAssignableTo
 
     let isRuntimeTypeHandleTargetAssignableTo =

--- a/WoofWare.PawPrint/IlMachineThreadState.fs
+++ b/WoofWare.PawPrint/IlMachineThreadState.fs
@@ -730,6 +730,26 @@ module IlMachineThreadState =
 
         alloc, state
 
+    /// Overwrite one field of the non-array heap object at `addr` and write the updated object
+    /// back. `field` must already identify the type that *declares* the field, which is not
+    /// necessarily the object's own concrete type: a field inherited from a base class (e.g.
+    /// `System.Exception._HResult` on a derived exception) carries the base type's handle.
+    /// Callers naming a field declared on the object's own type should prefer
+    /// `IlMachineState.setOwnInstanceField`, which resolves the `FieldId` for them.
+    let setInstanceFieldById
+        (addr : ManagedHeapAddress)
+        (field : FieldId)
+        (value : CliType)
+        (state : IlMachineState)
+        : IlMachineState
+        =
+        let obj = ManagedHeap.get addr state.ManagedHeap
+        let obj = AllocatedNonArrayObject.SetFieldById field value obj
+
+        { state with
+            ManagedHeap = ManagedHeap.set addr obj state.ManagedHeap
+        }
+
     let popFromStackToLocalVariable
         (thread : ThreadId)
         (localVariableIndex : int)

--- a/WoofWare.PawPrint/Native/NativeGc.fs
+++ b/WoofWare.PawPrint/Native/NativeGc.fs
@@ -4,30 +4,6 @@ open System.Collections.Immutable
 
 [<RequireQualifiedAccess>]
 module NativeGc =
-    let private objectOwnFieldId
-        (state : IlMachineState)
-        (obj : AllocatedNonArrayObject)
-        (fieldName : string)
-        : FieldId
-        =
-        IlMachineState.requiredOwnInstanceFieldId state obj.ConcreteType fieldName
-
-    /// Overwrite one field of the heap object at `addr` and write the updated object back.
-    let private setField
-        (state : IlMachineState)
-        (addr : ManagedHeapAddress)
-        (fieldName : string)
-        (value : CliType)
-        : IlMachineState
-        =
-        let obj = ManagedHeap.get addr state.ManagedHeap
-        let field = objectOwnFieldId state obj fieldName
-        let obj = AllocatedNonArrayObject.SetFieldById field value obj
-
-        { state with
-            ManagedHeap = ManagedHeap.set addr obj state.ManagedHeap
-        }
-
     /// Zero out a field whose declared type is itself a value type (`GCGenerationInfo`,
     /// `TimeSpan`) rather than a primitive: looks up the field's declared signature so the
     /// zero value gets the field's own concrete shape (recursing into that struct's fields),
@@ -60,7 +36,7 @@ module NativeGc =
                 ImmutableArray.Empty
                 state
 
-        setField state addr fieldName zero
+        IlMachineState.setOwnInstanceField addr fieldName zero state
 
     let private zeroInt64 : CliType =
         CliType.Numeric (CliNumericType.Int64 (Int64Source.Verbatim 0L))
@@ -187,7 +163,9 @@ module NativeGc =
                     "_compacted", zeroByte
                     "_concurrent", zeroByte
                 ]
-                |> List.fold (fun state (fieldName, value) -> setField state dataAddr fieldName value) state
+                |> List.fold
+                    (fun state (fieldName, value) -> IlMachineState.setOwnInstanceField dataAddr fieldName value state)
+                    state
 
             let state =
                 [

--- a/WoofWare.PawPrint/Native/NativeThreading.fs
+++ b/WoofWare.PawPrint/Native/NativeThreading.fs
@@ -208,23 +208,23 @@ module NativeThreading =
         let threadPriorityNormal = 2
         let (ManagedHeapAddress addrInt) = threadAddr
 
-        let threadObj = ManagedHeap.get threadAddr state.ManagedHeap
-
-        let updatedObj =
-            threadObj
-            |> AllocatedNonArrayObject.SetFieldById
-                (objectOwnFieldId state threadObj "_managedThreadId")
+        let state =
+            state
+            |> IlMachineState.setOwnInstanceField
+                threadAddr
+                "_managedThreadId"
                 (CliType.Numeric (CliNumericType.Int32 managedThreadId))
-            |> AllocatedNonArrayObject.SetFieldById
-                (objectOwnFieldId state threadObj "_priority")
+            |> IlMachineState.setOwnInstanceField
+                threadAddr
+                "_priority"
                 (CliType.Numeric (CliNumericType.Int32 threadPriorityNormal))
-            |> AllocatedNonArrayObject.SetFieldById
-                (objectOwnFieldId state threadObj "_DONT_USE_InternalThread")
+            |> IlMachineState.setOwnInstanceField
+                threadAddr
+                "_DONT_USE_InternalThread"
                 (CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim (int64 addrInt))))
 
         let state =
             { state with
-                ManagedHeap = ManagedHeap.set threadAddr updatedObj state.ManagedHeap
                 NextManagedThreadId = state.NextManagedThreadId + 1
             }
 


### PR DESCRIPTION
Targets `wip-gcmemoryinfo` rather than `main`, since it grew out of reviewing that branch.

`NativeGc.fs` defined a private `setField` (read heap object, resolve field by name against the object's own concrete type, write back) plus a private `objectOwnFieldId`. The latter was a **byte-identical** duplicate of the one already in `NativeThreading.fs`, and the read-modify-write it wrapped was spelled out inline at around a dozen sites across the interpreter. There was no central helper to reach for.

## What this adds

* **`IlMachineThreadState.setInstanceFieldById`** — the primitive, taking a `FieldId` that already names the *declaring* type. Placed next to `allocateManagedObject` because that is the earliest point in compile order reachable from `IlMachineRuntimeMetadata` onwards, which several call sites need.
* **`IlMachineState.setOwnInstanceField`** — resolves the field by name against the object's own concrete type, then delegates. This is `NativeGc`'s `setField` verbatim.

The split is load-bearing rather than cosmetic. A field inherited from a base class carries the *base* type's handle, so `System.Exception._HResult` on a derived exception cannot be resolved by name against the object's own type: `requiredOwnInstanceFieldId` would fail. Those callers must keep resolving the `FieldId` themselves. Keeping "own" in the name means the helper stays honest about which lookup it performs instead of quietly broadening into a base-class walk.

## Call sites converted

`NativeGc.fs` (both private helpers deleted), `NativeThreading.fs`, `ExceptionDispatching.fs` (x2), `IlMachineRuntimeMetadata.fs` (x2).

Sites that chain several `SetFieldById` calls onto one locally-held object before a single heap write are deliberately left alone: they already compose the central `AllocatedNonArrayObject.SetFieldById`, and splitting them would trade one heap write for N.

## Verification

No behaviour change. Full suite green: 1639 passed, 0 failed. `codex review --base origin/main` raised nothing.

## Not addressed here

Reviewing `wip-gcmemoryinfo` turned up a separate finding this PR deliberately does not act on: `newobj GCMemoryInfoData` already zeroes all 21 fields (CoreLib's `GetGCMemoryInfo` does `var data = new GCMemoryInfoData();` immediately before the InternalCall, and PawPrint's `newobj` runs `collectAllInstanceFields` -> `cliTypeZeroOf` over every field), so the handler's writes are redundant, and `zeroStructField` re-derives per-field what that already did for the whole object. Verified empirically: with every field write disabled, `GCGetMemoryInfo` and `GCMemoryInfoAllZero` both still pass. Making the helper central does not make those writes any more necessary; whether to collapse the handler body is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)