### PR TITLE
Don't reach an unrelated unimplemented boundary in ArrayClearReferenceElements

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/ArrayClearReferenceElements.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/ArrayClearReferenceElements.cs
@@ -18,7 +18,10 @@ public class TestArrayClearReferenceElements
         public Box B;
     }
 
-    private static int SweepStrings()
+    // Deliberately fresh `Box` instances rather than constructed strings: `new string(char,
+    // int)` is a separate unimplemented InternalCall, and reaching it would make this file
+    // fail for a reason that has nothing to do with clearing reference elements.
+    private static int SweepReferences()
     {
         for (int len = 0; len <= 8; len++)
         {
@@ -26,11 +29,11 @@ public class TestArrayClearReferenceElements
             {
                 for (int length = 0; length <= len - index; length++)
                 {
-                    string[] a = new string[len];
-                    string[] seed = new string[len];
+                    Box[] a = new Box[len];
+                    Box[] seed = new Box[len];
                     for (int i = 0; i < len; i++)
                     {
-                        seed[i] = new string('x', i + 1);
+                        seed[i] = new Box { Value = i + 1 };
                         a[i] = seed[i];
                     }
 
@@ -101,7 +104,7 @@ public class TestArrayClearReferenceElements
     {
         int result;
 
-        result = SweepStrings();
+        result = SweepReferences();
         if (result != 0) return 1000000 + result;
 
         result = TestStructContainingReference();


### PR DESCRIPTION
Small follow-up to #733.

`sourcesPure/ArrayClearReferenceElements.cs` seeded its reference arrays with `new string('x', i + 1)`, which is a separate unimplemented InternalCall (`System.String::.ctor(char, int)`).

The file sits in the `unimplemented` set today, so nothing noticed. But the moment the `ClearWithReferences` follow-up un-gates it, it would have failed at string construction rather than at anything to do with clearing reference elements — exactly the misleading signal an `unimplemented` entry exists to prevent, and it would have looked like the follow-up hadn't worked.

Seeds with fresh `Box` instances instead, which gives the same distinct-reference-per-slot property with no string construction. `SweepStrings` is renamed to `SweepReferences` to match.

Found while spiking the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)