### PR TITLE
Implement the AssemblyNative_GetEntryAssembly QCall

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/AssemblyGetEntryAssembly.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/AssemblyGetEntryAssembly.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Reflection;
+
+// `Assembly.GetEntryAssembly()` bottoms out in the `AssemblyNative_GetEntryAssembly` QCall,
+// which hands back CoreCLR's root assembly for the AppDomain. Each assertion below is
+// sensitive to a different way of getting that wrong, so a handler that returns the wrong
+// assembly, or a fresh object each call, fails loudly rather than silently passing.
+
+public class AssemblyGetEntryAssemblyTests
+{
+    public static int Main(string[] argv)
+    {
+        Assembly entry = Assembly.GetEntryAssembly();
+
+        // There is always a root assembly for a guest launched from its own image.
+        if (entry == null) return 1;
+
+        // The root assembly is the one declaring Main, and RuntimeAssembly objects are
+        // cached per assembly identity, so this must be the very same instance that
+        // ordinary reflection hands out for a type in that assembly.
+        if (!object.ReferenceEquals(entry, typeof(AssemblyGetEntryAssemblyTests).Assembly)) return 2;
+
+        // Repeated calls observe that cache rather than allocating afresh.
+        if (!object.ReferenceEquals(entry, Assembly.GetEntryAssembly())) return 3;
+
+        // CoreLib is loaded first and is emphatically not the entry assembly; this catches
+        // a handler that answers with whatever assembly happens to be nearest to hand.
+        if (object.ReferenceEquals(entry, typeof(object).Assembly)) return 4;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/IlMachineStateModel.fs
+++ b/WoofWare.PawPrint/IlMachineStateModel.fs
@@ -45,6 +45,14 @@ type IlMachineState =
         /// compatibility facades reference implementation assemblies as `Version=0.0.0.0`), so the
         /// two must not be conflated; see `LoadedAssemblies`.
         _LoadedAssemblies : LoadedAssemblies
+        /// The definition identity of the assembly whose entry point this run was started from:
+        /// CoreCLR's "root assembly" for the AppDomain, which is what `Assembly.GetEntryAssembly`
+        /// reports. Recorded at `IlMachineState.initial` rather than derived, because neither
+        /// candidate derivation is truthful: `_LoadedAssemblies` has no ordering (and even if it
+        /// did, registration order is an accident of type resolution), and the bottom stack frame
+        /// of the entry thread is a CoreLib `.cctor` during pre-`Main` pumping and absent entirely
+        /// once `Main` has returned.
+        EntryAssembly : AssemblyName
         /// Tracks initialization state of types across assemblies
         TypeInitTable : TypeInitTable
         /// For each static-storage owner, then for each concrete type, a map of field definition

--- a/WoofWare.PawPrint/IlMachineThreadState.fs
+++ b/WoofWare.PawPrint/IlMachineThreadState.fs
@@ -287,6 +287,7 @@ module IlMachineThreadState =
                 ThreadState = Map.empty
                 InternedStrings = ImmutableDictionary.Empty
                 _LoadedAssemblies = LoadedAssemblies.empty
+                EntryAssembly = entryAssembly.Name
                 _Statics = ImmutableDictionary.Empty
                 TypeInitTable = ImmutableDictionary.Empty
                 DotnetRuntimeDirs = dotnetRuntimeDirs

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -86,6 +86,7 @@ module NativeQCall =
             "Array_CreateInstance", NativeArray.tryExecuteQCall "Array_CreateInstance"
             "Enum_GetValuesAndNames", NativeEnum.tryExecuteQCall "Enum_GetValuesAndNames"
             "MetadataImport_Enum", NativeMetadataImport.tryExecuteQCall "MetadataImport_Enum"
+            "AssemblyNative_GetEntryAssembly", NativeRuntimeAssembly.tryExecuteQCall "AssemblyNative_GetEntryAssembly"
             "AssemblyNative_GetResource", NativeRuntimeAssembly.tryExecuteQCall "AssemblyNative_GetResource"
             "AssemblyNative_GetTypeCore", NativeRuntimeAssembly.tryExecuteQCall "AssemblyNative_GetTypeCore"
             "AssemblyNative_IsApplyUpdateSupported",

--- a/WoofWare.PawPrint/Native/NativeRuntimeAssembly.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeAssembly.fs
@@ -204,6 +204,48 @@ module NativeRuntimeAssembly =
                         $"TODO: %s{operation} does not support assembly-forwarded manifest resource %s{actualResourceName} in %s{assemblyFullName} forwarded to %s{assemblyReference.Name.FullName}"
 
             NativeHandlerResult.completed state |> Some
+        // Declared on `Assembly` itself rather than `RuntimeAssembly` — the `LibraryImport`
+        // lives in `Assembly.CoreCLR.cs`, next to `GetEntryAssemblyInternal` which is its only
+        // caller.
+        | "AssemblyNative_GetEntryAssembly",
+          "System.Private.CoreLib",
+          "System.Reflection",
+          "Assembly",
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "ObjectHandleOnStack",
+                                              objectHandleGenerics) ],
+          MethodReturnType.Void when objectHandleGenerics.IsEmpty ->
+            let operation = "AssemblyNative_GetEntryAssembly"
+
+            if instruction.Arguments.Length <> 1 then
+                failwith $"%s{operation}: expected one native argument, got %d{instruction.Arguments.Length}"
+
+            let retAssembly =
+                NativeCall.objectHandleOnStackTarget operation state "retAssembly" instruction.Arguments.[0]
+
+            // CoreCLR leaves `retAssembly` untouched when the AppDomain has no root assembly —
+            // it was hosted rather than launched from an image — and `GetEntryAssemblyInternal`
+            // preinitializes its local to null so that reads back as `null`. PawPrint is only
+            // ever entered through an entry assembly (`IlMachineState.initial` demands one), so
+            // that branch does not arise here and the write below is unconditional.
+            let assembly =
+                state.LoadedAssembly state.EntryAssembly
+                |> Option.defaultWith (fun () ->
+                    failwith $"%s{operation}: entry assembly %s{state.EntryAssembly.FullName} is not loaded"
+                )
+
+            let runtimeAssemblyAddr, state =
+                NativeRuntimeType.getOrAllocateRuntimeAssembly ctx.LoggerFactory ctx.BaseClassTypes assembly.Name state
+
+            let state =
+                IlMachineState.writeManagedByrefWithBase
+                    ctx.BaseClassTypes
+                    state
+                    retAssembly
+                    (CliType.ObjectRef (Some runtimeAssemblyAddr))
+
+            NativeHandlerResult.completed state |> Some
         | "AssemblyNative_GetTypeCore",
           "System.Private.CoreLib",
           "System.Reflection",

--- a/WoofWare.PawPrint/Native/NativeRuntimeType.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeType.fs
@@ -5,6 +5,9 @@ module NativeRuntimeType =
     let getOrAllocateNonGenericRuntimeType =
         NativeRuntimeTypeHelpers.getOrAllocateNonGenericRuntimeType
 
+    let getOrAllocateRuntimeAssembly =
+        NativeRuntimeTypeHelpers.getOrAllocateRuntimeAssembly
+
     let getOrAllocateRuntimeModule = NativeRuntimeTypeHelpers.getOrAllocateRuntimeModule
     let tryExecuteQCall = NativeRuntimeTypeQCall.tryExecute
     let tryExecute = NativeRuntimeTypeFCall.tryExecute


### PR DESCRIPTION
`Assembly.GetEntryAssembly()` bottoms out in this QCall, which CoreCLR answers with the AppDomain's root assembly ([`assemblynative.cpp:1132`](https://github.com/dotnet/runtime/blob/main/src/coreclr/vm/assemblynative.cpp)). The `LibraryImport` is declared on `System.Reflection.Assembly` rather than `RuntimeAssembly` — it lives in `Assembly.CoreCLR.cs` next to its only caller, `GetEntryAssemblyInternal` — so the handler matches on that type, even though it sits in `NativeRuntimeAssembly` alongside its `assemblynative.cpp` siblings.

## Where the root assembly lives

Nothing in `IlMachineState` recorded which assembly is the root, so this adds `EntryAssembly : AssemblyName`, set in `IlMachineState.initial` — whose parameter was already named `entryAssembly`, so no plumbing changed.

It is deliberately *recorded* rather than derived. Neither candidate derivation is truthful:

* `LoadedAssemblies` has no ordering, and even if it did, registration order is an accident of type resolution.
* The entry thread's bottom stack frame is a CoreLib `.cctor` during pre-`Main` pumping, and absent entirely once `Main` has returned.

It is also not `EmulatedKernel` material: that record's remit is kernel-visible state, and the root assembly is an AppDomain fact, not something a syscall reports.

## Reuse

Handing the assembly to the existing `getOrAllocateRuntimeAssembly` means the returned object comes from the same per-identity `RuntimeAssemblyObjects` cache that `RuntimeTypeHandle.GetAssembly` uses. So `Assembly.GetEntryAssembly()` is reference-equal to `typeof(X).Assembly` for a type in that assembly, exactly as on real .NET, with no extra machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)