### PR TITLE
Add a recursive resolver for the cells a byte range names

### DIFF
--- a/WoofWare.PawPrint.Test/TestCliTypeCellPaths.fs
+++ b/WoofWare.PawPrint.Test/TestCliTypeCellPaths.fs
@@ -220,6 +220,25 @@ module TestCliTypeCellPaths =
         CliType.CellPathsExactlyCovering 0 0 value |> shouldEqual []
         CliType.CellPathsExactlyCovering 0 -4 value |> shouldEqual []
 
+    /// The offset is guest-controlled: it accumulates `Unsafe.Add`/`Unsafe.AddByteOffset`
+    /// arithmetic, which the guest may drive to either end of the range. Such a range names nothing,
+    /// and must *say* so — this file compiles under `open Checked`, so computing the range's end
+    /// point would raise `OverflowException` out of a lookup documented to return `[]`.
+    [<Test>]
+    let ``a range whose end point does not fit in an int names nothing`` () : unit =
+        let value =
+            ofFields [ cliField "A" (CliType.Numeric (CliNumericType.Int32 0)) None int32Handle ]
+
+        CliType.CellPathsExactlyCovering System.Int32.MaxValue 4 value |> shouldEqual []
+
+        CliType.CellPathsExactlyCovering (System.Int32.MaxValue - 1) 8 value
+        |> shouldEqual []
+
+        CliType.CellPathsExactlyCovering System.Int32.MinValue 4 value |> shouldEqual []
+
+        CliType.CellPathsExactlyCovering System.Int32.MinValue System.Int32.MaxValue value
+        |> shouldEqual []
+
     /// `f.Size` is set from `SizeOf(f.Contents)` when a value is built, but `WithFieldSetById`
     /// replaces `Contents` without recomputing it — so a field record can be made inconsistent, and
     /// a cell whose recorded extent disagrees with what it now holds must not be named. Reached

--- a/WoofWare.PawPrint.Test/TestCliTypeCellPaths.fs
+++ b/WoofWare.PawPrint.Test/TestCliTypeCellPaths.fs
@@ -1,0 +1,423 @@
+namespace WoofWare.PawPrint.Test
+
+open System.Runtime.InteropServices
+open FsCheck
+open FsCheck.FSharp
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+/// `CliType.CellPathsExactlyCovering` answers "which storage cells does this byte range name?",
+/// descending through nested value types rather than stopping at the top level. It is the primitive
+/// the byref layer needs when storage cannot be rendered as bytes at all — a value type containing
+/// object references — because then naming the cell is the only way to serve the access.
+///
+/// It is deliberately *structural*: it reports every cell whose extent is exactly the range,
+/// outermost first, and says nothing about whether any of them is type-compatible with what the
+/// caller wants to read or write. Callers apply their own rule to the returned contents. More than
+/// one answer is normal and not an ambiguity — a transparent wrapper and the field it wraps occupy
+/// the same bytes, and which one a caller wants depends on the type it is reinterpreting to.
+[<TestFixture>]
+module TestCliTypeCellPaths =
+
+    // Factory intentionally undisposed: corelib.Logger outlives this scope.
+    let private corelib : DumpedAssembly =
+        let corelibPath = typeof<obj>.Assembly.Location
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        Assembly.readFile loggerFactory corelibPath
+
+    let private bct : BaseClassTypes<DumpedAssembly> = Corelib.getBaseTypes corelib
+
+    let private loaded : LoadedAssemblies = LoadedAssemblies.ofAssemblies [ corelib ]
+
+    let private allCt : AllConcreteTypes =
+        Corelib.concretizeAll loaded bct AllConcreteTypes.Empty
+
+    let private declaredHandle : ConcreteTypeHandle =
+        AllConcreteTypes.getRequiredNonGenericHandle allCt bct.TypedReference
+
+    let private int32Handle : ConcreteTypeHandle =
+        AllConcreteTypes.getRequiredNonGenericHandle allCt bct.Int32
+
+    let private int64Handle : ConcreteTypeHandle =
+        AllConcreteTypes.getRequiredNonGenericHandle allCt bct.Int64
+
+    let private byteHandle : ConcreteTypeHandle =
+        AllConcreteTypes.getRequiredNonGenericHandle allCt bct.Byte
+
+    let private objectHandle : ConcreteTypeHandle =
+        AllConcreteTypes.getRequiredNonGenericHandle allCt bct.Object
+
+    let private config : Config = Config.QuickThrowOnFailure.WithMaxTest 300
+
+    let private cliField
+        (name : string)
+        (contents : CliType)
+        (offset : int option)
+        (fieldType : ConcreteTypeHandle)
+        : CliField
+        =
+        {
+            Id = FieldId.named name
+            Name = name
+            Contents = contents
+            Offset = offset
+            Type = fieldType
+            MarshallingDescriptor = None
+        }
+
+    let private ofFields (fields : CliField list) : CliType =
+        CliValueType.OfFields bct allCt declaredHandle Layout.Default CharSet.Ansi fields
+        |> CliType.ValueType
+
+    let private ofFieldsSized (size : int) (fields : CliField list) : CliType =
+        CliValueType.OfFields
+            bct
+            allCt
+            declaredHandle
+            (Layout.Custom (size = size, packingSize = 0))
+            CharSet.Ansi
+            fields
+        |> CliType.ValueType
+
+    // ----------------------------------------------------------------------------------------
+    // Worked examples
+    // ----------------------------------------------------------------------------------------
+
+    /// The shape that motivated the primitive: `[InlineArray(2)] struct { Elem _item; }` where
+    /// `Elem = { byte Tag; Box Payload }`. The reference is laid out first (GC auto-layout promotes
+    /// it), so `Tag` sits at offset 8 *inside* each slot — depth 2 from the buffer's point of view,
+    /// which no top-level cover can reach.
+    let private elem () : CliType =
+        ofFields
+            [
+                cliField "Payload" (CliType.ObjectRef None) None objectHandle
+                cliField "Tag" (CliType.Numeric (CliNumericType.UInt8 0uy)) None byteHandle
+            ]
+
+    let private buffer () : CliType =
+        let e = elem ()
+
+        ofFields
+            [
+                cliField "_item" e None declaredHandle
+                cliField "_item[1]" e None declaredHandle
+            ]
+
+    [<Test>]
+    let ``inline array of reference-containing structs: slot is found at depth 1`` () : unit =
+        let value = buffer ()
+        CliType.SizeOf(value).Size |> shouldEqual 32
+
+        match CliType.CellPathsExactlyCovering 16 16 value with
+        | [ (path, contents) ] ->
+            path |> shouldEqual [ FieldId.named "_item[1]" ]
+            contents |> shouldEqual (elem ())
+        | other -> failwith $"expected exactly one cover of slot 1, got %O{other}"
+
+    [<Test>]
+    let ``inline array of reference-containing structs: primitive leaf is found at depth 2`` () : unit =
+        let value = buffer ()
+
+        // `Tag` of slot 0 lives at offset 8; only the depth-2 descent can name it.
+        match CliType.CellPathsExactlyCovering 8 1 value with
+        | [ (path, contents) ] ->
+            path |> shouldEqual [ FieldId.named "_item" ; FieldId.named "Tag" ]
+            contents |> shouldEqual (CliType.Numeric (CliNumericType.UInt8 0uy))
+        | other -> failwith $"expected exactly one cover of slot 0's Tag, got %O{other}"
+
+    [<Test>]
+    let ``inline array of reference-containing structs: reference leaf is found at depth 2`` () : unit =
+        let value = buffer ()
+
+        match CliType.CellPathsExactlyCovering 16 8 value with
+        | [ (path, contents) ] ->
+            path |> shouldEqual [ FieldId.named "_item[1]" ; FieldId.named "Payload" ]
+            contents |> shouldEqual (CliType.ObjectRef None)
+        | other -> failwith $"expected exactly one cover of slot 1's Payload, got %O{other}"
+
+    /// A transparent wrapper and the field it wraps occupy the same bytes, so both are legitimate
+    /// answers. The caller decides which it wants by looking at the contents; the resolver must not
+    /// pick for it, and must report the outer one first so a caller that stops at the first
+    /// compatible answer gets the shallowest.
+    [<Test>]
+    let ``nested transparent wrappers all report, outermost first`` () : unit =
+        let inner = ofFields [ cliField "_item" (CliType.ObjectRef None) None objectHandle ]
+        let middle = ofFields [ cliField "wrapped" inner None declaredHandle ]
+        let value = ofFields [ cliField "outer" middle None declaredHandle ]
+
+        CliType.CellPathsExactlyCovering 0 8 value
+        |> List.map fst
+        |> shouldEqual
+            [
+                [ FieldId.named "outer" ]
+                [ FieldId.named "outer" ; FieldId.named "wrapped" ]
+                [ FieldId.named "outer" ; FieldId.named "wrapped" ; FieldId.named "_item" ]
+            ]
+
+    [<Test>]
+    let ``a range straddling two fields names nothing`` () : unit =
+        let value =
+            ofFields
+                [
+                    cliField "A" (CliType.Numeric (CliNumericType.Int32 0)) None int32Handle
+                    cliField "B" (CliType.Numeric (CliNumericType.Int32 0)) None int32Handle
+                ]
+
+        // [2, 6) straddles A and B.
+        CliType.CellPathsExactlyCovering 2 4 value |> shouldEqual []
+
+    [<Test>]
+    let ``a range covering part of one field names nothing`` () : unit =
+        let value =
+            ofFields
+                [
+                    cliField "A" (CliType.Numeric (CliNumericType.Int64 (Int64Source.Verbatim 0L))) None int64Handle
+                ]
+
+        CliType.CellPathsExactlyCovering 0 4 value |> shouldEqual []
+        CliType.CellPathsExactlyCovering 4 4 value |> shouldEqual []
+
+    /// Under explicit layout two fields can alias. Naming either would let a write leave the other
+    /// stale, so an aliased range names nothing even though one field covers it exactly.
+    [<Test>]
+    let ``an aliased range names nothing`` () : unit =
+        let value =
+            ofFieldsSized
+                8
+                [
+                    cliField
+                        "AsLong"
+                        (CliType.Numeric (CliNumericType.Int64 (Int64Source.Verbatim 0L)))
+                        (Some 0)
+                        int64Handle
+                    cliField "Upper" (CliType.Numeric (CliNumericType.Int32 0)) (Some 4) int32Handle
+                ]
+
+        CliType.CellPathsExactlyCovering 0 8 value |> shouldEqual []
+        CliType.CellPathsExactlyCovering 4 4 value |> shouldEqual []
+
+    /// An *abutting* sibling must not block: otherwise no field past the first could ever be named.
+    /// This is the boundary case of the aliasing rule.
+    [<Test>]
+    let ``an adjacent sibling does not block`` () : unit =
+        let value =
+            ofFields
+                [
+                    cliField "A" (CliType.Numeric (CliNumericType.Int32 0)) None int32Handle
+                    cliField "B" (CliType.Numeric (CliNumericType.Int32 0)) None int32Handle
+                ]
+
+        CliType.CellPathsExactlyCovering 4 4 value
+        |> List.map fst
+        |> shouldEqual [ [ FieldId.named "B" ] ]
+
+    [<Test>]
+    let ``a degenerate range names nothing`` () : unit =
+        let value =
+            ofFields [ cliField "A" (CliType.Numeric (CliNumericType.Int32 0)) None int32Handle ]
+
+        CliType.CellPathsExactlyCovering 0 0 value |> shouldEqual []
+        CliType.CellPathsExactlyCovering 0 -4 value |> shouldEqual []
+
+    /// `f.Size` is set from `SizeOf(f.Contents)` when a value is built, but `WithFieldSetById`
+    /// replaces `Contents` without recomputing it — so a field record can be made inconsistent, and
+    /// a cell whose recorded extent disagrees with what it now holds must not be named. Reached
+    /// through the public API rather than asserted as unreachable, because mutation-testing the
+    /// guard showed nothing else covers it.
+    [<Test>]
+    let ``a cell whose recorded size disagrees with its contents names nothing`` () : unit =
+        let value =
+            ofFields
+                [
+                    cliField "A" (CliType.Numeric (CliNumericType.Int32 0)) None int32Handle
+                    cliField "B" (CliType.Numeric (CliNumericType.Int32 0)) None int32Handle
+                ]
+
+        CliType.CellPathsExactlyCovering 0 4 value
+        |> List.map fst
+        |> shouldEqual [ [ FieldId.named "A" ] ]
+
+        // Widen A's contents to 8 bytes without its recorded 4-byte extent following.
+        let inconsistent =
+            CliType.withFieldSetById
+                (FieldId.named "A")
+                (CliType.Numeric (CliNumericType.Int64 (Int64Source.Verbatim 0L)))
+                value
+
+        CliType.CellPathsExactlyCovering 0 4 inconsistent |> shouldEqual []
+        CliType.CellPathsExactlyCovering 0 8 inconsistent |> shouldEqual []
+
+    [<Test>]
+    let ``a non-value-type names nothing`` () : unit =
+        CliType.CellPathsExactlyCovering 0 8 (CliType.ObjectRef None) |> shouldEqual []
+
+    // ----------------------------------------------------------------------------------------
+    // Properties
+    // ----------------------------------------------------------------------------------------
+
+    /// A random nested value type, built only from alias-free sequential layout so that every cell
+    /// has a well-defined extent.
+    type private Shape =
+        | Prim of width : int
+        | Ref
+        | Struct of Shape list
+
+    let private shapeGen : Gen<Shape> =
+        let leaf =
+            Gen.oneof
+                [
+                    Gen.elements [ 1 ; 2 ; 4 ; 8 ] |> Gen.map Shape.Prim
+                    Gen.constant Shape.Ref
+                ]
+
+        let rec go (depth : int) : Gen<Shape> =
+            if depth <= 0 then
+                leaf
+            else
+                Gen.frequency
+                    [
+                        2, leaf
+                        1,
+                        gen {
+                            let! n = Gen.choose (1, 3)
+                            let! children = Gen.listOfLength n (go (depth - 1))
+                            return Shape.Struct children
+                        }
+                    ]
+
+        go 3
+
+    let rec private buildShape (path : string) (shape : Shape) : CliType * ConcreteTypeHandle =
+        match shape with
+        | Shape.Prim 1 -> CliType.Numeric (CliNumericType.UInt8 0uy), byteHandle
+        | Shape.Prim 2 -> CliType.Numeric (CliNumericType.UInt16 0us), byteHandle
+        | Shape.Prim 4 -> CliType.Numeric (CliNumericType.Int32 0), int32Handle
+        | Shape.Prim 8 -> CliType.Numeric (CliNumericType.Int64 (Int64Source.Verbatim 0L)), int64Handle
+        | Shape.Prim w -> failwith $"unexpected generated primitive width %d{w}"
+        | Shape.Ref -> CliType.ObjectRef None, objectHandle
+        | Shape.Struct children ->
+            let fields =
+                children
+                |> List.mapi (fun i child ->
+                    let name = $"%s{path}_f%d{i}"
+                    let contents, handle = buildShape name child
+                    cliField name contents None handle
+                )
+
+            ofFields fields, declaredHandle
+
+    /// Independent recursive walk of the constructed value: every cell at every depth, with its
+    /// absolute offset. This is the oracle — the resolver *searches* for a cell given a range, and
+    /// this *enumerates* what is there, so agreement between them is a real check rather than the
+    /// same code twice.
+    let rec private enumerateCells
+        (prefix : FieldId list)
+        (baseOffset : int)
+        (value : CliType)
+        : (FieldId list * int * CliType) list
+        =
+        match value with
+        | CliType.ValueType vt ->
+            CliValueType.TryAllFields vt
+            |> List.map CliConcreteField.ToCliField
+            |> List.collect (fun f ->
+                // Deliberately via the public `getFieldLayoutById` rather than the concrete field's
+                // own offset: the resolver reads the latter, so going through a different accessor
+                // keeps this an independent check rather than the same lookup twice.
+                let off, _ = CliType.getFieldLayoutById f.Id value
+                let path = prefix @ [ f.Id ]
+                let abs = baseOffset + off
+                (path, abs, f.Contents) :: enumerateCells path abs f.Contents
+            )
+        | _ -> []
+
+    [<Test>]
+    let ``every cell of an alias-free tree is named by its own extent`` () : unit =
+        let property (shape : Shape) : bool =
+            let value, _ = buildShape "r" (Shape.Struct [ shape ])
+
+            enumerateCells [] 0 value
+            |> List.forall (fun (path, abs, contents) ->
+                let size = CliType.SizeOf(contents).Size
+                let found = CliType.CellPathsExactlyCovering abs size value
+
+                // The cell must be among the answers, and every answer must genuinely be a cell of
+                // that extent — so this pins both directions, not just "finds at least something".
+                List.exists (fun (p, c) -> p = path && c = contents) found
+                && found |> List.forall (fun (_, c) -> CliType.SizeOf(c).Size = size)
+            )
+
+        Check.One (config, Prop.forAll (Arb.fromGen shapeGen) property)
+
+    /// Answers are ordered outermost-first, i.e. by path length. A caller that takes the first
+    /// compatible answer therefore gets the shallowest cell that will do, which is the one that
+    /// disturbs least on write.
+    [<Test>]
+    let ``answers are ordered outermost first`` () : unit =
+        let property (shape : Shape) : bool =
+            let value, _ = buildShape "r" (Shape.Struct [ shape ])
+
+            enumerateCells [] 0 value
+            |> List.forall (fun (_, abs, contents) ->
+                let size = CliType.SizeOf(contents).Size
+
+                CliType.CellPathsExactlyCovering abs size value
+                |> List.map (fst >> List.length)
+                |> fun lengths -> lengths = List.sort lengths
+            )
+
+        Check.One (config, Prop.forAll (Arb.fromGen shapeGen) property)
+
+    /// Every answer is a prefix-extension of the one before it: they are nested cells sharing the
+    /// same bytes, not unrelated cells that happen to have the same extent.
+    [<Test>]
+    let ``answers form a single nesting chain`` () : unit =
+        let property (shape : Shape) : bool =
+            let value, _ = buildShape "r" (Shape.Struct [ shape ])
+
+            enumerateCells [] 0 value
+            |> List.forall (fun (_, abs, contents) ->
+                let size = CliType.SizeOf(contents).Size
+
+                CliType.CellPathsExactlyCovering abs size value
+                |> List.map fst
+                |> List.pairwise
+                |> List.forall (fun (shorter, longer) ->
+                    List.length longer > List.length shorter
+                    && List.truncate (List.length shorter) longer = shorter
+                )
+            )
+
+        Check.One (config, Prop.forAll (Arb.fromGen shapeGen) property)
+
+    /// The load-bearing equivalence: wherever the storage *can* be rendered as bytes, naming a cell
+    /// and reading its bytes must give the same answer as the byte path would. This is what makes
+    /// the descent a faithful substitute for the byte view rather than a second, divergent way to
+    /// read memory — and it is checkable on exactly the values the incumbent path already handles.
+    [<Test>]
+    let ``naming a cell agrees with the byte view wherever bytes are defined`` () : unit =
+        let property (shape : Shape) : bool =
+            let value, _ = buildShape "r" (Shape.Struct [ shape ])
+
+            match CliType.ByteAddressability value with
+            | CliByteAddressability.Rejected _ -> true
+            | CliByteAddressability.ByteAddressable ->
+
+            enumerateCells [] 0 value
+            |> List.forall (fun (_, abs, contents) ->
+                let size = CliType.SizeOf(contents).Size
+
+                match CliType.CellPathsExactlyCovering abs size value with
+                | [] -> true
+                | answers ->
+                    answers
+                    |> List.forall (fun (_, cell) ->
+                        // Reading the cell's own bytes out of the whole value must reproduce the
+                        // cell.
+                        let viaBytes = CliType.ofBytesLike cell (CliType.BytesAt abs size value)
+                        CliType.ToBytes viaBytes = CliType.ToBytes cell
+                    )
+            )
+
+        Check.One (config, Prop.forAll (Arb.fromGen shapeGen) property)

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -35,6 +35,7 @@
     <Compile Include="TestPointerHashSynthesis.fs" />
     <Compile Include="TestCliTypeBytes.fs" />
     <Compile Include="TestCliTypeSingleWholeField.fs" />
+    <Compile Include="TestCliTypeCellPaths.fs" />
     <Compile Include="TestInlineArrayStorage.fs" />
     <Compile Include="TestStructLayout.fs" />
     <Compile Include="TestManagedHeap.fs" />

--- a/WoofWare.PawPrint/CliType.fs
+++ b/WoofWare.PawPrint/CliType.fs
@@ -472,6 +472,78 @@ type CliType =
             | _ -> None
         | _ -> None
 
+    /// Every storage cell of `value` whose extent is exactly the byte range
+    /// `[offset, offset + size)`, as a path of `FieldId`s from `value` down to the cell, paired
+    /// with the cell's contents. Ordered outermost first. Empty if the range names no cell.
+    ///
+    /// This is `TryFieldExactlyCovering` made total over depth. Naming a cell is what lets the
+    /// byref layer serve an access whose storage has no byte rendering at all — a value type
+    /// containing object references — since there the bytewise path cannot run and the cell is the
+    /// only thing left to read or write. A range that is *part* of a cell, that spans two, or that
+    /// one cell covers exactly while another *aliases* it, names nothing: the first two have no
+    /// single cell to point at, and the third would leave the alias stale on write.
+    ///
+    /// More than one answer is normal rather than an ambiguity: a transparent wrapper and the field
+    /// it wraps occupy the same bytes, and which one a caller wants depends on the type it is
+    /// reinterpreting to. Answers therefore form a nesting chain, and a caller that takes the first
+    /// type-compatible one gets the shallowest cell that will do — the one that disturbs least on
+    /// write.
+    ///
+    /// Like `TryFieldExactlyCovering`, this is deliberately *structural*: it does not look at what
+    /// a cell contains, so callers must apply their own compatibility rule to the contents. It
+    /// walks fields rather than bytes, so it stays defined precisely where the byte path is not.
+    /// Raw-bytes storage has no fields, so it never answers.
+    static member CellPathsExactlyCovering
+        (offset : int)
+        (size : int)
+        (value : CliType)
+        : (FieldId list * CliType) list
+        =
+        if size <= 0 then
+            []
+        else
+
+        match value with
+        | CliType.ValueType vt ->
+            let fields = CliValueType.TryAllFields vt
+
+            // The range must sit inside a single field for any cell to name it. Under explicit
+            // layout several fields can contain it, in which case a write through one would strand
+            // the others, so we refuse rather than pick.
+            let containing =
+                fields
+                |> List.filter (fun f -> f.Offset <= offset && offset + size <= f.Offset + f.Size)
+
+            match containing with
+            | [ f ] ->
+                let aliased =
+                    fields
+                    |> List.exists (fun g ->
+                        not (FieldId.exactlyEqual g.Id f.Id)
+                        && g.Offset < offset + size
+                        && offset < g.Offset + g.Size
+                    )
+
+                if aliased then
+                    []
+                else
+
+                // A field whose laid-out extent exceeds its contents' own size has padding in it,
+                // so the range covers the field but not the *value*; descend without naming it.
+                let namesThisField =
+                    f.Offset = offset && f.Size = size && f.Size = CliType.SizeOf(f.Contents).Size
+
+                let deeper =
+                    CliType.CellPathsExactlyCovering (offset - f.Offset) size f.Contents
+                    |> List.map (fun (path, leaf) -> f.Id :: path, leaf)
+
+                if namesThisField then
+                    ([ f.Id ], f.Contents) :: deeper
+                else
+                    deeper
+            | _ -> []
+        | _ -> []
+
     /// If `value` is a value type holding exactly one field, laid out at offset 0 and spanning
     /// the whole value, return that field's id and its contents. Otherwise `None`.
     ///

--- a/WoofWare.PawPrint/CliType.fs
+++ b/WoofWare.PawPrint/CliType.fs
@@ -507,12 +507,21 @@ type CliType =
         | CliType.ValueType vt ->
             let fields = CliValueType.TryAllFields vt
 
+            // Widened to 64 bits because `offset` is guest-controlled — it accumulates
+            // `Unsafe.Add`/`Unsafe.AddByteOffset` arithmetic — so the range's end point need not
+            // fit in an `int`. This file compiles under `open Checked`, so computing it narrowly
+            // would raise `OverflowException` out of a lookup whose contract is to return `[]`.
+            // Field offsets and sizes come from a laid-out type and are small; only the range is
+            // suspect.
+            let rangeStart = int64 offset
+            let rangeEnd = int64 offset + int64 size
+
             // The range must sit inside a single field for any cell to name it. Under explicit
             // layout several fields can contain it, in which case a write through one would strand
             // the others, so we refuse rather than pick.
             let containing =
                 fields
-                |> List.filter (fun f -> f.Offset <= offset && offset + size <= f.Offset + f.Size)
+                |> List.filter (fun f -> int64 f.Offset <= rangeStart && rangeEnd <= int64 f.Offset + int64 f.Size)
 
             match containing with
             | [ f ] ->
@@ -520,8 +529,8 @@ type CliType =
                     fields
                     |> List.exists (fun g ->
                         not (FieldId.exactlyEqual g.Id f.Id)
-                        && g.Offset < offset + size
-                        && offset < g.Offset + g.Size
+                        && int64 g.Offset < rangeEnd
+                        && rangeStart < int64 g.Offset + int64 g.Size
                     )
 
                 if aliased then


### PR DESCRIPTION
First of two. **Inert**: nothing calls the new function.

`TryFieldExactlyCovering` answers "is this byte range exactly one field of this value?", but only at the top level. That is enough to name a slot of an `[InlineArray(N)]`, and not enough to name a field *inside* one — `Elem { byte Tag; Box Payload }` lays out as `Payload@0, Tag@8` because auto layout promotes references, so reaching `Tag` from the buffer is a depth-2 descent.

`CellPathsExactlyCovering` is that question made total over depth, returning the path of `FieldId`s down to each cell whose extent is exactly the range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)