### PR TITLE
Share the custom-attribute constructor-parent lookup

### DIFF
--- a/WoofWare.PawPrint.Domain/CustomAttribute.fs
+++ b/WoofWare.PawPrint.Domain/CustomAttribute.fs
@@ -92,6 +92,57 @@ module CustomAttribute =
             Value = value
         }
 
+    /// Namespace and name of the type declaring the constructor a custom attribute invokes, or
+    /// `None` when the parent provably cannot be a non-generic well-known attribute.
+    ///
+    /// This walk deliberately uses raw `MetadataReader` calls only: it runs while metadata is being
+    /// parsed, before any cross-assembly resolution (or even this assembly's method dictionary)
+    /// exists. `TypeRef` rows carry `Namespace`/`Name` directly, so no resolution is needed. The
+    /// match this feeds is therefore on namespace+name strings and does not verify that the type
+    /// resolves to corelib's copy of the attribute.
+    ///
+    /// A `TypeSpecification` parent denotes a member of a *generic instantiation* (`[MyAttr&lt;int&gt;]`,
+    /// legal since C# 11). No non-generic well-known attribute can be reached that way, so `None`
+    /// is a correct answer rather than the silent `("", "")` false negative the shape of this walk
+    /// otherwise invites. ECMA-335 II.22.10 admits only `MethodDef` and `MemberRef` for a
+    /// `CustomAttribute`'s `Type` column, so every other shape is malformed metadata and fails
+    /// loudly; `describeTarget` names the entity carrying the attribute in that message.
+    let constructorParentName
+        (mr : MetadataReader)
+        (describeTarget : unit -> string)
+        (constructor : EntityHandle)
+        : (string * string) option
+        =
+        match constructor.Kind with
+        | HandleKind.MemberReference ->
+            let memberRef =
+                mr.GetMemberReference (MemberReferenceHandle.op_Explicit constructor)
+
+            match memberRef.Parent.Kind with
+            | HandleKind.TypeReference ->
+                let typeRef = mr.GetTypeReference (TypeReferenceHandle.op_Explicit memberRef.Parent)
+                Some (mr.GetString typeRef.Namespace, mr.GetString typeRef.Name)
+            | HandleKind.TypeDefinition ->
+                let typeDef =
+                    mr.GetTypeDefinition (TypeDefinitionHandle.op_Explicit memberRef.Parent)
+
+                Some (mr.GetString typeDef.Namespace, mr.GetString typeDef.Name)
+            | HandleKind.TypeSpecification ->
+                // A generic attribute instantiation; cannot be a non-generic well-known attribute.
+                None
+            | parentKind ->
+                failwith
+                    $"custom attribute on %s{describeTarget ()}: constructor MemberReference has unsupported parent kind %O{parentKind}, so we cannot identify the attribute type"
+        | HandleKind.MethodDefinition ->
+            let methodDef =
+                mr.GetMethodDefinition (MethodDefinitionHandle.op_Explicit constructor)
+
+            let typeDef = mr.GetTypeDefinition (methodDef.GetDeclaringType ())
+            Some (mr.GetString typeDef.Namespace, mr.GetString typeDef.Name)
+        | constructorKind ->
+            failwith
+                $"custom attribute on %s{describeTarget ()}: constructor has unsupported handle kind %O{constructorKind}, so we cannot identify the attribute type"
+
     /// <summary>
     /// Decode the leading <c>SerString</c> from a <c>CustomAttrib</c> blob
     /// (ECMA-335 II.23.3). The blob must start with the two-byte prolog

--- a/WoofWare.PawPrint.Domain/FieldInfo.fs
+++ b/WoofWare.PawPrint.Domain/FieldInfo.fs
@@ -119,71 +119,25 @@ module FieldMarshalDescriptor =
 
 [<RequireQualifiedAccess>]
 module FieldInfo =
-    /// Namespace and name of the type declaring a custom attribute's constructor, or `None` when
-    /// the parent provably cannot be `System.ThreadStaticAttribute`.
-    ///
-    /// This walk deliberately uses raw `MetadataReader` calls only: it runs while fields are
-    /// being parsed, before any cross-assembly resolution (or even this assembly's method
-    /// dictionary) exists. `TypeRef` rows carry `Namespace`/`Name` directly, so no resolution is
-    /// needed.
-    ///
-    /// A `TypeSpecification` parent denotes a member of a *generic instantiation*
-    /// (`[MyAttr<int>]`, legal since C# 11). `System.ThreadStaticAttribute` is non-generic, so
-    /// such a parent can never be it; returning `None` there is a correct answer rather than the
-    /// silent `("", "")` false negative the shape of this walk otherwise invites. Every other
-    /// shape is unexpected, and we fail loudly rather than silently reporting "not thread
-    /// static".
-    let private attributeConstructorParentName
-        (mr : MetadataReader)
-        (describeField : unit -> string)
-        (attr : CustomAttribute)
-        : (string * string) option
-        =
-        match attr.Constructor.Kind with
-        | HandleKind.MemberReference ->
-            let memberRef =
-                mr.GetMemberReference (MemberReferenceHandle.op_Explicit attr.Constructor)
-
-            match memberRef.Parent.Kind with
-            | HandleKind.TypeReference ->
-                let typeRef = mr.GetTypeReference (TypeReferenceHandle.op_Explicit memberRef.Parent)
-                Some (mr.GetString typeRef.Namespace, mr.GetString typeRef.Name)
-            | HandleKind.TypeDefinition ->
-                let typeDef =
-                    mr.GetTypeDefinition (TypeDefinitionHandle.op_Explicit memberRef.Parent)
-
-                Some (mr.GetString typeDef.Namespace, mr.GetString typeDef.Name)
-            | HandleKind.TypeSpecification ->
-                // A generic attribute instantiation; cannot be the non-generic
-                // System.ThreadStaticAttribute.
-                None
-            | parentKind ->
-                failwith
-                    $"custom attribute on field %s{describeField ()}: constructor MemberReference has unsupported parent kind %O{parentKind}, so we cannot decide whether it is System.ThreadStaticAttribute"
-        | HandleKind.MethodDefinition ->
-            let methodDef =
-                mr.GetMethodDefinition (MethodDefinitionHandle.op_Explicit attr.Constructor)
-
-            let typeDef = mr.GetTypeDefinition (methodDef.GetDeclaringType ())
-            Some (mr.GetString typeDef.Namespace, mr.GetString typeDef.Name)
-        | constructorKind ->
-            failwith
-                $"custom attribute on field %s{describeField ()}: constructor has unsupported handle kind %O{constructorKind}, so we cannot decide whether it is System.ThreadStaticAttribute"
-
     /// Does this field carry `[System.ThreadStaticAttribute]`?
     ///
-    /// Accepted risk (consistent with the existing precedent in `MethodInfo.isIntrinsicAttribute`):
-    /// the match is on namespace+name strings and does not verify that the type resolves to
-    /// corelib's `System.ThreadStaticAttribute`.
+    /// Accepted risk (consistent with the existing precedent in `MethodInfo.isIntrinsicAttribute`,
+    /// and inherited from `CustomAttribute.constructorParentName`): the match is on namespace+name
+    /// strings and does not verify that the type resolves to corelib's
+    /// `System.ThreadStaticAttribute`.
     let private hasThreadStaticAttribute
         (mr : MetadataReader)
         (describeField : unit -> string)
         (def : FieldDefinition)
         : bool
         =
+        let describeTarget () = $"field %s{describeField ()}"
+
         def.GetCustomAttributes ()
         |> Seq.exists (fun handle ->
-            match attributeConstructorParentName mr describeField (mr.GetCustomAttribute handle) with
+            let attr = mr.GetCustomAttribute handle
+
+            match CustomAttribute.constructorParentName mr describeTarget attr.Constructor with
             | Some (ns, name) -> ns = "System" && name = "ThreadStaticAttribute"
             | None -> false
         )


### PR DESCRIPTION
First of a five-PR stack that gives `[InlineArray(N)]` types a real N-slot layout, splitting up what was #789.

Pure code motion, no behaviour change. `FieldInfo.hasThreadStaticAttribute` had a private helper for "which type does this custom attribute's constructor belong to?"; that question isn't specific to fields, so it moves to `CustomAttribute` alongside the rest of the attribute decoding, where the next PR in the stack needs it too.

Unchanged, including the treatment of a `TypeSpecification` parent (a generic attribute instantiation) as "no simple name", and the refusal of constructor handle kinds ECMA-335 II.22.10 doesn't admit.

**Stack:** **#1 (this)** → #2 byref offsets → #3 `TypeInfo` read → #4 `FieldId` case → #5 the feature (#789)

🤖 Generated with [Claude Code](https://claude.com/claude-code)