### PR TITLE
Implement MetadataImport::GetMemberRefProps

### DIFF
--- a/WoofWare.PawPrint.Test/TestNativeMetadataImport.fs
+++ b/WoofWare.PawPrint.Test/TestNativeMetadataImport.fs
@@ -68,6 +68,16 @@ public class OuterMetadataField
     }
 }
 
+public class ReferencesOtherAssemblyMembers
+{
+    // `string.Empty` is a static field on a corelib type, so the reference is a MemberRef row
+    // carrying a FIELD signature blob rather than a METHOD one.
+    public static string FieldMemberRef() => string.Empty;
+
+    // A call to a corelib instance method is a MemberRef row with a METHOD signature blob.
+    public static string MethodMemberRef(int x) => x.ToString();
+}
+
 public class TypesWithMembers
 {
     public int InstanceMethod(int x, string y) => x + y.Length;
@@ -1062,3 +1072,184 @@ public class TypesWithMembers
         // Sanity check: the [Obsolete("deprecated")] blob must contain the literal "deprecated".
         let blobAsString = System.Text.Encoding.UTF8.GetString bytes
         blobAsString.Contains "deprecated" |> shouldEqual true
+
+    let private memberRefToken (handle : MemberReferenceHandle) : int32 =
+        let handle : EntityHandle = MemberReferenceHandle.op_Implicit handle
+        MetadataTokens.GetToken handle
+
+    let private invokeGetMemberRefProps
+        (fixture : MetadataImportFixture)
+        (memberTokenRef : int32)
+        (state : IlMachineState)
+        : EvalStackValue * (int32 * byte array) * IlMachineState
+        =
+        let state, metadataImportType, getMemberRefPropsMethod =
+            metadataImportMethod fixture state "GetMemberRefProps" 3
+
+        let signatureOut, state = allocateConstArrayOut fixture state
+
+        let state =
+            invokeMetadataImportNative
+                fixture
+                metadataImportType
+                getMemberRefPropsMethod
+                [
+                    metadataImportHandle fixture
+                    CliType.Numeric (CliNumericType.Int32 memberTokenRef)
+                    CliType.RuntimePointer (CliRuntimePointer.Managed signatureOut)
+                ]
+                state
+
+        let returnValue, state = IlMachineState.popEvalStack (ThreadId 0) state
+        returnValue, readConstArrayOut fixture state signatureOut, state
+
+    /// The MemberRef row referring to <paramref name="memberName"/>; there must be exactly one.
+    let private singleMemberRefNamed
+        (assembly : DumpedAssembly)
+        (memberName : string)
+        : MemberReferenceHandle * MemberReference<MetadataToken>
+        =
+        assembly.Members
+        |> Seq.filter (fun kvp -> kvp.Value.PrettyName = memberName)
+        |> Seq.map (fun kvp -> kvp.Key, kvp.Value)
+        |> Seq.toList
+        |> function
+            | [ result ] -> result
+            | [] -> failwith $"no MemberRef named %s{memberName}"
+            | many -> failwith $"expected exactly one MemberRef named %s{memberName}, got %d{many.Length}"
+
+    /// ECMA-335 II.23.2 compressed unsigned integer; returns the value and the offset just past it.
+    let private readCompressedUInt (bytes : byte array) (offset : int) : uint32 * int =
+        let b0 = bytes.[offset]
+
+        if b0 &&& 0x80uy = 0uy then
+            uint32 b0, offset + 1
+        elif b0 &&& 0xC0uy = 0x80uy then
+            ((uint32 b0 &&& 0x3Fu) <<< 8) ||| uint32 bytes.[offset + 1], offset + 2
+        else
+            ((uint32 b0 &&& 0x1Fu) <<< 24)
+            ||| (uint32 bytes.[offset + 1] <<< 16)
+            ||| (uint32 bytes.[offset + 2] <<< 8)
+            ||| uint32 bytes.[offset + 3],
+            offset + 4
+
+    [<Test>]
+    let ``MetadataImport GetMemberRefProps returns the signature of a corelib attribute ctor`` () : unit =
+        let fixture = makeFixture ()
+
+        let _, expected =
+            singleCustomAttributeForType fixture.Assembly fixture.ParameterlessAttrType
+
+        // [System.Obsolete] is declared in corelib, so the test assembly refers to its ctor
+        // through a MemberRef rather than a MethodDef. This is exactly the split that makes
+        // CoreLib's MetadataImport.GetMethodSignature dispatch here instead of to
+        // GetSigOfMethodDef (which the sibling MetadataImportGetSigOfMethodDef.cs covers).
+        let ctorToken = MetadataToken.toInt expected.Constructor
+
+        match MetadataToken.ofInt ctorToken with
+        | MetadataToken.MemberReference _ -> ()
+        | other -> failwith $"expected [Obsolete] ctor to be a MemberRef, got %O{other}"
+
+        let returnValue, (length, bytes), _ =
+            invokeGetMemberRefProps fixture ctorToken fixture.State
+
+        returnValue |> shouldEqual (EvalStackValue.Int32 0)
+        // HASTHIS | DEFAULT (0x20), zero parameters, ELEMENT_TYPE_VOID (0x01) return.
+        bytes |> shouldEqual [| 0x20uy ; 0x00uy ; 0x01uy |]
+        length |> shouldEqual bytes.Length
+
+    [<Test>]
+    let ``MetadataImport GetMemberRefProps returns the signature of a ctor with parameters`` () : unit =
+        let fixture = makeFixture ()
+
+        let _, expected =
+            singleCustomAttributeForType fixture.Assembly fixture.ArgumentAttrType
+
+        let ctorToken = MetadataToken.toInt expected.Constructor
+
+        let returnValue, (length, bytes), _ =
+            invokeGetMemberRefProps fixture ctorToken fixture.State
+
+        returnValue |> shouldEqual (EvalStackValue.Int32 0)
+        // HASTHIS | DEFAULT (0x20), one parameter, ELEMENT_TYPE_VOID (0x01) return,
+        // ELEMENT_TYPE_STRING (0x0e) parameter.
+        bytes |> shouldEqual [| 0x20uy ; 0x01uy ; 0x01uy ; 0x0Euy |]
+        length |> shouldEqual bytes.Length
+
+    [<Test>]
+    let ``MetadataImport GetMemberRefProps returns a FIELD signature for a field MemberRef`` () : unit =
+        let fixture = makeFixture ()
+
+        // `string.Empty` — a static field on a corelib type, so its MemberRef carries a FIELD
+        // signature. CoreCLR's callers rely on the leading calling-convention byte to tell
+        // field references apart from method references (RuntimeModule.ResolveMethod rejects
+        // MdSigCallingConvention.Field), so the distinction has to survive this call.
+        let handle, memberRef = singleMemberRefNamed fixture.Assembly "Empty"
+
+        match memberRef.Signature with
+        | MemberSignature.Field _ -> ()
+        | MemberSignature.Method _ -> failwith "expected String.Empty MemberRef to have a field signature"
+
+        let returnValue, (length, bytes), _ =
+            invokeGetMemberRefProps fixture (memberRefToken handle) fixture.State
+
+        returnValue |> shouldEqual (EvalStackValue.Int32 0)
+        // FIELD (0x06), ELEMENT_TYPE_STRING (0x0e).
+        bytes |> shouldEqual [| 0x06uy ; 0x0Euy |]
+        length |> shouldEqual bytes.Length
+
+    [<Test>]
+    let ``MetadataImport GetMemberRefProps blob decodes to the eagerly-parsed signature`` () : unit =
+        let fixture = makeFixture ()
+
+        let members =
+            fixture.Assembly.Members
+            |> Seq.map (fun kvp -> kvp.Key, kvp.Value)
+            |> Seq.toList
+
+        members |> List.isEmpty |> shouldEqual false
+
+        let mutable state = fixture.State
+
+        for handle, memberRef in members do
+            let returnValue, (length, bytes), nextState =
+                invokeGetMemberRefProps fixture (memberRefToken handle) state
+
+            state <- nextState
+
+            returnValue |> shouldEqual (EvalStackValue.Int32 0)
+            length |> shouldEqual bytes.Length
+            bytes.Length > 0 |> shouldEqual true
+
+            // The blob we hand back must agree with the signature PawPrint decoded independently
+            // (via MemberReference.make) when the assembly was read.
+            let header = SignatureHeader bytes.[0]
+
+            match memberRef.Signature with
+            | MemberSignature.Field _ -> header.Kind |> shouldEqual SignatureKind.Field
+            | MemberSignature.Method methodSig ->
+                header.Kind |> shouldEqual SignatureKind.Method
+                bytes.[0] |> shouldEqual methodSig.Header.Get.RawValue
+
+                let offset =
+                    if header.IsGeneric then
+                        let genericParameterCount, offset = readCompressedUInt bytes 1
+                        int genericParameterCount |> shouldEqual methodSig.GenericParameterCount
+                        offset
+                    else
+                        1
+
+                let parameterCount, _ = readCompressedUInt bytes offset
+                int parameterCount |> shouldEqual methodSig.ParameterTypes.Length
+
+    [<Test>]
+    let ``MetadataImport GetMemberRefProps rejects a non-MemberRef token`` () : unit =
+        let fixture = makeFixture ()
+
+        let ex =
+            Assert.Throws (fun () ->
+                invokeGetMemberRefProps fixture (typeDefToken fixture.TargetType.TypeDefHandle) fixture.State
+                |> ignore
+            )
+
+        ex.Message |> shouldContainText "expected MemberRef token"

--- a/WoofWare.PawPrint.Test/sourcesPure/MetadataImportGetMemberRefProps.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/MetadataImportGetMemberRefProps.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace MetadataImportGetMemberRefProps
+{
+    [Obsolete]
+    public class Decorated { }
+
+    public class Plain { }
+
+    public class Program
+    {
+        public static int Main(string[] args)
+        {
+            // The mirror of MetadataImportGetSigOfMethodDef.cs, with the attribute moved out of
+            // this assembly. Attribute.IsDefined reaches RuntimeCustomAttributeData's
+            // FilterCustomAttributeRecord, which calls scope.GetMethodSignature(caCtorToken) on
+            // each candidate ctor. ObsoleteAttribute lives in corelib, so the ctor token is a
+            // MemberRef and GetMethodSignature dispatches to MetadataImport.GetMemberRefProps
+            // instead of GetSigOfMethodDef.
+            if (!Attribute.IsDefined(typeof(Decorated), typeof(ObsoleteAttribute))) return 1;
+            if (Attribute.IsDefined(typeof(Plain), typeof(ObsoleteAttribute))) return 2;
+
+            return 0;
+        }
+    }
+}

--- a/WoofWare.PawPrint/Native/NativeMetadataImport.fs
+++ b/WoofWare.PawPrint/Native/NativeMetadataImport.fs
@@ -689,6 +689,57 @@ module NativeMetadataImport =
         | "System.Private.CoreLib",
           "System.Reflection",
           "MetadataImport",
+          "GetMemberRefProps",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32
+            ConcreteByref (ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                                             "System.Reflection",
+                                                             "ConstArray",
+                                                             constArrayGenerics)) ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) when
+            constArrayGenerics.IsEmpty
+            ->
+            let operation = "MetadataImport.GetMemberRefProps"
+            let assemblyFullName = metadataImportHandleOfArg operation instruction.Arguments.[0]
+            let assembly = metadataImportAssembly operation state assemblyFullName
+
+            let mdToken =
+                match CliType.unwrapPrimitiveLikeDeep instruction.Arguments.[1] with
+                | CliType.Numeric (CliNumericType.Int32 mdToken) -> mdToken
+                | other -> failwith $"%s{operation}: expected Int32 memberTokenRef argument, got %O{other}"
+
+            let signatureOut =
+                NativeCall.managedPointerOfPointerArgument operation "signature out pointer" instruction.Arguments.[2]
+
+            let memberRefHandle =
+                match MetadataToken.ofInt mdToken with
+                | MetadataToken.MemberReference h -> h
+                | token -> failwith $"%s{operation}: expected MemberRef token, got %O{token} from 0x%08x{mdToken}"
+
+            if not (assembly.Members.ContainsKey memberRefHandle) then
+                failwith $"%s{operation}: MemberRef token 0x%08x{mdToken} was not present in %s{assemblyFullName}"
+
+            // CoreCLR's FCall forwards to `IMDInternalImport::GetNameAndSigOfMemberRef` and discards
+            // the name, so the contract is "raw signature blob bytes for the supplied MemberRef
+            // token". PawPrint decodes MemberRef signatures eagerly into `MemberSignature`; the
+            // unparsed blob is recovered on demand from the metadata reader, as for GetSigOfMethodDef.
+            let mr = metadataReaderOf assembly
+            let memberRef = mr.GetMemberReference memberRefHandle
+            let blob = ImmutableArray.Create<byte> (mr.GetBlobBytes memberRef.Signature)
+
+            let constArrayValue, state =
+                buildConstArray ctx.LoggerFactory ctx.BaseClassTypes operation blob state
+
+            let state =
+                IlMachineState.writeManagedByrefWithBase ctx.BaseClassTypes state signatureOut constArrayValue
+
+            let state =
+                IlMachineState.pushToEvalStack' (EvalStackValue.Int32 0) ctx.Thread state
+
+            NativeHandlerResult.completed state |> Some
+        | "System.Private.CoreLib",
+          "System.Reflection",
+          "MetadataImport",
           "GetParentToken",
           [ ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr
             ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32


### PR DESCRIPTION
CoreLib's `MetadataImport.GetMethodSignature` dispatches on the token kind: MethodDef tokens go to `GetSigOfMethodDef` (already implemented), MemberRef tokens go to `GetMemberRefProps`, which was unimplemented.

## Implementation

The InternalCall's contract is "raw signature blob bytes for the supplied MemberRef token" — CoreCLR's FCall forwards to `IMDInternalImport::GetNameAndSigOfMemberRef` and discards the name.

PawPrint decodes MemberRef signatures eagerly into `MemberSignature` when an assembly is read, so the unparsed blob isn't retained. Two options for recovering it:

1. **Read it back from the metadata reader on demand.** This is what `GetSigOfMethodDef` already does for MethodDef blobs, so it keeps the two siblings symmetric and is trivially reversible.
2. **Store the raw blob on `MemberReference<'parent>` at parse time.** Preserves more information at the domain level, but grows a hot domain type and costs memory for every MemberRef row in every loaded assembly, to serve one InternalCall.

I took (1). If a future caller needs blobs often enough that the re-read matters, (2) is a mechanical change from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)