### PR TITLE
Implement AssemblyNative_GetLocation, reporting no file backing

### DIFF
--- a/WoofWare.PawPrint.Test/TestImpureCases.fs
+++ b/WoofWare.PawPrint.Test/TestImpureCases.fs
@@ -381,6 +381,20 @@ module TestImpureCases =
                 ExpectsUnhandledException = false
                 AssertTerminalState = None
             }
+            {
+                // `Assembly.Location` is empty for every assembly, because under
+                // PawPrint no assembly has a file the guest could reach — the
+                // same state CoreCLR reports for a byte-array load or a
+                // single-file-published app. Deliberately not a differential
+                // case: the real runtime is launched from a real .dll and
+                // reports its path, so there is no cross-runtime fact here.
+                // Recorded in docs/divergences.md.
+                FileName = "AssemblyLocationEmpty.cs"
+                ExpectedReturnCode = 0
+                KernelConfig = KernelConfig.Default
+                ExpectsUnhandledException = false
+                AssertTerminalState = None
+            }
         ]
 
     let runTest (case : EndToEndTestCase) : unit =

--- a/WoofWare.PawPrint.Test/sourcesImpure/AssemblyLocationEmpty.cs
+++ b/WoofWare.PawPrint.Test/sourcesImpure/AssemblyLocationEmpty.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Reflection;
+
+// PawPrint reports every assembly as having no file backing: `Location` is the
+// empty string, which is what CoreCLR reports for a byte-array load or a
+// single-file-published app. See docs/divergences.md for why that is the honest
+// answer rather than a synthesised path.
+//
+// This is a PawPrint-only test rather than a differential one precisely because
+// the real runtime, launched from a real .dll on disk, reports a real path here
+// — so there is no cross-runtime fact to assert.
+
+public class AssemblyLocationEmpty
+{
+    public static int Main(string[] argv)
+    {
+        Assembly entry = typeof(AssemblyLocationEmpty).Assembly;
+
+        // Never null: CoreCLR's QCall always sets the out-parameter, so the
+        // managed `location!` is a genuine string. A handler that left the
+        // StringHandleOnStack untouched would surface here.
+        string loc = entry.Location;
+        if (loc == null) return 1;
+        if (loc.Length != 0) return 2;
+
+        // A framework assembly resolves from the host's runtime directories.
+        // Reporting the host's real path here would leak the machine that
+        // produced the run into the replay contract, so it is empty too.
+        string corelib = typeof(object).Assembly.Location;
+        if (corelib == null) return 3;
+        if (corelib.Length != 0) return 4;
+
+        // CoreCLR's StringObject::NewString hands back the shared empty-string
+        // instance for a zero-length string, so these identities hold there
+        // too; allocating a fresh empty string per call would break them.
+        if (!object.ReferenceEquals(loc, string.Empty)) return 5;
+        if (!object.ReferenceEquals(loc, corelib)) return 6;
+
+        // The knock-on effect. `AppContext.BaseDirectory` falls back to
+        // `Path.GetDirectoryName(Assembly.GetEntryAssembly()?.Location)` when no
+        // host has supplied the APP_CONTEXT_BASE_DIRECTORY property, and
+        // `GetDirectoryName("")` is null, so the fallback yields string.Empty
+        // rather than throwing. Asserted here so that an empty Location cannot
+        // quietly turn into a crash further down this path.
+        string baseDir = AppContext.BaseDirectory;
+        if (baseDir == null) return 7;
+        if (baseDir.Length != 0) return 8;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -87,6 +87,7 @@ module NativeQCall =
             "Enum_GetValuesAndNames", NativeEnum.tryExecuteQCall "Enum_GetValuesAndNames"
             "MetadataImport_Enum", NativeMetadataImport.tryExecuteQCall "MetadataImport_Enum"
             "AssemblyNative_GetEntryAssembly", NativeRuntimeAssembly.tryExecuteQCall "AssemblyNative_GetEntryAssembly"
+            "AssemblyNative_GetLocation", NativeRuntimeAssembly.tryExecuteQCall "AssemblyNative_GetLocation"
             "AssemblyNative_GetResource", NativeRuntimeAssembly.tryExecuteQCall "AssemblyNative_GetResource"
             "AssemblyNative_GetTypeCore", NativeRuntimeAssembly.tryExecuteQCall "AssemblyNative_GetTypeCore"
             "AssemblyNative_IsApplyUpdateSupported",

--- a/WoofWare.PawPrint/Native/NativeRuntimeAssembly.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeAssembly.fs
@@ -246,6 +246,63 @@ module NativeRuntimeAssembly =
                     (CliType.ObjectRef (Some runtimeAssemblyAddr))
 
             NativeHandlerResult.completed state |> Some
+        | "AssemblyNative_GetLocation",
+          "System.Private.CoreLib",
+          "System.Reflection",
+          "RuntimeAssembly",
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "QCallAssembly",
+                                              qCallAssemblyGenerics)
+            ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "StringHandleOnStack",
+                                              stringHandleGenerics) ],
+          MethodReturnType.Void when qCallAssemblyGenerics.IsEmpty && stringHandleGenerics.IsEmpty ->
+            let operation = "AssemblyNative_GetLocation"
+
+            if instruction.Arguments.Length <> 2 then
+                failwith $"%s{operation}: expected two native arguments, got %d{instruction.Arguments.Length}"
+
+            let assemblyFullName =
+                instruction.Arguments.[0]
+                |> NativeCall.qCallAssemblyToAssemblyFullName operation state
+
+            // Decoded and checked only to keep the handler honest about its
+            // input: a caller handing us an assembly we have not loaded is a
+            // bug worth hearing about, even though the answer below does not
+            // depend on which assembly this is.
+            state.LoadedAssembly' assemblyFullName
+            |> Option.defaultWith (fun () -> failwith $"%s{operation}: assembly %s{assemblyFullName} is not loaded")
+            |> ignore<DumpedAssembly>
+
+            let retString =
+                NativeCall.stringHandleOnStackTarget operation state "retString" instruction.Arguments.[1]
+
+            // CoreCLR answers `pAssembly->GetPEAssembly()->GetPath()`, which is
+            // empty for any assembly with no file backing — a byte-array load, a
+            // dynamic assembly, or a single-file-published app. Under PawPrint
+            // *every* assembly is that shape: the guest has no filesystem, so
+            // there is no path it could open. Synthesising a plausible-looking
+            // path would be a fiction the guest cannot act on, and for a
+            // framework assembly resolved from `DotnetRuntimeDirs` it would also
+            // leak the host machine's layout into the run's replay contract.
+            //
+            // `internCanonicalEmptyString` rather than a fresh allocation because
+            // CoreCLR's `StringObject::NewString` returns the shared empty-string
+            // instance for a zero-length string, so `ReferenceEquals(asm.Location,
+            // string.Empty)` holds there and must hold here.
+            let emptyAddr, state =
+                IlMachineState.internCanonicalEmptyString ctx.LoggerFactory ctx.BaseClassTypes state
+
+            let state =
+                IlMachineState.writeManagedByrefWithBase
+                    ctx.BaseClassTypes
+                    state
+                    retString
+                    (CliType.ObjectRef (Some emptyAddr))
+
+            NativeHandlerResult.completed state |> Some
         | "AssemblyNative_GetTypeCore",
           "System.Private.CoreLib",
           "System.Reflection",

--- a/docs/divergences.md
+++ b/docs/divergences.md
@@ -128,3 +128,33 @@ long r = ((delegate*<int, long>)p)(3);  // CoreCLR: r == 3. PawPrint: refused at
 **Testing note**: Cannot be a `sourcesPure` comparison test, since CoreCLR succeeds and PawPrint deliberately does not. Covered by the PawPrint-only tests `calli refuses a punned return type at the faulting instruction` and `calli refuses a punned parameter type at the faulting instruction` in `TestPureCases.fs`.
 
 **Where this lives in code**: `UnaryMetadataCallOps.executeCalli`, and the `CalliStackKind` classifier above it.
+
+## `Assembly.Location` is empty for every assembly
+
+**CoreCLR**: Returns `pAssembly->GetPEAssembly()->GetPath()` (`assemblynative.cpp`, `AssemblyNative_GetLocation`) — the path the assembly was loaded from. For an app launched as `dotnet app.dll`, both the app's own assembly and every framework assembly report a real absolute path. The empty string is reserved for assemblies with no file backing: byte-array loads (`Assembly.Load(byte[])`), dynamic assemblies, and single-file-published apps.
+
+**PawPrint**: Returns the empty string for *every* assembly, which is that no-file-backing state.
+
+**Spec status**: Compliant. `Location` returning an empty string is a documented, first-class CoreCLR state that the BCL itself handles — see the suppression justification above `AppContext.GetBaseDirectoryCore`, "Single File apps should always set APP_CONTEXT_BASE_DIRECTORY therefore code handles Assembly.Location equals null". PawPrint is structurally exactly that shape of app.
+
+**Why we chose this**: A guest under PawPrint has no filesystem, so there is no path it could open. The two alternatives are both worse:
+
+* *Report the host's real path.* The framework assemblies resolve from `HostConfig.DotnetRuntimeDirs`, so a guest would observe the developer's `/nix/store/...` layout, and a recorded trace would depend on the machine that produced it. That is the determinism leak the whole `EmulatedKernel` design exists to prevent.
+* *Synthesise a plausible path.* Deterministic, but a fiction: nothing is there, the guest cannot act on it, and it would become actively wrong once an emulated filesystem exists and does not contain that file.
+
+The empty string is simply true, and it is what the runtime already reports for an app with no assembly files to point at.
+
+**Knock-on effect**: `AppContext.BaseDirectory` is likewise empty. Its fallback `GetBaseDirectoryCore()` computes `Path.GetDirectoryName(Assembly.GetEntryAssembly()?.Location)`, and `GetDirectoryName("")` returns `null`, so the fallback returns `string.Empty`. Note this is only the *fallback*: on a real host `BaseDirectory` never reaches it, because `hostpolicy` always supplies the `APP_CONTEXT_BASE_DIRECTORY` property (see CoreCLR's own comment in `gcheaputilities.cpp`, "The APP_CONTEXT_BASE_DIRECTORY is always set by the host"). PawPrint does not yet populate that property; when it does, guests will see a real directory there by the same route a real host uses, and this entry will cover only `Location` itself.
+
+**Observable example**:
+
+```csharp
+// dotnet app.dll:  "/path/to/app.dll", then "/path/to/"
+// PawPrint:        "",                 then ""
+Console.WriteLine(typeof(Program).Assembly.Location);
+Console.WriteLine(AppContext.BaseDirectory);
+```
+
+**Testing note**: Cannot be a `sourcesPure` comparison test, since the real runtime is launched from a real `.dll` and reports its path — there is no cross-runtime fact to assert. Covered by the PawPrint-only `sourcesImpure/AssemblyLocationEmpty.cs`, which asserts the empty `Location` for both the guest's own assembly and a framework assembly, the resulting empty `AppContext.BaseDirectory`, and `ReferenceEquals(asm.Location, string.Empty)` — CoreCLR's `StringObject::NewString` hands back the shared empty-string instance for a zero-length string, so allocating a fresh empty string here would be observably wrong.
+
+**Where this lives in code**: `NativeRuntimeAssembly.tryExecuteQCall`, the `AssemblyNative_GetLocation` case.


### PR DESCRIPTION
Next blocker after #800 on the `AppContext.BaseDirectory` path.

CoreCLR answers this QCall with `pAssembly->GetPEAssembly()->GetPath()`, reserving the empty string for assemblies with no file behind them: byte-array loads, dynamic assemblies, and single-file-published apps. PawPrint returns the empty string for **every** assembly, because structurally every assembly here is that shape — the guest has no filesystem, so there is no path it could open.

## Why empty rather than a path

Both alternatives are worse:

* **Report the host's real path.** Framework assemblies resolve from `HostConfig.DotnetRuntimeDirs`, so a guest would observe the developer's `/nix/store/...` layout and a recorded trace would depend on the machine that produced it — the determinism leak `EmulatedKernel` exists to prevent.
* **Synthesise a plausible path.** Deterministic, but a fiction the guest cannot act on, and actively wrong once an emulated filesystem exists and does not contain that file.

The empty string is simply true, and CoreLib handles it first-class — the suppression justification above `AppContext.GetBaseDirectoryCore` reads *"Single File apps should always set APP_CONTEXT_BASE_DIRECTORY therefore code handles Assembly.Location equals null."*

Answering uniformly also means there is **no per-assembly policy to get wrong**: the handler does not branch on which assembly it was asked about. An earlier sketch of this change did carry such a policy; dropping it removed the only contentious decision.

## Interning

The empty string comes from the existing `internCanonicalEmptyString`, not a fresh allocation. CoreCLR's `StringObject::NewString` hands back the shared empty-string instance for a zero-length string, so `ReferenceEquals(asm.Location, string.Empty)` holds there and must hold here. This was nearly got wrong, and is the mutation that mattered most.

## Measured

Same published image, real runtime vs PawPrint:

```
real:     Location=[/Users/.../publish/CSharpExample.dll]
          CoreLibLocation=[/Users/.../publish/System.Private.CoreLib.dll]
          BaseDirectory=[/Users/.../publish/]
PawPrint: Location=[]  CoreLibLocation=[]  BaseDirectory=[]
```

`BaseDirectory` follows because `Path.GetDirectoryName("")` is `null`, so `GetBaseDirectoryCore` returns `string.Empty` rather than throwing.

## Testing

Not a differential test — the real runtime is launched from a real `.dll` and reports its path, so there is no cross-runtime fact to assert. Covered by the PawPrint-only `sourcesImpure/AssemblyLocationEmpty.cs` and recorded in `docs/divergences.md`.

Mutation-tested, four kills, each at a distinct exit code:

| mutation | caught by |
|---|---|
| never write the out-parameter | 1 (null) |
| a non-empty path | 2 |
| synthesised path for framework assemblies only | 4 |
| fresh rather than interned empty string | 5 |

Full suite 2097/2097; `codex review --base origin/main` found nothing actionable.

## Note on the remaining gap

This makes PawPrint behave as a host that does *not* set `APP_CONTEXT_BASE_DIRECTORY`. A real host always does — CoreCLR's own comment in `gcheaputilities.cpp` says so — and `GetBaseDirectoryCore` is explicitly the documented fallback for hosts that don't. Once PawPrint populates that property (natural follow-on to #794, whose App layer already has the dll path), guests will see a real directory by the same route a real host uses, and this divergence will cover only `Location` itself. An emulated filesystem is not needed for any of that, and is only worth building when a guest wants real file IO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)