### PR TITLE
Implement RuntimeMethodHandle_GetMethodInstantiation (#718)

### DIFF
--- a/WoofWare.PawPrint.Test/TestFSharpPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestFSharpPureCases.fs
@@ -113,17 +113,20 @@ module TestFSharpPureCases =
         Set.ofList
             [
                 // The `RuntimeMethodHandle.IsGenericMethodDefinition` InternalCall this case was
-                // written to pin (issue #690) now works, and so does the `stelem` TypeReference
-                // token (issue #691) that `Printf`'s boxed-argument array reaches next. `sprintf`
-                // now gets as far as the `RuntimeMethodHandle_GetMethodInstantiation` QCall
-                // (`System.RuntimeMethodHandle::GetMethodInstantiation(RuntimeMethodHandleInternal,
-                // ObjectHandleOnStack, BOOL) -> void`), which is unimplemented: it has to
-                // materialise the method's type arguments as a managed `RuntimeType[]` and hand it
-                // back through an `ObjectHandleOnStack`, so it is a genuine piece of work rather
-                // than another scalar. Tracked as issue #718; the `isGenericMethodDefinition`
-                // predicate itself is pinned directly by `TestNativeRuntimeMethodHandle.fs` and by
-                // `sourcesPure/MethodIsGenericMethodDefinition.cs`, so #690's coverage does not
-                // depend on this case passing.
+                // written to pin (issue #690) now works, and so do the `stelem` TypeReference
+                // token (issue #691) that `Printf`'s boxed-argument array reaches next and the
+                // `RuntimeMethodHandle_GetMethodInstantiation` QCall (issue #718). `sprintf` now
+                // gets as far as the `RuntimeMethodHandle_GetStubIfNeededSlow` QCall
+                // (`System.RuntimeMethodHandle::GetStubIfNeededSlow(RuntimeMethodHandleInternal,
+                // QCallTypeHandle, ObjectHandleOnStack) -> RuntimeMethodHandleInternal`), which is
+                // unimplemented: it is the slow path of `GetStubIfNeeded`, reached when reflection
+                // binds a generic method's type arguments (`MakeGenericMethod`), and it has to
+                // materialise an instantiated method handle rather than return an existing one.
+                // The `GetMethodInstantiation` behaviour #718 added is pinned directly by
+                // `TestNativeRuntimeMethodHandle.fs` and by
+                // `sourcesPure/MethodGetGenericArguments.cs`, and the `isGenericMethodDefinition`
+                // predicate by `sourcesPure/MethodIsGenericMethodDefinition.cs`, so neither #690's
+                // nor #718's coverage depends on this case passing.
                 "SprintfBasic"
             ]
 

--- a/WoofWare.PawPrint.Test/TestNativeRuntimeMethodHandle.fs
+++ b/WoofWare.PawPrint.Test/TestNativeRuntimeMethodHandle.fs
@@ -1,13 +1,19 @@
 namespace WoofWare.PawPrint.Test
 
+open System.Reflection
+open System.Reflection.Metadata.Ecma335
 open FsCheck
 open FsCheck.FSharp
 open FsUnitTyped
 open NUnit.Framework
 open WoofWare.PawPrint
 
-/// Tests for the predicate behind the `RuntimeMethodHandle.IsGenericMethodDefinition`
-/// InternalCall (NativeRuntimeMethodHandle.fs).
+/// Tests for the pure cores of the `RuntimeMethodHandle` natives (NativeRuntimeMethodHandle.fs):
+/// `isGenericMethodDefinition` (behind the `IsGenericMethodDefinition` InternalCall) and
+/// `methodInstantiationTargets` (behind the `RuntimeMethodHandle_GetMethodInstantiation` QCall).
+/// Each has partial end-to-end coverage in `sourcesPure/`; these tests pin the arms that are not
+/// yet reachable end-to-end, plus the ordering and fail-loud behaviour that a passing end-to-end
+/// case would not distinguish.
 ///
 /// The end-to-end coverage lives in `sourcesPure/MethodIsGenericMethodDefinition.cs`, which pins
 /// two of the predicate's three arms: a generic method definition, and a plain non-generic
@@ -75,3 +81,129 @@ module TestNativeRuntimeMethodHandle =
             NativeRuntimeMethodHandle.isGenericMethodDefinition methodGenericParamCount 0
 
         Check.One (propertyConfig, property)
+
+    // ---------------------------------------------------------------------------------------
+    // `methodInstantiationTargets`: the instantiation reported by CoreCLR's
+    // `MethodDesc::LoadMethodInstantiation`, which backs the
+    // `RuntimeMethodHandle_GetMethodInstantiation` QCall.
+    //
+    // End-to-end coverage lives in `sourcesPure/MethodGetGenericArguments.cs`, but that can only
+    // reach the unbound arms: PawPrint has no reflection path yet that hands the BCL a *bound*
+    // method handle (see that file's comment). These tests pin all three arms directly.
+    // ---------------------------------------------------------------------------------------
+
+    let private operation : string = "test"
+
+    /// Synthetic declaring type. `methodInstantiationTargets` is pure: it never dereferences the
+    /// identity or the MethodDef token, it only copies them into each result element, so entirely
+    /// fabricated metadata handles are sufficient (and keep the test independent of any assembly).
+    let private declaringType : ResolvedTypeIdentity =
+        ResolvedTypeIdentity.ofTypeDefinition
+            (AssemblyName "Synthetic.Assembly")
+            (MetadataTokens.TypeDefinitionHandle 1)
+
+    let private methodDefinition : ComparableMethodDefinitionHandle =
+        ComparableMethodDefinitionHandle.Make (MetadataTokens.MethodDefinitionHandle 7)
+
+    let private syntheticArgument (index : int) : ConcreteTypeHandle =
+        ConcreteTypeHandle.Concrete (100 + index)
+
+    /// A *consistent* (declared-count, handle-instantiation) pair: either the handle is unbound
+    /// (the method definition / non-generic case) or it binds exactly as many arguments as the
+    /// method declares. Generating the consistency by construction matters: an unconstrained pair
+    /// would almost always be inconsistent, and every such case takes the fail-loud path instead
+    /// of exercising the arms these properties are about. The mismatch path is pinned separately
+    /// below.
+    let private consistentInstantiation : Gen<int * ConcreteTypeHandle list> =
+        gen {
+            let! declaredCount = Gen.choose (0, 8)
+            let! bound = Gen.elements [ true ; false ]
+
+            let handleInstantiation =
+                if bound then
+                    List.init declaredCount syntheticArgument
+                else
+                    []
+
+            return declaredCount, handleInstantiation
+        }
+
+    let private targetsFor
+        (declaredCount : int)
+        (handleInstantiation : ConcreteTypeHandle list)
+        : RuntimeTypeHandleTarget list
+        =
+        NativeRuntimeMethodHandle.methodInstantiationTargets
+            operation
+            declaringType
+            methodDefinition
+            declaredCount
+            handleInstantiation
+
+    [<Test>]
+    let ``property: the instantiation always has one element per declared generic parameter`` () : unit =
+        let property (declaredCount : int, handleInstantiation : ConcreteTypeHandle list) : bool =
+            List.length (targetsFor declaredCount handleInstantiation) = declaredCount
+
+        Check.One (propertyConfig, Prop.forAll (Arb.fromGen consistentInstantiation) property)
+
+    [<Test>]
+    let ``property: a generic method definition reports its own type variables, in declaration order`` () : unit =
+        let property (declaredCount : int) : bool =
+            let declaredCount = 1 + abs (declaredCount % 8)
+
+            let expected : RuntimeTypeHandleTarget list =
+                List.init
+                    declaredCount
+                    (fun position ->
+                        RuntimeTypeHandleTarget.MethodGenericParameter (declaringType, methodDefinition, position)
+                    )
+
+            // Precondition of this arm, stated in terms of the classifier the implementation uses.
+            NativeRuntimeMethodHandle.isGenericMethodDefinition declaredCount 0
+            && targetsFor declaredCount [] = expected
+
+        Check.One (propertyConfig, property)
+
+    [<Test>]
+    let ``property: a bound handle reports exactly its type arguments, order-preserving`` () : unit =
+        let property (declaredCount : int) : bool =
+            let declaredCount = 1 + abs (declaredCount % 8)
+            let handleInstantiation = List.init declaredCount syntheticArgument
+
+            let expected : RuntimeTypeHandleTarget list =
+                handleInstantiation |> List.map RuntimeTypeHandleTarget.Closed
+
+            targetsFor declaredCount handleInstantiation = expected
+
+        Check.One (propertyConfig, property)
+
+    [<Test>]
+    let ``a non-generic method has an empty instantiation`` () : unit = targetsFor 0 [] |> shouldEqual []
+
+    [<Test>]
+    let ``property: a handle whose instantiation disagrees with the metadata is rejected`` () : unit =
+        let property (declaredCount : int, boundCount : int) : bool =
+            let declaredCount = abs (declaredCount % 8)
+            let boundCount = 1 + abs (boundCount % 8)
+
+            if boundCount = declaredCount then
+                // Not a mismatch; nothing to assert.
+                true
+            else
+                let handleInstantiation = List.init boundCount syntheticArgument
+
+                try
+                    targetsFor declaredCount handleInstantiation
+                    |> ignore<RuntimeTypeHandleTarget list>
+
+                    false
+                with _ ->
+                    true
+
+        Check.One (propertyConfig, property)
+
+    [<Test>]
+    let ``a negative declared generic-parameter count is rejected`` () : unit =
+        (fun () -> targetsFor -1 [] |> ignore<RuntimeTypeHandleTarget list>)
+        |> shouldFail<exn>

--- a/WoofWare.PawPrint.Test/sourcesPure/MethodGetGenericArguments.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/MethodGetGenericArguments.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Reflection;
+
+class Program
+{
+    static void Generic<T>()
+    {
+    }
+
+    static void NotGeneric()
+    {
+    }
+
+    static int Main(string[] args)
+    {
+        // Exercises the `RuntimeMethodHandle_GetMethodInstantiation` QCall, which materialises a
+        // method's instantiation as a managed array handed back through an ObjectHandleOnStack.
+        //
+        // The declaring type is deliberately non-generic, for the same reason as in
+        // MethodIsGenericMethodDefinition.cs: reflecting any method off a generic type currently
+        // hits unrelated pre-existing gaps (`RuntimeMethodHandle_GetStubIfNeededSlow` for a closed
+        // instantiation, `RuntimeTypeHandle.GetNumVirtuals` for an open generic type definition).
+        MethodInfo genericDef = typeof (Program).GetMethod (
+            "Generic",
+            BindingFlags.Static | BindingFlags.NonPublic
+        );
+
+        if (genericDef == null)
+            return 1;
+
+        // `GetGenericArguments()` is `GetMethodInstantiationPublic(this) ?? Type.EmptyTypes`, i.e.
+        // the Interop.BOOL.FALSE / `Type[]` arm of the QCall.
+        //
+        // For a generic method *definition* CoreCLR's `MethodDesc::LoadMethodInstantiation` reports
+        // the method's own type variables rather than an empty instantiation, so this is `[T]`.
+        Type[] arguments = genericDef.GetGenericArguments ();
+
+        if (arguments.Length != 1)
+            return 2;
+
+        if (!arguments[0].IsGenericParameter)
+            return 3;
+
+        if (arguments[0].GenericParameterPosition != 0)
+            return 4;
+
+        // A non-generic method has an empty instantiation. CoreCLR's `CopyRuntimeTypeHandles`
+        // returns NULL rather than a zero-length array for that case, so the QCall leaves the
+        // caller's local null and the managed wrapper's `?? Type.EmptyTypes` supplies the empty
+        // array; this pins that the QCall does not instead write a wrongly-shaped array.
+        MethodInfo plain = typeof (Program).GetMethod ("NotGeneric", BindingFlags.Static | BindingFlags.NonPublic);
+
+        if (plain == null)
+            return 5;
+
+        if (plain.GetGenericArguments ().Length != 0)
+            return 6;
+
+        // The third arm of the QCall -- a handle that *binds* concrete type arguments, which must
+        // report those arguments rather than the method's type variables -- is not exercised here.
+        // Producing such a handle through reflection requires `MakeGenericMethod`, which routes
+        // through `RuntimeMethodHandle.GetStubIfNeeded`'s slow path and reaches the unimplemented
+        // `RuntimeMethodHandle_GetStubIfNeededSlow` QCall. That arm is pinned directly against
+        // `NativeRuntimeMethodHandle.methodInstantiationTargets` in TestNativeRuntimeMethodHandle.fs.
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -10,6 +10,8 @@ module NativeQCall =
             NativeRuntimeFieldHandle.tryExecuteQCall "RuntimeFieldHandle_GetRVAFieldInfo"
             "RuntimeMethodHandle_IsCAVisibleFromDecoratedType",
             NativeRuntimeMethodHandle.tryExecuteQCall "RuntimeMethodHandle_IsCAVisibleFromDecoratedType"
+            "RuntimeMethodHandle_GetMethodInstantiation",
+            NativeRuntimeMethodHandle.tryExecuteQCall "RuntimeMethodHandle_GetMethodInstantiation"
             "QCall_GetGCHandleForTypeHandle", NativeGcHandle.tryExecuteQCall "QCall_GetGCHandleForTypeHandle"
             "QCall_FreeGCHandleForTypeHandle", NativeGcHandle.tryExecuteQCall "QCall_FreeGCHandleForTypeHandle"
             "MarshalNative_SizeOfHelper", NativeMarshal.tryExecuteQCall "MarshalNative_SizeOfHelper"

--- a/WoofWare.PawPrint/Native/NativeRuntimeMethodHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeMethodHandle.fs
@@ -24,11 +24,63 @@ module NativeRuntimeMethodHandle =
     let isGenericMethodDefinition (methodGenericParamCount : int) (handleInstantiationCount : int) : bool =
         methodGenericParamCount > 0 && handleInstantiationCount = 0
 
-    let private resolveMethodInfoFromHandleArg
+    /// The instantiation CoreCLR's `MethodDesc::LoadMethodInstantiation` (method.cpp:793) reports
+    /// for a method, expressed over PawPrint's representation so it can be pinned independently of
+    /// the QCall plumbing. The two counts are exactly the ones `isGenericMethodDefinition` above
+    /// consumes, and the three arms line up with `MethodDesc::GetMethodInstantiation`
+    /// (method.hpp:3787):
+    ///  - a non-generic method is never `mcInstantiated`, so its instantiation is empty;
+    ///  - a *generic method definition* (the typical form: the method declares type parameters but
+    ///    this handle binds none) reports its own type variables, i.e. `[T]` for `void Foo&lt;T&gt;()`.
+    ///    This is not an empty list: `IMD_GetMethodInstantiation` (method.hpp:3531) returns the
+    ///    typical instantiation's `TypeVarTypeDesc`s;
+    ///  - an instantiated generic method reports the type arguments bound to the handle.
+    ///
+    /// <c>declaringType</c> is the *uninstantiated* metadata identity of the type that declares the
+    /// method, which is what <c>RuntimeTypeHandleTarget.MethodGenericParameter</c> carries (a
+    /// <c>ResolvedTypeIdentity</c> has no room for an instantiation). That is not a lossy shortcut:
+    /// CoreCLR canonicalises the same way, redirecting any non-typical generic method definition to
+    /// <c>LoadTypicalMethodDefinition()->GetMethodInstantiation()</c> (method.cpp:803-806), so a
+    /// method's type variables are reported against the typical declaring type however the handle
+    /// was reached.
+    let methodInstantiationTargets
+        (operation : string)
+        (declaringType : ResolvedTypeIdentity)
+        (methodDefinition : ComparableMethodDefinitionHandle)
+        (methodGenericParamCount : int)
+        (handleInstantiation : ConcreteTypeHandle list)
+        : RuntimeTypeHandleTarget list
+        =
+        if methodGenericParamCount < 0 then
+            failwith
+                $"%s{operation}: method %O{methodDefinition.Get} reported a negative generic-parameter count %d{methodGenericParamCount}"
+
+        match handleInstantiation with
+        | [] ->
+            if isGenericMethodDefinition methodGenericParamCount 0 then
+                List.init
+                    methodGenericParamCount
+                    (fun position ->
+                        RuntimeTypeHandleTarget.MethodGenericParameter (declaringType, methodDefinition, position)
+                    )
+            else
+                []
+        | _ ->
+            // A bound handle must bind exactly as many arguments as the method declares. A
+            // mismatch means the registry and the metadata disagree about the same method, which
+            // would silently produce a wrong-length `RuntimeType[]`; refuse instead.
+            if List.length handleInstantiation <> methodGenericParamCount then
+                failwith
+                    $"%s{operation}: method %O{methodDefinition.Get} on %O{declaringType.TypeDefinition.Get} declares %d{methodGenericParamCount} generic parameters but its handle binds %d{List.length handleInstantiation} type arguments"
+
+            handleInstantiation |> List.map RuntimeTypeHandleTarget.Closed
+
+    /// Resolve a `RuntimeMethodHandleInternal` argument to the `MethodHandle` it denotes.
+    let private resolveMethodHandleFromArg
         (operation : string)
         (state : IlMachineState)
         (arg : CliType)
-        : MethodInfo<GenericParamFromMetadata, GenericParamFromMetadata, TypeDefn>
+        : MethodHandle
         =
         // CoreCLR's RuntimeMethodHandle FCalls dereference the MethodDesc* directly and
         // assert non-null; PawPrint's existing callers never yield a null handle, so we
@@ -37,12 +89,18 @@ module NativeRuntimeMethodHandle =
             NativeCall.methodHandleIdOfRuntimeMethodHandleInternal operation arg
             |> Option.defaultWith (fun () -> failwith $"%s{operation}: null RuntimeMethodHandleInternal")
 
-        let methodHandle =
-            MethodHandleRegistry.resolveMethodFromId methodHandleId state.MethodHandles
-            |> Option.defaultWith (fun () ->
-                failwith $"%s{operation}: registry id %d{methodHandleId} did not resolve to a known MethodHandle"
-            )
+        MethodHandleRegistry.resolveMethodFromId methodHandleId state.MethodHandles
+        |> Option.defaultWith (fun () ->
+            failwith $"%s{operation}: registry id %d{methodHandleId} did not resolve to a known MethodHandle"
+        )
 
+    /// The metadata `MethodInfo` the given handle's MethodDef token names.
+    let private methodInfoOfMethodHandle
+        (operation : string)
+        (state : IlMachineState)
+        (methodHandle : MethodHandle)
+        : MethodInfo<GenericParamFromMetadata, GenericParamFromMetadata, TypeDefn>
+        =
         let assemblyFullName = methodHandle.GetAssemblyFullName ()
 
         let assembly =
@@ -58,6 +116,15 @@ module NativeRuntimeMethodHandle =
             failwith $"%s{operation}: MethodDef %O{methodDefHandle} not found in assembly %s{assemblyFullName}"
 
         methodInfo
+
+    let private resolveMethodInfoFromHandleArg
+        (operation : string)
+        (state : IlMachineState)
+        (arg : CliType)
+        : MethodInfo<GenericParamFromMetadata, GenericParamFromMetadata, TypeDefn>
+        =
+        resolveMethodHandleFromArg operation state arg
+        |> methodInfoOfMethodHandle operation state
 
     /// Resolve a <c>QCallTypeHandle</c>-encoded type to its
     /// <c>(DumpedAssembly, TypeInfo)</c>, accepting the MethodTable-backed
@@ -320,6 +387,77 @@ module NativeRuntimeMethodHandle =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 ret)) ctx.Thread state
 
             NativeHandlerResult.completed state |> Some
+        | "RuntimeMethodHandle_GetMethodInstantiation",
+          "System.Private.CoreLib",
+          "System",
+          "RuntimeMethodHandle",
+          "GetMethodInstantiation",
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System",
+                                              "RuntimeMethodHandleInternal",
+                                              handleGenerics)
+            ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "ObjectHandleOnStack",
+                                              objectHandleGenerics)
+            ConcreteType state.ConcreteTypes ("System.Private.CoreLib", "", "BOOL", boolGenerics) ],
+          MethodReturnType.Void when handleGenerics.IsEmpty && objectHandleGenerics.IsEmpty && boolGenerics.IsEmpty ->
+            // CoreCLR runtimehandles.cpp:1708:
+            //   Instantiation inst = pMethod->LoadMethodInstantiation();
+            //   retTypes.Set(CopyRuntimeTypeHandles(inst.GetRawArgs(), inst.GetNumArgs(),
+            //                                       fAsRuntimeTypeArray ? CLASS__CLASS : CLASS__TYPE));
+            // See `methodInstantiationTargets` above for the instantiation itself.
+            let operation = "RuntimeMethodHandle.GetMethodInstantiation"
+
+            if instruction.Arguments.Length <> 3 then
+                failwith $"%s{operation}: expected three native arguments, got %d{instruction.Arguments.Length}"
+
+            let methodHandle =
+                resolveMethodHandleFromArg operation state instruction.Arguments.[0]
+
+            let methodInfo = methodInfoOfMethodHandle operation state methodHandle
+
+            let retTypes =
+                NativeCall.objectHandleOnStackTarget operation state "retTypes" instruction.Arguments.[1]
+
+            // Interop.BOOL is an int32-backed enum. TRUE selects RuntimeType[] (CLASS__CLASS);
+            // FALSE selects Type[] (CLASS__TYPE).
+            let asRuntimeTypeArray =
+                match CliType.unwrapPrimitiveLikeDeep instruction.Arguments.[2] with
+                | CliType.Numeric (CliNumericType.Int32 i) -> i <> 0
+                | other -> failwith $"%s{operation}: expected Interop.BOOL as Int32, got %O{other}"
+
+            let targets =
+                methodInstantiationTargets
+                    operation
+                    methodInfo.DeclaringType.Identity
+                    (methodHandle.GetMethodDefinitionHandle ())
+                    methodInfo.Generics.Length
+                    (methodHandle.GetMethodGenerics ())
+
+            // An empty instantiation leaves `retTypes` unwritten, so the caller's local stays
+            // null. That is what CopyRuntimeTypeHandles does for 0 args (runtimehandles.cpp:573),
+            // and the managed wrappers are written for it: `GetMethodInstantiationPublic` launders
+            // the null through `?? Type.EmptyTypes` (RuntimeMethodInfo.CoreCLR.cs:461), while
+            // `GetMethodInstantiationInternal` propagates it via a null-forgiving `types!`
+            // (RuntimeHandles.cs:1217). The latter's nullable-oblivious signature is not a claim
+            // that the null never arrives: `RuntimeType.GetMethodBase` calls it whenever the
+            // handle is not a generic method *definition* -- which includes every non-generic
+            // method -- and deliberately tolerates the result being null, passing it on to
+            // `GetStubIfNeeded` under the comment "If methodInstantiation is not null,
+            // GetStubIfNeeded will rebind the generic method arguments"
+            // (RuntimeType.CoreCLR.cs:1905-1929). So writing a zero-length array here instead
+            // would be observably wrong, not merely redundant.
+            let state =
+                NativeRuntimeTypeHelpers.copyRuntimeTypeHandles
+                    ctx.LoggerFactory
+                    ctx.BaseClassTypes
+                    state
+                    asRuntimeTypeArray
+                    retTypes
+                    targets
+
+            NativeHandlerResult.completed state |> Some
         | _ -> None
 
     let tryExecute (ctx : NativeCallContext) : NativeHandlerResult option =
@@ -405,18 +543,10 @@ module NativeRuntimeMethodHandle =
             // PawPrint's representation.
             let operation = "RuntimeMethodHandle.IsGenericMethodDefinition"
 
-            let methodInfo =
-                resolveMethodInfoFromHandleArg operation state instruction.Arguments.[0]
-
-            let methodHandleId =
-                NativeCall.methodHandleIdOfRuntimeMethodHandleInternal operation instruction.Arguments.[0]
-                |> Option.defaultWith (fun () -> failwith $"%s{operation}: null RuntimeMethodHandleInternal")
-
             let methodHandle =
-                MethodHandleRegistry.resolveMethodFromId methodHandleId state.MethodHandles
-                |> Option.defaultWith (fun () ->
-                    failwith $"%s{operation}: registry id %d{methodHandleId} did not resolve to a known MethodHandle"
-                )
+                resolveMethodHandleFromArg operation state instruction.Arguments.[0]
+
+            let methodInfo = methodInfoOfMethodHandle operation state methodHandle
 
             let result =
                 isGenericMethodDefinition methodInfo.Generics.Length (methodHandle.GetMethodGenerics ()).Length

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
@@ -1705,3 +1705,57 @@ module NativeRuntimeTypeHelpers =
 
             let parameter, _ = methodInfo.Generics.[position]
             parameter.Name
+
+    /// PawPrint's rendering of CoreCLR's `CopyRuntimeTypeHandles` (runtimehandles.cpp:561), the
+    /// single helper behind every QCall that hands a type list back through an
+    /// `ObjectHandleOnStack`: `RuntimeTypeHandle_GetInstantiation`,
+    /// `RuntimeTypeHandle_GetConstraints`, and `RuntimeMethodHandle_GetMethodInstantiation`.
+    ///
+    /// `asRuntimeTypeArray` is the upstream `BinderClassID` choice: `CLASS__CLASS`
+    /// (`RuntimeType[]`) when true, `CLASS__TYPE` (`Type[]`) when false. Every element is the same
+    /// `RuntimeType` object either way; only the array's element type differs, and the BCL casts
+    /// the result to whichever it asked for.
+    ///
+    /// When `targets` is empty, CoreCLR returns NULL rather than a zero-length array
+    /// (runtimehandles.cpp:573), so we leave `destination` untouched: every managed caller
+    /// initialises its local to `null` before the QCall, and either tolerates that null or
+    /// launders it through `?? Type.EmptyTypes`.
+    let copyRuntimeTypeHandles
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (asRuntimeTypeArray : bool)
+        (destination : ManagedPointerSource)
+        (targets : RuntimeTypeHandleTarget list)
+        : IlMachineState
+        =
+        match targets with
+        | [] -> state
+        | _ ->
+
+        let elementTypeName = if asRuntimeTypeArray then "RuntimeType" else "Type"
+
+        let state, _, elementTypeHandle =
+            concretizeNonGenericCorelibType loggerFactory baseClassTypes state "System" elementTypeName
+
+        let arrayAddr, state =
+            IlMachineState.allocateArray
+                (ConcreteTypeHandle.OneDimArrayZero elementTypeHandle)
+                (fun () -> CliType.ObjectRef None)
+                (List.length targets)
+                state
+
+        let state =
+            ((state, 0), targets)
+            ||> List.fold (fun (state, index) target ->
+                let runtimeTypeAddr, state =
+                    IlMachineState.getOrAllocateType loggerFactory baseClassTypes target state
+
+                let state =
+                    IlMachineState.setArrayValue arrayAddr (CliType.ObjectRef (Some runtimeTypeAddr)) index state
+
+                state, index + 1
+            )
+            |> fst
+
+        IlMachineState.writeManagedByrefWithBase baseClassTypes state destination (CliType.ObjectRef (Some arrayAddr))

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
@@ -282,7 +282,7 @@ module NativeRuntimeTypeQCall =
                 | CliType.Numeric (CliNumericType.Int32 i) -> i <> 0
                 | other -> failwith $"%s{operation}: expected Interop.BOOL as Int32, got %O{other}"
 
-            let genericArgumentTargets : ImmutableArray<RuntimeTypeHandleTarget> =
+            let genericArgumentTargets : RuntimeTypeHandleTarget list =
                 match typeHandleTarget with
                 | RuntimeTypeHandleTarget.Closed handle ->
                     match handle with
@@ -293,9 +293,7 @@ module NativeRuntimeTypeQCall =
                                 failwith $"%s{operation}: concrete type handle was not registered: %O{handle}"
                             )
 
-                        concreteType.Generics
-                        |> Seq.map RuntimeTypeHandleTarget.Closed
-                        |> ImmutableArray.CreateRange
+                        concreteType.Generics |> Seq.map RuntimeTypeHandleTarget.Closed |> List.ofSeq
                     | ConcreteTypeHandle.Byref _
                     | ConcreteTypeHandle.Pointer _
                     | ConcreteTypeHandle.FunctionPointer _
@@ -304,7 +302,7 @@ module NativeRuntimeTypeQCall =
                         // Real .NET strips array/byref/pointer wrappers via GetRootElementType
                         // before reaching this QCall, but be defensive: these wrappers carry
                         // no generic instantiation of their own.
-                        ImmutableArray.Empty
+                        []
                 | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
                     // Real .NET returns Type[] { typeof(T), ... } where each T is a generic
                     // type parameter. We surface each parameter as a RuntimeType backed by a
@@ -322,58 +320,28 @@ module NativeRuntimeTypeQCall =
                         failwith
                             $"%s{operation}: open generic type definition %O{identity} declares no generic parameters"
 
-                    Seq.init
+                    List.init
                         typeInfo.Generics.Length
                         (fun position -> RuntimeTypeHandleTarget.GenericParameter (identity, position))
-                    |> ImmutableArray.CreateRange
                 | RuntimeTypeHandleTarget.GenericParameter _
                 | RuntimeTypeHandleTarget.MethodGenericParameter _ ->
                     // GetInstantiation on a generic parameter T returns Type.EmptyTypes in CoreCLR,
                     // because a parameter has no instantiation of its own.
-                    ImmutableArray.Empty
+                    []
 
-            // Empty: leave the caller's local null. RuntimeType.GetGenericArguments handles
-            // null via `?? EmptyTypes`, matching native CopyRuntimeTypeHandles for 0 args.
-            if genericArgumentTargets.IsEmpty then
-                NativeHandlerResult.completed state |> Some
-            else
-                let elementTypeName = if asRuntimeTypeArray then "RuntimeType" else "Type"
+            // `copyRuntimeTypeHandles` leaves the caller's local null when the list is empty,
+            // matching native CopyRuntimeTypeHandles for 0 args; RuntimeType.GetGenericArguments
+            // handles that null via `?? EmptyTypes`.
+            let state =
+                copyRuntimeTypeHandles
+                    ctx.LoggerFactory
+                    ctx.BaseClassTypes
+                    state
+                    asRuntimeTypeArray
+                    retTypes
+                    genericArgumentTargets
 
-                let state, _, elementTypeHandle =
-                    concretizeNonGenericCorelibType ctx.LoggerFactory ctx.BaseClassTypes state "System" elementTypeName
-
-                let arrayAddr, state =
-                    IlMachineState.allocateArray
-                        (ConcreteTypeHandle.OneDimArrayZero elementTypeHandle)
-                        (fun () -> CliType.ObjectRef None)
-                        genericArgumentTargets.Length
-                        state
-
-                let state =
-                    ((state, 0), genericArgumentTargets)
-                    ||> Seq.fold (fun (state, index) target ->
-                        let runtimeTypeAddr, state =
-                            IlMachineState.getOrAllocateType ctx.LoggerFactory ctx.BaseClassTypes target state
-
-                        let state =
-                            IlMachineState.setArrayValue
-                                arrayAddr
-                                (CliType.ObjectRef (Some runtimeTypeAddr))
-                                index
-                                state
-
-                        state, index + 1
-                    )
-                    |> fst
-
-                let state =
-                    IlMachineState.writeManagedByrefWithBase
-                        ctx.BaseClassTypes
-                        state
-                        retTypes
-                        (CliType.ObjectRef (Some arrayAddr))
-
-                NativeHandlerResult.completed state |> Some
+            NativeHandlerResult.completed state |> Some
         | "RuntimeTypeHandle_GetConstraints",
           "System.Private.CoreLib",
           "System",

--- a/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
+++ b/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
@@ -95,7 +95,6 @@
     <Compile Include="Native\NativeMonitor.fs" />
     <Compile Include="Native\NativeMetadataImport.fs" />
     <Compile Include="Native\NativeRuntimeFieldHandle.fs" />
-    <Compile Include="Native\NativeRuntimeMethodHandle.fs" />
     <Compile Include="Native\NativeRuntimeHelpers.fs" />
     <Compile Include="Native\NativeMarshal.fs" />
     <Compile Include="Native\NativeGcHandle.fs" />
@@ -103,6 +102,10 @@
     <Compile Include="Native\NativeBuffer.fs" />
     <Compile Include="Native\NativeException.fs" />
     <Compile Include="Native\NativeRuntimeTypeHelpers.fs" />
+    <!-- After NativeRuntimeTypeHelpers.fs: the RuntimeMethodHandle QCalls share that module's
+         `copyRuntimeTypeHandles` (CoreCLR's runtimehandles.cpp helper of the same name) with the
+         RuntimeTypeHandle QCalls. -->
+    <Compile Include="Native\NativeRuntimeMethodHandle.fs" />
     <Compile Include="Native\NativeSignature.fs" />
     <Compile Include="Native\NativeRuntimeTypeQCall.fs" />
     <Compile Include="Native\NativeRuntimeTypeFCall.fs" />


### PR DESCRIPTION
Closes #718.

Unlike its scalar neighbours in `NativeRuntimeMethodHandle.fs`, this QCall has to materialise a method's instantiation as a managed `RuntimeType[]`/`Type[]` and write it back through an `ObjectHandleOnStack`. CoreCLR (runtimehandles.cpp:1708) is:

```cpp
Instantiation inst = pMethod->LoadMethodInstantiation();
retTypes.Set(CopyRuntimeTypeHandles(inst.GetRawArgs(), inst.GetNumArgs(),
                                    fAsRuntimeTypeArray ? CLASS__CLASS : CLASS__TYPE));
```

Two parts of that are easy to get wrong, so both are pinned by tests:

* **`LoadMethodInstantiation` on a *generic method definition* reports the method's own type variables, not an empty instantiation** (method.hpp:3531). So `typeof(X).GetMethod("Foo").GetGenericArguments()` is `[T]`. This makes the change the repo's first-ever *producer* of `RuntimeTypeHandleTarget.MethodGenericParameter`, which until now was matched everywhere and constructed nowhere.
* **`CopyRuntimeTypeHandles` returns NULL rather than a zero-length array for an empty instantiation** (runtimehandles.cpp:573), so the QCall must leave the caller's local null. That is not merely a redundant-allocation question: `RuntimeType.GetMethodBase` calls `GetMethodInstantiationInternal` whenever the handle is not a generic method *definition* — which includes every non-generic method — and branches on the result being null (RuntimeType.CoreCLR.cs:1905-1929).

## Structure

The branch selection is extracted as the pure `methodInstantiationTargets`. It reuses the existing `isGenericMethodDefinition` classifier to justify the type-variable arm (keeping that classifier load-bearing rather than duplicating its condition), and refuses a handle whose bound-argument count disagrees with the metadata rather than silently producing a wrong-length array.

The array materialisation is the same upstream primitive that `RuntimeTypeHandle_GetInstantiation` already renders, so rather than duplicating the subtle null-for-empty rule it is extracted as `NativeRuntimeTypeHelpers.copyRuntimeTypeHandles` and shared by both arms. That requires moving `NativeRuntimeMethodHandle.fs` after `NativeRuntimeTypeHelpers.fs` in the fsproj; only `NativeQCall.fs` and `NativeDispatch.fs` reference it and both come later. The alternative of placing the helper in the earlier `NativeCall.fs` was rejected: it would need `concretizeNonGenericCorelibType` too, so callers would have to pre-resolve the element type and pass it in, dissolving the point of sharing.

## SprintfBasic

The issue's repro advances past this QCall and now stops at `RuntimeMethodHandle_GetStubIfNeededSlow`, so it stays in `TestFSharpPureCases.unimplemented` with an updated reason (one feature at a time, per AGENTS.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)