### PR TITLE
Support tag bits on GC handle pointers

### DIFF
--- a/WoofWare.PawPrint.Test/TestCliTypeBytes.fs
+++ b/WoofWare.PawPrint.Test/TestCliTypeBytes.fs
@@ -438,7 +438,7 @@ module TestCliTypeBytes =
             NativeIntSource.AssemblyHandle "assembly"
             NativeIntSource.ModuleHandle "module"
             NativeIntSource.MetadataImportHandle "metadata"
-            NativeIntSource.GcHandlePtr (GcHandleAddress 0)
+            NativeIntSource.GcHandlePtr (GcHandleAddress 0, 0L)
             syntheticCrossStorageNativeIntSource ()
         ]
 

--- a/WoofWare.PawPrint.Test/TestEvalStack.fs
+++ b/WoofWare.PawPrint.Test/TestEvalStack.fs
@@ -55,25 +55,39 @@ module TestEvalStack =
         | EvalStackValue.NativeInt (NativeIntSource.MethodTablePtr actual) when actual = typeHandle -> ()
         | other -> failwith $"Expected NativeInt(MethodTablePtr %O{typeHandle}), got %O{other}"
 
-    [<Test>]
-    let ``toCliTypeCoerced RuntimePointer target preserves GC handle pointer provenance`` () : unit =
+    // A GC handle's tag bits are part of the value managed code is holding — a
+    // `WeakReference` keeps `handle | TracksResurrectionBit` in a field for the
+    // object's whole lifetime — so they have to survive storage round-trips
+    // alongside the handle's identity, not just the identity on its own.
+    [<TestCase(0L)>]
+    [<TestCase(1L)>]
+    [<TestCase(3L)>]
+    let ``toCliTypeCoerced RuntimePointer target preserves GC handle pointer provenance`` (tag : int64) : unit =
         let handle = GcHandleAddress.GcHandleAddress 42
 
         match
             EvalStackValue.toCliTypeCoerced
                 runtimePointerTarget
-                (EvalStackValue.NativeInt (NativeIntSource.GcHandlePtr handle))
+                (EvalStackValue.NativeInt (NativeIntSource.GcHandlePtr (handle, tag)))
         with
-        | CliType.RuntimePointer (CliRuntimePointer.GcHandlePtr actual) when actual = handle -> ()
-        | other -> failwith $"Expected RuntimePointer(GcHandlePtr %O{handle}), got %O{other}"
+        | CliType.RuntimePointer (CliRuntimePointer.GcHandlePtr (actual, actualTag)) when
+            actual = handle && actualTag = tag
+            ->
+            ()
+        | other -> failwith $"Expected RuntimePointer(GcHandlePtr %O{handle}, tag 0x%x{tag}), got %O{other}"
 
-    [<Test>]
-    let ``RuntimePointer carrying GC handle pointer flattens back to native int`` () : unit =
+    [<TestCase(0L)>]
+    [<TestCase(1L)>]
+    [<TestCase(3L)>]
+    let ``RuntimePointer carrying GC handle pointer flattens back to native int`` (tag : int64) : unit =
         let handle = GcHandleAddress.GcHandleAddress 42
 
-        match EvalStackValue.ofCliType (CliType.RuntimePointer (CliRuntimePointer.GcHandlePtr handle)) with
-        | EvalStackValue.NativeInt (NativeIntSource.GcHandlePtr actual) when actual = handle -> ()
-        | other -> failwith $"Expected NativeInt(GcHandlePtr %O{handle}), got %O{other}"
+        match EvalStackValue.ofCliType (CliType.RuntimePointer (CliRuntimePointer.GcHandlePtr (handle, tag))) with
+        | EvalStackValue.NativeInt (NativeIntSource.GcHandlePtr (actual, actualTag)) when
+            actual = handle && actualTag = tag
+            ->
+            ()
+        | other -> failwith $"Expected NativeInt(GcHandlePtr %O{handle}, tag 0x%x{tag}), got %O{other}"
 
     [<Test>]
     let ``Conv_U preserves PE byte-range managed pointer provenance`` () : unit =
@@ -307,8 +321,13 @@ module TestEvalStack =
         if not (EvalStackValueComparisons.cleUn one nan) then
             failwith "Expected ble.un-style float comparison to be true when right operand is NaN"
 
-    [<Test>]
-    let ``unsigned comparisons treat GcHandlePtr as strictly greater than zero`` () : unit =
+    // Tag bits never make a handle look null: `base` is non-zero on its own, so
+    // `WeakReference.get_Target`'s `if (th == 0) return default` must not fire for
+    // a stripped-but-still-live handle either.
+    [<TestCase(0L)>]
+    [<TestCase(1L)>]
+    [<TestCase(3L)>]
+    let ``unsigned comparisons treat GcHandlePtr as strictly greater than zero`` (tag : int64) : unit =
         // GC handle addresses are minted starting from 1 by GcHandleRegistry, so a
         // GcHandlePtr is never null. `cgt.un` is the unsigned greater-than
         // comparison; on native-int operands it's emitted by `nuint`/`UIntPtr`
@@ -319,7 +338,7 @@ module TestEvalStack =
         // therefore `cge.un` / `cle.un`, which are derived from the two) must
         // also answer truthfully.
         let handle =
-            EvalStackValue.NativeInt (NativeIntSource.GcHandlePtr (GcHandleAddress.GcHandleAddress 42))
+            EvalStackValue.NativeInt (NativeIntSource.GcHandlePtr (GcHandleAddress.GcHandleAddress 42, tag))
 
         let zero = EvalStackValue.NativeInt (NativeIntSource.Verbatim 0L)
 

--- a/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
+++ b/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
@@ -909,7 +909,7 @@ public unsafe struct PointerWrapper
             NativeIntSource.AssemblyHandle "test-assembly"
             NativeIntSource.ModuleHandle "test-module"
             NativeIntSource.MetadataImportHandle "test-metadata-import"
-            NativeIntSource.GcHandlePtr (GcHandleAddress 42)
+            NativeIntSource.GcHandlePtr (GcHandleAddress 42, 0L)
             syntheticCrossStorageNativeIntSource ()
         ]
 

--- a/WoofWare.PawPrint.Test/TestNullaryIlOp.fs
+++ b/WoofWare.PawPrint.Test/TestNullaryIlOp.fs
@@ -751,3 +751,144 @@ module TestNullaryIlOp =
             faultingFrame.IlOpIndex |> shouldEqual 0
             faultingFrame.EvaluationStack.Values |> shouldEqual []
         | other -> failwith $"Expected Conv_ovf_i overflow to step, got %O{other}"
+
+    // --- Bitwise operations on tagged GC handles ---
+    //
+    // PawPrint models a GC handle as an opaque registry index with no numeric
+    // address, but CoreLib stores tag bits in the handle's low bits and strips
+    // them off again on every read. These pin the arithmetic that makes that
+    // possible without inventing an address; see `TestTaggedPointerBits` for the
+    // decision procedure itself, and
+    // docs/plans/2026-08-06-tagged-gc-handles.md for the CoreLib IL each case
+    // corresponds to.
+
+    let private gcHandleUnderTest : GcHandleAddress = GcHandleAddress.GcHandleAddress 7
+
+    let private taggedHandle (tag : int64) : EvalStackValue =
+        EvalStackValue.NativeInt (NativeIntSource.GcHandlePtr (gcHandleUnderTest, tag))
+
+    let private stateWithBinaryNullary
+        (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
+        (op : NullaryIlOp)
+        (first : EvalStackValue)
+        (second : EvalStackValue)
+        : IlMachineState * ThreadId
+        =
+        let state, thread = stateWithNullary loggerFactory op first
+        IlMachineState.pushToEvalStack' second thread state, thread
+
+    let private runBinary (op : NullaryIlOp) (first : EvalStackValue) (second : EvalStackValue) : EvalStackValue =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+
+        let state, thread = stateWithBinaryNullary loggerFactory op first second
+
+        match NullaryIlOp.execute loggerFactory baseClassTypes state thread op with
+        | ExecutionResult.Stepped (state, whatWeDid, _) ->
+            whatWeDid |> shouldEqual WhatWeDid.Executed
+
+            match state.ThreadState.[thread].MethodState.EvaluationStack.Values with
+            | [ actual ] -> actual
+            | other -> failwith $"Expected %O{op} to leave one stack value, got %O{other}"
+        | other -> failwith $"Expected %O{op} to step, got %O{other}"
+
+    /// `conv.i` of an `ldc.i4` constant, which is how CoreLib materialises its
+    /// tag masks: the operand reaches `and`/`or` as a native int, not an int32.
+    let private nativeConst (value : int64) : EvalStackValue =
+        EvalStackValue.NativeInt (NativeIntSource.Verbatim value)
+
+    [<Test>]
+    let ``Or tags a GC handle, and And reads the tag back`` () : unit =
+        // `WeakReference.Create`: `h | TracksResurrectionBit`.
+        runBinary NullaryIlOp.Or (taggedHandle 0L) (nativeConst 1L)
+        |> shouldEqual (taggedHandle 1L)
+
+        // `WeakReference.IsTrackResurrection`: `_taggedHandle & 1`.
+        runBinary NullaryIlOp.And (taggedHandle 1L) (nativeConst 1L)
+        |> shouldEqual (nativeConst 1L)
+
+        runBinary NullaryIlOp.And (taggedHandle 0L) (nativeConst 1L)
+        |> shouldEqual (nativeConst 0L)
+
+    [<Test>]
+    let ``And strips tag bits and leaves a usable handle`` () : unit =
+        // `WeakReference.get_Target`: `_taggedHandle & ~TracksResurrectionBit`.
+        // The ComAware bit (2) must survive that mask, and be cleared by
+        // `get_WeakHandle`'s wider `& ~HandleTagBits`.
+        runBinary NullaryIlOp.And (taggedHandle 1L) (nativeConst ~~~1L)
+        |> shouldEqual (taggedHandle 0L)
+
+        runBinary NullaryIlOp.And (taggedHandle 3L) (nativeConst ~~~1L)
+        |> shouldEqual (taggedHandle 2L)
+
+        runBinary NullaryIlOp.And (taggedHandle 3L) (nativeConst ~~~3L)
+        |> shouldEqual (taggedHandle 0L)
+
+    [<Test>]
+    let ``an int32 operand is sign-extended before it reaches the tag region`` () : unit =
+        // An `int32` mask on the stack alongside a native int: `-2` must not be
+        // read as `0x00000000FFFFFFFE`, which would clear the handle's high bits.
+        runBinary NullaryIlOp.And (taggedHandle 3L) (EvalStackValue.Int32 -2)
+        |> shouldEqual (taggedHandle 2L)
+
+        runBinary NullaryIlOp.And (EvalStackValue.Int32 -2) (taggedHandle 3L)
+        |> shouldEqual (taggedHandle 2L)
+
+        runBinary NullaryIlOp.Or (EvalStackValue.Int32 1) (taggedHandle 0L)
+        |> shouldEqual (taggedHandle 1L)
+
+    [<Test>]
+    let ``Xor flips tag bits rather than losing the handle to hash synthesis`` () : unit =
+        runBinary NullaryIlOp.Xor (taggedHandle 1L) (nativeConst 3L)
+        |> shouldEqual (taggedHandle 2L)
+
+        runBinary NullaryIlOp.Xor (nativeConst 3L) (taggedHandle 1L)
+        |> shouldEqual (taggedHandle 2L)
+
+    [<Test>]
+    let ``an operand reaching outside the tag region is refused loudly`` () : unit =
+        // These ask about bits of the handle's address, which PawPrint does not
+        // model. Answering would mean inventing them.
+        let shouldRefuse (op : NullaryIlOp) (operand : EvalStackValue) : unit =
+            let exn =
+                Assert.Throws (fun () -> runBinary op (taggedHandle 1L) operand |> ignore<EvalStackValue>)
+
+            exn.Message |> shouldContainText "which PawPrint does not model"
+
+        shouldRefuse NullaryIlOp.And (nativeConst 4L)
+        shouldRefuse NullaryIlOp.And (EvalStackValue.Int32 4)
+        shouldRefuse NullaryIlOp.Or (nativeConst 8L)
+        shouldRefuse NullaryIlOp.Or (EvalStackValue.Int32 8)
+        shouldRefuse NullaryIlOp.Xor (nativeConst 4L)
+
+    [<Test>]
+    let ``dereferencing a tagged GC handle is refused loudly`` () : unit =
+        // Release CoreLib's `GCHandle.InternalGet` is `*(object*)handle`, and
+        // managed code always masks the tag off first. A tagged dereference would
+        // be a misaligned read in reality.
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+
+        let state, thread =
+            stateWithNullary loggerFactory NullaryIlOp.Ldind_ref (taggedHandle 1L)
+
+        let exn =
+            Assert.Throws (fun () ->
+                NullaryIlOp.execute loggerFactory baseClassTypes state thread NullaryIlOp.Ldind_ref
+                |> ignore<ExecutionResult>
+            )
+
+        exn.Message |> shouldContainText "refusing to dereference GC handle"
+
+    [<Test>]
+    let ``a GC handle InternalCall refuses a tagged handle`` () : unit =
+        let exn =
+            Assert.Throws (fun () ->
+                NativeCall.gcHandleAddressOfEvalStackValue "test" (taggedHandle 1L)
+                |> ignore<GcHandleAddress>
+            )
+
+        exn.Message |> shouldContainText "expected an untagged GC handle"
+
+        NativeCall.gcHandleAddressOfEvalStackValue "test" (taggedHandle 0L)
+        |> shouldEqual gcHandleUnderTest

--- a/WoofWare.PawPrint.Test/TestPointerHashSynthesis.fs
+++ b/WoofWare.PawPrint.Test/TestPointerHashSynthesis.fs
@@ -225,9 +225,32 @@ module TestPointerHashSynthesis =
     [<Test>]
     let ``low bits are clear for GcHandlePtr`` () : unit =
         let bits, _ =
-            materialise (NativeIntSource.GcHandlePtr (GcHandleAddress.GcHandleAddress 17)) PointerHashCounters.empty
+            materialise (NativeIntSource.GcHandlePtr (GcHandleAddress.GcHandleAddress 17, 0L)) PointerHashCounters.empty
 
         bits &&& 3L |> shouldEqual 0L
+
+    [<Test>]
+    let ``a GC handle's tag bits land in the low bits and leave its identity alone`` () : unit =
+        // Tag bits are a view over one identity, so all three views must agree
+        // above the tag region and differ exactly within it — which is what
+        // happens for real, where the tag really is stored in the pointer's spare
+        // low bits.
+        let handle = GcHandleAddress.GcHandleAddress 17
+
+        let untagged, counters =
+            materialise (NativeIntSource.GcHandlePtr (handle, 0L)) PointerHashCounters.empty
+
+        let tagged1, counters =
+            materialise (NativeIntSource.GcHandlePtr (handle, 1L)) counters
+
+        let tagged3, counters =
+            materialise (NativeIntSource.GcHandlePtr (handle, 3L)) counters
+
+        tagged1 |> shouldEqual (untagged ||| 1L)
+        tagged3 |> shouldEqual (untagged ||| 3L)
+
+        // One identity, so only one counter was ever spent.
+        counters.NextCounter |> shouldEqual 1UL
 
     [<Test>]
     let ``low bits are clear for AssemblyHandle / ModuleHandle / MetadataImportHandle`` () : unit =
@@ -331,7 +354,7 @@ module TestPointerHashSynthesis =
                     )
                 for i in 0..9 -> NativeIntSource.MethodHandlePtr (int64 i)
                 for i in 0..9 -> NativeIntSource.FieldHandlePtr (int64 i)
-                for i in 0..9 -> NativeIntSource.GcHandlePtr (GcHandleAddress.GcHandleAddress i)
+                for i in 0..9 -> NativeIntSource.GcHandlePtr (GcHandleAddress.GcHandleAddress i, 0L)
                 for i in 0..9 -> NativeIntSource.EventPipeProviderPtr (int64 i)
                 for i in 0..9 -> NativeIntSource.EventPipeEventPtr (int64 i)
             ]

--- a/WoofWare.PawPrint.Test/TestTaggedPointerBits.fs
+++ b/WoofWare.PawPrint.Test/TestTaggedPointerBits.fs
@@ -1,0 +1,337 @@
+namespace WoofWare.PawPrint.Test
+
+open FsCheck
+open FsCheck.FSharp
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+/// `TaggedPointerBits` decides whether a bitwise operation against a pointer of
+/// the form `base ||| tag` — `base` unknown, non-zero, low bits clear — has an
+/// answer that holds for *every* admissible base.
+///
+/// The oracle here is deliberately derived a different way from the
+/// implementation. The implementation tests the operand's high region against the
+/// two knife-edge values `0` and `~tagMask` in closed form; the oracle instead
+/// walks bit positions one at a time, asking of each "does this operation preserve
+/// this base bit, force it to a constant, or neither", and reads the concrete
+/// answer off probe evaluations. That keeps the two from sharing a mistake.
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestTaggedPointerBits =
+
+    /// The three operations under test, each paired with its per-bit behaviour on
+    /// a single unknown base bit.
+    type private Op =
+        | And
+        | Or
+        | Xor
+
+        member this.Apply (a : int64, b : int64) : int64 =
+            match this with
+            | Op.And -> a &&& b
+            | Op.Or -> a ||| b
+            | Op.Xor -> a ^^^ b
+
+        /// Does this operation leave an unknown base bit unchanged, given the
+        /// operand's bit at the same position?
+        member this.PreservesBaseBit (operandBit : bool) : bool =
+            match this with
+            // b &&& 1 = b; b &&& 0 = 0
+            | Op.And -> operandBit
+            // b ||| 0 = b; b ||| 1 = 1
+            | Op.Or -> not operandBit
+            // b ^^^ 0 = b; b ^^^ 1 = ~b
+            | Op.Xor -> not operandBit
+
+        /// Does this operation force an unknown base bit to a constant, given the
+        /// operand's bit at the same position?
+        member this.ForcesBaseBit (operandBit : bool) : bool =
+            match this with
+            | Op.And -> not operandBit
+            | Op.Or -> operandBit
+            // Inverting an unknown bit is still unknown.
+            | Op.Xor -> false
+
+        member this.Invoke (tagWidthBits : int) (tag : int64) (operand : int64) : TaggedPointerBitsResult =
+            match this with
+            | Op.And -> TaggedPointerBits.bitAnd tagWidthBits tag operand
+            | Op.Or -> TaggedPointerBits.bitOr tagWidthBits tag operand
+            | Op.Xor -> TaggedPointerBits.bitXor tagWidthBits tag operand
+
+    /// Bit positions of the unknown base: everything at or above the tag region.
+    /// Bit 63 is included; all three operations are bit-parallel, so the sign bit
+    /// is not special.
+    let private baseBitPositions (tagWidthBits : int) : int list = [ tagWidthBits..63 ]
+
+    let private bitIsSet (value : int64) (position : int) : bool = (value >>> position) &&& 1L = 1L
+
+    /// A base that is admissible under the model: non-zero, low `tagWidthBits`
+    /// bits clear. Used as a probe to read off the concrete answer once the
+    /// per-bit analysis has established that one exists.
+    let private probeBase (tagWidthBits : int) : int64 = 1L <<< tagWidthBits
+
+    /// The oracle: classify by per-bit reasoning, and read the concrete payload
+    /// off a probe evaluation.
+    let private expected (op : Op) (tagWidthBits : int) (tag : int64) (operand : int64) : TaggedPointerBitsResult =
+        let positions = baseBitPositions tagWidthBits
+
+        let allPreserved =
+            positions |> List.forall (fun i -> op.PreservesBaseBit (bitIsSet operand i))
+
+        let allForced =
+            positions |> List.forall (fun i -> op.ForcesBaseBit (bitIsSet operand i))
+
+        let b = probeBase tagWidthBits
+        let probeResult = op.Apply (b ||| tag, operand)
+
+        if allPreserved then
+            TaggedPointerBitsResult.Retagged (probeResult &&& TaggedPointerBits.tagMask tagWidthBits)
+        elif allForced then
+            TaggedPointerBitsResult.TagBitsOnly probeResult
+        else
+            TaggedPointerBitsResult.NotStatable
+
+    /// Admissible bases to check a stated answer against. Includes each individual
+    /// base bit set on its own, so that any single mishandled bit position shows up.
+    let private sampleBases (tagWidthBits : int) : int64 list =
+        let singles = baseBitPositions tagWidthBits |> List.map (fun i -> 1L <<< i)
+        let mask = ~~~(TaggedPointerBits.tagMask tagWidthBits)
+
+        singles
+        @ [
+            mask
+            0x0123456789ABCDEFL &&& mask ||| (1L <<< tagWidthBits)
+            0x7EDCBA9876543210L &&& mask ||| (1L <<< tagWidthBits)
+        ]
+
+    type private Scenario =
+        {
+            TagWidthBits : int
+            Tag : int64
+            Operand : int64
+            Op : Op
+        }
+
+        override this.ToString () : string =
+            $"{this.Op} width=%i{this.TagWidthBits} tag=0x%x{this.Tag} operand=0x%x{this.Operand}"
+
+    /// `Retagged` / `TagBitsOnly` only ever fire on the knife-edge conditions
+    /// "operand's high region is all zeros" and "all ones". A uniformly sampled
+    /// `int64` essentially never hits either, so those branches would be tested
+    /// vacuously; the generator constructs the high region explicitly instead.
+    let private genScenario : Gen<Scenario> =
+        gen {
+            let! tagWidthBits = Gen.choose (1, 8)
+            let low = TaggedPointerBits.tagMask tagWidthBits
+            let! tagRaw = ArbMap.defaults |> ArbMap.generate<int64>
+            let! operandLow = ArbMap.defaults |> ArbMap.generate<int64>
+            let! arbitraryHigh = ArbMap.defaults |> ArbMap.generate<int64>
+
+            let! high =
+                Gen.frequency
+                    [
+                        // Every base bit preserved / forced: the two statable shapes.
+                        3, Gen.constant 0L
+                        3, Gen.constant ~~~low
+                        // Partial high regions, including near-misses at either end.
+                        2, Gen.constant (arbitraryHigh &&& ~~~low)
+                        1, Gen.constant (~~~low &&& ~~~(1L <<< tagWidthBits))
+                        1, Gen.constant (1L <<< tagWidthBits)
+                        1, Gen.constant System.Int64.MinValue
+                        1, Gen.constant (~~~low &&& ~~~System.Int64.MinValue)
+                    ]
+
+            let! op = Gen.elements [ Op.And ; Op.Or ; Op.Xor ]
+
+            return
+                {
+                    TagWidthBits = tagWidthBits
+                    Tag = tagRaw &&& low
+                    Operand = (operandLow &&& low) ||| high
+                    Op = op
+                }
+        }
+
+    type private Arbitraries =
+        static member Scenario () : Arbitrary<Scenario> = Arb.fromGen genScenario
+
+    /// FsCheck reports a raised exception as the counterexample's failure, which
+    /// keeps the scenario visible without needing labelled properties.
+    let private holds (message : string) (condition : bool) : bool =
+        if not condition then
+            failwith message
+
+        true
+
+    let private config : Config =
+        Config.QuickThrowOnFailure.WithMaxTest(2000).WithArbitrary [ typeof<Arbitraries> ]
+
+    [<Test>]
+    let ``classification matches the per-bit oracle`` () : unit =
+        Check.One (
+            config,
+            Prop.forAll
+                (Arb.fromGen genScenario)
+                (fun scenario ->
+                    let actual = scenario.Op.Invoke scenario.TagWidthBits scenario.Tag scenario.Operand
+
+                    let expected =
+                        expected scenario.Op scenario.TagWidthBits scenario.Tag scenario.Operand
+
+                    holds $"%O{scenario}: got %O{actual}, oracle says %O{expected}" (actual = expected)
+                )
+        )
+
+    [<Test>]
+    let ``a stated answer holds for every admissible base`` () : unit =
+        Check.One (
+            config,
+            Prop.forAll
+                (Arb.fromGen genScenario)
+                (fun scenario ->
+                    let low = TaggedPointerBits.tagMask scenario.TagWidthBits
+
+                    match scenario.Op.Invoke scenario.TagWidthBits scenario.Tag scenario.Operand with
+                    | TaggedPointerBitsResult.NotStatable -> true
+                    | TaggedPointerBitsResult.Retagged tag ->
+                        // The tag must stay inside the tag region, or the result is not
+                        // a well-formed tagged pointer.
+                        let inRange = tag &&& ~~~low = 0L
+
+                        let agrees =
+                            sampleBases scenario.TagWidthBits
+                            |> List.forall (fun b ->
+                                scenario.Op.Apply (b ||| scenario.Tag, scenario.Operand) = (b ||| tag)
+                            )
+
+                        holds
+                            $"%O{scenario}: claimed Retagged 0x%x{tag} (in range: %b{inRange}, agrees: %b{agrees})"
+                            (inRange && agrees)
+                    | TaggedPointerBitsResult.TagBitsOnly bits ->
+                        sampleBases scenario.TagWidthBits
+                        |> List.forall (fun b -> scenario.Op.Apply (b ||| scenario.Tag, scenario.Operand) = bits)
+                        |> holds $"%O{scenario}: claimed TagBitsOnly 0x%x{bits}"
+                )
+        )
+
+    [<Test>]
+    let ``a refusal is a refusal of something genuinely unanswerable`` () : unit =
+        // Completeness: we must never decline to answer a question we could have
+        // answered. Whenever the implementation says NotStatable, exhibit concrete
+        // admissible bases ruling out both answer shapes.
+        Check.One (
+            config,
+            Prop.forAll
+                (Arb.fromGen genScenario)
+                (fun scenario ->
+                    match scenario.Op.Invoke scenario.TagWidthBits scenario.Tag scenario.Operand with
+                    | TaggedPointerBitsResult.Retagged _
+                    | TaggedPointerBitsResult.TagBitsOnly _ -> true
+                    | TaggedPointerBitsResult.NotStatable ->
+                        let low = TaggedPointerBits.tagMask scenario.TagWidthBits
+
+                        let results =
+                            sampleBases scenario.TagWidthBits
+                            |> List.map (fun b -> b, scenario.Op.Apply (b ||| scenario.Tag, scenario.Operand))
+
+                        // No TagBitsOnly answer: two bases disagree.
+                        let notConstant = results |> List.map snd |> List.distinct |> List.length > 1
+
+                        // No Retagged answer: some base does not survive into its own
+                        // bit positions in the result.
+                        let notPreserving =
+                            results |> List.exists (fun (b, result) -> result &&& ~~~low <> b)
+
+                        holds
+                            $"%O{scenario}: refused, but notConstant=%b{notConstant} notPreserving=%b{notPreserving}"
+                            (notConstant && notPreserving)
+                )
+        )
+
+    // The specific operations the CoreLib IL performs on a tagged GC handle. See
+    // docs/plans/2026-08-06-tagged-gc-handles.md for the IL these come from.
+
+    let private w : int = TaggedPointerBits.gcHandleTagWidthBits
+
+    [<Test>]
+    let ``WeakReference IsTrackResurrection reads the tag`` () : unit =
+        // `_taggedHandle & 1`
+        TaggedPointerBits.bitAnd w 0L 1L
+        |> shouldEqual (TaggedPointerBitsResult.TagBitsOnly 0L)
+
+        TaggedPointerBits.bitAnd w 1L 1L
+        |> shouldEqual (TaggedPointerBitsResult.TagBitsOnly 1L)
+
+    [<Test>]
+    let ``WeakReference Create sets the tag`` () : unit =
+        // `h | TracksResurrectionBit`
+        TaggedPointerBits.bitOr w 0L 1L
+        |> shouldEqual (TaggedPointerBitsResult.Retagged 1L)
+
+    [<Test>]
+    let ``WeakReference get_Target strips the resurrection bit and keeps the handle`` () : unit =
+        // `_taggedHandle & ~TracksResurrectionBit`
+        TaggedPointerBits.bitAnd w 1L ~~~1L
+        |> shouldEqual (TaggedPointerBitsResult.Retagged 0L)
+
+        // A COM-aware bit, had one been set, must survive that mask.
+        TaggedPointerBits.bitAnd w 3L ~~~1L
+        |> shouldEqual (TaggedPointerBitsResult.Retagged 2L)
+
+    [<Test>]
+    let ``WeakReference get_WeakHandle strips every tag bit`` () : unit =
+        // `_taggedHandle & ~HandleTagBits`
+        TaggedPointerBits.bitAnd w 3L ~~~3L
+        |> shouldEqual (TaggedPointerBitsResult.Retagged 0L)
+
+    [<Test>]
+    let ``GCHandle pinned marker round-trips`` () : unit =
+        // `handle |= 1`, then `handle & 1` and `handle & ~1`.
+        TaggedPointerBits.bitOr w 0L 1L
+        |> shouldEqual (TaggedPointerBitsResult.Retagged 1L)
+
+        TaggedPointerBits.bitAnd w 1L 1L
+        |> shouldEqual (TaggedPointerBitsResult.TagBitsOnly 1L)
+
+        TaggedPointerBits.bitAnd w 1L ~~~1L
+        |> shouldEqual (TaggedPointerBitsResult.Retagged 0L)
+
+    [<Test>]
+    let ``masks reaching outside the tag region are refused`` () : unit =
+        // 4 is the first bit above the tag region: `handle & 4` is a question
+        // about the unknown base.
+        TaggedPointerBits.bitAnd w 1L 4L
+        |> shouldEqual TaggedPointerBitsResult.NotStatable
+
+        TaggedPointerBits.bitOr w 1L 8L
+        |> shouldEqual TaggedPointerBitsResult.NotStatable
+
+        TaggedPointerBits.bitXor w 1L 4L
+        |> shouldEqual TaggedPointerBitsResult.NotStatable
+
+    [<Test>]
+    let ``an all-ones operand is answerable for and and or but not xor`` () : unit =
+        // `handle & -1` is the identity; `handle | -1` is -1 regardless of base;
+        // `handle ^ -1` is the complement of an unknown value.
+        TaggedPointerBits.bitAnd w 2L -1L
+        |> shouldEqual (TaggedPointerBitsResult.Retagged 2L)
+
+        TaggedPointerBits.bitOr w 2L -1L
+        |> shouldEqual (TaggedPointerBitsResult.TagBitsOnly -1L)
+
+        TaggedPointerBits.bitXor w 2L -1L
+        |> shouldEqual TaggedPointerBitsResult.NotStatable
+
+    [<Test>]
+    let ``a zero operand is answerable for or and xor but not and`` () : unit =
+        // `handle & 0` is 0 regardless of base; `handle | 0` and `handle ^ 0` are
+        // the identity.
+        TaggedPointerBits.bitAnd w 2L 0L
+        |> shouldEqual (TaggedPointerBitsResult.TagBitsOnly 0L)
+
+        TaggedPointerBits.bitOr w 2L 0L
+        |> shouldEqual (TaggedPointerBitsResult.Retagged 2L)
+
+        TaggedPointerBits.bitXor w 2L 0L
+        |> shouldEqual (TaggedPointerBitsResult.Retagged 2L)

--- a/WoofWare.PawPrint.Test/TestTaggedPointerBits.fs
+++ b/WoofWare.PawPrint.Test/TestTaggedPointerBits.fs
@@ -153,9 +153,6 @@ module TestTaggedPointerBits =
                 }
         }
 
-    type private Arbitraries =
-        static member Scenario () : Arbitrary<Scenario> = Arb.fromGen genScenario
-
     /// FsCheck reports a raised exception as the counterexample's failure, which
     /// keeps the scenario visible without needing labelled properties.
     let private holds (message : string) (condition : bool) : bool =
@@ -164,8 +161,7 @@ module TestTaggedPointerBits =
 
         true
 
-    let private config : Config =
-        Config.QuickThrowOnFailure.WithMaxTest(2000).WithArbitrary [ typeof<Arbitraries> ]
+    let private config : Config = Config.QuickThrowOnFailure.WithMaxTest 2000
 
     [<Test>]
     let ``classification matches the per-bit oracle`` () : unit =

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -26,6 +26,7 @@
     <Compile Include="TestTypeResolution.fs" />
     <Compile Include="TestTypeIdentityProperties.fs" />
     <Compile Include="TestEvalStack.fs" />
+    <Compile Include="TestTaggedPointerBits.fs" />
     <Compile Include="TestNativeIntSource.fs" />
     <Compile Include="TestPointerHashSynthesis.fs" />
     <Compile Include="TestCliTypeBytes.fs" />

--- a/WoofWare.PawPrint.Test/sourcesPure/WeakReferenceBasic.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/WeakReferenceBasic.cs
@@ -1,0 +1,57 @@
+using System;
+
+public class Program
+{
+    private sealed class Box
+    {
+        public int Value;
+    }
+
+    public static int Main(string[] args)
+    {
+        // Non-track-resurrection: WeakReference.Create stores the handle untagged,
+        // and get_Target masks off TracksResurrectionBit (`handle & ~1`) before
+        // dereferencing.
+        Box target = new Box { Value = 17 };
+        WeakReference weak = new WeakReference(target);
+
+        if (weak.TrackResurrection) return 1;
+        if (!weak.IsAlive) return 2;
+
+        object? got = weak.Target;
+        if (!ReferenceEquals(got, target)) return 3;
+
+        // Track-resurrection: Create ORs TracksResurrectionBit into the handle,
+        // so every read has to strip a tag bit that is actually set.
+        WeakReference weakTracked = new WeakReference(target, true);
+        if (!weakTracked.TrackResurrection) return 4;
+        if (!weakTracked.IsAlive) return 5;
+        if (!ReferenceEquals(weakTracked.Target, target)) return 6;
+
+        // Setting the target goes through InternalSet on the untagged handle.
+        Box other = new Box { Value = 23 };
+        weak.Target = other;
+        if (!ReferenceEquals(weak.Target, other)) return 7;
+        if (weak.TrackResurrection) return 8;
+
+        weakTracked.Target = other;
+        if (!ReferenceEquals(weakTracked.Target, other)) return 9;
+        if (!weakTracked.TrackResurrection) return 10;
+
+        // Generic form: WeakReference<T>.TryGetTarget goes through the same
+        // tagged-handle masking.
+        WeakReference<Box> generic = new WeakReference<Box>(target);
+        if (!generic.TryGetTarget(out Box? fromGeneric)) return 11;
+        if (!ReferenceEquals(fromGeneric, target)) return 12;
+
+        generic.SetTarget(other);
+        if (!generic.TryGetTarget(out Box? fromGenericAgain)) return 13;
+        if (!ReferenceEquals(fromGenericAgain, other)) return 14;
+
+        WeakReference<Box> genericTracked = new WeakReference<Box>(target, true);
+        if (!genericTracked.TryGetTarget(out Box? fromTracked)) return 15;
+        if (!ReferenceEquals(fromTracked, target)) return 16;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/EvalStack.fs
+++ b/WoofWare.PawPrint/EvalStack.fs
@@ -55,7 +55,7 @@ module EvalStackValue =
             failwith $"%s{operation}: refusing to convert RuntimeFieldHandle pointer %d{handle} to an integer"
         | NativeIntSource.MethodHandlePtr handle ->
             failwith $"%s{operation}: refusing to convert RuntimeMethodHandle pointer %d{handle} to an integer"
-        | NativeIntSource.GcHandlePtr handle ->
+        | NativeIntSource.GcHandlePtr (handle, _) ->
             failwith $"%s{operation}: refusing to convert GC handle pointer %O{handle} to an integer"
         | NativeIntSource.EventPipeProviderPtr id ->
             failwith $"%s{operation}: refusing to convert EventPipe provider handle #%d{id} to an integer"
@@ -248,7 +248,7 @@ module EvalStackValue =
                 failwith $"Conv_U: refusing to convert PerInstInfo pointer %O{handle} to unsigned native int"
             | NativeIntSource.PerInstDictPtr handle ->
                 failwith $"Conv_U: refusing to convert PerInstDict pointer %O{handle} to unsigned native int"
-            | NativeIntSource.GcHandlePtr handle ->
+            | NativeIntSource.GcHandlePtr (handle, _) ->
                 failwith $"Conv_U: refusing to convert GC handle pointer %O{handle} to unsigned native int"
             | NativeIntSource.EventPipeProviderPtr id ->
                 failwith $"Conv_U: refusing to convert EventPipe provider handle #%d{id} to unsigned native int"
@@ -531,7 +531,8 @@ module EvalStackValue =
             | CliRuntimePointer.PerInstDictPtr handle ->
                 NativeIntSource.PerInstDictPtr handle |> EvalStackValue.NativeInt
             | CliRuntimePointer.Managed ptr -> ptr |> EvalStackValue.ManagedPointer
-            | CliRuntimePointer.GcHandlePtr addr -> NativeIntSource.GcHandlePtr addr |> EvalStackValue.NativeInt
+            | CliRuntimePointer.GcHandlePtr (addr, tag) ->
+                NativeIntSource.GcHandlePtr (addr, tag) |> EvalStackValue.NativeInt
         | CliType.ValueType vt ->
             // Primitive-like single-field wrappers (IntPtr, RuntimeTypeHandle, enums, ...) all get
             // flattened to their underlying primitive on the stack. ECMA III.1.8 treats enums as
@@ -571,7 +572,7 @@ module EvalStackValue =
                         failwith $"refusing to coerce PerInstInfo pointer %O{f} to int64"
                     | NativeIntSource.PerInstDictPtr f ->
                         failwith $"refusing to coerce PerInstDict pointer %O{f} to int64"
-                    | NativeIntSource.GcHandlePtr f -> failwith $"TODO: {f}"
+                    | NativeIntSource.GcHandlePtr (f, tag) -> failwith $"TODO: {f} (tag 0x%x{tag})"
                     | NativeIntSource.EventPipeProviderPtr id ->
                         failwith $"refusing to coerce EventPipe provider handle #%d{id} to int64"
                     | NativeIntSource.EventPipeEventPtr id ->
@@ -643,8 +644,8 @@ module EvalStackValue =
                             CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.PerInstDictPtr handle))
                         | CliRuntimePointer.Managed src ->
                             CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.ManagedPointer src))
-                        | CliRuntimePointer.GcHandlePtr addr ->
-                            CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.GcHandlePtr addr))
+                        | CliRuntimePointer.GcHandlePtr (addr, tag) ->
+                            CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.GcHandlePtr (addr, tag)))
                     | _ -> failwith $"TODO: {popped}"
                 | _ -> failwith $"TODO: {popped}"
             | CliNumericType.NativeFloat f -> failwith "todo"
@@ -763,7 +764,8 @@ module EvalStackValue =
                     CliType.RuntimePointer (CliRuntimePointer.FieldRegistryHandle ptr)
                 | NativeIntSource.MethodHandlePtr ptr ->
                     CliType.RuntimePointer (CliRuntimePointer.MethodRegistryHandle ptr)
-                | NativeIntSource.GcHandlePtr addr -> CliType.RuntimePointer (CliRuntimePointer.GcHandlePtr addr)
+                | NativeIntSource.GcHandlePtr (addr, tag) ->
+                    CliType.RuntimePointer (CliRuntimePointer.GcHandlePtr (addr, tag))
                 | NativeIntSource.EventPipeProviderPtr id ->
                     failwith
                         $"refusing to coerce EventPipe provider handle #%d{id} to runtime pointer: tracing handles are opaque, not addresses"

--- a/WoofWare.PawPrint/Native/NativeCall.fs
+++ b/WoofWare.PawPrint/Native/NativeCall.fs
@@ -136,13 +136,19 @@ module NativeCall =
         | EvalStackValue.ObjectRef addr -> Some addr
         | other -> failwith $"%s{operation}: expected object reference, got %O{other}"
 
+    /// The GC handle entry points take the raw handle, not a tagged view of one:
+    /// `GCHandle` strips its pinned marker via `GetHandleValue` and `WeakReference`
+    /// strips its tag bits before calling `InternalSet`, so a tagged handle
+    /// arriving here means the guest skipped a mask and we must not guess.
     let gcHandleAddressOfEvalStackValue (operation : string) (arg : EvalStackValue) : GcHandleAddress =
         match arg with
-        | EvalStackValue.NativeInt (NativeIntSource.GcHandlePtr handle) -> handle
+        | EvalStackValue.NativeInt (NativeIntSource.GcHandlePtr (handle, 0L)) -> handle
+        | EvalStackValue.NativeInt (NativeIntSource.GcHandlePtr (handle, tag)) ->
+            failwith $"%s{operation}: expected an untagged GC handle, got %O{handle} carrying tag bits 0x%x{tag}"
         | other -> failwith $"%s{operation}: expected GC handle pointer, got %O{other}"
 
     let pushGcHandleAddress (handle : GcHandleAddress) (thread : ThreadId) (state : IlMachineState) : IlMachineState =
-        IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt (NativeIntSource.GcHandlePtr handle)) thread state
+        IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt (NativeIntSource.gcHandlePtr handle)) thread state
 
     let pushObjectTarget
         (target : ManagedHeapAddress option)

--- a/WoofWare.PawPrint/NativeIntSource.fs
+++ b/WoofWare.PawPrint/NativeIntSource.fs
@@ -1,6 +1,7 @@
 namespace WoofWare.PawPrint
 
 open System
+open System.Diagnostics
 open Checked
 
 /// The delta between the addresses of two locations in memory that aren't within the same ByteStorageIdentity.
@@ -120,7 +121,23 @@ type NativeIntSource =
     | AssemblyHandle of string
     | ModuleHandle of string
     | MetadataImportHandle of string
-    | GcHandlePtr of GcHandleAddress
+    /// A GC handle, plus whatever tag bits managed code has stuffed into its low
+    /// bits. `GcHandleAddress` is the handle's identity; `tag` is a view the guest
+    /// has imposed on it, and is always inside
+    /// `TaggedPointerBits.tagMask TaggedPointerBits.gcHandleTagWidthBits`.
+    ///
+    /// CoreLib genuinely does this: `System.WeakReference` stores
+    /// `handle | TracksResurrectionBit` and masks the bit off again on every read,
+    /// and `GCHandle` marks pinned handles with bit 0. PawPrint models neither the
+    /// handle's numeric address nor a fake stand-in for it, so the tag has to
+    /// travel alongside the identity — see `TaggedPointerBits` for the arithmetic
+    /// this admits, and `docs/plans/2026-08-06-tagged-gc-handles.md` for why.
+    ///
+    /// Consumers that dereference or free the handle (`ldind.ref`, the
+    /// `GCHandle`/`DependentHandle` InternalCalls) require `tag = 0`: real managed
+    /// code always strips the tag first, and a tagged dereference is a misaligned
+    /// read.
+    | GcHandlePtr of handle : GcHandleAddress * tag : int64
     /// Opaque handle returned by `EventPipeInternal_CreateProvider` /
     /// `EventPipeInternal_GetProvider`. PawPrint never opens a tracing
     /// session, so the payload is just a monotonically increasing ID; the
@@ -180,7 +197,8 @@ type NativeIntSource =
         | NativeIntSource.AssemblyHandle name -> $"<assembly %s{name}>"
         | NativeIntSource.ModuleHandle name -> $"<module %s{name}>"
         | NativeIntSource.MetadataImportHandle name -> $"<metadata import for %s{name}>"
-        | NativeIntSource.GcHandlePtr handle -> $"<GC handle %O{handle}>"
+        | NativeIntSource.GcHandlePtr (handle, 0L) -> $"<GC handle %O{handle}>"
+        | NativeIntSource.GcHandlePtr (handle, tag) -> $"<GC handle %O{handle}, tagged 0x%x{tag}>"
         | NativeIntSource.EventPipeProviderPtr id -> $"<EventPipe provider #%i{id}>"
         | NativeIntSource.EventPipeEventPtr id -> $"<EventPipe event #%i{id}>"
         | NativeIntSource.LowLevelMonitorPtr id -> $"%O{id}"
@@ -207,7 +225,8 @@ type NativeIntSource =
             | NativeIntSource.AssemblyHandle left, NativeIntSource.AssemblyHandle right -> left = right
             | NativeIntSource.ModuleHandle left, NativeIntSource.ModuleHandle right -> left = right
             | NativeIntSource.MetadataImportHandle left, NativeIntSource.MetadataImportHandle right -> left = right
-            | NativeIntSource.GcHandlePtr left, NativeIntSource.GcHandlePtr right -> left = right
+            | NativeIntSource.GcHandlePtr (leftHandle, leftTag), NativeIntSource.GcHandlePtr (rightHandle, rightTag) ->
+                leftHandle = rightHandle && leftTag = rightTag
             | NativeIntSource.EventPipeProviderPtr left, NativeIntSource.EventPipeProviderPtr right -> left = right
             | NativeIntSource.EventPipeEventPtr left, NativeIntSource.EventPipeEventPtr right -> left = right
             | NativeIntSource.LowLevelMonitorPtr left, NativeIntSource.LowLevelMonitorPtr right -> left = right
@@ -259,7 +278,7 @@ type NativeIntSource =
         | NativeIntSource.AssemblyHandle name -> HashCode.Combine (8, name)
         | NativeIntSource.ModuleHandle name -> HashCode.Combine (9, name)
         | NativeIntSource.MetadataImportHandle name -> HashCode.Combine (10, name)
-        | NativeIntSource.GcHandlePtr handle -> HashCode.Combine (11, handle)
+        | NativeIntSource.GcHandlePtr (handle, tag) -> HashCode.Combine (11, handle, tag)
         | NativeIntSource.EventPipeProviderPtr id -> HashCode.Combine (12, id)
         | NativeIntSource.EventPipeEventPtr id -> HashCode.Combine (13, id)
         | NativeIntSource.SyntheticCrossArrayOffset s -> HashCode.Combine (14, hash s)
@@ -278,6 +297,22 @@ module NativeIntSource =
         =
         SyntheticCrossArrayOffset.make targetStorage targetByteOffset originStorage originByteOffset
         |> NativeIntSource.SyntheticCrossArrayOffset
+
+    /// A freshly-minted GC handle, as the runtime hands it to managed code:
+    /// untagged. Managed code is what adds tag bits, via `and`/`or`/`xor`.
+    let gcHandlePtr (handle : GcHandleAddress) : NativeIntSource =
+        NativeIntSource.GcHandlePtr (handle, 0L)
+
+    /// A GC handle carrying tag bits managed code has put there. The tag must lie
+    /// inside the tag region, which is guaranteed when it comes from
+    /// `TaggedPointerBits`; the assertion catches any site that bypasses that.
+    let gcHandlePtrTagged (handle : GcHandleAddress) (tag : int64) : NativeIntSource =
+        Debug.Assert (
+            tag &&& ~~~(TaggedPointerBits.tagMask TaggedPointerBits.gcHandleTagWidthBits) = 0L,
+            $"tag 0x%x{tag} escapes the GC handle tag region; tags must come from TaggedPointerBits"
+        )
+
+        NativeIntSource.GcHandlePtr (handle, tag)
 
     let isZero (n : NativeIntSource) : bool =
         match n with
@@ -371,7 +406,11 @@ module NativeIntSource =
         | NativeIntSource.AssemblyHandle f1, NativeIntSource.AssemblyHandle f2 -> f1 = f2
         | NativeIntSource.ModuleHandle f1, NativeIntSource.ModuleHandle f2 -> f1 = f2
         | NativeIntSource.MetadataImportHandle f1, NativeIntSource.MetadataImportHandle f2 -> f1 = f2
-        | NativeIntSource.GcHandlePtr f1, NativeIntSource.GcHandlePtr f2 -> f1 = f2
+        // Two views of one handle are the same value only if they carry the same
+        // tag: CoreLib's `GCHandle.Equals` compares the raw tagged `IntPtr`, so a
+        // pinned handle does not equal the same handle with its pin marker
+        // stripped.
+        | NativeIntSource.GcHandlePtr (h1, tag1), NativeIntSource.GcHandlePtr (h2, tag2) -> h1 = h2 && tag1 = tag2
         | NativeIntSource.EventPipeProviderPtr f1, NativeIntSource.EventPipeProviderPtr f2 -> f1 = f2
         | NativeIntSource.EventPipeEventPtr f1, NativeIntSource.EventPipeEventPtr f2 -> f1 = f2
         | NativeIntSource.LowLevelMonitorPtr f1, NativeIntSource.LowLevelMonitorPtr f2 -> f1 = f2
@@ -582,9 +621,11 @@ type CliRuntimePointer =
     /// counterpart is `NativeIntSource.PerInstDictPtr`.
     | PerInstDictPtr of ConcreteTypeHandle
     | Managed of ManagedPointerSource
-    /// A GC handle stored in a typed-pointer slot (e.g. `void*`, `T*`). Arithmetic
+    /// A GC handle stored in a typed-pointer slot (e.g. `void*`, `T*`), plus any
+    /// tag bits managed code has put in its low bits (see
+    /// `NativeIntSource.GcHandlePtr`, whose contract this mirrors). Arithmetic
     /// and comparison operations on this case must go through eval-stack
     /// flattening (`EvalStack.ofCliType`) into `NativeIntSource.GcHandlePtr`;
     /// helpers like `NativeIntSource.isZero`/`isNonnegative` and conv ops only
     /// match the `NativeIntSource` form.
-    | GcHandlePtr of GcHandleAddress
+    | GcHandlePtr of handle : GcHandleAddress * tag : int64

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -95,6 +95,25 @@ module NullaryIlOp =
             | ConcreteTypeHandle.OneDimArrayZero _
             | ConcreteTypeHandle.Array _ -> 0L
 
+    /// Apply a bitwise operation to the low tag region of a GC handle, if the
+    /// model can state the answer. See `TaggedPointerBits`: PawPrint does not
+    /// model a handle's numeric address, so only operations that either preserve
+    /// the whole (unknown) handle or reduce to the known tag bits are answerable.
+    let private gcHandleTagOp
+        (operation : string)
+        (decide : int -> int64 -> int64 -> TaggedPointerBitsResult)
+        (handle : GcHandleAddress)
+        (tag : int64)
+        (operand : int64)
+        : NativeIntSource
+        =
+        match decide TaggedPointerBits.gcHandleTagWidthBits tag operand with
+        | TaggedPointerBitsResult.Retagged tag -> NativeIntSource.gcHandlePtrTagged handle tag
+        | TaggedPointerBitsResult.TagBitsOnly bits -> NativeIntSource.Verbatim bits
+        | TaggedPointerBitsResult.NotStatable ->
+            failwith
+                $"%s{operation}: refusing to apply 0x%x{operand} to GC handle %O{handle}; the result would depend on the handle's address, which PawPrint does not model"
+
     let private andNativeIntAddressBits
         (state : IlMachineState)
         (source : NativeIntSource)
@@ -104,6 +123,9 @@ module NullaryIlOp =
         match source with
         | NativeIntSource.Verbatim bits -> NativeIntSource.Verbatim (bits &&& mask) |> EvalStackValue.NativeInt
         | NativeIntSource.ManagedPointer ptr -> andManagedPointerAddressBits state ptr mask
+        | NativeIntSource.GcHandlePtr (handle, tag) ->
+            gcHandleTagOp "And" TaggedPointerBits.bitAnd handle tag mask
+            |> EvalStackValue.NativeInt
         | NativeIntSource.TypeHandlePtr target ->
             NativeIntSource.Verbatim (typeHandleLowAddressBits target &&& mask)
             |> EvalStackValue.NativeInt
@@ -127,6 +149,13 @@ module NullaryIlOp =
         =
         match i1, i2 with
         | NativeIntSource.Verbatim a, NativeIntSource.Verbatim b -> NativeIntSource.Verbatim (a ^^^ b), counters
+        // A GC handle's tag region is exactly representable, so flipping bits
+        // inside it has an exact answer. Without these arms the pair would fall
+        // through to hash synthesis below, which would *silently* replace the
+        // handle with opaque bits.
+        | NativeIntSource.GcHandlePtr (handle, tag), NativeIntSource.Verbatim operand
+        | NativeIntSource.Verbatim operand, NativeIntSource.GcHandlePtr (handle, tag) ->
+            gcHandleTagOp "Xor" TaggedPointerBits.bitXor handle tag operand, counters
         | _ ->
             let a, counters = PointerHashSynthesis.materialiseHashBits "Xor" i1 counters
             let b, counters = PointerHashSynthesis.materialiseHashBits "Xor" i2 counters
@@ -346,7 +375,8 @@ module NullaryIlOp =
                 failwith $"Neg: refusing to negate RuntimeMethodHandle pointer %d{handle}"
             | NativeIntSource.FieldHandlePtr handle ->
                 failwith $"Neg: refusing to negate RuntimeFieldHandle pointer %d{handle}"
-            | NativeIntSource.GcHandlePtr handle -> failwith $"Neg: refusing to negate GC handle pointer %O{handle}"
+            | NativeIntSource.GcHandlePtr (handle, _) ->
+                failwith $"Neg: refusing to negate GC handle pointer %O{handle}"
             | NativeIntSource.AssemblyHandle assemblyName ->
                 failwith $"Neg: refusing to negate assembly handle %s{assemblyName}"
             | NativeIntSource.ModuleHandle moduleName ->
@@ -700,7 +730,7 @@ module NullaryIlOp =
                 failwith $"Conv_ovf_u: refusing to convert PerInstInfo pointer %O{handle} to unsigned native int"
             | NativeIntSource.PerInstDictPtr handle ->
                 failwith $"Conv_ovf_u: refusing to convert PerInstDict pointer %O{handle} to unsigned native int"
-            | NativeIntSource.GcHandlePtr handle ->
+            | NativeIntSource.GcHandlePtr (handle, _) ->
                 failwith $"Conv_ovf_u: refusing to convert GC handle pointer %O{handle} to unsigned native int"
             | NativeIntSource.EventPipeProviderPtr id ->
                 failwith $"Conv_ovf_u: refusing to convert EventPipe provider handle #%d{id} to unsigned native int"
@@ -788,7 +818,7 @@ module NullaryIlOp =
                 failwith $"Conv_ovf_i: refusing to convert PerInstInfo pointer %O{handle} to signed native int"
             | NativeIntSource.PerInstDictPtr handle ->
                 failwith $"Conv_ovf_i: refusing to convert PerInstDict pointer %O{handle} to signed native int"
-            | NativeIntSource.GcHandlePtr handle ->
+            | NativeIntSource.GcHandlePtr (handle, _) ->
                 failwith $"Conv_ovf_i: refusing to convert GC handle pointer %O{handle} to signed native int"
             | NativeIntSource.EventPipeProviderPtr id ->
                 failwith $"Conv_ovf_i: refusing to convert EventPipe provider handle #%d{id} to signed native int"
@@ -1781,6 +1811,22 @@ module NullaryIlOp =
             let result, state =
                 match v1, v2 with
                 | EvalStackValue.Int32 v1, EvalStackValue.Int32 v2 -> v1 ||| v2 |> EvalStackValue.Int32, state
+                // Managed code tags GC handles by OR-ing bits into the low,
+                // known-clear region: `WeakReference.Create` stores
+                // `handle | TracksResurrectionBit`, and `GCHandle..ctor` marks a
+                // pinned handle with `handle |= 1`.
+                | EvalStackValue.Int32 operand, EvalStackValue.NativeInt (NativeIntSource.GcHandlePtr (handle, tag))
+                | EvalStackValue.NativeInt (NativeIntSource.GcHandlePtr (handle, tag)), EvalStackValue.Int32 operand ->
+                    gcHandleTagOp "Or" TaggedPointerBits.bitOr handle tag (int64<int32> operand)
+                    |> EvalStackValue.NativeInt,
+                    state
+                | EvalStackValue.NativeInt (NativeIntSource.Verbatim operand),
+                  EvalStackValue.NativeInt (NativeIntSource.GcHandlePtr (handle, tag))
+                | EvalStackValue.NativeInt (NativeIntSource.GcHandlePtr (handle, tag)),
+                  EvalStackValue.NativeInt (NativeIntSource.Verbatim operand) ->
+                    gcHandleTagOp "Or" TaggedPointerBits.bitOr handle tag operand
+                    |> EvalStackValue.NativeInt,
+                    state
                 | EvalStackValue.Int32 v1, EvalStackValue.NativeInt (NativeIntSource.Verbatim v2) ->
                     int64<int32> v1 ||| v2 |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt, state
                 | EvalStackValue.Int32 _, EvalStackValue.NativeInt _ ->
@@ -2621,8 +2667,18 @@ module NullaryIlOp =
                     // routing through a byte reconstruction that would
                     // silently do the wrong thing.
                     IlMachineState.readManagedByref corelib state src
-                | EvalStackValue.NativeInt (NativeIntSource.GcHandlePtr handle) ->
+                // Release CoreLib's `GCHandle.InternalGet` is literally
+                // `*(object*)handle` (GCHandle.CoreCLR.cs), so this is the
+                // dereference of the handle table slot.
+                | EvalStackValue.NativeInt (NativeIntSource.GcHandlePtr (handle, 0L)) ->
                     GcHandleRegistry.target handle state.GcHandles |> CliType.ObjectRef
+                | EvalStackValue.NativeInt (NativeIntSource.GcHandlePtr (handle, tag)) ->
+                    // Managed code always strips its tag bits before dereferencing
+                    // (`WeakReference.Target` does `_taggedHandle & ~TracksResurrectionBit`
+                    // first). Dereferencing a tagged handle would be a misaligned
+                    // read in reality, so it must not quietly succeed here.
+                    failwith
+                        $"Ldind_ref: refusing to dereference GC handle %O{handle} while it carries tag bits 0x%x{tag}; managed code must mask them off first"
                 | EvalStackValue.NullObjectRef -> failwith "unreachable: NullObjectRef handled above"
                 | a -> failwith $"TODO: Ldind_ref on unsupported eval stack value {a}"
 

--- a/WoofWare.PawPrint/PointerHashSynthesis.fs
+++ b/WoofWare.PawPrint/PointerHashSynthesis.fs
@@ -98,7 +98,11 @@ module PointerHashSynthesis =
             )
         | NativeIntSource.MethodHandlePtr id -> CanonicalPointerKey.MethodHandle id
         | NativeIntSource.FieldHandlePtr id -> CanonicalPointerKey.FieldHandle id
-        | NativeIntSource.GcHandlePtr handle -> CanonicalPointerKey.GcHandle handle
+        // The canonical key is the handle's *identity*; its tag bits are a view
+        // the guest imposed, and are folded back in by `materialiseHashBits` so
+        // that two differently-tagged views of one handle differ exactly in their
+        // low bits, as they would in reality.
+        | NativeIntSource.GcHandlePtr (handle, _) -> CanonicalPointerKey.GcHandle handle
         | NativeIntSource.EventPipeProviderPtr id -> CanonicalPointerKey.EventPipeProvider id
         | NativeIntSource.EventPipeEventPtr id -> CanonicalPointerKey.EventPipeEvent id
         | NativeIntSource.LowLevelMonitorPtr id -> CanonicalPointerKey.LowLevelMonitor id
@@ -192,8 +196,18 @@ module PointerHashSynthesis =
         | _ ->
             let key = canonicalKey src
 
+            // Tag bits the guest has stuffed into a pointer's low bits are part of
+            // the value's bit pattern, but not part of its identity, so they are
+            // OR-ed onto the identity's assigned bits rather than keyed on. The
+            // counter scheme leaves the low 2 bits clear for exactly this, so the
+            // no-collision property is preserved.
+            let tagBits =
+                match src with
+                | NativeIntSource.GcHandlePtr (_, tag) -> Operators.uint64 tag
+                | _ -> 0UL
+
             match Map.tryFind key counters.Assigned with
-            | Some bits -> Operators.int64 bits, counters
+            | Some bits -> Operators.int64 (bits ||| tagBits), counters
             | None ->
                 let n = counters.NextCounter
                 let bits = ((n + 1UL) <<< 2) ||| lowBitsForKey key
@@ -204,4 +218,4 @@ module PointerHashSynthesis =
                         Assigned = Map.add key bits counters.Assigned
                     }
 
-                Operators.int64 bits, counters'
+                Operators.int64 (bits ||| tagBits), counters'

--- a/WoofWare.PawPrint/TaggedPointerBits.fs
+++ b/WoofWare.PawPrint/TaggedPointerBits.fs
@@ -1,0 +1,129 @@
+namespace WoofWare.PawPrint
+
+open System.Diagnostics
+
+/// Result of a bitwise operation against the low "tag" region of a pointer whose
+/// numeric value PawPrint does not model.
+///
+/// PawPrint never fabricates machine addresses (see
+/// `docs/developer/pointers-and-byte-representations.md`), but managed code does
+/// stuff tag bits into the low, known-clear bits of a pointer and later strip them
+/// back off. `System.WeakReference` tags its GC handle with "tracks resurrection"
+/// / "COM aware", and `System.Runtime.InteropServices.GCHandle` tags its handle
+/// with "pinned". Such a pointer's value is modelled as
+///
+///     value = base ||| tag
+///
+/// where `base` is unknown and non-zero but is guaranteed to have its low
+/// `tagWidthBits` bits clear — that is an alignment guarantee the real runtime
+/// makes, not a fabricated address — and `tag` is known and lies in
+/// `[0, 2^tagWidthBits)`.
+///
+/// A bitwise operation against such a value is answerable in exactly two shapes,
+/// and otherwise not at all.
+[<RequireQualifiedAccess>]
+type TaggedPointerBitsResult =
+    /// Every bit of the unknown base survived unchanged, so the result is still
+    /// the same pointer, now carrying this tag. The tag is inside the tag region.
+    | Retagged of tag : int64
+    /// Every bit of the unknown base was forced to a constant, so the result is
+    /// exactly these bits and is no longer a pointer.
+    | TagBitsOnly of bits : int64
+    /// The result would depend on bits of the base that PawPrint does not model.
+    /// Callers must fail loudly rather than guess.
+    | NotStatable
+
+/// Decision procedure for bitwise operations against the low tag region of a
+/// pointer whose numeric value PawPrint does not model. See
+/// `TaggedPointerBitsResult` for the model this is derived from.
+///
+/// The rule is uniform across the operations: look at what the operation does to
+/// each bit of the unknown base. The answer is `Retagged` exactly when every base
+/// bit survives unchanged, `TagBitsOnly` exactly when every base bit is forced to
+/// a constant, and `NotStatable` otherwise. Because `&&&`, `|||` and `^^^` act
+/// independently on each bit position, that reduces to inspecting the operand's
+/// high bits:
+///
+/// * `&&&` preserves bit `i` when the mask bit is 1 and clears it when it is 0;
+/// * `|||` preserves bit `i` when the operand bit is 0 and forces it to 1 when it
+///   is 1 (1 is OR's absorbing element — this case is easy to miss, and dropping
+///   it would refuse an answer the model can give);
+/// * `^^^` preserves bit `i` when the operand bit is 0 and inverts it when it is
+///   1, and inversion of an unknown bit is never constant, so XOR has no
+///   `TagBitsOnly` case at all.
+///
+/// This is sound (each stated answer holds for *every* admissible base) and
+/// complete (a high region that is neither wholly preserved nor wholly forced
+/// genuinely differs between two admissible bases, so no single answer exists).
+[<RequireQualifiedAccess>]
+module TaggedPointerBits =
+
+    /// CoreCLR GC handles are pointers into the handle table, and CoreLib relies
+    /// on their alignment to tag them: `System.WeakReferenceHandleTags` takes bit
+    /// 0 for "tracks resurrection" ("handles are at least 2-byte aligned") and bit
+    /// 1 for "COM aware" ("on COM-supporting platforms a handle is at least
+    /// 4-byte aligned"), and `GCHandle` takes bit 0 for "pinned". Two bits is
+    /// therefore exactly what CoreLib itself claims, and is also what
+    /// `PointerHashSynthesis`'s `((n + 1) <<< 2)` counter scheme already leaves
+    /// free for GC handles.
+    let gcHandleTagWidthBits : int = 2
+
+    /// Mask selecting the tag region: the low `tagWidthBits` bits.
+    let tagMask (tagWidthBits : int) : int64 =
+        Debug.Assert (
+            tagWidthBits >= 0 && tagWidthBits < 63,
+            $"tag width %i{tagWidthBits} out of range; a tag region must fit strictly inside an int64"
+        )
+
+        (1L <<< tagWidthBits) - 1L
+
+    let private assertTagInRange (tagWidthBits : int) (tag : int64) : unit =
+        Debug.Assert (
+            tag &&& ~~~(tagMask tagWidthBits) = 0L,
+            $"tag 0x%x{tag} escapes the %i{tagWidthBits}-bit tag region; tags must be produced by TaggedPointerBits"
+        )
+
+    /// `(base ||| tag) &&& mask`, where `base` is unknown.
+    let bitAnd (tagWidthBits : int) (tag : int64) (mask : int64) : TaggedPointerBitsResult =
+        assertTagInRange tagWidthBits tag
+        let low = tagMask tagWidthBits
+        let high = ~~~low
+        let resultTag = tag &&& mask &&& low
+
+        if mask &&& high = high then
+            // Every base bit is kept.
+            TaggedPointerBitsResult.Retagged resultTag
+        elif mask &&& high = 0L then
+            // Every base bit is cleared.
+            TaggedPointerBitsResult.TagBitsOnly resultTag
+        else
+            TaggedPointerBitsResult.NotStatable
+
+    /// `(base ||| tag) ||| operand`, where `base` is unknown.
+    let bitOr (tagWidthBits : int) (tag : int64) (operand : int64) : TaggedPointerBitsResult =
+        assertTagInRange tagWidthBits tag
+        let low = tagMask tagWidthBits
+        let high = ~~~low
+        let resultTag = (tag ||| operand) &&& low
+
+        if operand &&& high = 0L then
+            // Every base bit is kept.
+            TaggedPointerBitsResult.Retagged resultTag
+        elif operand &&& high = high then
+            // Every base bit is forced to 1, so the whole value is known.
+            TaggedPointerBitsResult.TagBitsOnly (high ||| resultTag)
+        else
+            TaggedPointerBitsResult.NotStatable
+
+    /// `(base ||| tag) ^^^ operand`, where `base` is unknown. XOR never forces a
+    /// base bit to a constant, so there is no `TagBitsOnly` case.
+    let bitXor (tagWidthBits : int) (tag : int64) (operand : int64) : TaggedPointerBitsResult =
+        assertTagInRange tagWidthBits tag
+        let low = tagMask tagWidthBits
+        let high = ~~~low
+
+        if operand &&& high = 0L then
+            // Every base bit is kept.
+            TaggedPointerBitsResult.Retagged ((tag ^^^ operand) &&& low)
+        else
+            TaggedPointerBitsResult.NotStatable

--- a/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
+++ b/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
@@ -23,6 +23,7 @@
     <Compile Include="ImmutableArray.fs" />
     <Compile Include="Result.fs" />
     <Compile Include="Corelib.fs" />
+    <Compile Include="TaggedPointerBits.fs" />
     <Compile Include="AbstractMachineDomain.fs" />
     <Compile Include="SchedulerState.fs" />
     <Compile Include="FieldId.fs" />

--- a/docs/developer/pointers-and-byte-representations.md
+++ b/docs/developer/pointers-and-byte-representations.md
@@ -66,11 +66,21 @@ For distinct storage containers there is no honest byte distance. `NativeIntSour
 
 Low address bits are only exposed for narrow cases where managed code masks alignment bits and the model can state a stable answer. Localloc and PE byte ranges can provide synthetic low bits directly; array elements and string characters can provide offsets from their container starts when their stride is known. Arbitrary byrefs and object fields cannot.
 
+## Tag Bits On Opaque Handles
+
+Managed code sometimes stores its own bits in a pointer's low, known-clear bits and strips them off again later. `System.WeakReference` keeps `handle | TracksResurrectionBit` in an `nint` field and masks the tag off on every read; `GCHandle` marks pinned handles with bit 0.
+
+PawPrint answers those operations without inventing an address, by carrying the tag alongside the handle's identity: `NativeIntSource.GcHandlePtr` is a `GcHandleAddress` *plus* a tag. The value is modelled as `base ||| tag`, where `base` is unknown and non-zero but has its low bits clear by the runtime's own alignment guarantee, and `tag` is known.
+
+`TaggedPointerBits` decides what such a model can say. A bitwise operation is answerable in exactly two shapes — the whole unknown base survives (so the result is the same handle with a new tag), or the whole unknown base is forced to a constant (so the result is a plain integer and no longer a pointer) — and is refused otherwise. Identity stays in `GcHandleAddress`; the tag is a view over it, so `PointerHashSynthesis` keys on the address alone and folds the tag into the low bits it already leaves free.
+
+Consumers that dereference or free a handle require the tag to be zero. Real managed code always masks first, and a tagged dereference is a misaligned read.
+
 ## Extension Rules
 
 When extending this area, keep the model honest:
 
-- Represent identity as structured storage plus offset, not as fabricated host addresses.
+- Represent identity as structured storage plus offset, not as fabricated host addresses. Where managed code imposes a *view* on an identity (tag bits on a handle), carry the view beside the identity rather than collapsing both into a bit pattern.
 - Keep object references out of `ManagedPointerSource`.
 - Add roots or projections when the storage relationship is real; do not coerce one identity into another just to reuse a lookup.
 - Normalise byte cursors before structural equality or `ceq`-style byref comparison.

--- a/docs/plans/2026-08-06-tagged-gc-handles.md
+++ b/docs/plans/2026-08-06-tagged-gc-handles.md
@@ -1,0 +1,278 @@
+# Tag bits on GC handle pointers (`and`/`or` on `GcHandlePtr`)
+
+## Problem
+
+`System.WeakReference` and `System.WeakReference<T>` store their GC handle in an `nint` field
+with the low bits used as tags, and strip those tags on every read.
+
+From the host CoreLib IL (`FEATURE_COMWRAPPERS` **is** compiled in — the `ComAwareBit` branches
+are present in the shipped IL, confirmed via `WoofWare.PawPrint.IlDump`):
+
+| Site | IL | Meaning |
+| --- | --- | --- |
+| `WeakReference::Create` | `ldloc.0; ldc.i4.1; conv.i; or` | `h \| TracksResurrectionBit` |
+| `WeakReference::IsTrackResurrection` | `ldfld; ldc.i4.1; conv.i; and` | `tagged & 1` |
+| `WeakReference::get_WeakHandle` | `ldc.i4.2; conv.i; and` then `ldc.i4.3; conv.i; not; and` | `tagged & 2`, then `tagged & ~3` |
+| `WeakReference::get_Target` | `ldc.i4.1; conv.i; not; and` then `ldc.i4.2; conv.i; and` | `tagged & ~1`, then `& 2` |
+| `GCHandle..ctor` | `handle \|= 1` | pinned marker |
+| `GCHandle::GetHandleValue` | `handle & ~1` | strip pinned marker |
+| `GCHandle::IsPinned` | `handle & 1` | read pinned marker |
+
+PawPrint models a GC handle as `NativeIntSource.GcHandlePtr of GcHandleAddress`, an opaque
+registry index with *no numeric value at all*. Every one of the above operations therefore
+fails today. Verified repro (new `sourcesPure/WeakReferenceBasic.cs`):
+
+```
+System.Exception : can't do binary operation on non-verbatim native int <GC handle <GC handle #1>>
+  at NullaryIlOp.andNativeIntAddressBits (NullaryIlOp.fs:111)
+```
+
+Note that the failure is reached *after* `GCHandle.InternalAlloc` and
+`ComAwareWeakReference.ComInfo.FromObject` have both run successfully, so tag arithmetic is
+genuinely the only blocker on this path.
+
+The constraint from the user, and from `docs/developer/pointers-and-byte-representations.md`:
+**do not manufacture fake bits.** We must not give GC handles a synthetic numeric address just
+so `and` falls out of integer arithmetic.
+
+## What we can honestly state
+
+A CoreCLR GC handle is a pointer into the handle table. CoreLib itself states the alignment
+guarantee it relies on (`WeakReferenceHandleTags`):
+
+> handles are at least 2-byte aligned, so we can use one bit for tagging
+> … on COM-supporting platforms a handle is at least 4-byte aligned
+
+So the honest model of a GC handle's numeric value is
+
+```
+value = base ||| tag        where  base &&& 3 = 0,  base <> 0,  tag ∈ [0, 4)
+```
+
+with `base` **unknown** (PawPrint never invents it) and `tag` **known**. This claims exactly
+what alignment guarantees and nothing more. It is also already the model the rest of the
+codebase assumes: `PointerHashSynthesis.lowBitsForKey` returns `0UL` for `CanonicalPointerKey.GcHandle`
+and the counter scheme `((n + 1) <<< 2)` deliberately leaves the bottom two bits free
+(`TestPointerHashSynthesis.fs:226`, ``low bits are clear for GcHandlePtr``).
+
+Given that model, masking is decidable in exactly three ways. Split a mask `m` into
+`mLow = m &&& 3` and `mHigh = m &&& ~3`:
+
+- `mHigh = ~3` (every base bit kept) → the result **is still the same handle**, retagged to `tag &&& mLow`.
+- `mHigh = 0` (every base bit cleared) → the result is **exactly the tag bits** `tag &&& mLow`, an ordinary integer.
+- otherwise → the result depends on bits of `base` we do not model. **Fail loudly.**
+
+`or` needs the same three-way split, but with the roles reversed, because `1` is OR's absorbing
+element: splitting an operand `v` into `vLow`/`vHigh` the same way,
+
+- `vHigh = 0` (no base bit forced) → `Retagged (tag ||| vLow)`.
+- `vHigh = ~3` (every base bit forced to 1) → the result is base-independent:
+  `TagBitsOnly (~3 ||| tag ||| vLow)`.
+- otherwise → `NotStatable`.
+
+`xor` has no absorbing element, so only the base-preserving case is statable: `vHigh = 0` →
+`Retagged (tag ^^^ vLow)`; anything else is `NotStatable`.
+
+In each case the rule is mechanical: the result is `Retagged` exactly when every base bit
+survives unchanged, `TagBitsOnly` exactly when every base bit is forced to a constant, and
+`NotStatable` otherwise. That is sound (each stated answer holds for *every* admissible base)
+and complete (a partially-preserved high region genuinely differs between two admissible
+bases, so no single answer exists).
+
+Every operation in the table above lands in a statable case:
+
+| Operation | mask | decision |
+| --- | --- | --- |
+| `tagged & 1` | `mHigh = 0` | `Verbatim (tag &&& 1)` |
+| `tagged & 2` | `mHigh = 0` | `Verbatim (tag &&& 2)` |
+| `tagged & ~1` (`-2`) | `mHigh = ~3` | `GcHandlePtr (h, tag &&& 2)` |
+| `tagged & ~3` (`-4`) | `mHigh = ~3` | `GcHandlePtr (h, 0)` |
+| `h \| 1` | `v &&& ~3 = 0` | `GcHandlePtr (h, tag ||| 1)` |
+
+## Design options
+
+### Option A (recommended): tag lives on the `GcHandlePtr` payload
+
+`NativeIntSource.GcHandlePtr of GcHandleAddress` becomes
+`NativeIntSource.GcHandlePtr of handle : GcHandleAddress * tag : int64`, and likewise
+`CliRuntimePointer.GcHandlePtr`. `GcHandleAddress` itself is untouched — identity stays
+identity; the tag is a *view* the guest has imposed on it.
+
+- Blast radius: ~30 mechanical match sites, all in-repo, all compiler-caught.
+- The tag travels with the value automatically wherever `IntPtr`s travel (fields, locals,
+  eval stack, `CliRuntimePointer` slots), because it is part of the value.
+- Reversible: if a general mechanism is later wanted, this collapses into it.
+- Cost: `GcHandleRegistry` lookups must be handed the address, not the tagged value — enforced
+  by making `Native/NativeCall.gcHandleAddressOfEvalStackValue` reject a non-zero tag.
+
+### Option C: keep the tag as auxiliary state on `GcHandleCell` in `GcHandleRegistry`
+
+Leave `NativeIntSource.GcHandlePtr` alone and record "this handle is currently tagged 1" beside
+the handle's target in the registry.
+
+**Rejected**, because a tag is a property of a *value the guest is holding*, not of the handle.
+`GCHandle.GetHandleValue(handle)` and `WeakReference.get_Target` both produce an untagged
+`nint` that coexists, at the same instant, with the tagged one still sitting in
+`_taggedHandle`/`_handle`. One tag per registry cell cannot express two simultaneous views of
+one handle. It also puts a per-value view into process-wide state, which is exactly the
+identity-versus-projection confusion `AGENTS.md` warns against.
+
+### Option B: a general `NativeIntSource.TaggedPointer of underlying : NativeIntSource * tag : int64`
+
+A wrapper case usable for any pointer shape with known-clear low bits.
+
+- Would also cover `TypeHandlePtr`'s TypeDesc bit (currently a special case, see below) and
+  anything future.
+- But: it admits states that should be unrepresentable — `TaggedPointer (Verbatim _, _)`,
+  `TaggedPointer (TaggedPointer (_, _), _)`, `TaggedPointer (ManagedPointer _, _)` — each of
+  which needs a normalisation rule and an equality rule.
+- More fundamentally, the other pointer kind with interesting low bits (`TypeHandlePtr`) does
+  not have a *tag* in this sense at all: its low bits are a pure function of the
+  `RuntimeTypeHandleTarget` (CoreCLR sets them, CoreLib only reads them, the guest can never
+  store a differently-tagged one). Only `GcHandlePtr` carries a guest-controlled, mutable tag.
+  A single wrapper would be conflating two different things.
+- Speculative generality: today exactly one pointer kind needs a mutable tag.
+
+**Choice: Option A.** But the *decision procedure* above is factored into its own small,
+kind-agnostic module (`TaggedPointerBits`, parameterised by tag width), so that if a second
+pointer kind later needs tags we reuse the arithmetic without having reached for Option B's
+representation. Small orthogonal core; per-kind representation.
+
+Explicitly rejected: giving GC handles a synthetic numeric address (e.g. `index * 8`) so that
+`and` becomes ordinary integer arithmetic. That is exactly the "manufacture fake bits" move
+the project has avoided elsewhere, and it would make `handle == someInt` answerable with a
+fabricated answer.
+
+## Plan
+
+### 1. `TaggedPointerBits` (new file, after `AbstractMachineDomain.fs`)
+
+```fsharp
+/// Result of a bitwise operation against the low tag region of a pointer whose
+/// numeric value PawPrint does not model. The pointer's value is modelled as
+/// `base ||| tag`, where `base` is unknown, non-zero, and has its low
+/// `tagWidthBits` bits clear.
+[<RequireQualifiedAccess>]
+type TaggedPointerBitsResult =
+    /// Every bit of the unknown base survived: the result is the same pointer,
+    /// carrying this tag.
+    | Retagged of tag : int64
+    /// Every bit of the unknown base was cleared: the result is exactly these
+    /// bits, and is no longer a pointer.
+    | TagBitsOnly of bits : int64
+    /// The result would depend on bits of the base that PawPrint does not model.
+    | NotStatable
+
+[<RequireQualifiedAccess>]
+module TaggedPointerBits =
+    /// CoreCLR GC handles are at least 4-byte aligned on COM-supporting
+    /// platforms; CoreLib's `WeakReferenceHandleTags` relies on exactly this.
+    let gcHandleTagWidthBits : int = 2
+
+    val tagMask : tagWidthBits : int -> int64
+    val bitAnd  : tagWidthBits : int -> tag : int64 -> mask : int64 -> TaggedPointerBitsResult
+    val bitOr   : tagWidthBits : int -> tag : int64 -> operand : int64 -> TaggedPointerBitsResult
+    val bitXor  : tagWidthBits : int -> tag : int64 -> operand : int64 -> TaggedPointerBitsResult
+```
+
+Total, no state, no `failwith`. Callers turn `NotStatable` into their own loud error with a
+site-specific message.
+
+### 2. Widen the representation (Option A)
+
+- `NativeIntSource.GcHandlePtr of handle : GcHandleAddress * tag : int64`
+- `CliRuntimePointer.GcHandlePtr of handle : GcHandleAddress * tag : int64`
+- Update: `ToString` (render the tag only when non-zero), custom equality (equal iff same
+  address **and** same tag), hash, `equalsForCli` arms, and the `EvalStack` conversions. All
+  compiler-caught. `isZero`/`isNonnegative` and the `cgt.un`/`clt.un`-vs-zero arms in
+  `EvalStackValueComparisons` match with a wildcard and stay correct unchanged: a tagged handle
+  is still non-zero.
+- A helper `NativeIntSource.gcHandlePtr (h : GcHandleAddress) : NativeIntSource` for the
+  common untagged construction, so producer sites read unchanged, and a
+  `NativeIntSource.gcHandlePtrTagged` that asserts `tag` is inside the tag region. The only
+  way to obtain a non-zero tag is from a `TaggedPointerBits` result, which is in range by
+  construction; the assertion catches any future site that bypasses it.
+
+### 3. Consumers that require an untagged handle
+
+- `Native/NativeCall.gcHandleAddressOfEvalStackValue`: accept only `tag = 0`; otherwise fail
+  loudly ("expected an untagged GC handle, got …"). Real CoreLib always strips before calling
+  `_InternalFree` / `InternalSet` / `InternalCompareExchange`.
+- `NullaryIlOp` `Ldind_ref` on `GcHandlePtr` (this is release CoreLib's
+  `GCHandle.InternalGet` = `*(object*)handle`): accept only `tag = 0`; a tagged deref is a
+  misaligned read in reality and must not silently succeed.
+
+### 4. `And` / `Or` / `Xor`
+
+In `NullaryIlOp.fs`:
+
+- `andNativeIntAddressBits` grows a `GcHandlePtr` arm driven by `TaggedPointerBits.bitAnd`.
+- `Or` grows `GcHandlePtr` arms (against `Int32` and against `NativeInt (Verbatim _)`, both
+  operand orders) driven by `TaggedPointerBits.bitOr`. Today `Or` rejects *every* non-verbatim
+  native int.
+- `Xor`'s `xorNativeIntSources` grows `GcHandlePtr` × `Verbatim` cases **in both operand
+  orders** (the function matches positionally, so one order alone would leave the other
+  silently falling through). This is not needed by `WeakReference`, but the current fallback
+  routes a handle through `PointerHashSynthesis` and returns `OpaqueHashBits` — i.e. it
+  **silently** discards handle identity for an operation that now has an exact answer. Adding
+  the arms narrows an existing silently-lossy path rather than adding new capability.
+- `Not` on a handle stays as it is (`~handle` genuinely depends on unknown base bits; the
+  existing `OpaqueHashBits` behaviour and its doc comment already say so).
+
+### 5. Not in scope: the `TypeHandlePtr` / `MethodTablePtr` arms of `andNativeIntAddressBits`
+
+An earlier draft proposed tightening these in passing. They return `Verbatim (lowBits &&& mask)`
+and `Verbatim (0L &&& mask)` respectively, which is right only when the mask clears every high
+bit; for a base-preserving mask they silently answer `0` where the true answer is a pointer.
+Confirmed by grep that no test and no reachable guest IL path exercises those arms with any
+mask today (CoreCLR's `TypeHandle::AsMethodTable()` is native C++, not managed IL), so this is
+a latent-but-unreachable issue about a different pointer kind. **Split out as follow-up work**
+rather than mixed into this change.
+
+### 6. `PointerHashSynthesis`
+
+`CanonicalPointerKey.GcHandle` keeps carrying only the `GcHandleAddress` (identity, not view).
+`materialiseHashBits` ORs the source's tag onto the counter-derived bits. Since
+`lowBitsForKey (GcHandle _) = 0UL` and the counter scheme shifts left by 2, this is
+non-colliding by construction and makes two differently-tagged views of one handle produce
+bit patterns that differ exactly in the tag — which is what reality does.
+
+### 7. Tests (written first)
+
+1. **Property test**, `TestTaggedPointerBits.fs`, against a concrete-integer oracle. Generate a
+   concrete `base` (non-zero, low `w` bits clear), a `tag`, and a `mask`/`operand`. The
+   generator must *not* sample the operand uniformly: `Retagged`/`TagBitsOnly` fire only on the
+   knife-edge conditions `high = 0` / `high = ~tagMask`, which a uniform `int64` essentially
+   never hits, so the interesting branches would be tested vacuously. Build the operand as
+   `low ||| oneOf [0L; ~tagMask; arbitrary high bits]`. Then:
+   - `Retagged t'` ⟹ for **every** such base, `(base ||| tag) op v = base ||| t'`.
+   - `TagBitsOnly b` ⟹ for **every** such base, `(base ||| tag) op v = b`.
+   - `NotStatable` ⟹ *completeness*: exhibit two bases whose results are neither equal to each
+     other (so no `TagBitsOnly` answer exists) nor of the form `base ||| t` for one fixed `t`
+     (so no `Retagged` answer exists). i.e. we never refuse an answer we could have given.
+   - Round-trip: `bitAnd w tag (tagMask w |> (~~~))` is always `Retagged 0`.
+2. **Unit tests** at the `EvalStackValue` level (`TestNullaryIlOp.fs`) for each row of the table
+   in "What we can honestly state", plus the loud refusals (`h & 4`, `h | 8`), plus
+   `Ldind_ref`/`gcHandleAddressOfEvalStackValue` rejecting a tagged handle.
+3. **Round-trip** in `TestEvalStack.fs`: a tagged handle survives
+   `EvalStackValue ↔ CliType` in both directions with its tag.
+4. **End-to-end** `sourcesPure/WeakReferenceBasic.cs` (already written and confirmed failing):
+   covers `WeakReference` and `WeakReference<T>`, tracking and non-tracking, `Target` get/set,
+   `TryGetTarget`, `SetTarget`, `IsAlive`, `TrackResurrection`. Every assertion it makes is
+   also true on real .NET.
+5. Update `docs/developer/pointers-and-byte-representations.md` — the "Low address bits" and
+   "Extension Rules" sections — to record the tag-region model.
+
+## Risks / open questions
+
+- **Does the end-to-end test reach further gaps?** The repro shows the path gets past
+  `InternalAlloc` and `ComInfo.FromObject`, and `DependentHandleBasic.cs` already exercises
+  `InternalSet`/`InternalGet`/`InternalFree`, so the remaining surface is small — but if
+  `WeakReference<T>` hits an unrelated blocker, per AGENTS.md the right move is to keep the
+  unit and property coverage, park the end-to-end case in `unimplemented` with a precise note,
+  and not chase the rabbit hole.
+- **Tag width 2 vs 3.** 2 is what CoreLib itself claims and what `PointerHashSynthesis` already
+  assumes. Claiming fewer bits is the conservative direction (it only ever makes us fail more
+  loudly), so 2 it is.
+- **PawPrint has no GC**, so a weak reference never dies. That is a pre-existing, documented
+  property of the model (`GcHandleRegistry`), not something this change alters.


### PR DESCRIPTION
Managed code routinely stashes its own bits in a pointer's low, known-clear bits and strips them off again later. `System.WeakReference` keeps `handle | TracksResurrectionBit` in an `nint` field and masks the tag off on every read; `GCHandle` marks pinned handles with bit 0. PawPrint models a GC handle as an opaque registry index with no numeric address, so every one of those operations hit:

```
can't do binary operation on non-verbatim native int <GC handle #1>
  at NullaryIlOp.andNativeIntAddressBits
```

`IlDump` on the shipped CoreLib confirms `FEATURE_COMWRAPPERS` is compiled in, so the tag region is 2 bits (resurrection + COM-aware), not 1.

## Approach

No fabricated address bits. A handle's value is modelled as `base ||| tag`, where `base` is unknown and non-zero but has its low bits clear *by the runtime's own alignment guarantee* — CoreLib states this itself — and `tag` is known. `NativeIntSource.GcHandlePtr` now carries `GcHandleAddress * tag`: identity stays identity, and the tag is the view the guest imposed on it.

New `TaggedPointerBits` is the decision procedure, deliberately kind-agnostic and parameterised by tag width so it is reusable if a second pointer kind ever needs tags. A bitwise op against such a model is answerable in exactly two shapes, and refused otherwise:

- **`Retagged`** — every base bit survives unchanged, so the result is the same handle with a new tag.
- **`TagBitsOnly`** — every base bit is forced to a constant, so the result is a plain integer and no longer a pointer.
- **`NotStatable`** — the answer would depend on the address. Fail loudly.

This is both sound and complete for the model: a refusal is a refusal of something genuinely unanswerable, not a gap in the implementation.

`ldind.ref` and the GC-handle InternalCalls require the tag to be zero. Real managed code always masks first, and a tagged dereference is a misaligned read.

`PointerHashSynthesis` keys on the handle address alone and ORs the tag into the low bits it already leaves free, so two differently-tagged views of one handle differ in exactly their low bits, as they would in reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
