### PR TITLE
Give arrays an object header, so Monitor.Enter works on them

### DIFF
--- a/WoofWare.PawPrint.App/DebuggerServer.fs
+++ b/WoofWare.PawPrint.App/DebuggerServer.fs
@@ -760,7 +760,7 @@ module DebuggerServer =
             writer.WriteString ("concreteType", string object.ConcreteType)
             writer.WriteString ("contents", string object.Contents)
             writeOptionalString writer "string" (ManagedHeap.getStringContents address state.ManagedHeap)
-            writer.WriteString ("syncBlock", string object.SyncBlock)
+            writer.WriteString ("syncBlock", string (ManagedHeap.getSyncBlock address state.ManagedHeap))
         | None ->
             match state.ManagedHeap.Arrays |> Map.tryFind address with
             | Some array ->
@@ -768,6 +768,9 @@ module DebuggerServer =
                 writer.WriteString ("concreteType", string array.ConcreteType)
                 writer.WriteNumber ("length", array.Length)
                 writeValueArray writer "elements" array.Elements writeCliType
+                // Arrays carry an object header exactly like any other heap object, so a
+                // `lock (array)` is visible here too.
+                writer.WriteString ("syncBlock", string (ManagedHeap.getSyncBlock address state.ManagedHeap))
             | None ->
                 writer.WriteString ("kind", "missing")
                 writer.WriteString ("error", $"heap address %d{heapAddressValue address} does not exist")

--- a/WoofWare.PawPrint.Test/TestManagedHeap.fs
+++ b/WoofWare.PawPrint.Test/TestManagedHeap.fs
@@ -3,6 +3,8 @@ namespace WoofWare.PawPrint.Test
 open System.Collections.Generic
 open System.Collections.Immutable
 open System.IO
+open FsCheck
+open FsCheck.FSharp
 open FsUnitTyped
 open NUnit.Framework
 open WoofWare.PawPrint
@@ -357,3 +359,172 @@ module TestManagedHeap =
             )
 
         exn.Message |> shouldContainText "negative length"
+
+    // ---------------------------------------------------------------------
+    // Sync blocks (object headers).
+    //
+    // In CoreCLR every heap object carries an `ObjHeader` immediately before
+    // its payload, arrays and strings included (`src/coreclr/vm/object.h`);
+    // there is no array-shaped carve-out. So the sync block belongs to the
+    // *address*, not to the kind of payload stored there, and every live
+    // address must have exactly one.
+    // ---------------------------------------------------------------------
+
+    let private stubArray (length : int) : AllocatedArray =
+        {
+            ConcreteType = ConcreteTypeHandle.OneDimArrayZero (ConcreteTypeHandle.Concrete 1)
+            Length = length
+            Lengths = ImmutableArray.Create length
+            Elements =
+                Seq.replicate length (CliType.Numeric (CliNumericType.Int32 0))
+                |> ImmutableArray.CreateRange
+        }
+
+    /// A placeholder non-array object whose payload is never inspected by the
+    /// sync-block machinery. Constructed as `Unchecked.defaultof<_>` because
+    /// minting a real `CliValueType` needs `BaseClassTypes` plumbing that is
+    /// irrelevant here; if the sync-block code ever starts reading the payload,
+    /// these tests fail loudly with an NRE instead of silently passing.
+    let private stubNonArray : AllocatedNonArrayObject =
+        {
+            Contents = Unchecked.defaultof<CliValueType>
+            ConcreteType = ConcreteTypeHandle.Concrete 0
+        }
+
+    [<Test>]
+    let ``a freshly allocated array has an empty sync block`` () : unit =
+        let addr, heap = ManagedHeap.allocateArray (stubArray 3) ManagedHeap.empty
+
+        ManagedHeap.getSyncBlock addr heap |> shouldEqual SyncBlock.Empty
+
+    [<Test>]
+    let ``setSyncBlock then getSyncBlock round-trips on an array`` () : unit =
+        let addr, heap = ManagedHeap.allocateArray (stubArray 3) ManagedHeap.empty
+
+        let held : SyncBlock =
+            {
+                Lock =
+                    SyncBlockLock.Held
+                        {
+                            LockingThread = ThreadId 7
+                            ReentrancyCount = 2
+                            AcquireQueue = [ ThreadId 9, None ]
+                        }
+                WaitQueue = [ ThreadId 11, 1 ]
+            }
+
+        let heap = ManagedHeap.setSyncBlock addr held heap
+
+        ManagedHeap.getSyncBlock addr heap |> shouldEqual held
+
+    [<Test>]
+    let ``locking one array does not lock another`` () : unit =
+        let addr1, heap = ManagedHeap.allocateArray (stubArray 1) ManagedHeap.empty
+        let addr2, heap = ManagedHeap.allocateArray (stubArray 1) heap
+        let objAddr, heap = ManagedHeap.allocateNonArray stubNonArray heap
+
+        let held : SyncBlock =
+            {
+                Lock =
+                    SyncBlockLock.Held
+                        {
+                            LockingThread = ThreadId 1
+                            ReentrancyCount = 1
+                            AcquireQueue = []
+                        }
+                WaitQueue = []
+            }
+
+        let heap = ManagedHeap.setSyncBlock addr1 held heap
+
+        ManagedHeap.getSyncBlock addr1 heap |> shouldEqual held
+        ManagedHeap.getSyncBlock addr2 heap |> shouldEqual SyncBlock.Empty
+        ManagedHeap.getSyncBlock objAddr heap |> shouldEqual SyncBlock.Empty
+
+    [<Test>]
+    let ``getSyncBlock fails loudly for an address that was never allocated`` () : unit =
+        let exn =
+            Assert.Throws<System.Exception> (fun () ->
+                ManagedHeap.getSyncBlock (ManagedHeapAddress 42) ManagedHeap.empty |> ignore
+            )
+
+        exn.Message |> shouldContainText "not a live managed heap allocation"
+
+    [<Test>]
+    let ``setSyncBlock fails loudly for an address that was never allocated`` () : unit =
+        let exn =
+            Assert.Throws<System.Exception> (fun () ->
+                ManagedHeap.setSyncBlock (ManagedHeapAddress 42) SyncBlock.Empty ManagedHeap.empty
+                |> ignore
+            )
+
+        exn.Message |> shouldContainText "not a live managed heap allocation"
+
+    [<Test>]
+    let ``cloneArray gives the copy a fresh sync block, not the source's lock state`` () : unit =
+        // `Array.Clone` copies the elements, never the object header: the clone is a
+        // brand-new object and cannot inherit the source's monitor ownership or its
+        // queues. Getting this wrong would let `lock (source)` leak onto the clone.
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        let state = state loggerFactory
+
+        let elementHandle = ConcreteTypeHandle.Concrete 1
+        let arrayHandle = ConcreteTypeHandle.OneDimArrayZero elementHandle
+        let zero = CliType.Numeric (CliNumericType.Int32 0)
+
+        let source, state =
+            IlMachineState.allocateArray arrayHandle (fun () -> zero) 2 state
+
+        let held : SyncBlock =
+            {
+                Lock =
+                    SyncBlockLock.Held
+                        {
+                            LockingThread = ThreadId 3
+                            ReentrancyCount = 4
+                            AcquireQueue = [ ThreadId 5, None ]
+                        }
+                WaitQueue = [ ThreadId 6, 2 ]
+            }
+
+        let state = IlMachineState.setSyncBlock source held state
+
+        let clone, state = IlMachineState.cloneArray source state
+
+        clone |> shouldNotEqual source
+        IlMachineState.getSyncBlock source state |> shouldEqual held
+        IlMachineState.getSyncBlock clone state |> shouldEqual SyncBlock.Empty
+
+    [<Test>]
+    let ``every live heap address has exactly one sync block`` () : unit =
+        // The invariant that makes `getSyncBlock` total over live addresses: allocation
+        // is the only way to mint an address, and every allocation path must register a
+        // sync block for it. Anything that adds a new allocation kind without doing so
+        // breaks this property rather than silently reintroducing "arrays can't be
+        // locked".
+        let property (ops : bool list) : bool =
+            let heap =
+                ops
+                |> List.fold
+                    (fun heap isArray ->
+                        if isArray then
+                            ManagedHeap.allocateArray (stubArray 1) heap |> snd
+                        else
+                            ManagedHeap.allocateNonArray stubNonArray heap |> snd
+                    )
+                    ManagedHeap.empty
+
+            let live =
+                Set.union (heap.NonArrayObjects |> Map.keys |> Set.ofSeq) (heap.Arrays |> Map.keys |> Set.ofSeq)
+
+            let withSyncBlocks = heap.SyncBlocks |> Map.keys |> Set.ofSeq
+
+            live = withSyncBlocks
+            && live.Count = ops.Length
+            && live
+               |> Set.forall (fun addr -> ManagedHeap.getSyncBlock addr heap = SyncBlock.Empty)
+
+        Check.One (
+            Config.QuickThrowOnFailure.WithMaxTest 200,
+            Prop.forAll (ArbMap.defaults |> ArbMap.arbitrary) property
+        )

--- a/WoofWare.PawPrint.Test/TestSyncBlockMonitor.fs
+++ b/WoofWare.PawPrint.Test/TestSyncBlockMonitor.fs
@@ -76,10 +76,31 @@ module TestSyncBlockMonitor =
             {
                 Contents = Unchecked.defaultof<CliValueType>
                 ConcreteType = ConcreteTypeHandle.Concrete 0
-                SyncBlock = SyncBlock.Empty
             }
 
         let addr, heap = state.ManagedHeap |> ManagedHeap.allocateNonArray stub
+
+        let state =
+            { state with
+                ManagedHeap = heap
+            }
+
+        addr, state
+
+    /// The array counterpart of `allocateHeapObject`. Arrays carry an object header
+    /// just like any other heap object, so every `SyncBlockMonitor` transition must
+    /// behave identically whichever kind of address it is handed; the tests below
+    /// exercise both.
+    let private allocateHeapArray (state : IlMachineState) : ManagedHeapAddress * IlMachineState =
+        let stub : AllocatedArray =
+            {
+                ConcreteType = ConcreteTypeHandle.OneDimArrayZero (ConcreteTypeHandle.Concrete 0)
+                Length = 0
+                Lengths = ImmutableArray.Create 0
+                Elements = ImmutableArray.Empty
+            }
+
+        let addr, heap = state.ManagedHeap |> ManagedHeap.allocateArray stub
 
         let state =
             { state with
@@ -600,6 +621,81 @@ module TestSyncBlockMonitor =
         exn.Message |> shouldContainText "WaitQueue"
 
     // -------------------------------------------------------------------
+    // Allocation kind is irrelevant to monitors
+    //
+    // An array is a heap object with an object header like any other (CoreCLR:
+    // `ArrayBase` derives from `Object`, and `EnterObjMonitor`/`Wait`/`Pulse`
+    // are defined once on `Object`). So the whole transition system must be
+    // blind to whether an address names an array or a non-array object. Rather
+    // than duplicating every case above, run the same scripts against both
+    // allocation kinds and assert the observable outcomes coincide.
+    // -------------------------------------------------------------------
+
+    /// Every transition `SyncBlockMonitor` exposes that does not need real method
+    /// frames, expressed as a script we can replay against any allocation kind.
+    let private allTransitionScripts : (string * (ManagedHeapAddress -> IlMachineState -> IlMachineState)) list =
+        [
+            "wait", fun addr state -> state |> forceHeld t0 3 addr |> SyncBlockMonitor.wait t0 addr None
+
+            "wait then pulse",
+            fun addr state ->
+                state
+                |> parkInWaitAtDepth t0 5 addr
+                |> forceHeld t1 1 addr
+                |> SyncBlockMonitor.pulse t1 addr
+
+            "wait twice then pulseAll",
+            fun addr state ->
+                state
+                |> parkInWaitAtDepth t0 2 addr
+                |> parkInWaitAtDepth t1 4 addr
+                |> forceHeld t2 1 addr
+                |> SyncBlockMonitor.pulseAll t2 addr
+
+            "wait then spuriousWake",
+            fun addr state -> state |> parkInWaitAtDepth t0 6 addr |> SyncBlockMonitor.spuriousWake addr t0
+
+            "wait then applySpuriousWakeups AlwaysAll",
+            fun addr state ->
+                state
+                |> parkInWaitAtDepth t0 1 addr
+                |> parkInWaitAtDepth t1 2 addr
+                |> SyncBlockMonitor.applySpuriousWakeups SyncBlockSpuriousWakeupStrategy.AlwaysAll 0L
+        ]
+
+    [<Test>]
+    let ``monitor transitions are identical for array and non-array targets`` () : unit =
+        let run
+            (script : ManagedHeapAddress -> IlMachineState -> IlMachineState)
+            (allocate : IlMachineState -> ManagedHeapAddress * IlMachineState)
+            =
+            let state = baseState () |> withThreads [ t0 ; t1 ; t2 ]
+            let addr, state = allocate state
+            let state = script addr state
+            syncBlockOf addr state, (state.ThreadState |> Map.map (fun _ ts -> ts.Status))
+
+        for name, script in allTransitionScripts do
+            // Both allocators hand out address 1 from a fresh heap, so the statuses —
+            // which embed the address — are directly comparable.
+            let objBlock, objStatuses = run script allocateHeapObject
+            let arrBlock, arrStatuses = run script allocateHeapArray
+
+            if arrBlock <> objBlock then
+                failwith
+                    $"script %s{name}: array target produced SyncBlock %A{arrBlock} but non-array target produced %A{objBlock}"
+
+            if arrStatuses <> objStatuses then
+                failwith
+                    $"script %s{name}: array target produced thread statuses %A{arrStatuses} but non-array target produced %A{objStatuses}"
+
+    [<Test>]
+    let ``a freshly allocated array is an unlocked monitor target`` () : unit =
+        let state = baseState ()
+        let addr, state = allocateHeapArray state
+
+        syncBlockOf addr state |> shouldEqual SyncBlock.Empty
+
+    // -------------------------------------------------------------------
     // applySpuriousWakeups — strategy interpretation
     // -------------------------------------------------------------------
 
@@ -608,7 +704,7 @@ module TestSyncBlockMonitor =
     /// is not equality-comparable (it embeds MethodStates with structural
     /// non-equality), so we compare what we care about explicitly.
     let private wakeupVisibleState (state : IlMachineState) =
-        let blocks = state.ManagedHeap.NonArrayObjects |> Map.map (fun _ v -> v.SyncBlock)
+        let blocks = state.ManagedHeap.SyncBlocks
 
         let statuses = state.ThreadState |> Map.map (fun _ ts -> ts.Status)
         blocks, statuses

--- a/WoofWare.PawPrint.Test/sourcesPure/ContendedMonitorEnterOnArray.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/ContendedMonitorEnterOnArray.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+
+namespace HelloWorldApp
+{
+    class Program
+    {
+        static int[] locker = new int[1];
+        static int shared = 0;
+
+        static void Worker()
+        {
+            lock (locker)
+            {
+                shared = 99;
+            }
+        }
+
+        static int Main(string[] args)
+        {
+            Thread t = new Thread(Worker);
+            lock (locker)
+            {
+                t.Start();
+                shared = 7;
+            }
+            t.Join();
+            return shared == 99 ? 0 : 1;
+        }
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/LockOnArray.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/LockOnArray.cs
@@ -1,0 +1,60 @@
+using System.Threading;
+
+namespace HelloWorldApp
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            // Arrays are ordinary heap objects and carry an object header just like any
+            // other reference type, so they are legal monitor targets. Exercise a
+            // single-dimensional array, a multi-dimensional array (a separate allocation
+            // path in the runtime), and reentrant acquisition of the same array.
+            int[] szArray = new int[3];
+            int[,] multiDim = new int[2, 2];
+
+            lock (szArray)
+            {
+                if (!Monitor.IsEntered(szArray))
+                {
+                    return 1;
+                }
+
+                lock (szArray)
+                {
+                    if (!Monitor.IsEntered(szArray))
+                    {
+                        return 2;
+                    }
+                }
+
+                // Still held after the inner lock released one level of reentrancy.
+                if (!Monitor.IsEntered(szArray))
+                {
+                    return 3;
+                }
+
+                // Locking one array must not lock a different one.
+                if (Monitor.IsEntered(multiDim))
+                {
+                    return 4;
+                }
+
+                lock (multiDim)
+                {
+                    if (!Monitor.IsEntered(multiDim))
+                    {
+                        return 5;
+                    }
+                }
+            }
+
+            if (Monitor.IsEntered(szArray))
+            {
+                return 6;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/MonitorPulseWaitOnArray.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/MonitorPulseWaitOnArray.cs
@@ -1,0 +1,34 @@
+using System.Threading;
+
+namespace HelloWorldApp
+{
+    class Program
+    {
+        static object[] locker = new object[1];
+        static int produced = 0;
+
+        static void Worker()
+        {
+            lock (locker)
+            {
+                produced = 42;
+                Monitor.Pulse(locker);
+            }
+        }
+
+        static int Main(string[] args)
+        {
+            Thread t = new Thread(Worker);
+            lock (locker)
+            {
+                t.Start();
+                while (produced == 0)
+                {
+                    Monitor.Wait(locker);
+                }
+            }
+            t.Join();
+            return produced == 42 ? 0 : 1;
+        }
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesPure/MonitorTryEnterOnArray.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/MonitorTryEnterOnArray.cs
@@ -1,0 +1,48 @@
+using System.Threading;
+
+namespace HelloWorldApp
+{
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            // The `ref bool` and timeout-carrying entry points are separate fastpaths
+            // from plain `Monitor.Enter`, so exercise them against an array target too.
+            byte[] locker = new byte[4];
+
+            bool taken = false;
+            Monitor.Enter(locker, ref taken);
+            if (!taken)
+            {
+                return 1;
+            }
+
+            if (!Monitor.IsEntered(locker))
+            {
+                return 2;
+            }
+
+            // Reentrant TryEnter on a monitor we already own succeeds immediately.
+            if (!Monitor.TryEnter(locker, 0))
+            {
+                return 3;
+            }
+
+            Monitor.Exit(locker);
+
+            if (!Monitor.IsEntered(locker))
+            {
+                return 4;
+            }
+
+            Monitor.Exit(locker);
+
+            if (Monitor.IsEntered(locker))
+            {
+                return 5;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/WoofWare.PawPrint/IlMachineThreadState.fs
+++ b/WoofWare.PawPrint/IlMachineThreadState.fs
@@ -718,7 +718,6 @@ module IlMachineThreadState =
             {
                 Contents = fields
                 ConcreteType = ty
-                SyncBlock = SyncBlock.Empty
             }
 
         let alloc, heap = state.ManagedHeap |> ManagedHeap.allocateNonArray o

--- a/WoofWare.PawPrint/ManagedHeap.fs
+++ b/WoofWare.PawPrint/ManagedHeap.fs
@@ -66,7 +66,6 @@ type AllocatedNonArrayObject =
         // TODO: this is a slightly odd domain; the same type for value types as class types!
         Contents : CliValueType
         ConcreteType : ConcreteTypeHandle
-        SyncBlock : SyncBlock
     }
 
     static member DereferenceField (name : string) (f : AllocatedNonArrayObject) : CliType =
@@ -119,6 +118,21 @@ type ManagedHeap =
         /// `StringArrayData`. `_firstChar` and byref/trailing-data reads both walk
         /// from this offset.
         StringDataOffsets : ImmutableDictionary<ManagedHeapAddress, int>
+        /// Object headers, keyed by address. In CoreCLR every heap object carries an
+        /// `ObjHeader` immediately preceding its payload — arrays and strings included
+        /// (`src/coreclr/vm/object.h`); `Object::EnterObjMonitor` and friends are defined
+        /// once on the base `Object` and there is no array-shaped carve-out. The sync
+        /// block therefore belongs to the *address*, not to which of `NonArrayObjects` /
+        /// `Arrays` holds the payload, so it lives here rather than as a field of either
+        /// payload record. Keeping it out of the payload records also means a fresh
+        /// allocation can never inherit a stale header: `Array.Clone` reuses the source's
+        /// `AllocatedArray` record verbatim (see `IlMachineThreadState.cloneArray`), which
+        /// would otherwise copy the source's monitor ownership onto the clone.
+        ///
+        /// Invariant: the key set is exactly the union of the `NonArrayObjects` and
+        /// `Arrays` key sets. `allocateNonArray` / `allocateArray` are the only ways to
+        /// mint an address and both register an `Empty` entry here.
+        SyncBlocks : Map<ManagedHeapAddress, SyncBlock>
     }
 
 [<RequireQualifiedAccess>]
@@ -131,25 +145,26 @@ module ManagedHeap =
             StringArrayData = ImmutableArray.Empty
             StringContents = ImmutableDictionary.Empty
             StringDataOffsets = ImmutableDictionary.Empty
+            SyncBlocks = Map.empty
         }
 
+    /// The object header of the object at `addr`. Every live heap object has one,
+    /// whatever its payload kind; an address with no header is not a live allocation.
     let getSyncBlock (addr : ManagedHeapAddress) (heap : ManagedHeap) : SyncBlock =
-        match heap.NonArrayObjects.TryGetValue addr with
-        | false, _ -> failwith "TODO: getting sync block of array"
-        | true, v -> v.SyncBlock
+        match heap.SyncBlocks.TryGetValue addr with
+        | false, _ -> failwith $"getSyncBlock: %O{addr} is not a live managed heap allocation, so has no object header"
+        | true, v -> v
 
+    /// Overwrite the object header of the object at `addr`. Rejects addresses that were
+    /// never allocated rather than conjuring a header for them: a caller reaching here
+    /// with a dangling address has a bug we would otherwise hide.
     let setSyncBlock (addr : ManagedHeapAddress) (syncValue : SyncBlock) (heap : ManagedHeap) : ManagedHeap =
-        match heap.NonArrayObjects.TryGetValue addr with
-        | false, _ -> failwith "TODO: locked on an array object"
-        | true, v ->
-            let newV =
-                { v with
-                    SyncBlock = syncValue
-                }
+        if not (heap.SyncBlocks.ContainsKey addr) then
+            failwith $"setSyncBlock: %O{addr} is not a live managed heap allocation, so has no object header"
 
-            { heap with
-                NonArrayObjects = heap.NonArrayObjects |> Map.add addr newV
-            }
+        { heap with
+            SyncBlocks = heap.SyncBlocks |> Map.add addr syncValue
+        }
 
     let allocateArray (ty : AllocatedArray) (heap : ManagedHeap) : ManagedHeapAddress * ManagedHeap =
         let addr = heap.FirstAvailableAddress
@@ -158,6 +173,7 @@ module ManagedHeap =
             { heap with
                 FirstAvailableAddress = heap.FirstAvailableAddress + 1
                 Arrays = heap.Arrays |> Map.add (ManagedHeapAddress addr) ty
+                SyncBlocks = heap.SyncBlocks |> Map.add (ManagedHeapAddress addr) SyncBlock.Empty
             }
 
         ManagedHeapAddress addr, heap
@@ -207,6 +223,7 @@ module ManagedHeap =
             { heap with
                 FirstAvailableAddress = addr + 1
                 NonArrayObjects = heap.NonArrayObjects |> Map.add (ManagedHeapAddress addr) ty
+                SyncBlocks = heap.SyncBlocks |> Map.add (ManagedHeapAddress addr) SyncBlock.Empty
             }
 
         ManagedHeapAddress addr, heap

--- a/WoofWare.PawPrint/Scheduler.fs
+++ b/WoofWare.PawPrint/Scheduler.fs
@@ -365,10 +365,10 @@ module Scheduler =
         // RAII-style release is the guest's responsibility, and a loud failure is far
         // easier to diagnose than a silent deadlock.
         let orphanedSyncBlocks =
-            state.ManagedHeap.NonArrayObjects
+            state.ManagedHeap.SyncBlocks
             |> Map.toSeq
-            |> Seq.choose (fun (addr, obj) ->
-                match obj.SyncBlock.Lock with
+            |> Seq.choose (fun (addr, syncBlock) ->
+                match syncBlock.Lock with
                 | SyncBlockLock.Held locked when locked.LockingThread = terminated -> Some (addr, locked)
                 | _ -> None
             )

--- a/WoofWare.PawPrint/SyncBlockMonitor.fs
+++ b/WoofWare.PawPrint/SyncBlockMonitor.fs
@@ -433,10 +433,10 @@ module SyncBlockMonitor =
         | SyncBlockSpuriousWakeupStrategy.Disabled -> state
 
         | SyncBlockSpuriousWakeupStrategy.AlwaysAll ->
-            state.ManagedHeap.NonArrayObjects
+            state.ManagedHeap.SyncBlocks
             |> Map.toSeq
             |> Seq.sortBy (fun (ManagedHeapAddress aid, _) -> aid)
-            |> Seq.collect (fun (addr, obj) -> obj.SyncBlock.WaitQueue |> List.map (fun (tid, _) -> addr, tid))
+            |> Seq.collect (fun (addr, syncBlock) -> syncBlock.WaitQueue |> List.map (fun (tid, _) -> addr, tid))
             |> Seq.toList
             |> List.fold (fun acc (addr, tid) -> spuriousWake addr tid acc) state
 
@@ -445,10 +445,10 @@ module SyncBlockMonitor =
                 failwith
                     $"SyncBlockSpuriousWakeupStrategy.Random: probability %f{probability} is outside [0.0, 1.0] (NaN or out of range)."
 
-            state.ManagedHeap.NonArrayObjects
+            state.ManagedHeap.SyncBlocks
             |> Map.toSeq
             |> Seq.sortBy (fun (ManagedHeapAddress aid, _) -> aid)
-            |> Seq.collect (fun (addr, obj) -> obj.SyncBlock.WaitQueue |> List.map (fun (tid, _) -> addr, tid))
+            |> Seq.collect (fun (addr, syncBlock) -> syncBlock.WaitQueue |> List.map (fun (tid, _) -> addr, tid))
             |> Seq.filter (fun (addr, tid) -> coinFlip seed tick addr tid < probability)
             |> Seq.toList
             |> List.fold (fun acc (addr, tid) -> spuriousWake addr tid acc) state


### PR DESCRIPTION
`lock (someArray)` previously died on `failwith "TODO: getting sync block of array"`: `ManagedHeap.getSyncBlock`/`setSyncBlock` only knew how to answer for `NonArrayObjects`, and `AllocatedArray` carried no sync block at all.

## Approach

In CoreCLR the `ObjHeader` precedes *every* heap object — `ArrayBase` derives from `Object`, and `EnterObjMonitor`/`Wait`/`Pulse` are defined once on `Object` with no array-shaped carve-out (`src/coreclr/vm/object.h`). So the sync block is a property of the *address*, not of which payload map holds the object.

Chosen option: hoist the header into a `ManagedHeap.SyncBlocks` side table, keyed by address. This matches the precedent already set by `StringContents`/`StringDataOffsets` in the same record, and registration happens in exactly the two functions that mint addresses — `allocateArray` and `allocateNonArray` — so every allocation path, `cloneArray` included, gets a fresh empty header keyed by the *new* address with nothing to forget to reset. It also makes the existing `getSyncBlock : ManagedHeapAddress -> ManagedHeap -> SyncBlock` signature honest rather than adding a second kind-aware code path.

`SyncBlock` is therefore removed from `AllocatedNonArrayObject`, with the invariant that `SyncBlocks`' key set is exactly the union of the `NonArrayObjects` and `Arrays` key sets. Nothing ever removes heap entries (there is no collecting GC), so `getSyncBlock` is total over live addresses and fails loudly on a dangling one; `setSyncBlock` likewise refuses to conjure a header for an address that was never allocated.

## Knock-on fixes

* `Scheduler`'s orphaned-lock check (a thread must not terminate still holding a monitor) and `SyncBlockMonitor`'s `AlwaysAll`/`Random` spurious-wakeup strategies both iterated `NonArrayObjects` directly, so they silently ignored arrays. They now iterate `SyncBlocks` and cover every allocation kind.
* The debugger's heap-object response reports `syncBlock` for arrays as well as objects.

Note this does *not* change array identity hash codes: `RuntimeHelpers.GetHashCode` derives from the raw address (`Native/NativeRuntimeHelpers.fs`), not from the header, and already worked for arrays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)