### PR TITLE
Move sub-cell ranges in bulk copies, and let stack slots name cells

### DIFF
--- a/WoofWare.PawPrint.Test/TestBulkMoveCellAccess.fs
+++ b/WoofWare.PawPrint.Test/TestBulkMoveCellAccess.fs
@@ -1,0 +1,467 @@
+namespace WoofWare.Pawprint.Test
+
+open System
+open System.Collections.Immutable
+open System.IO
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.DotnetRuntimeLocator
+open WoofWare.PawPrint
+open WoofWare.PawPrint.Test
+
+/// A differential sweep over the *bulk byte-range* primitives — `Span<T>.CopyTo`, which bottoms out
+/// in `Buffer.Memmove` and, for `T` containing references, in
+/// `Buffer.BulkMoveWithWriteBarrierInternal` — taking the real runtime as the oracle.
+///
+/// PawPrint stores values as typed cells rather than as flat bytes, so `CellAwareMemOps` serves
+/// these by walking the range and taking whole typed cells where it can, falling back to a byte
+/// walk otherwise. Storage containing object references has no byte image at all, so for it the
+/// cell step is not an optimisation but the only route: what the sweep is really checking is that
+/// the cell the step picks is the right one, for cursors that land at every offset of every shape
+/// below.
+///
+/// The shapes vary how deeply the cell that should move is buried and what surrounds it: a slot of
+/// an `[InlineArray(N)]` (the whole buffer is one indivisible cell, so a single-element copy is a
+/// strict sub-range of it), a plain field, a field of a field, and a field of a field alongside a
+/// byte-addressable sibling. The `noReference*` rows are controls: their storage *is*
+/// byte-addressable, so those copies must keep going through the byte path, and they are here to
+/// catch cell naming quietly taking over moves that already worked.
+///
+/// Each scenario returns a checksum depending on every slot, so a move landing one cell over
+/// changes the answer rather than going unnoticed. Scenarios are grouped in threes because a real
+/// process's exit code on Unix is only 8 bits: PawPrint runs once and returns all three groups
+/// packed into an int32, while the oracle is run once per group.
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestBulkMoveCellAccess =
+
+    /// A storage shape to copy in and out of. `Declarations` must define the element type, a
+    /// four-slot buffer type `Buf`, and the three accessors the template calls: `Slot`, `SetSlot`
+    /// and `SpanOf`. Keeping those per shape is what lets the template read a buffer back by
+    /// ordinary field access — a route with no bulk move in it — so the checksum measures the copy
+    /// rather than measuring itself.
+    type private BufferShape =
+        {
+            Declarations : string
+            /// Expression building an element from the `int` seed `SEED`.
+            Make : string
+            /// Expression scoring the element-valued expression `ELEM` to an `int`.
+            ScoreElem : string
+        }
+
+    /// The four slots as named fields, reached by ordinary `ldfld`, with the span built by
+    /// reinterpreting the buffer as its element type.
+    let private fieldBuffer (elementDeclarations : string) (elementType : string) : string =
+        $"""
+    %s{elementDeclarations}
+
+    private struct Buf {{ public %s{elementType} A; public %s{elementType} B; public %s{elementType} C; public %s{elementType} D; }}
+
+    private static %s{elementType} Slot(ref Buf b, int i) => i switch {{ 0 => b.A, 1 => b.B, 2 => b.C, _ => b.D }};
+
+    private static void SetSlot(ref Buf b, int i, %s{elementType} v)
+    {{
+        switch (i) {{ case 0: b.A = v; break; case 1: b.B = v; break; case 2: b.C = v; break; default: b.D = v; break; }}
+    }}
+
+    private static Span<%s{elementType}> SpanOf(ref Buf b) => MemoryMarshal.CreateSpan(ref Unsafe.As<Buf, %s{elementType}>(ref b), 4);
+"""
+
+    /// The four slots as an `[InlineArray(4)]`, where PawPrint models the whole buffer as one cell
+    /// and a slot is a sub-cell of it.
+    let private inlineArrayBuffer (elementDeclarations : string) (elementType : string) : string =
+        $"""
+    %s{elementDeclarations}
+
+    [InlineArray(4)]
+    private struct Buf {{ private %s{elementType} _item; }}
+
+    private static %s{elementType} Slot(ref Buf b, int i) => b[i];
+
+    private static void SetSlot(ref Buf b, int i, %s{elementType} v) {{ b[i] = v; }}
+
+    private static Span<%s{elementType}> SpanOf(ref Buf b) => b;
+"""
+
+    let private box = "private sealed class Box { public int V; }"
+
+    let private shapes : Map<string, BufferShape> =
+        [
+            // The report's shape: an inline array over a bare object reference. The buffer is one
+            // 32-byte cell with no byte image, so copying a single 8-byte element out of it needs
+            // the slot naming rather than a whole-cell move.
+            "inlineArrayOfReferences",
+            {
+                Declarations = inlineArrayBuffer box "object"
+                Make = "(object)new Box { V = SEED + 1 }"
+                ScoreElem = "((ELEM) == null ? -1 : ((Box)(ELEM)).V)"
+            }
+            // The deepest shape: inline-array slots whose element is a struct *containing* a
+            // reference. The buffer is one indivisible 64-byte cell with no byte image, a slot is a
+            // 16-byte sub-cell of it, and auto layout promotes the reference so `Tag` sits at a
+            // non-zero offset *within* the slot — two levels of descent from the storage the byref
+            // names.
+            "inlineArrayOfReferenceStructs",
+            {
+                Declarations = inlineArrayBuffer $"%s{box} private struct W {{ public byte Tag; public Box P; }}" "W"
+                Make = "new W { Tag = (byte)(SEED + 1), P = new Box { V = SEED + 1 } }"
+                ScoreElem = "((ELEM).Tag * 7 + ((ELEM).P == null ? -1 : (ELEM).P.V))"
+            }
+            // The same element, but as four declared fields rather than inline-array slots: the
+            // cells are the same width and at the same offsets, reached by a different route.
+            "referenceFields",
+            {
+                Declarations = fieldBuffer box "Box"
+                Make = "new Box { V = SEED + 1 }"
+                ScoreElem = "((ELEM) == null ? -1 : (ELEM).V)"
+            }
+            // One level deeper: each slot is a struct wrapping the reference, so the cell that
+            // moves and the cell that encloses it have the same extent. Both are legitimate
+            // answers, and the step must not be confused by there being two.
+            "nestedReferenceFields",
+            {
+                Declarations = fieldBuffer $"%s{box} private struct W {{ public Box P; }}" "W"
+                Make = "new W { P = new Box { V = SEED + 1 } }"
+                ScoreElem = "((ELEM).P == null ? -1 : (ELEM).P.V)"
+            }
+            // A reference beside a byte-addressable sibling. Auto layout promotes the reference, so
+            // `N` sits at a non-zero offset inside each slot: the enclosing cell has no byte image
+            // while one of its children does, which is the shape where a cell step and a byte step
+            // have to interleave correctly.
+            "mixedReferenceFields",
+            {
+                Declarations = fieldBuffer $"%s{box} private struct W {{ public Box P; public long N; }}" "W"
+                Make = "new W { P = new Box { V = SEED + 1 }, N = (SEED + 2) * 1000L }"
+                ScoreElem = "((((ELEM).P == null) ? -1 : (ELEM).P.V) * 7 + (int)((ELEM).N))"
+            }
+            // Control: an inline array with no references anywhere, so its storage *is*
+            // byte-addressable and these copies must keep going through the byte path.
+            "noReferenceInlineArray",
+            {
+                Declarations = inlineArrayBuffer "" "long"
+                Make = "(SEED + 1) * 1000L"
+                ScoreElem = "(int)(ELEM)"
+            }
+            // Control, field-rooted: the same, reached the way the reference shapes above are.
+            "noReferenceFields",
+            {
+                Declarations = fieldBuffer "" "long"
+                Make = "(SEED + 1) * 1000L"
+                ScoreElem = "(int)(ELEM)"
+            }
+        ]
+        |> Map.ofList
+
+    let private cases : string[] = shapes |> Map.toSeq |> Seq.map fst |> Array.ofSeq
+
+    let private source (shape : BufferShape) : string =
+        let template =
+            """
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+public class TestBulkMoveCellAccessSweep
+{
+    DECLARATIONS
+
+    private sealed class Holder { public Buf B; }
+
+    private static Buf StaticBuf;
+
+    private static int Mix(int acc, int x) => acc * 31 + x;
+
+    private static int ScoreBuf(ref Buf b)
+    {
+        int acc = 0;
+        for (int i = 0; i < 4; i++) acc = Mix(acc, SCORE_SLOT);
+        return acc;
+    }
+
+    private static int ScoreArr(ELEMTYPE[] arr)
+    {
+        int acc = 0;
+        for (int i = 0; i < arr.Length; i++) acc = Mix(acc, SCORE_ARR);
+        return acc;
+    }
+
+    private static void Fill(ref Buf b, int seedBase)
+    {
+        for (int i = 0; i < 4; i++) SetSlot(ref b, i, MAKE_LOOP);
+    }
+
+    // Reached through an *argument* root. The buffer must be passed by value: a `ref Buf`
+    // parameter carries the caller's byref, so it would root at the caller's local and this would
+    // silently be the same case as everything above.
+    private static int ViaArg(Buf b, ELEMTYPE[] arr)
+    {
+        Array.Clear(arr);
+        SpanOf(ref b).CopyTo(arr);
+        return ScoreArr(arr);
+    }
+
+    // Copies that cross between two distinct storages.
+    private static int Group0()
+    {
+        ELEMTYPE[] arr = new ELEMTYPE[4];
+        int acc = 0;
+
+        // Whole buffer out to an array.
+        Buf b1 = default;
+        Fill(ref b1, 0);
+        SpanOf(ref b1).CopyTo(arr);
+        acc = Mix(acc, ScoreArr(arr));
+
+        // One element out of the middle: a strict sub-range of the buffer's storage, and the
+        // report's own case.
+        Array.Clear(arr);
+        SpanOf(ref b1).Slice(1, 1).CopyTo(arr.AsSpan(0, 1));
+        acc = Mix(acc, ScoreArr(arr));
+
+        // A run from the middle to the middle: neither cursor starts at its storage's origin, so
+        // the two intra-cell offsets differ throughout.
+        Array.Clear(arr);
+        SpanOf(ref b1).Slice(1, 2).CopyTo(arr.AsSpan(2, 2));
+        acc = Mix(acc, ScoreArr(arr));
+
+        // Array back into a buffer: the descending side is now the destination.
+        Buf b2 = default;
+        for (int i = 0; i < 4; i++) arr[i] = MAKE_ARR;
+        arr.AsSpan().CopyTo(SpanOf(ref b2));
+        acc = Mix(acc, ScoreBuf(ref b2));
+
+        // One element from one buffer to another. Both sides could name a cell far wider than the
+        // copy — the whole buffer, at the same offset, of the same type — so this is where a step
+        // that forgot to cap its width by the bytes remaining would overrun and take all four
+        // slots. The two buffers are seeded differently so that overrunning shows up.
+        Buf b3 = default;
+        Fill(ref b3, 100);
+        Buf b4 = default;
+        Fill(ref b4, 200);
+        SpanOf(ref b3).Slice(0, 1).CopyTo(SpanOf(ref b4).Slice(0, 1));
+        acc = Mix(acc, ScoreBuf(ref b4));
+
+        return acc;
+    }
+
+    // Copies within one storage, where direction matters, plus zeroing.
+    private static int Group1()
+    {
+        int acc = 0;
+
+        // Overlapping shift down: destination before source, so the loop runs forwards.
+        Buf b3 = default;
+        Fill(ref b3, 20);
+        SpanOf(ref b3).Slice(1, 3).CopyTo(SpanOf(ref b3).Slice(0, 3));
+        acc = Mix(acc, ScoreBuf(ref b3));
+
+        // Overlapping shift up: destination after source, so the loop runs backwards and the
+        // cursor is each move's *last* byte rather than its first.
+        Buf b4 = default;
+        Fill(ref b4, 30);
+        SpanOf(ref b4).Slice(0, 3).CopyTo(SpanOf(ref b4).Slice(1, 3));
+        acc = Mix(acc, ScoreBuf(ref b4));
+
+        // A single slot moved backwards within one storage: both cursors sit inside the *same*
+        // cell at *different* offsets, which is the case a step requiring one shared intra-cell
+        // offset cannot serve.
+        Buf b5 = default;
+        Fill(ref b5, 40);
+        SpanOf(ref b5).Slice(2, 1).CopyTo(SpanOf(ref b5).Slice(0, 1));
+        acc = Mix(acc, ScoreBuf(ref b5));
+
+        // Zeroing a sub-range. `tryWholeCellZeroAt` gates on the same root predicate, so this is
+        // cover for the reclassification on the zeroing side.
+        Buf b7 = default;
+        Fill(ref b7, 80);
+        SpanOf(ref b7).Slice(1).Clear();
+        acc = Mix(acc, ScoreBuf(ref b7));
+
+        return acc;
+    }
+
+    // The same copy from each root a buffer can sit in.
+    private static int Group2()
+    {
+        ELEMTYPE[] arr = new ELEMTYPE[4];
+        int acc = 0;
+
+        // Static-field root.
+        Fill(ref StaticBuf, 50);
+        Array.Clear(arr);
+        SpanOf(ref StaticBuf).CopyTo(arr);
+        acc = Mix(acc, ScoreArr(arr));
+
+        // Argument root.
+        Buf b6 = default;
+        Fill(ref b6, 60);
+        acc = Mix(acc, ViaArg(b6, arr));
+
+        // Heap-object-field root.
+        Holder h = new Holder();
+        Fill(ref h.B, 70);
+        Array.Clear(arr);
+        SpanOf(ref h.B).CopyTo(arr);
+        acc = Mix(acc, ScoreArr(arr));
+
+        return acc;
+    }
+
+    // 251 is the largest prime an exit code can carry, and folding into it keeps every group
+    // comparable against a real process.
+    private static int Reduce(int x) => ((x % 251) + 251) % 251;
+
+    public static int Main(string[] argv)
+    {
+        if (argv.Length == 0) return Reduce(Group0()) | (Reduce(Group1()) << 8) | (Reduce(Group2()) << 16);
+        if (argv[0] == "0") return Reduce(Group0());
+        if (argv[0] == "1") return Reduce(Group1());
+        return Reduce(Group2());
+    }
+}
+"""
+
+        // `ELEMTYPE` is read off the generated `SpanOf`, so a shape cannot get it out of step with
+        // its own declarations.
+        let elementType =
+            let marker = "private static Span<"
+
+            let start = shape.Declarations.IndexOf (marker, StringComparison.Ordinal)
+
+            if start < 0 then
+                failwith "shape declarations must define SpanOf, from which the element type is read"
+
+            let from = start + marker.Length
+            let stop = shape.Declarations.IndexOf ('>', from)
+            shape.Declarations.Substring (from, stop - from)
+
+        template
+            .Replace("DECLARATIONS", shape.Declarations)
+            .Replace("SCORE_SLOT", shape.ScoreElem.Replace ("ELEM", "Slot(ref b, i)"))
+            .Replace("SCORE_ARR", shape.ScoreElem.Replace ("ELEM", "arr[i]"))
+            .Replace("MAKE_LOOP", shape.Make.Replace ("SEED", "(seedBase + i)"))
+            .Replace("MAKE_ARR", shape.Make.Replace ("SEED", "(i + 10)"))
+            .Replace ("ELEMTYPE", elementType)
+
+    let private assy = typeof<RunResult>.Assembly
+
+    let private runUnderPawPrint (sourceName : string) (image : byte[]) : int =
+        let messages, loggerFactory =
+            LoggerFactory.makeTestWithProperties [ "source_file", sourceName ]
+
+        use _loggerFactoryResource = loggerFactory
+
+        let dotnetRuntimes =
+            DotnetRuntime.SelectForDll assy.Location |> ImmutableArray.CreateRange
+
+        use peImage = new MemoryStream (image)
+
+        let outcome =
+            try
+                Program.run
+                    loggerFactory
+                    (Some sourceName)
+                    peImage
+                    { HostConfig.Default dotnetRuntimes with
+                        Kernel = KernelConfig.Default
+                    }
+            with _ ->
+                for message in messages () do
+                    Console.Error.WriteLine $"{message}"
+
+                reraise ()
+
+        match outcome with
+        | RunOutcome.NormalExit (terminalState, terminatingThread)
+        | RunOutcome.ProcessExit (terminalState, terminatingThread) ->
+            match terminalState.ThreadState.[terminatingThread].MethodState.EvaluationStack.Values with
+            | EvalStackValue.Int32 (Int32Source.Verbatim i) :: _ -> i
+            | [] -> failwith $"%s{sourceName}: expected the program to return an int, but it returned void"
+            | ret :: _ -> failwith $"%s{sourceName}: expected the program to return an int, but it returned %O{ret}"
+        | RunOutcome.GuestUnhandledException (_, _, exn) ->
+            failwith $"%s{sourceName}: guest threw an unhandled exception: %O{exn.ExceptionObject}"
+        | RunOutcome.FailFast (_, _, message) ->
+            let message = message |> Option.defaultValue "<no message>"
+            failwith $"%s{sourceName}: guest called Environment.FailFast: %s{message}"
+        | RunOutcome.SignalTerminated (_, signal) ->
+            failwith $"%s{sourceName}: guest was terminated by POSIX signal %O{signal}"
+
+    /// A same-width copy whose two ends are differently *typed* — `long` cells into `double` cells,
+    /// which `MemoryMarshal.Cast` makes ordinary. Both sides are byte-addressable, so the byte path
+    /// serves it and the reinterpreted bit patterns must come back out unchanged.
+    ///
+    /// Reclassifying stack slots as cell-aware is what brings this shape to the cell step at all —
+    /// before, a local-rooted endpoint declined before anything was examined — so it is here as
+    /// cover for that widening rather than as an assertion about any one guard.
+    ///
+    /// In particular it does **not** pin `cellsHaveCompatibleShape`, and that is measured, not
+    /// assumed: the guard demonstrably fires on exactly this copy (`Numeric Int64` against
+    /// `Numeric Float64`), yet removing it changes no answer here, because PawPrint's read path
+    /// carries the 64-bit payload through either cell shape. The guard refuses shapes the real
+    /// runtime accepts, so no differential test can distinguish it — the same position #797
+    /// records for `isCellIdentityCompatible` one layer up. Treat it as load-bearing anyway.
+    [<Test>]
+    let ``a same-width copy between differently-typed cells goes by bytes`` () : unit =
+        let text =
+            """
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+public class TestBulkMoveShapeMismatch
+{
+    [InlineArray(4)]
+    private struct DoubleBuf { private double _item; }
+
+    public static int Main()
+    {
+        long[] src = new long[4];
+        for (int i = 0; i < 4; i++) src[i] = 0x4010000000000000L + (i + 1);
+
+        DoubleBuf dst = default;
+        MemoryMarshal.Cast<long, double>(src.AsSpan()).CopyTo(dst);
+
+        int acc = 0;
+        for (int i = 0; i < 4; i++) acc = acc * 31 + (int)(BitConverter.DoubleToInt64Bits(dst[i]) & 0xFFFF);
+        return ((acc % 251) + 251) % 251;
+    }
+}
+"""
+
+        let image = Roslyn.compile [ text ]
+
+        let expected =
+            match RealRuntime.executeWithRealRuntime [||] image with
+            | RealRuntimeResult.NormalExit exitCode -> exitCode
+            | RealRuntimeResult.UnhandledException report ->
+                failwith $"real runtime terminated with an unhandled exception:\n%s{report}"
+            | RealRuntimeResult.FailFast report -> failwith $"real runtime called FailFast:\n%s{report}"
+
+        runUnderPawPrint "shapeMismatch" image |> shouldEqual expected
+
+    [<TestCaseSource(nameof cases)>]
+    let ``Bulk moves through typed cells match the real runtime`` (case : string) : unit =
+        let text = source shapes.[case]
+        let image = Roslyn.compile [ text ]
+
+        // The oracle is a real process, so it carries one group per run; PawPrint costs seconds per
+        // run and carries all three at once.
+        let measure (group : int) : int =
+            match RealRuntime.executeWithRealRuntime [| string group |] image with
+            | RealRuntimeResult.NormalExit exitCode -> exitCode
+            | RealRuntimeResult.UnhandledException report ->
+                failwith $"%s{case}: real runtime terminated with an unhandled exception:\n%s{report}"
+            | RealRuntimeResult.FailFast report -> failwith $"%s{case}: real runtime called FailFast:\n%s{report}"
+
+        let expected = (measure 0) ||| ((measure 1) <<< 8) ||| ((measure 2) <<< 16)
+
+        let actual = runUnderPawPrint case image
+
+        if actual <> expected then
+            let decode (packed : int) =
+                $"group0=%d{packed &&& 0xFF}, group1=%d{(packed >>> 8) &&& 0xFF}, group2=%d{(packed >>> 16) &&& 0xFF}"
+
+            failwith
+                $"%s{case}: PawPrint and the real runtime disagree on the bulk-move checksum.\n  real runtime: %s{decode expected}\n  PawPrint:     %s{decode actual}\n\nSource:\n%s{text}"
+
+        actual |> shouldEqual expected

--- a/WoofWare.PawPrint.Test/TestCliTypeCellPaths.fs
+++ b/WoofWare.PawPrint.Test/TestCliTypeCellPaths.fs
@@ -581,3 +581,129 @@ module TestCliTypeCellPaths =
             )
 
         Check.One (config, Prop.forAll (Arb.fromGen shapeGen) property)
+
+    // ----------------------------------------------------------------------------------------
+    // `CandidateCellExtentsContainingByte`
+    // ----------------------------------------------------------------------------------------
+    //
+    // The subordinate half of the pair. `CellAwareMemOps` steps a copy cursor through a byte range
+    // and must decide how wide the next move should be *before* it can ask whether that width names
+    // a cell; this generator proposes the widths and `CellPathsExactlyCovering` disposes of them.
+    // Because the validator has the last word, the only thing that can actually go wrong here is
+    // under-reporting — a width the validator would have accepted but which is never offered to it,
+    // which silently costs the caller a route it should have had. That is what the completeness
+    // property below is for, and it is stated against a brute-force enumeration of every width
+    // rather than against a second hand-written walk.
+
+    [<Test>]
+    let ``candidate extents are reported outermost first and rebased through nesting`` () : unit =
+        let value = buffer ()
+
+        // Byte 8 is `Tag` inside slot 0: the whole buffer, then the slot, then the byte itself.
+        CliType.CandidateCellExtentsContainingByte 8 value
+        |> shouldEqual [ 0, 32 ; 0, 16 ; 8, 1 ]
+
+        // Byte 16 opens slot 1, whose own `Payload` starts there too — so both are rebased by 16.
+        CliType.CandidateCellExtentsContainingByte 16 value
+        |> shouldEqual [ 0, 32 ; 16, 16 ; 16, 8 ]
+
+    [<Test>]
+    let ``a byte in padding stops the descent at the enclosing cell`` () : unit =
+        let value = buffer ()
+
+        // `Elem` is `{ Box Payload@0; byte Tag@8 }` padded to 16, so bytes 9..15 belong to no
+        // field. The slot is still a cell and is still reported; there is nothing below it.
+        CliType.CandidateCellExtentsContainingByte 9 value
+        |> shouldEqual [ 0, 32 ; 0, 16 ]
+
+    [<Test>]
+    let ``a byte outside the value proposes nothing`` () : unit =
+        let value = buffer ()
+        CliType.CandidateCellExtentsContainingByte -1 value |> shouldEqual []
+        CliType.CandidateCellExtentsContainingByte 32 value |> shouldEqual []
+
+    [<Test>]
+    let ``overlapping fields stop the descent`` () : unit =
+        // Explicit layout, two fields sharing byte 0: there is no single field to descend into.
+        let value =
+            ofFieldsSized
+                8
+                [
+                    cliField "a" (CliType.Numeric (CliNumericType.Int32 0)) (Some 0) int32Handle
+                    cliField "b" (CliType.Numeric (CliNumericType.Int32 0)) (Some 0) int32Handle
+                ]
+
+        CliType.CandidateCellExtentsContainingByte 0 value |> shouldEqual [ 0, 8 ]
+
+    /// Every extent proposed genuinely lies within the value and contains the byte asked about.
+    /// Weak on its own — the validator would catch a violation — but it keeps the generator from
+    /// drifting into nonsense that happens to be harmless.
+    [<Test>]
+    let ``every proposed extent contains the byte it was asked about`` () : unit =
+        let property (shape : Shape) : bool =
+            let value, _ = buildShape "r" (Shape.Struct [ shape ])
+            let size = CliType.SizeOf(value).Size
+
+            [ 0 .. size - 1 ]
+            |> List.forall (fun byteOffset ->
+                CliType.CandidateCellExtentsContainingByte byteOffset value
+                |> List.forall (fun (offset, width) ->
+                    offset >= 0
+                    && width > 0
+                    && offset + width <= size
+                    && offset <= byteOffset
+                    && byteOffset < offset + width
+                )
+            )
+
+        Check.One (config, Prop.forAll (Arb.fromGen shapeGen) property)
+
+    /// The property the design rests on: **the generator is complete**. `CellAwareMemOps` proposes
+    /// widths from one endpoint only, so a width the validator would have accepted but which was
+    /// never proposed is a move silently lost.
+    ///
+    /// The oracle is brute force — every width from 1 to the value's size, asked of
+    /// `CellPathsExactlyCovering` directly — which is the implementation the caller would have if
+    /// it did not have this generator. Both anchorings are checked, since the copy loop runs
+    /// forwards (the cursor is the move's first byte) and backwards (its last).
+    [<Test>]
+    let ``every width the validator accepts at an anchor is proposed`` () : unit =
+        let property (shape : Shape) : bool =
+            let value, _ = buildShape "r" (Shape.Struct [ shape ])
+            let size = CliType.SizeOf(value).Size
+
+            // Mirrors `CellAwareMemOps.namedCells`: the validator reports *fields*, so the range
+            // being the whole value is the caller's own base case rather than something it returns.
+            let namesACell (start : int) (width : int) : bool =
+                (start = 0 && width = size)
+                || not (List.isEmpty (CliType.CellPathsExactlyCovering start width value))
+
+            [ 0 .. size - 1 ]
+            |> List.forall (fun byteOffset ->
+                [ false ; true ]
+                |> List.forall (fun backwards ->
+                    let proposed =
+                        CliType.CandidateCellExtentsContainingByte byteOffset value
+                        |> List.filter (fun (offset, width) ->
+                            if backwards then
+                                offset + width = byteOffset + 1
+                            else
+                                offset = byteOffset
+                        )
+                        |> List.map snd
+                        |> Set.ofList
+
+                    let accepted =
+                        [ 1..size ]
+                        |> List.filter (fun width ->
+                            let start = if backwards then byteOffset - width + 1 else byteOffset
+
+                            start >= 0 && start + width <= size && namesACell start width
+                        )
+                        |> Set.ofList
+
+                    Set.isSubset accepted proposed
+                )
+            )
+
+        Check.One (config, Prop.forAll (Arb.fromGen shapeGen) property)

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -116,6 +116,7 @@
     <Compile Include="TestLinuxCoreLibFlavour.fs" />
     <Compile Include="TestInlineArrayLayout.fs" />
     <Compile Include="TestReinterpretCellAccess.fs" />
+    <Compile Include="TestBulkMoveCellAccess.fs" />
     <Compile Include="TestPureCases.fs" />
     <Compile Include="TestFSharpPureCases.fs" />
     <Compile Include="TestImpureCases.fs" />

--- a/WoofWare.PawPrint.Test/sourcesPure/InlineArrayBufferMoveToArray.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/InlineArrayBufferMoveToArray.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Runtime.CompilerServices;
+
+// The minimal end-to-end case for a *sub-cell* bulk move.
+//
+// `Span<object>.CopyTo` bottoms out in `Buffer.BulkMoveWithWriteBarrierInternal`, which PawPrint
+// serves by walking the byte range and moving whole typed cells. Here the source is one slot of an
+// `[InlineArray(8)] struct { object _item; }` local, which PawPrint models as a single indivisible
+// 64-byte cell: the 8 bytes being moved are a strict sub-range of it, so a step that could only
+// move a residual cell in its entirety had nothing to offer. Object references have no byte image,
+// so there is no bytewise fallback either — before, this failed outright.
+//
+// Deliberately kept to *one* element rather than the whole buffer, since a whole-buffer copy is a
+// whole-cell move on the source side and would pass without any of this. `TestBulkMoveCellAccess`
+// sweeps the surrounding space (both directions, overlapping in-place moves, every root a buffer
+// can sit in, and byte-addressable controls) against the real runtime.
+public class TestInlineArrayBufferMoveToArray
+{
+    [InlineArray(8)]
+    private struct Buffer
+    {
+        private object _item;
+    }
+
+    public static int Main(string[] argv)
+    {
+        Buffer buffer = default;
+        buffer[0] = "first";
+        buffer[1] = "second";
+
+        object[] destination = new object[8];
+
+        Span<object> source = buffer;
+        source.Slice(1, 1).CopyTo(destination);
+
+        if (!ReferenceEquals(destination[0], "second")) return 1;
+
+        // Everything past the one-element window must be untouched: an over-copying move would
+        // have brought "first" along, or landed it one cell over.
+        for (int i = 1; i < destination.Length; i++)
+        {
+            if (destination[i] != null) return 2;
+        }
+
+        // The source is unchanged, including the slot that was not read.
+        if (!ReferenceEquals(buffer[0], "first")) return 3;
+        if (!ReferenceEquals(buffer[1], "second")) return 4;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/CellAwareMemOps.fs
+++ b/WoofWare.PawPrint/CellAwareMemOps.fs
@@ -319,6 +319,17 @@ module internal CellAwareMemOps =
     /// (`writeRootValue` for `ArrayElement`/`HeapObjectField`/`HeapValue`)
     /// overwrite wholesale and would silently rewrite the cell's shape on
     /// a mismatch.
+    ///
+    /// No test distinguishes this, and that is measured rather than assumed:
+    /// `TestBulkMoveCellAccess` drives a copy on which the guard demonstrably
+    /// fires (`long` cells into `double` cells via `MemoryMarshal.Cast`), and
+    /// removing it still changes no answer, because the read path carries the
+    /// payload through either cell shape. The shapes it refuses are ones the
+    /// real runtime accepts, so the difference cannot be asserted
+    /// differentially at all — the same position `isCellIdentityCompatible`
+    /// records one layer up. It is a deliberate choice of the safe direction;
+    /// treat it as load-bearing regardless of what mutating it does to the
+    /// suite.
     let private cellsHaveCompatibleShape (a : CliType) (b : CliType) : bool =
         match a, b with
         | CliType.Bool _, CliType.Bool _
@@ -341,30 +352,36 @@ module internal CellAwareMemOps =
         | CliType.ValueType a, CliType.ValueType b -> a.Declared = b.Declared
         | _ -> false
 
-    /// True for byref roots whose cell shape is non-trivial (each root
-    /// designates a typed cell, possibly non-byte-addressable). The byte-walk
-    /// path through `readManagedByrefBytesAs` works for byte-addressable
-    /// cells under these roots, but fails for non-byte-addressable cells
-    /// (ObjectRef, RuntimePointer, value types containing those); the
-    /// cell-aware fast path handles both. Byte-storage roots
-    /// (`StackMemoryByte`, `NativeMemoryByte`, `PeByteRange`,
-    /// `StringCharAt`) and stack-slot roots (`LocalVariable`, `Argument`,
-    /// `StaticField`) are not considered here — the byte-walk path is the
-    /// modelled access shape for them, and stripping to a `[]` residual
-    /// for a `readManagedByref` call into a byte-storage root would fail
-    /// because the root carries no typed cell at arbitrary byte offsets.
+    /// True for byref roots that designate a typed cell, as opposed to a flat pool of bytes.
+    /// Stripping such a byref to a `[]` residual and handing it to `readManagedByref` yields that
+    /// cell; doing the same to a byte-pool root fails, because those carry no typed cell at an
+    /// arbitrary byte offset. That difference is the whole content of this predicate.
+    ///
+    /// The byte-walk path through `readManagedByrefBytesAs` serves byte-addressable cells under
+    /// either kind of root, but fails outright on cells that have no byte image (`ObjectRef`,
+    /// `RuntimePointer`, value types containing those); for those the typed step is the only
+    /// correct route. Where both routes are defined they agree, so the typed step is taken
+    /// whenever it applies rather than only when bytes would have failed.
+    ///
+    /// Stack and static slots belong on the typed side and used to be listed with the byte pools,
+    /// justified as "the byte-walk path is the modelled access shape for them". That is a policy
+    /// dressed as a structural fact, and it cost every bulk move through a local its only route
+    /// into reference-containing storage. Gating them on the *contents* being byte-unaddressable
+    /// would be worse than either honest answer: the same local would flip between routes
+    /// depending on what it happened to hold at the time, making a predicate named for the root's
+    /// kind quietly mean "and bytes would not have worked".
     let private rootIsCellAware (root : ByrefRoot) : bool =
         match root with
         | ByrefRoot.ArrayElement _
         | ByrefRoot.HeapValue _
         | ByrefRoot.HeapObjectField _
-        | ByrefRoot.ExposedClassObject _ -> true
+        | ByrefRoot.ExposedClassObject _
         | ByrefRoot.LocalVariable _
         | ByrefRoot.Argument _
+        | ByrefRoot.StaticField _ -> true
         | ByrefRoot.StackMemoryByte _
         | ByrefRoot.NativeMemoryByte _
         | ByrefRoot.PeByteRange _
-        | ByrefRoot.StaticField _
         | ByrefRoot.StringCharAt _ -> false
 
     /// True if the residual byref (after stripping its byte-view suffix)
@@ -376,25 +393,51 @@ module internal CellAwareMemOps =
         | ManagedPointerSource.Byref (root, _) -> rootIsCellAware root
         | _ -> false
 
-    /// Attempt to copy a single whole cell, starting at byte offset `i` in
-    /// the buffer. Returns `Some cellSize` when the move succeeded; in that
-    /// case `state` has been updated and the caller must advance `i` by
-    /// `cellSize` bytes. Returns `None` when the cell-aware path is not
-    /// applicable; the caller must then fall back to a single byte step.
+    /// Attempt to move one whole storage cell across, with the copy cursor sitting at byte `i` of
+    /// the requested range. Returns `Some (state, width)` when a move happened, in which case the
+    /// caller advances the cursor by `width`; `None` when no cell could be named, in which case the
+    /// caller falls back to a single byte step.
     ///
-    /// The path is taken iff both src and dest byrefs are anchored on
-    /// cell-aware roots (see `rootIsCellAware`), strip to a typed
-    /// residual at the same intra-cell byte offset (which must be 0 for a
-    /// forward step, or `cellSize - 1` for a backward step), the residual
-    /// cells have compatible CLI shape (so the wholesale typed write does
-    /// not silently change the dest's shape), and there are at least
-    /// `cellSize` bytes remaining in the requested copy. The path is the
-    /// only correct option for non-byte-addressable cells (`ObjectRef`,
-    /// `RuntimePointer`, value-type cells containing those); for
-    /// byte-addressable cells under cell-aware roots it remains correct
-    /// (and faster than the byte-by-byte loop), so we take it
-    /// unconditionally when the preconditions hold rather than
-    /// restricting to non-byte-addressable cells only.
+    /// Each endpoint is considered on its own terms. A byref strips to a typed residual plus an
+    /// intra-cell byte offset, and the cell the move should take is whichever one the range
+    /// anchored at that offset names — which need not be the residual cell itself, and need not be
+    /// at the same offset on both sides. `[InlineArray(8)] struct { object _item; }` is the shape
+    /// that forces both points: a `Span<object>` over such a local is one indivisible 64-byte cell,
+    /// so copying a single element out of it is a strict sub-range on the source side while the
+    /// destination is a whole 8-byte array cell, and once the cursor passes the first element the
+    /// two offsets diverge (the array side canonicalises into `arr[k]` at offset 0, the buffer side
+    /// walks up through one cell). Object references have no byte image, so there is no bytewise
+    /// route to fall back to: naming the cell is the only way to serve this at all.
+    ///
+    /// Widths are proposed from the *source* by `CliType.CandidateCellExtentsContainingByte` and
+    /// validated on both sides by `CliType.CellPathsExactlyCovering`, which stays the authority on
+    /// whether a range names a cell. Proposing from one side suffices because a width the
+    /// destination can name and the source cannot is not a width we could move anyway, and because
+    /// the generator is complete for the source (argued at its definition).
+    ///
+    /// Three properties this relies on, none of them accidental:
+    ///
+    /// - **Largest width first is a preference, not a correctness question.** Every validated
+    ///   candidate at a given width covers the identical byte range on both sides, so the choices
+    ///   differ only in which level of a nesting chain is replaced wholesale, and a same-`Declared`
+    ///   value-type replacement over the same extent is not observable. Across widths, one step of
+    ///   `n` bytes and `n / k` steps of `k` bytes move the same bytes.
+    /// - **Variable widths keep `shouldCopyBackwards`'s overlap guarantee**, which was written when
+    ///   every step was one whole cell. A step reads its entire source range before writing its
+    ///   destination range, and the cursor then advances by exactly the width moved. So for a
+    ///   forward loop (used when the destination is at or before the source in shared storage), a
+    ///   step's writes land at or before the bytes it just read, and every later step reads from
+    ///   strictly beyond the cursor — untouched. The backward loop is the mirror image. The
+    ///   argument never mentions the width, so letting it vary changes nothing.
+    /// - **A step always advances.** Widths are positive and at most `cap`, so the caller cannot
+    ///   spin. PawPrint gives fieldless default-layout structs `sizeOf = 0`, and a zero-sized cell
+    ///   would otherwise return a zero-width "success" and loop forever; that shape is rejected
+    ///   here rather than being left to the byte step, which would itself fail loudly — the
+    ///   intended outcome, since a positive byte copy anchored on a zero-sized cell is an
+    ///   interpreter-bug shape.
+    ///
+    /// Cells must additionally have compatible CLI shape (`cellsHaveCompatibleShape`), so that the
+    /// wholesale typed write does not silently rewrite what the destination cell claims to hold.
     let private tryWholeCellMoveAt
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (state : IlMachineState)
@@ -409,39 +452,105 @@ module internal CellAwareMemOps =
         else
 
         match inCellOffsetAndStripByteView src, inCellOffsetAndStripByteView dest with
-        | Some (srcPlain, srcInCell), Some (destPlain, destInCell) when srcInCell = destInCell ->
+        | Some (srcPlain, srcInCell), Some (destPlain, destInCell) ->
             let srcCell = IlMachineState.readManagedByref baseClassTypes state srcPlain
-            let cellSize = CliType.sizeOf srcCell
+            let destCell = IlMachineState.readManagedByref baseClassTypes state destPlain
+            let srcCellSize = CliType.sizeOf srcCell
+            let destCellSize = CliType.sizeOf destCell
 
-            let aligned =
-                if backwards then
-                    srcInCell = cellSize - 1
-                else
-                    srcInCell = 0
+            // Bytes the cursor can consume within its own cell: forwards, to the cell's end;
+            // backwards, back to the cell's start (the cursor byte is the move's *last*).
+            let available (inCell : int) (cellSize : int) : int =
+                if backwards then inCell + 1 else cellSize - inCell
 
-            // Reject `cellSize <= 0`: a zero-sized value-type cell (PawPrint
-            // gives fieldless default-layout structs `sizeOf = 0`) would
-            // return `Some (newState, 0)`, and the caller would advance `i`
-            // by zero — spinning the copy loop forever for any positive
-            // requested byte count. Falling back to the byte step is also
-            // wrong here (we'd read a byte off a non-existent cell), so the
-            // caller's byte step would itself fail loudly — which is the
-            // intended behaviour, since a positive byte copy against a
-            // zero-sized cell anchor is an interpreter-bug shape.
-            if not aligned || cellSize <= 0 || cellSize > bytesRemaining then
+            let cap =
+                List.min
+                    [
+                        available srcInCell srcCellSize
+                        available destInCell destCellSize
+                        bytesRemaining
+                    ]
+
+            let cursorsAreInsideTheirCells =
+                srcInCell >= 0
+                && srcInCell < srcCellSize
+                && destInCell >= 0
+                && destInCell < destCellSize
+
+            if cap <= 0 || not cursorsAreInsideTheirCells then
                 None
             else
-                let destCell = IlMachineState.readManagedByref baseClassTypes state destPlain
 
-                if CliType.sizeOf destCell <> cellSize then
-                    None
-                elif not (cellsHaveCompatibleShape srcCell destCell) then
-                    None
-                else
-                    let newState =
-                        IlMachineState.writeManagedByrefWithBase baseClassTypes state destPlain srcCell
+            // Where a move of `width` bytes anchored at this cursor begins.
+            let startOf (inCell : int) (width : int) : int =
+                if backwards then inCell - width + 1 else inCell
 
-                    Some (newState, cellSize)
+            /// The cells of `cell` whose extent is exactly the `width`-byte range anchored at
+            /// `inCell`, outermost first, as the `FieldId` path to reach each and its contents.
+            /// `CellPathsExactlyCovering` reports *fields*, so the case where the range is the
+            /// whole of `cell` is this function's own base case rather than something it returns.
+            let namedCells (cell : CliType) (inCell : int) (width : int) : (FieldId list * CliType) list =
+                let start = startOf inCell width
+
+                let whole =
+                    if start = 0 && width = CliType.sizeOf cell then
+                        [ [], cell ]
+                    else
+                        []
+
+                whole @ CliType.CellPathsExactlyCovering start width cell
+
+            let candidateWidths : int list =
+                CliType.CandidateCellExtentsContainingByte srcInCell srcCell
+                |> List.choose (fun (offset, width) ->
+                    let anchoredAtCursor =
+                        if backwards then
+                            offset + width = srcInCell + 1
+                        else
+                            offset = srcInCell
+
+                    if anchoredAtCursor && width > 0 && width <= cap then
+                        Some width
+                    else
+                        None
+                )
+
+            // Outermost-first at every level, so the first hit is the widest move whose two ends
+            // both name a cell and agree on shape.
+            let move =
+                candidateWidths
+                |> List.tryPick (fun width ->
+                    namedCells srcCell srcInCell width
+                    |> List.tryPick (fun (_, srcContents) ->
+                        namedCells destCell destInCell width
+                        |> List.tryPick (fun (destPath, destContents) ->
+                            if cellsHaveCompatibleShape srcContents destContents then
+                                Some (srcContents, destPath, width)
+                            else
+                                None
+                        )
+                    )
+                )
+
+            match move with
+            | None -> None
+            | Some (srcContents, destPath, width) ->
+                if width <= 0 then
+                    failwith
+                        $"tryWholeCellMoveAt: chose a non-advancing move of width %d{width}; the caller's cursor would not progress (this is an interpreter bug)"
+
+                let destByref =
+                    match destPlain with
+                    | ManagedPointerSource.Byref (root, projs) ->
+                        ManagedPointerSource.Byref (root, projs @ List.map ByrefProjection.Field destPath)
+                    | other ->
+                        failwith
+                            $"tryWholeCellMoveAt: byte-view stripping returned a non-Byref pointer %O{other} (this is an interpreter bug)"
+
+                let newState =
+                    IlMachineState.writeManagedByrefWithBase baseClassTypes state destByref srcContents
+
+                Some (newState, width)
         | _ -> None
 
     /// Attempt to zero a single whole cell, starting at byte offset `i` in the

--- a/WoofWare.PawPrint/CliType.fs
+++ b/WoofWare.PawPrint/CliType.fs
@@ -427,6 +427,55 @@ type CliType =
         // only cost of a false "changed" is one redundant write of an identical value.
         | _ -> before <> after
 
+    /// The extents `(offset, size)`, relative to `value`, of the nested storage cells that contain
+    /// byte `byteOffset`. Outermost first, so sizes descend.
+    ///
+    /// This is a *candidate generator*, not an answer: it navigates the layout and performs none of
+    /// `CellPathsExactlyCovering`'s aliasing or padding checks, so an extent it reports may name no
+    /// cell at all. It exists for callers that must discover a byte range before they can ask
+    /// whether that range names a cell — a bulk copy stepping through a buffer knows where its
+    /// cursor is but not how wide the next move should be. Such a caller proposes from here and
+    /// disposes with `CellPathsExactlyCovering`, which remains the sole authority on nameability.
+    /// Correctness therefore never rests on this function: an extent it invents is thrown out by
+    /// the validator, and an extent it fails to report costs the caller only the fallback route it
+    /// would have taken anyway.
+    ///
+    /// It is nonetheless *complete* for the anchored queries `CellAwareMemOps` makes of it — every
+    /// width the validator would accept at a given anchor byte is proposed here — and that is what
+    /// makes proposing from one endpoint enough. `CellPathsExactlyCovering` reaches a cell only by
+    /// descending through the unique unaliased field containing the whole range; any field
+    /// containing the range contains every byte of it, so each cell it names lies on the
+    /// containment chain of every byte in the range, which is precisely what this walks. Where this
+    /// stops early — several fields containing the byte, or none, the latter meaning the byte is
+    /// padding — the validator necessarily declines too: a second field containing the byte
+    /// overlaps the range and trips the alias check, and a range whose bytes no field contains has
+    /// no containing field either. Only the whole value survives those cases, and it is always
+    /// proposed. `TestCliTypeCellPaths` pins this against a brute-force enumeration of every width.
+    static member CandidateCellExtentsContainingByte (byteOffset : int) (value : CliType) : (int * int) list =
+        let size = CliType.SizeOf(value).Size
+
+        if byteOffset < 0 || byteOffset >= size then
+            []
+        else
+
+        let here = 0, size
+
+        match value with
+        | CliType.ValueType vt ->
+            match
+                CliValueType.TryAllFields vt
+                |> List.filter (fun f -> f.Offset <= byteOffset && byteOffset < f.Offset + f.Size)
+            with
+            | [ f ] ->
+                here
+                :: (CliType.CandidateCellExtentsContainingByte (byteOffset - f.Offset) f.Contents
+                    |> List.map (fun (offset, size) -> f.Offset + offset, size))
+            // Either several fields contain the byte (explicit layout can overlap them), in which
+            // case there is no single one to descend into, or none does and the byte is padding.
+            // Both times the whole value is the only candidate.
+            | _ -> [ here ]
+        | _ -> [ here ]
+
     /// Every storage cell of `value` whose extent is exactly the byte range
     /// `[offset, offset + size)`, as a path of `FieldId`s from `value` down to the cell, paired
     /// with the cell's contents. Ordered outermost first. Empty if the range names no cell.

--- a/WoofWare.PawPrint/Native/NativeBuffer.fs
+++ b/WoofWare.PawPrint/Native/NativeBuffer.fs
@@ -97,8 +97,9 @@ module NativeBuffer =
     /// `Array.Copy` of reference-typed arrays, the reflection-cache growth
     /// path, etc.) hand in byrefs that land on non-byte-addressable cells
     /// (object references, value types containing object references);
-    /// `CellAwareMemOps.copy` detects cell-aligned ranges via
-    /// `tryWholeCellMoveAt` and moves whole typed cells through
+    /// `CellAwareMemOps.copy` names the cell each endpoint's cursor addresses
+    /// — which may be a *field* of the storage rather than the whole of it,
+    /// as it is for one slot of an `[InlineArray(N)]` — and moves it through
     /// `readManagedByref` / `writeManagedByrefWithBase` so the dest cell's
     /// CLI shape and the stored ObjectRef provenance are preserved.
     let tryExecute (ctx : NativeCallContext) : NativeHandlerResult option =


### PR DESCRIPTION
`CellAwareMemOps.copy` serves every bulk byte-range primitive (`Buffer.__Memmove`,
`Buffer.BulkMoveWithWriteBarrierInternal`, `cpblk`, `Marshal.Copy`, …) by walking the range and
taking whole typed cells where it can, with a byte walk as the fallback. Storage containing object
references has no byte image at all, so for it the cell step is not an optimisation — it is the only
route.

The step now names the cell each cursor addresses, per endpoint, at whatever depth it lies.

## How the width is chosen

Widths are proposed by a new `CliType.CandidateCellExtentsContainingByte` — the extents of the nested
cells containing the cursor byte — and each is validated on **both** sides by
`CellPathsExactlyCovering` (#796), which stays the sole authority on whether a range names a cell.
The generator does no aliasing or padding checking at all and is documented as subordinate: an
extent it invents is thrown out by the validator, and one it misses costs only the fallback route.

**Sub-cell *zeroing* is out of scope.** `tryWholeCellZeroAt` gates on the same root predicate, so
  reclassifying the roots reroutes whole-cell zeroing of locals/args/statics too, and the sweep's
  sub-range `Clear` scenario covers that — verified by probe that it really does reach
  `tryWholeCellZeroAt`, and by the root mutation failing the `Clear`-bearing shapes. What is *not*
  here is teaching the zero path the same sub-cell descent; nothing I could construct needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
