### PR TITLE
Separate a method's universal facts from its metadata-backed ones

### DIFF
--- a/WoofWare.PawPrint.App/DebuggerServer.fs
+++ b/WoofWare.PawPrint.App/DebuggerServer.fs
@@ -722,10 +722,15 @@ module DebuggerServer =
             // The executing method has been concretised, so its own generic parameters no longer
             // carry their declared names; recover them from the metadata flavour of the same
             // method. If it isn't in the index, the indices render positionally.
+            // A synthesised frame has no metadata flavour to recover names from, so it renders
+            // positionally too.
             let scope =
-                match assembly.Methods.TryGetValue frame.ExecutingMethod.Handle with
-                | true, method -> GenericScope.ofMethod method
-                | false, _ -> GenericScope.unknown
+                match frame.ExecutingMethod.TryMetadata with
+                | None -> GenericScope.unknown
+                | Some facts ->
+                    match assembly.Methods.TryGetValue facts.Handle with
+                    | true, method -> GenericScope.ofMethod method
+                    | false, _ -> GenericScope.unknown
 
             writer.WriteStartObject ()
             writer.WriteNumber ("thread", threadIdValue threadId)

--- a/WoofWare.PawPrint.Domain/Assembly.fs
+++ b/WoofWare.PawPrint.Domain/Assembly.fs
@@ -676,7 +676,17 @@ module Assembly =
         // TODO: this probably misses any methods out which aren't associated with a type definition?
         let methods =
             typeDefs
-            |> Seq.collect (fun (KeyValue (_, ty)) -> ty.Methods |> List.map (fun mi -> KeyValuePair (mi.Handle, mi)))
+            |> Seq.collect (fun (KeyValue (_, ty)) ->
+                ty.Methods
+                // Keyed by MethodDef token, so only metadata-backed methods belong in it. Nothing
+                // synthesised exists at read time — this dictionary is built straight out of the
+                // PE image — but the match keeps the key honest rather than inventing a token.
+                |> List.choose (fun mi ->
+                    match mi with
+                    | MethodInfo.Metadata (_, facts) -> Some (KeyValuePair (facts.Handle, mi))
+                    | MethodInfo.Synthesised _ -> None
+                )
+            )
             |> ImmutableDictionary.CreateRange
 
         let methodSpecs =
@@ -1062,7 +1072,7 @@ module Assembly =
             Console.WriteLine $"\nType: %s{typ.Namespace}.%s{typ.Name}"
 
             for method in typ.Methods do
-                if method.Handle = main then
+                if method.TryMetadata |> Option.map _.Handle = Some main then
                     Console.WriteLine "Entry point!"
 
                 Console.WriteLine $"\nMethod: %s{method.Name}"

--- a/WoofWare.PawPrint.Domain/AttributeFormatting.fs
+++ b/WoofWare.PawPrint.Domain/AttributeFormatting.fs
@@ -204,7 +204,7 @@ module AttributeFormatting =
         match attr.Constructor with
         | MetadataToken.MethodDef handle ->
             match assembly.Methods.TryGetValue handle with
-            | true, m -> Some m.RawSignature.ParameterTypes
+            | true, m -> Some m.Signature.ParameterTypes
             | false, _ -> None
         | MetadataToken.MemberReference handle ->
             match assembly.Members.TryGetValue handle with
@@ -365,12 +365,12 @@ module AttributeFormatting =
         let scope = GenericScope.ofMethod method
 
         let paramTypes =
-            method.RawSignature.ParameterTypes
+            method.Signature.ParameterTypes
             |> List.map (IlFormatting.renderTypeDefn assembly scope)
             |> String.concat ", "
 
         let returnType =
-            IlFormatting.renderMethodReturnType assembly scope method.RawSignature.ReturnType
+            IlFormatting.renderMethodReturnType assembly scope method.Signature.ReturnType
 
         sprintf "// method %s::%s%s%s(%s) : %s" qualifiedTypeName staticStr method.Name generics paramTypes returnType
 

--- a/WoofWare.PawPrint.Domain/IlFormatting.fs
+++ b/WoofWare.PawPrint.Domain/IlFormatting.fs
@@ -435,12 +435,11 @@ module IlFormatting =
         let generics = formatGenericsClause method.Generics
 
         let paramTypes =
-            method.RawSignature.ParameterTypes
+            method.Signature.ParameterTypes
             |> List.map (renderTypeDefn assembly scope)
             |> String.concat ", "
 
-        let returnType =
-            renderMethodReturnType assembly scope method.RawSignature.ReturnType
+        let returnType = renderMethodReturnType assembly scope method.Signature.ReturnType
 
         let header =
             $"// %s{qualifiedTypeName}::%s{staticStr}%s{method.Name}%s{generics}(%s{paramTypes}) : %s{returnType}"

--- a/WoofWare.PawPrint.Domain/MethodInfo.fs
+++ b/WoofWare.PawPrint.Domain/MethodInfo.fs
@@ -249,27 +249,38 @@ module MethodBody =
 /// Represents detailed information about a method in a .NET assembly.
 /// This is a strongly-typed representation of MethodDefinition from System.Reflection.Metadata.
 /// </summary>
-type MethodInfo<'typeGenerics, 'methodGenerics, 'methodVars> =
-    {
-        /// <summary>
-        /// The type that declares this method, along with its assembly information.
-        /// </summary>
-        DeclaringType : ConcreteType<'typeGenerics>
+/// A method the runtime supplies rather than metadata declaring: it has no row in the MethodDef
+/// table, so none of <see cref="MetadataMethodFacts"/> exists for it.
+///
+/// CoreCLR builds these as real <c>MethodDesc</c>s over synthesised IL — see
+/// <c>PInvoke::CreateStructMarshalILStub</c> (dllimport.cpp:5289). PawPrint has no IL synthesis,
+/// so the case identifies *which* runtime behaviour this is and the interpreter supplies it
+/// directly.
+///
+/// The case carries no payload: a synthesised method's identity is its declaring type plus its
+/// kind. For a struct-marshal stub the declaring type is the type being marshalled, so two stubs
+/// for the same type are the same method — which is exactly the per-MethodTable identity
+/// CoreCLR's stub cache has.
+[<RequireQualifiedAccess>]
+type SynthesisedMethod =
+    /// The struct-marshalling stub for this method's declaring type, as returned by
+    /// <c>MarshalNative_TryGetStructMarshalStub</c>'s has-layout-non-blittable arm.
+    | StructMarshalStub
 
+/// The facts that exist only because a method was read from a MethodDef row.
+///
+/// Split out of <see cref="MethodInfo"/> so a synthesised method cannot be asked for them. Every
+/// one of these was previously a field on the method itself, which meant a synthesised method had
+/// to invent a plausible-looking value for each — a metadata token that indexes nothing, an empty
+/// Param collection, attribute flags of zero. Those are lies in fields other code keys on, and
+/// the point of the split is that the compiler now forces each consumer to say what it does when
+/// they are absent.
+type MetadataMethodFacts =
+    {
         /// <summary>
         /// The metadata token handle that uniquely identifies this method in the assembly.
         /// </summary>
         Handle : MethodDefinitionHandle
-
-        /// <summary>The name of the method.</summary>
-        Name : string
-
-        /// <summary>
-        /// The implementation this method carries. The CLR distinguishes IL bodies,
-        /// InternalCalls, P/Invokes, runtime-synthesised methods (delegates etc.), and
-        /// abstract methods; see <see cref="MethodBody"/>.
-        /// </summary>
-        Body : MethodBody<'methodVars>
 
         /// <summary>
         /// The parameters of this method, as read from the metadata Param table.
@@ -296,16 +307,6 @@ type MethodInfo<'typeGenerics, 'methodGenerics, 'methodVars> =
         Parameters : Parameter ImmutableArray
 
         /// <summary>
-        /// The generic type parameters defined by this method, if any.
-        /// </summary>
-        Generics : 'methodGenerics ImmutableArray
-
-        /// <summary>
-        /// The signature of the method, including return type and parameter types.
-        /// </summary>
-        Signature : TypeMethodSignature<'methodVars>
-
-        /// <summary>
         /// The signature as it was read from assembly metadata.
         /// </summary>
         RawSignature : TypeMethodSignature<TypeDefn>
@@ -320,6 +321,35 @@ type MethodInfo<'typeGenerics, 'methodGenerics, 'methodVars> =
         ImplAttributes : MethodImplAttributes
 
         NativeImport : NativeMethodImport option
+    }
+
+/// The facts every method has, however it came to exist.
+type MethodCore<'typeGenerics, 'methodGenerics, 'methodVars> =
+    {
+        /// <summary>
+        /// The type that declares this method, along with its assembly information.
+        /// </summary>
+        DeclaringType : ConcreteType<'typeGenerics>
+
+        /// <summary>The name of the method.</summary>
+        Name : string
+
+        /// <summary>
+        /// The implementation this method carries. The CLR distinguishes IL bodies,
+        /// InternalCalls, P/Invokes, runtime-synthesised methods (delegates etc.), and
+        /// abstract methods; see <see cref="MethodBody"/>.
+        /// </summary>
+        Body : MethodBody<'methodVars>
+
+        /// <summary>
+        /// The generic type parameters defined by this method, if any.
+        /// </summary>
+        Generics : 'methodGenerics ImmutableArray
+
+        /// <summary>
+        /// The signature of the method, including return type and parameter types.
+        /// </summary>
+        Signature : TypeMethodSignature<'methodVars>
 
         /// <summary>
         /// Whether this method is static (true) or an instance method (false).
@@ -327,11 +357,150 @@ type MethodInfo<'typeGenerics, 'methodGenerics, 'methodVars> =
         IsStatic : bool
     }
 
+/// <summary>
+/// Represents detailed information about a method: either one declared by a MethodDef row, or one
+/// the runtime synthesises.
+/// </summary>
+/// <remarks>
+/// The universal facts are reachable as members (<c>Name</c>, <c>Signature</c>, …) so the great
+/// majority of consumers neither know nor care which kind they hold. The metadata-only facts are
+/// deliberately *not* projected: reaching them requires matching, which is what stops a
+/// synthesised method being asked for a token it does not have.
+/// </remarks>
+type MethodInfo<'typeGenerics, 'methodGenerics, 'methodVars> =
+    /// Read from a MethodDef row.
+    | Metadata of core : MethodCore<'typeGenerics, 'methodGenerics, 'methodVars> * facts : MetadataMethodFacts
+    /// Supplied by the runtime; see <see cref="SynthesisedMethod"/>.
+    | Synthesised of core : MethodCore<'typeGenerics, 'methodGenerics, 'methodVars> * kind : SynthesisedMethod
+
+    member this.Core : MethodCore<'typeGenerics, 'methodGenerics, 'methodVars> =
+        match this with
+        | MethodInfo.Metadata (core, _) -> core
+        | MethodInfo.Synthesised (core, _) -> core
+
+    member this.DeclaringType : ConcreteType<'typeGenerics> = this.Core.DeclaringType
+    member this.Name : string = this.Core.Name
+    member this.Body : MethodBody<'methodVars> = this.Core.Body
+    member this.Generics : 'methodGenerics ImmutableArray = this.Core.Generics
+    member this.Signature : TypeMethodSignature<'methodVars> = this.Core.Signature
+    member this.IsStatic : bool = this.Core.IsStatic
+
+    /// Which kind of runtime-supplied method this is, or `None` if it was declared in metadata.
+    member this.SynthesisedKind : SynthesisedMethod option =
+        match this with
+        | MethodInfo.Metadata _ -> None
+        | MethodInfo.Synthesised (_, kind) -> Some kind
+
+    /// A hashable stand-in for "which method within its declaring type is this". Pairs the
+    /// metadata token with the synthesised kind, exactly the disjunction `NominallyEqual`
+    /// compares, so anything hashing a method identity stays consistent with it.
+    member this.IdentityKey : MethodDefinitionHandle option * SynthesisedMethod option =
+        (this.TryMetadata |> Option.map _.Handle), this.SynthesisedKind
+
+    /// The metadata facts, when this method has any. `None` for a synthesised method.
+    member this.TryMetadata : MetadataMethodFacts option =
+        match this with
+        | MethodInfo.Metadata (_, facts) -> Some facts
+        | MethodInfo.Synthesised _ -> None
+
+    // The four predicates below are projected deliberately, where the raw `MethodAttributes` is
+    // not. The distinction is that each has a genuine answer for a synthesised method rather than
+    // a fabricated one: the runtime supplies such a method directly, so it occupies no vtable
+    // slot, overrides nothing, and is reachable only from the interpreter that synthesised it.
+    // Handing out an attribute flags value of zero, by contrast, would be inventing metadata —
+    // which is why reflection paths that report the flags to the guest still have to match.
+
+    /// True iff this method is `virtual`. A synthesised method never is.
+    member this.IsVirtual : bool =
+        match this with
+        | MethodInfo.Metadata (_, facts) -> facts.MethodAttributes.HasFlag MethodAttributes.Virtual
+        | MethodInfo.Synthesised _ -> false
+
+    /// True iff this method introduces a new vtable slot rather than overriding one. A synthesised
+    /// method occupies no slot at all.
+    member this.IsNewSlot : bool =
+        match this with
+        | MethodInfo.Metadata (_, facts) -> facts.MethodAttributes.HasFlag MethodAttributes.NewSlot
+        | MethodInfo.Synthesised _ -> false
+
+    /// True iff this method is sealed against further overriding. Vacuously true of a synthesised
+    /// method, which is not virtual to begin with.
+    member this.IsFinal : bool =
+        match this with
+        | MethodInfo.Metadata (_, facts) -> facts.MethodAttributes.HasFlag MethodAttributes.Final
+        | MethodInfo.Synthesised _ -> true
+
+    /// The P/Invoke import this method carries, if any. `None` for a synthesised method: the
+    /// runtime supplies its body directly, so there is nothing to import. Already an option for
+    /// metadata-backed methods, so no information is lost by projecting it.
+    member this.TryNativeImport : NativeMethodImport option =
+        match this with
+        | MethodInfo.Metadata (_, facts) -> facts.NativeImport
+        | MethodInfo.Synthesised _ -> None
+
+    /// True iff this method is `public`. A synthesised method is not: it has no declaration for
+    /// anything to name, and nothing outside the interpreter can reach it.
+    member this.IsPublic : bool =
+        match this with
+        | MethodInfo.Metadata (_, facts) ->
+            (facts.MethodAttributes &&& MethodAttributes.MemberAccessMask) = MethodAttributes.Public
+        | MethodInfo.Synthesised _ -> false
+
     override this.ToString () =
         $"{this.DeclaringType.Assembly.Name}.{this.DeclaringType.Name}.{this.Name}"
 
 [<RequireQualifiedAccess>]
 module MethodInfo =
+    /// Rebuild a method with a different core, carrying whichever tail it already had. The
+    /// generic-mapping functions below are all this: they rewrite the universal facts and leave
+    /// the metadata (or the synthesised kind) exactly as it was.
+    let mapCore<'a, 'b, 'c, 'd, 'e, 'f>
+        (f : MethodCore<'a, 'b, 'c> -> MethodCore<'d, 'e, 'f>)
+        (m : MethodInfo<'a, 'b, 'c>)
+        : MethodInfo<'d, 'e, 'f>
+        =
+        match m with
+        | MethodInfo.Metadata (core, facts) -> MethodInfo.Metadata (f core, facts)
+        | MethodInfo.Synthesised (core, kind) -> MethodInfo.Synthesised (f core, kind)
+
+    /// The metadata facts, for a caller that can only meaningfully act on a declared method —
+    /// reflection, IL rendering, overload comparison. Fails for a synthesised method rather than
+    /// inventing the metadata, which is the whole point of keeping the two apart.
+    let requireMetadata
+        (operation : string)
+        (m : MethodInfo<'typeGenerics, 'methodGenerics, 'methodVars>)
+        : MetadataMethodFacts
+        =
+        match m.TryMetadata with
+        | Some facts -> facts
+        | None -> failwith $"%s{operation}: %O{m} is synthesised by the runtime and has no metadata to read"
+
+    /// The signature as metadata declared it, for a caller that genuinely needs the `TypeDefn`
+    /// form (comparing overloads, rendering a declaration).
+    let requireRawSignature
+        (operation : string)
+        (m : MethodInfo<'typeGenerics, 'methodGenerics, 'methodVars>)
+        : TypeMethodSignature<TypeDefn>
+        =
+        (requireMetadata operation m).RawSignature
+
+    /// True iff both methods are metadata-backed and share a MethodDef token — that is, they are
+    /// the same *declared* method, ignoring generic instantiation and declaring-type identity.
+    ///
+    /// False whenever either is synthesised. A synthesised method has no declaration, so it is
+    /// not the same declared method as anything, including another synthesised one; callers that
+    /// want to know whether two synthesised methods are the same should use `NominallyEqual`,
+    /// which compares the declaring type and the kind.
+    let sameDeclaredMethod
+        (a : MethodInfo<'typeGenerics, 'methodGenerics, 'methodVars>)
+        (b : MethodInfo<'typeGenericsB, 'methodGenericsB, 'methodVarsB>)
+        : bool
+        =
+        match a.TryMetadata, b.TryMetadata with
+        | Some a, Some b -> a.Handle = b.Handle
+        | None, _
+        | _, None -> false
+
     let NominallyEqual
         (a : MethodInfo<'typeGenerics, 'methodGenerics, 'methodVars>)
         (b : MethodInfo<'typeGenerics, 'methodGenerics, 'methodVars>)
@@ -339,8 +508,17 @@ module MethodInfo =
         =
         a.DeclaringType.Identity = b.DeclaringType.Identity
         && a.DeclaringType.Generics = b.DeclaringType.Generics
-        && a.Handle = b.Handle
         && a.Generics = b.Generics
+        && // Within a declaring type, a metadata method is identified by its token and a
+        // synthesised one by its kind. The two are never equal: a synthesised method has no
+        // MethodDef row, so nothing it could be confused with.
+        (
+            match a, b with
+            | MethodInfo.Metadata (_, a), MethodInfo.Metadata (_, b) -> a.Handle = b.Handle
+            | MethodInfo.Synthesised (_, a), MethodInfo.Synthesised (_, b) -> a = b
+            | MethodInfo.Metadata _, MethodInfo.Synthesised _
+            | MethodInfo.Synthesised _, MethodInfo.Metadata _ -> false
+        )
 
     /// The true number of declared parameters (excluding `this`), independent of how many
     /// Param-table rows the metadata happened to carry. See the doc comment on
@@ -387,51 +565,47 @@ module MethodInfo =
         (this : MethodInfo<'d, 'e, 'f>)
         : bool
         =
-        hasIntrinsicAttribute getMemberRefParentType methodDefs this.CustomAttributes
+        // A synthesised method carries no custom attributes: there is no MethodDef row for one
+        // to hang off. `[Intrinsic]` in particular is a metadata annotation on BCL methods, so
+        // the answer for a runtime-supplied method is simply "no".
+        match this with
+        | MethodInfo.Synthesised _ -> false
+        | MethodInfo.Metadata (_, facts) ->
+            hasIntrinsicAttribute getMemberRefParentType methodDefs facts.CustomAttributes
 
     let mapTypeGenerics<'a, 'b, 'methodGen, 'vars>
         (f : 'a -> 'b)
         (m : MethodInfo<'a, 'methodGen, 'vars>)
         : MethodInfo<'b, 'methodGen, 'vars>
         =
-        {
-            DeclaringType = m.DeclaringType |> ConcreteType.mapGeneric (fun _ -> f)
-            Handle = m.Handle
-            Name = m.Name
-            Body = m.Body
-            Parameters = m.Parameters
-            Generics = m.Generics
-            Signature = m.Signature
-            RawSignature = m.RawSignature
-            CustomAttributes = m.CustomAttributes
-            MethodAttributes = m.MethodAttributes
-            ImplAttributes = m.ImplAttributes
-            NativeImport = m.NativeImport
-            IsStatic = m.IsStatic
-        }
+        m
+        |> mapCore (fun core ->
+            {
+                DeclaringType = core.DeclaringType |> ConcreteType.mapGeneric (fun _ -> f)
+                Name = core.Name
+                Body = core.Body
+                Generics = core.Generics
+                Signature = core.Signature
+                IsStatic = core.IsStatic
+            }
+        )
 
     let mapMethodGenerics<'a, 'b, 'vars, 'typeGen>
         (f : int -> 'a -> 'b)
         (m : MethodInfo<'typeGen, 'a, 'vars>)
         : MethodInfo<'typeGen, 'b, 'vars>
         =
-        let generics = m.Generics |> Seq.mapi f |> ImmutableArray.CreateRange
-
-        {
-            DeclaringType = m.DeclaringType
-            Handle = m.Handle
-            Name = m.Name
-            Body = m.Body
-            Parameters = m.Parameters
-            Generics = generics
-            Signature = m.Signature
-            RawSignature = m.RawSignature
-            CustomAttributes = m.CustomAttributes
-            MethodAttributes = m.MethodAttributes
-            ImplAttributes = m.ImplAttributes
-            NativeImport = m.NativeImport
-            IsStatic = m.IsStatic
-        }
+        m
+        |> mapCore (fun core ->
+            {
+                DeclaringType = core.DeclaringType
+                Name = core.Name
+                Body = core.Body
+                Generics = core.Generics |> Seq.mapi f |> ImmutableArray.CreateRange
+                Signature = core.Signature
+                IsStatic = core.IsStatic
+            }
+        )
 
     let setMethodVars
         (body : MethodBody<'vars2>)
@@ -439,21 +613,17 @@ module MethodInfo =
         (m : MethodInfo<'typeGen, 'methodGen, 'vars1>)
         : MethodInfo<'typeGen, 'methodGen, 'vars2>
         =
-        {
-            DeclaringType = m.DeclaringType
-            Handle = m.Handle
-            Name = m.Name
-            Body = body
-            Parameters = m.Parameters
-            Generics = m.Generics
-            Signature = signature
-            RawSignature = m.RawSignature
-            CustomAttributes = m.CustomAttributes
-            MethodAttributes = m.MethodAttributes
-            ImplAttributes = m.ImplAttributes
-            NativeImport = m.NativeImport
-            IsStatic = m.IsStatic
-        }
+        m
+        |> mapCore (fun core ->
+            {
+                DeclaringType = core.DeclaringType
+                Name = core.Name
+                Body = body
+                Generics = core.Generics
+                Signature = signature
+                IsStatic = core.IsStatic
+            }
+        )
 
     /// View helper for sites that genuinely just want "the IL body if there is one,"
     /// e.g. formatters, the debugger, and the abstract-method filter. Prefer matching
@@ -1112,21 +1282,25 @@ module MethodInfo =
                 declaringTypeName
                 declaringTypeGenericParams
 
-        {
-            DeclaringType = declaringType
-            Handle = methodHandle
-            Name = methodName
-            Body = body
-            Parameters = methodParams
-            Generics = methodGenericParams
-            Signature = typeSig
-            RawSignature = typeSig
-            MethodAttributes = methodAttrs
-            CustomAttributes = attrs
-            IsStatic = not methodSig.Header.IsInstance
-            ImplAttributes = implAttrs
-            NativeImport = nativeImport
-        }
+        MethodInfo.Metadata (
+            {
+                DeclaringType = declaringType
+                Name = methodName
+                Body = body
+                Generics = methodGenericParams
+                Signature = typeSig
+                IsStatic = not methodSig.Header.IsInstance
+            },
+            {
+                Handle = methodHandle
+                Parameters = methodParams
+                RawSignature = typeSig
+                MethodAttributes = methodAttrs
+                CustomAttributes = attrs
+                ImplAttributes = implAttrs
+                NativeImport = nativeImport
+            }
+        )
 
     let rec resolveBaseType
         (methodGenerics : TypeDefn ImmutableArray option)

--- a/WoofWare.PawPrint.Domain/TypeConcretisation.fs
+++ b/WoofWare.PawPrint.Domain/TypeConcretisation.fs
@@ -1230,22 +1230,20 @@ module Concretization =
             method.Generics
             |> ImmutableArray.map (fun (gp, md) -> methodArgs.[gp.SequenceNumber])
 
+        // Concretization rewrites only the universal facts — declaring type, body, generics,
+        // signature — so whichever tail the method carries passes through untouched.
         let concretizedMethod : MethodInfo<_, _, _> =
-            {
-                DeclaringType = concretizedDeclaringType
-                Handle = method.Handle
-                Name = method.Name
-                Body = body
-                Parameters = method.Parameters
-                Generics = genericHandles
-                Signature = signature
-                RawSignature = method.RawSignature
-                CustomAttributes = method.CustomAttributes
-                MethodAttributes = method.MethodAttributes
-                ImplAttributes = method.ImplAttributes
-                NativeImport = method.NativeImport
-                IsStatic = method.IsStatic
-            }
+            method
+            |> MethodInfo.mapCore (fun core ->
+                {
+                    DeclaringType = concretizedDeclaringType
+                    Name = core.Name
+                    Body = body
+                    Generics = genericHandles
+                    Signature = signature
+                    IsStatic = core.IsStatic
+                }
+            )
 
         // Every ConcreteTypeHandle this method emits is subsequently fed to
         // CliType.zeroOf: locals when the frame is set up (MethodState.Empty),

--- a/WoofWare.PawPrint.IlDump/Program.fs
+++ b/WoofWare.PawPrint.IlDump/Program.fs
@@ -41,9 +41,14 @@ module Program =
         let methodGroups =
             typeInfo.Methods
             |> List.filter (fun m -> memberNameMatches m.Name)
-            |> List.map (fun m ->
-                let header = AttributeFormatting.methodHeader assembly qualified m
-                AttributeFormatting.renderOwnerLines assembly header (MetadataToken.MethodDef m.Handle)
+            // IlDump reads an assembly off disk, so every method it sees is metadata-backed;
+            // `choose` keeps the token honest rather than asserting that.
+            |> List.choose (fun m ->
+                m.TryMetadata
+                |> Option.map (fun facts ->
+                    let header = AttributeFormatting.methodHeader assembly qualified m
+                    AttributeFormatting.renderOwnerLines assembly header (MetadataToken.MethodDef facts.Handle)
+                )
             )
 
         let fieldGroups =

--- a/WoofWare.PawPrint.Test/TestAttributeFormatting.fs
+++ b/WoofWare.PawPrint.Test/TestAttributeFormatting.fs
@@ -213,7 +213,10 @@ module TestAttributeFormatting =
                     let ti = kvp.Value
 
                     for m in ti.Methods do
-                        for attr in AttributeFormatting.attributesFor corelib (MetadataToken.MethodDef m.Handle) do
+                        for attr in
+                            AttributeFormatting.attributesFor
+                                corelib
+                                (MetadataToken.MethodDef (MethodInfo.requireMetadata "test" m).Handle) do
                             yield AttributeFormatting.formatAttributeApplication corelib attr
             }
 
@@ -230,7 +233,10 @@ module TestAttributeFormatting =
         let allRenderings =
             seq {
                 for m in exn.Methods do
-                    for attr in AttributeFormatting.attributesFor corelib (MetadataToken.MethodDef m.Handle) do
+                    for attr in
+                        AttributeFormatting.attributesFor
+                            corelib
+                            (MetadataToken.MethodDef (MethodInfo.requireMetadata "test" m).Handle) do
                         yield AttributeFormatting.formatAttributeApplication corelib attr
             }
             |> Seq.toList

--- a/WoofWare.PawPrint.Test/TestFSharpPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestFSharpPureCases.fs
@@ -307,7 +307,11 @@ module TestFSharpPureCases =
          | MethodBody.Abstract -> ()
          | other -> failwith $"expected AbstractDispatch.Base::Combine to be MethodBody.Abstract, got %O{other}")
 
-        combine.Parameters.IsEmpty |> shouldEqual true
+        // Deliberately the Param *table*, not the arity: the whole point of this test is that the
+        // two disagree for an F#-emitted abstract member.
+        (MethodInfo.requireMetadata "test" combine).Parameters.IsEmpty
+        |> shouldEqual true
+
         MethodInfo.arity combine |> shouldEqual 1
 
     /// Regression guard for issue #692, mirroring the `AbstractDispatch` guard above. #692's
@@ -340,7 +344,8 @@ module TestFSharpPureCases =
          | MethodBody.Abstract -> ()
          | other -> failwith $"expected ByrefDispatch.Base::Bump to be MethodBody.Abstract, got %O{other}")
 
-        bump.Parameters.IsEmpty |> shouldEqual true
+        // As above: the Param table, not the arity.
+        (MethodInfo.requireMetadata "test" bump).Parameters.IsEmpty |> shouldEqual true
         MethodInfo.arity bump |> shouldEqual 1
 
         (match bump.Signature.ParameterTypes.[0] with

--- a/WoofWare.PawPrint.Test/TestFaultHandlers.fs
+++ b/WoofWare.PawPrint.Test/TestFaultHandlers.fs
@@ -36,7 +36,7 @@ module TestFaultHandlers =
         =
         let objectConstructor =
             bct.Object.Methods
-            |> List.find (fun method -> method.Name = ".ctor" && method.Parameters.IsEmpty)
+            |> List.find (fun method -> method.Name = ".ctor" && (MethodInfo.arity method = 0))
 
         let state, signature =
             TypeMethodSignature.map

--- a/WoofWare.PawPrint.Test/TestFieldHandleRegistry.fs
+++ b/WoofWare.PawPrint.Test/TestFieldHandleRegistry.fs
@@ -517,7 +517,7 @@ public class GenericHolder<T>
         let rawMethod =
             runtimeTypeHandleType.Methods
             |> List.filter (fun method ->
-                match method.NativeImport with
+                match method.TryNativeImport with
                 | Some import ->
                     import.ModuleName = "QCall"
                     && import.EntryPointName = "RuntimeTypeHandle_GetFields"
@@ -555,7 +555,7 @@ public class GenericHolder<T>
 
         let rawMethod =
             runtimeFieldHandleType.Methods
-            |> List.filter (fun method -> method.Name = "GetAttributes" && method.Parameters.Length = 1)
+            |> List.filter (fun method -> method.Name = "GetAttributes" && (MethodInfo.arity method) = 1)
             |> function
                 | [ method ] -> method
                 | [] -> failwith "RuntimeFieldHandle.GetAttributes native method not found"

--- a/WoofWare.PawPrint.Test/TestLinuxCoreLibFlavour.fs
+++ b/WoofWare.PawPrint.Test/TestLinuxCoreLibFlavour.fs
@@ -53,7 +53,7 @@ module TestLinuxCoreLibFlavour =
     let private nativeEntryPointNames (assembly : DumpedAssembly) : Set<string> =
         assembly.TypeDefs.Values
         |> Seq.collect (fun ty -> ty.Methods)
-        |> Seq.choose (fun method -> method.NativeImport |> Option.map _.EntryPointName)
+        |> Seq.choose (fun method -> method.TryNativeImport |> Option.map _.EntryPointName)
         |> Set.ofSeq
 
     /// Guards against `$DOTNET_LINUX_FRAMEWORK_DIR` pointing at the wrong pack — including at a

--- a/WoofWare.PawPrint.Test/TestLowLevelMonitor.fs
+++ b/WoofWare.PawPrint.Test/TestLowLevelMonitor.fs
@@ -113,7 +113,7 @@ module TestLowLevelMonitor =
 
         let objectToString =
             baseClassTypes.Object.Methods
-            |> List.find (fun method -> method.Name = "ToString" && method.Parameters.IsEmpty)
+            |> List.find (fun method -> method.Name = "ToString" && (MethodInfo.arity method = 0))
 
         let state, signature =
             TypeMethodSignature.map

--- a/WoofWare.PawPrint.Test/TestManifestResources.fs
+++ b/WoofWare.PawPrint.Test/TestManifestResources.fs
@@ -107,7 +107,7 @@ public static class Entry
         let rawMethod =
             runtimeAssemblyType.Methods
             |> List.filter (fun method ->
-                match method.NativeImport with
+                match method.TryNativeImport with
                 | Some import ->
                     import.ModuleName = "QCall"
                     && import.EntryPointName = "AssemblyNative_GetResource"

--- a/WoofWare.PawPrint.Test/TestMethodHandleRegistry.fs
+++ b/WoofWare.PawPrint.Test/TestMethodHandleRegistry.fs
@@ -206,7 +206,7 @@ public static class HasMethod
             }
 
         let token =
-            MetadataToken.MethodDef targetMethod.Handle
+            MetadataToken.MethodDef (MethodInfo.requireMetadata "test" targetMethod).Handle
             |> SourcedMetadataToken.make assembly.Name
 
         let state, whatWeDid =
@@ -249,7 +249,7 @@ public class GenericHasMethod<T>
             installFrameForMethod loggerFactory baseClassTypes assembly state currentMethod
 
         let token =
-            MetadataToken.MethodDef targetMethod.Handle
+            MetadataToken.MethodDef (MethodInfo.requireMetadata "test" targetMethod).Handle
             |> SourcedMetadataToken.make assembly.Name
 
         let ex =
@@ -298,7 +298,7 @@ public static class GenericMethodHolder
             installFrameForMethod loggerFactory baseClassTypes assembly state currentMethod
 
         let token =
-            MetadataToken.MethodDef targetMethod.Handle
+            MetadataToken.MethodDef (MethodInfo.requireMetadata "test" targetMethod).Handle
             |> SourcedMetadataToken.make assembly.Name
 
         let ex =
@@ -381,7 +381,7 @@ public static class GenericMethodHolder
             |> Option.defaultWith (fun () -> failwith $"registry id %d{registryId} did not resolve")
 
         resolved.GetMethodDefinitionHandle ()
-        |> shouldEqual (ComparableMethodDefinitionHandle.Make targetMethod.Handle)
+        |> shouldEqual (ComparableMethodDefinitionHandle.Make (MethodInfo.requireMetadata "test" targetMethod).Handle)
 
         // Open-form registration intentionally records empty MethodGenerics: the iterator
         // surfaces method-table slots, i.e. method definitions, not specific instantiations.

--- a/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
+++ b/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
@@ -748,7 +748,7 @@ public unsafe struct PointerWrapper
         =
         let objectToString =
             bct.Object.Methods
-            |> List.find (fun method -> method.Name = "ToString" && method.Parameters.IsEmpty)
+            |> List.find (fun method -> method.Name = "ToString" && (MethodInfo.arity method = 0))
 
         let state, signature =
             TypeMethodSignature.map

--- a/WoofWare.PawPrint.Test/TestNativeCustomAttribute.fs
+++ b/WoofWare.PawPrint.Test/TestNativeCustomAttribute.fs
@@ -248,7 +248,7 @@ public sealed class CctorAttribute : System.Attribute
         =
         customAttributeType.Methods
         |> List.filter (fun method ->
-            match method.NativeImport with
+            match method.TryNativeImport with
             | Some import ->
                 import.ModuleName = "QCall"
                 && import.EntryPointName = "CustomAttribute_CreateCustomAttributeInstance"

--- a/WoofWare.PawPrint.Test/TestNativeEnum.fs
+++ b/WoofWare.PawPrint.Test/TestNativeEnum.fs
@@ -129,7 +129,7 @@ public static class Entry
         let rawMethod =
             enumType.Methods
             |> List.filter (fun method ->
-                match method.NativeImport with
+                match method.TryNativeImport with
                 | Some import -> import.ModuleName = "QCall" && import.EntryPointName = "Enum_GetValuesAndNames"
                 | None -> false
             )

--- a/WoofWare.PawPrint.Test/TestNativeEventSource.fs
+++ b/WoofWare.PawPrint.Test/TestNativeEventSource.fs
@@ -83,7 +83,7 @@ public static class Entry
         let rawMethod =
             threadType.Methods
             |> List.filter (fun method ->
-                match method.NativeImport with
+                match method.TryNativeImport with
                 | Some import ->
                     import.ModuleName = "QCall"
                     && import.EntryPointName = "ThreadNative_YieldThread"
@@ -309,9 +309,12 @@ public static class Entry
             }
 
         let method =
-            { donor with
-                Signature = signature
-            }
+            donor
+            |> MethodInfo.mapCore (fun core ->
+                { core with
+                    Signature = signature
+                }
+            )
 
         let ctx = buildContext loggerFactory prepared state method
 
@@ -498,9 +501,12 @@ public static class Entry
             }
 
         let method =
-            { donor with
-                Signature = signature
-            }
+            donor
+            |> MethodInfo.mapCore (fun core ->
+                { core with
+                    Signature = signature
+                }
+            )
 
         let ctx = buildContext loggerFactory prepared state method
 

--- a/WoofWare.PawPrint.Test/TestNativeMetadataImport.fs
+++ b/WoofWare.PawPrint.Test/TestNativeMetadataImport.fs
@@ -258,7 +258,7 @@ public class TypesWithMembers
 
         let rawMethod =
             metadataImportType.Methods
-            |> List.filter (fun method -> method.Name = methodName && method.Parameters.Length = parameterCount)
+            |> List.filter (fun method -> method.Name = methodName && (MethodInfo.arity method) = parameterCount)
             |> function
                 | [ method ] -> method
                 | [] ->
@@ -299,7 +299,7 @@ public class TypesWithMembers
         let rawMethod =
             metadataImportType.Methods
             |> List.filter (fun method ->
-                match method.NativeImport with
+                match method.TryNativeImport with
                 | Some import -> import.ModuleName = "QCall" && import.EntryPointName = entryPointName
                 | None -> false
             )
@@ -822,7 +822,7 @@ public class TypesWithMembers
         =
         typeInfo.Methods
         |> List.tryFind (fun method -> method.Name = name)
-        |> Option.map (fun method -> method.Handle)
+        |> Option.map (fun method -> (MethodInfo.requireMetadata "test" method).Handle)
         |> Option.defaultWith (fun () -> failwith $"method %s{name} not found on %s{typeInfo.Name}")
 
     let private firstGenericParameterOfType
@@ -941,7 +941,7 @@ public class TypesWithMembers
 
         let methodHandle =
             match fixture.TargetType.Methods with
-            | method :: _ -> method.Handle
+            | method :: _ -> (MethodInfo.requireMetadata "test" method).Handle
             | [] -> failwith "expected at least one method on MetadataFields (implicit .ctor)"
 
         let returnValue, parent, _ =

--- a/WoofWare.PawPrint.Test/TestNativeMethodDetection.fs
+++ b/WoofWare.PawPrint.Test/TestNativeMethodDetection.fs
@@ -32,7 +32,7 @@ module TestNativeMethodDetection =
         match
             typeInfo.Methods
             |> List.filter (fun m ->
-                match m.NativeImport with
+                match m.TryNativeImport with
                 | Some import -> import.ModuleName = "QCall" && import.EntryPointName = entryPoint
                 | None -> false
             )

--- a/WoofWare.PawPrint.Test/TestNativeSignature.fs
+++ b/WoofWare.PawPrint.Test/TestNativeSignature.fs
@@ -208,7 +208,7 @@ public sealed class GenericFieldHost<T>
         let rawMethod =
             signatureType.Methods
             |> List.filter (fun method ->
-                match method.NativeImport with
+                match method.TryNativeImport with
                 | Some import -> import.ModuleName = "QCall" && import.EntryPointName = "Signature_Init"
                 | None -> false
             )

--- a/WoofWare.PawPrint.Test/TestNativeThreadSpinWait.fs
+++ b/WoofWare.PawPrint.Test/TestNativeThreadSpinWait.fs
@@ -130,7 +130,7 @@ public static class Entry
             (fun methods ->
                 methods
                 |> List.filter (fun method ->
-                    match method.NativeImport with
+                    match method.TryNativeImport with
                     | Some import -> import.ModuleName = "QCall" && import.EntryPointName = "ThreadNative_SpinWait"
                     | None -> false
                 )

--- a/WoofWare.PawPrint.Test/TestNativeThreadYield.fs
+++ b/WoofWare.PawPrint.Test/TestNativeThreadYield.fs
@@ -66,7 +66,7 @@ public static class Entry
         let rawMethod =
             threadType.Methods
             |> List.filter (fun method ->
-                match method.NativeImport with
+                match method.TryNativeImport with
                 | Some import ->
                     import.ModuleName = "QCall"
                     && import.EntryPointName = "ThreadNative_YieldThread"

--- a/WoofWare.PawPrint.Test/TestNullaryIlOp.fs
+++ b/WoofWare.PawPrint.Test/TestNullaryIlOp.fs
@@ -69,7 +69,7 @@ module TestNullaryIlOp =
         =
         let objectToString =
             baseClassTypes.Object.Methods
-            |> List.find (fun method -> method.Name = "ToString" && method.Parameters.IsEmpty)
+            |> List.find (fun method -> method.Name = "ToString" && (MethodInfo.arity method = 0))
 
         let state, signature =
             TypeMethodSignature.map

--- a/WoofWare.PawPrint.Test/TestSignalDispatch.fs
+++ b/WoofWare.PawPrint.Test/TestSignalDispatch.fs
@@ -66,7 +66,7 @@ module TestSignalDispatch =
 
         let rawMethod =
             typeDef.Methods
-            |> List.filter (fun m -> m.Name = methodName && m.IsStatic && m.Parameters.Length = arity)
+            |> List.filter (fun m -> m.Name = methodName && m.IsStatic && (MethodInfo.arity m) = arity)
             |> function
                 | [ method ] -> method
                 | [] ->

--- a/WoofWare.PawPrint.Test/TestSwitchIlOp.fs
+++ b/WoofWare.PawPrint.Test/TestSwitchIlOp.fs
@@ -135,7 +135,7 @@ module TestSwitchIlOp =
         =
         let objectToString =
             baseClassTypes.Object.Methods
-            |> List.find (fun method -> method.Name = "ToString" && method.Parameters.IsEmpty)
+            |> List.find (fun method -> method.Name = "ToString" && (MethodInfo.arity method = 0))
 
         let state, signature =
             TypeMethodSignature.map

--- a/WoofWare.PawPrint.Test/TestSyncBlockMonitor.fs
+++ b/WoofWare.PawPrint.Test/TestSyncBlockMonitor.fs
@@ -203,7 +203,7 @@ module TestSyncBlockMonitor =
 
         let objectToString =
             baseClassTypes.Object.Methods
-            |> List.find (fun method -> method.Name = "ToString" && method.Parameters.IsEmpty)
+            |> List.find (fun method -> method.Name = "ToString" && (MethodInfo.arity method = 0))
 
         let state, signature =
             TypeMethodSignature.map

--- a/WoofWare.PawPrint.Test/TestUnaryConstIlOp.fs
+++ b/WoofWare.PawPrint.Test/TestUnaryConstIlOp.fs
@@ -60,7 +60,7 @@ module TestUnaryConstIlOp =
         =
         let objectToString =
             baseClassTypes.Object.Methods
-            |> List.find (fun method -> method.Name = "ToString" && method.Parameters.IsEmpty)
+            |> List.find (fun method -> method.Name = "ToString" && (MethodInfo.arity method = 0))
 
         let state, signature =
             TypeMethodSignature.map

--- a/WoofWare.PawPrint.Test/TestUnaryMetadataIlOp.fs
+++ b/WoofWare.PawPrint.Test/TestUnaryMetadataIlOp.fs
@@ -38,7 +38,7 @@ module TestUnaryMetadataIlOp =
         =
         let objectToString =
             baseClassTypes.Object.Methods
-            |> List.find (fun method -> method.Name = "ToString" && method.Parameters.IsEmpty)
+            |> List.find (fun method -> method.Name = "ToString" && (MethodInfo.arity method = 0))
 
         let state, signature =
             TypeMethodSignature.map

--- a/WoofWare.PawPrint.Test/TestWaitHandle.fs
+++ b/WoofWare.PawPrint.Test/TestWaitHandle.fs
@@ -76,7 +76,7 @@ module TestWaitHandle =
         // instructions, only its frame's evaluation stack.
         let objectToString =
             baseClassTypes.Object.Methods
-            |> List.find (fun method -> method.Name = "ToString" && method.Parameters.IsEmpty)
+            |> List.find (fun method -> method.Name = "ToString" && (MethodInfo.arity method = 0))
 
         let state, signature =
             TypeMethodSignature.map

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -790,7 +790,11 @@ module IlMachineRuntimeMetadata =
             match declaringAssembly with
             | None -> Array.empty
             | Some assy ->
-                match assy.Methods.TryGetValue frame.Method.Handle with
+                match frame.Method.TryMetadata with
+                | None -> Array.empty
+                | Some facts ->
+
+                match assy.Methods.TryGetValue facts.Handle with
                 | true, m -> m.Generics |> Seq.map (fun (gp, _) -> gp.Name) |> Seq.toArray
                 | false, _ -> Array.empty
 
@@ -805,16 +809,24 @@ module IlMachineRuntimeMetadata =
 
         // Metadata Parameters skip SequenceNumber=0 (`this` / ref return), so signature index `i`
         // pairs with the parameter whose SequenceNumber is `i + 1` regardless of static-ness.
+        // A synthesised method has no Param rows at all, so its frame renders positionally.
         let parameterByPosition =
-            frame.Method.Parameters
-            |> Seq.map (fun p -> p.SequenceNumber, p.Name)
-            |> Map.ofSeq
+            match frame.Method.TryMetadata with
+            | None -> Map.empty
+            | Some facts -> facts.Parameters |> Seq.map (fun p -> p.SequenceNumber, p.Name) |> Map.ofSeq
 
         // Walk the raw (TypeDefn) signature rather than the concretized one so
         // `GenericTypeParameter`/`GenericMethodParameter` references survive to render
         // as their formal names (`TC`, `TM`, etc.).
+        // A synthesised method has no raw signature to walk. CoreCLR's own IL stubs do appear in
+        // stack traces, so render the frame rather than refusing — just without parameter detail,
+        // which is the only part that needs the metadata form.
         let paramText =
-            frame.Method.RawSignature.ParameterTypes
+            match frame.Method.TryMetadata with
+            | None -> "…"
+            | Some facts ->
+
+            facts.RawSignature.ParameterTypes
             |> List.mapi (fun i ty ->
                 let typeStr =
                     renderTypeDefnForStackFrame state typeGenericNames methodGenericNames ty

--- a/WoofWare.PawPrint/IlMachineStateExecution.fs
+++ b/WoofWare.PawPrint/IlMachineStateExecution.fs
@@ -398,7 +398,7 @@ module IlMachineStateExecution =
             if meth.Name <> methodToCall.Name then
                 state, false
             elif varianceInPlay then
-                state, meth.Handle = methodToCall.Handle
+                state, MethodInfo.sameDeclaredMethod meth methodToCall
             else
                 signatureMatchesTarget meth.DeclaringType.Assembly candidateTypeGenerics meth.Signature state
 
@@ -425,9 +425,8 @@ module IlMachineStateExecution =
                 None, state
             elif
                 not allowImplicitInterfaceImplementation
-                && (not (meth.MethodAttributes.HasFlag MethodAttributes.Virtual)
-                    || (meth.MethodAttributes.HasFlag MethodAttributes.NewSlot
-                        && meth.Handle <> methodToCall.Handle))
+                && (not meth.IsVirtual
+                    || (meth.IsNewSlot && not (MethodInfo.sameDeclaredMethod meth methodToCall)))
             then
                 None, state
             elif
@@ -447,8 +446,7 @@ module IlMachineStateExecution =
                 // explicit-implementation form and is private by construction.
                 allowImplicitInterfaceImplementation
                 && Some meth.Name <> interfaceExplicitNamedMethod
-                && meth.MethodAttributes &&& MethodAttributes.MemberAccessMask
-                   <> MethodAttributes.Public
+                && not meth.IsPublic
             then
                 None, state
             else
@@ -948,7 +946,7 @@ module IlMachineStateExecution =
 
         let possibleInterfaceMethods =
             possibleInterfaceMethods
-            |> List.distinctBy (fun (interfaceHandle, meth) -> interfaceHandle, meth.Handle)
+            |> List.distinctBy (fun (interfaceHandle, meth) -> interfaceHandle, meth.TryMetadata |> Option.map _.Handle)
 
         let rec hasMoreSpecificInterfaceImplementation
             (state : IlMachineState)
@@ -1312,7 +1310,10 @@ module IlMachineStateExecution =
 
             // Both instantiations share a TypeDef, so they share a method list: the slot is
             // identified by its MethodDef handle, exactly as the variance MethodImpl path does.
-            match chosenTypeInfo.Methods |> List.tryFind (fun m -> m.Handle = methodToCall.Handle) with
+            match
+                chosenTypeInfo.Methods
+                |> List.tryFind (fun m -> MethodInfo.sameDeclaredMethod m methodToCall)
+            with
             | None ->
                 failwith
                     $"variant interface dispatch: %s{chosenTy.Namespace}.%s{chosenTy.Name} has no method with handle matching %s{methodToCall.Name}, though it shares a TypeDef with the call target"
@@ -1551,8 +1552,8 @@ module IlMachineStateExecution =
         let shouldPerformVirtualResolution =
             performInterfaceResolution
             && not methodToCall.IsStatic
-            && methodToCall.MethodAttributes.HasFlag MethodAttributes.Virtual
-            && not (methodToCall.MethodAttributes.HasFlag MethodAttributes.Final)
+            && methodToCall.IsVirtual
+            && not methodToCall.IsFinal
 
         let state, methodToCall =
             if shouldPerformVirtualResolution then
@@ -1774,8 +1775,7 @@ module IlMachineStateExecution =
                 // `MissingMethodException` if the parameterless ctor is non-public — see
                 // RuntimeType.CoreCLR.cs:4034. Filter accordingly so an internal/private ctor is
                 // not silently invoked.
-                let isPublic (m : MethodInfo<_, _, _>) : bool =
-                    (m.MethodAttributes &&& MethodAttributes.MemberAccessMask) = MethodAttributes.Public
+                let isPublic (m : MethodInfo<_, _, _>) : bool = m.IsPublic
 
                 let ctor =
                     typeDef.Methods

--- a/WoofWare.PawPrint/MethodHandleRegistry.fs
+++ b/WoofWare.PawPrint/MethodHandleRegistry.fs
@@ -2,6 +2,7 @@ namespace WoofWare.PawPrint
 
 open System.Collections.Immutable
 open System.Reflection
+open System.Reflection.Metadata
 
 type MethodHandle =
     private
@@ -43,6 +44,18 @@ module MethodHandleRegistry =
             NextHandle = 1L
         }
 
+    /// A `MethodHandle` is the identity the guest sees through `RuntimeMethodHandle`, so it is
+    /// keyed on a MethodDef token. A synthesised method has no such token, and no reflection
+    /// surface either — nothing can name it, so nothing can ask for its handle. Reaching here
+    /// with one means some path handed a runtime-supplied method to reflection, which is a bug in
+    /// that path rather than something to paper over with a fabricated token.
+    let private requireDeclaredMethod (method : MethodInfo<'tyGen, 'methGen, 'vars>) : MethodDefinitionHandle =
+        match method.TryMetadata with
+        | Some facts -> facts.Handle
+        | None ->
+            failwith
+                $"cannot mint a RuntimeMethodHandle for %O{method}: it is synthesised by the runtime and has no MethodDef token"
+
     /// Build a `MethodHandle` describing the canonical identity of a concretised method.
     let private makeMethodHandle
         (allConcreteTypes : AllConcreteTypes)
@@ -51,7 +64,7 @@ module MethodHandleRegistry =
         =
         {
             AssemblyFullName = method.DeclaringType.Assembly.FullName
-            MethodHandle = ComparableMethodDefinitionHandle.Make method.Handle
+            MethodHandle = ComparableMethodDefinitionHandle.Make (requireDeclaredMethod method)
             DeclaringType =
                 AllConcreteTypes.findExistingConcreteType
                     allConcreteTypes
@@ -116,7 +129,7 @@ module MethodHandleRegistry =
         {
             AssemblyFullName = declaringType.Assembly.FullName
             DeclaringType = declaringHandle
-            MethodHandle = ComparableMethodDefinitionHandle.Make method.Handle
+            MethodHandle = ComparableMethodDefinitionHandle.Make (requireDeclaredMethod method)
             MethodGenerics = []
         }
 

--- a/WoofWare.PawPrint/Native/NativeCall.fs
+++ b/WoofWare.PawPrint/Native/NativeCall.fs
@@ -16,7 +16,7 @@ type NativeCallContext =
 [<RequireQualifiedAccess>]
 module NativeCall =
     let tryQCallEntryPoint (ctx : NativeCallContext) : string option =
-        match ctx.Instruction.ExecutingMethod.NativeImport with
+        match ctx.Instruction.ExecutingMethod.TryNativeImport with
         | Some import when import.ModuleName = "QCall" -> Some import.EntryPointName
         | _ -> None
 
@@ -635,7 +635,7 @@ module NativeCall =
             match instruction.ExecutingMethod.Body with
             | MethodBody.InternalCall -> "InternalCall"
             | MethodBody.PInvoke ->
-                match instruction.ExecutingMethod.NativeImport with
+                match instruction.ExecutingMethod.TryNativeImport with
                 | Some import -> $"PInvokeImpl %s{import.ModuleName}!%s{import.EntryPointName}"
                 | None -> "PInvokeImpl"
             | MethodBody.RuntimeProvided behaviour ->

--- a/WoofWare.PawPrint/Native/NativeLowLevelMonitor.fs
+++ b/WoofWare.PawPrint/Native/NativeLowLevelMonitor.fs
@@ -9,7 +9,7 @@ namespace WoofWare.PawPrint
 [<RequireQualifiedAccess>]
 module NativeLowLevelMonitor =
     let private trySystemNativeEntryPoint (ctx : NativeCallContext) : string option =
-        match ctx.Instruction.ExecutingMethod.NativeImport with
+        match ctx.Instruction.ExecutingMethod.TryNativeImport with
         | Some import when import.ModuleName = "libSystem.Native" -> Some import.EntryPointName
         | _ -> None
 

--- a/WoofWare.PawPrint/Native/NativeRuntimeMethodHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeMethodHandle.fs
@@ -506,7 +506,11 @@ module NativeRuntimeMethodHandle =
 
             let attrCtorAttrs : MethodAttributes =
                 match attrCtorMethodOpt with
-                | Some m -> m.MethodAttributes
+                | Some (MethodInfo.Synthesised _ as m) ->
+                    // A custom attribute's constructor is always a declared method; a synthesised
+                    // one has no attribute flags to report.
+                    failwith $"%s{operation}: attribute constructor %O{m} is synthesised and has no MethodAttributes"
+                | Some (MethodInfo.Metadata (_, facts)) -> facts.MethodAttributes
                 | None ->
                     // No constructor was supplied or found.
                     if DumpedAssembly.isValueType ctx.BaseClassTypes state._LoadedAssemblies attrTypeInfo then
@@ -915,9 +919,19 @@ module NativeRuntimeMethodHandle =
             let methodInfo =
                 resolveMethodInfoFromHandleArg operation state instruction.Arguments.[0]
 
+            // `RuntimeMethodHandle.GetAttributes` reports the raw flags to the guest. Only a
+            // declared method has any: a synthesised one cannot be reached through a
+            // `RuntimeMethodHandle` at all, because minting one for it already fails.
+            let attributes =
+                match methodInfo.TryMetadata with
+                | Some facts -> facts.MethodAttributes
+                | None ->
+                    failwith
+                        $"%s{operation}: %O{methodInfo} is synthesised by the runtime and has no MethodAttributes to report"
+
             let state =
                 IlMachineState.pushToEvalStack
-                    (CliType.Numeric (CliNumericType.Int32 (int32 methodInfo.MethodAttributes)))
+                    (CliType.Numeric (CliNumericType.Int32 (int32 attributes)))
                     ctx.Thread
                     state
 

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeFCall.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeFCall.fs
@@ -907,7 +907,11 @@ module NativeRuntimeTypeFCall =
                         failwith
                             $"%s{operation}: current method (token %O{currentMetadataHandle}) was not found in declaring type's introduced-methods list"
                     | head :: tail ->
-                        if ComparableMethodDefinitionHandle.Make head.Handle = currentMetadataHandle then
+                        if
+                            head.TryMetadata
+                            |> Option.map (fun facts -> ComparableMethodDefinitionHandle.Make facts.Handle) = Some
+                                currentMetadataHandle
+                        then
                             tail
                         else
                             findNext tail

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
@@ -640,11 +640,7 @@ module NativeRuntimeTypeHelpers =
     /// here; static virtual methods (default interface methods) live outside the instance vtable.
     let numVirtualsOwn (typeInfo : TypeInfo<GenericParamFromMetadata, TypeDefn>) : int =
         typeInfo.Methods
-        |> List.filter (fun method ->
-            not method.IsStatic
-            && method.MethodAttributes.HasFlag System.Reflection.MethodAttributes.Virtual
-            && method.MethodAttributes.HasFlag System.Reflection.MethodAttributes.NewSlot
-        )
+        |> List.filter (fun method -> not method.IsStatic && method.IsVirtual && method.IsNewSlot)
         |> List.length
 
     /// Walks the type's inheritance chain (from the given handle up to the root, typically
@@ -1334,12 +1330,7 @@ module NativeRuntimeTypeHelpers =
                 false
             else
                 typeInfo.Methods
-                |> List.exists (fun m ->
-                    m.Name = ".ctor"
-                    && not m.IsStatic
-                    && MethodInfo.arity m = 0
-                    && (m.MethodAttributes &&& System.Reflection.MethodAttributes.MemberAccessMask) = System.Reflection.MethodAttributes.Public
-                )
+                |> List.exists (fun m -> m.Name = ".ctor" && not m.IsStatic && MethodInfo.arity m = 0 && m.IsPublic)
 
     /// Validate the flag-style special constraints (`NotNullableValueTypeConstraint` /
     /// `ReferenceTypeConstraint` / `DefaultConstructorConstraint`, i.e. `where T : struct` /

--- a/WoofWare.PawPrint/Native/NativeSystemNative.fs
+++ b/WoofWare.PawPrint/Native/NativeSystemNative.fs
@@ -5,7 +5,7 @@ open System.Collections.Immutable
 [<RequireQualifiedAccess>]
 module NativeSystemNative =
     let private trySystemNativeEntryPoint (ctx : NativeCallContext) : string option =
-        match ctx.Instruction.ExecutingMethod.NativeImport with
+        match ctx.Instruction.ExecutingMethod.TryNativeImport with
         | Some import when import.ModuleName = "libSystem.Native" -> Some import.EntryPointName
         | _ -> None
 

--- a/WoofWare.PawPrint/NativeIntSource.fs
+++ b/WoofWare.PawPrint/NativeIntSource.fs
@@ -295,7 +295,7 @@ type NativeIntSource =
                 2,
                 methodDefinition.DeclaringType.Identity,
                 methodDefinition.DeclaringType.Generics,
-                methodDefinition.Handle,
+                methodDefinition.IdentityKey,
                 methodDefinition.Generics
             )
         | NativeIntSource.TypeHandlePtr ptr -> HashCode.Combine (3, ptr)

--- a/WoofWare.PawPrint/PointerHashSynthesis.fs
+++ b/WoofWare.PawPrint/PointerHashSynthesis.fs
@@ -100,10 +100,21 @@ module PointerHashSynthesis =
         | NativeIntSource.TypeDescPtr target -> CanonicalPointerKey.TypeHandle target
         | NativeIntSource.MethodTableAuxiliaryDataPtr target -> CanonicalPointerKey.MethodTableAuxiliaryData target
         | NativeIntSource.FunctionPointer methodInfo ->
+            // The key is a MethodDef token, so only a declared method has one. A function pointer
+            // to a synthesised method is possible — a struct-marshal stub is exactly that — but
+            // nothing hashes one: the guest only compares it against null and calls through it.
+            // Widening the key to admit synthesised methods is work for whichever consumer first
+            // needs it, so refuse rather than mint bits that would then have to stay stable.
+            match methodInfo.TryMetadata with
+            | None ->
+                failwith
+                    $"PointerHashSynthesis.canonicalKey: %O{methodInfo} is synthesised by the runtime, so it has no MethodDef token to key on"
+            | Some facts ->
+
             CanonicalPointerKey.FunctionPointer (
                 methodInfo.DeclaringType.Identity,
                 List.ofSeq methodInfo.DeclaringType.Generics,
-                ComparableMethodDefinitionHandle.Make methodInfo.Handle,
+                ComparableMethodDefinitionHandle.Make facts.Handle,
                 List.ofSeq methodInfo.Generics
             )
         | NativeIntSource.MethodHandlePtr id -> CanonicalPointerKey.MethodHandle id

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -717,9 +717,12 @@ module Program =
                         loggerFactory
                         baseTypes
                         ImmutableArray.Empty // No type generics for main method's declaring type
-                        { rawMainMethod with
-                            Body = MethodBody.Il (MethodInstructions.onlyRet ())
-                        }
+                        (rawMainMethod
+                         |> MethodInfo.mapCore (fun core ->
+                             { core with
+                                 Body = MethodBody.Il (MethodInstructions.onlyRet ())
+                             }
+                         ))
                         None
                         dumped.Name
                         ImmutableArray.Empty

--- a/WoofWare.PawPrint/SignalState.fs
+++ b/WoofWare.PawPrint/SignalState.fs
@@ -49,7 +49,7 @@ type SignalHandler =
         hash (
             this.Method.DeclaringType.Identity,
             this.Method.DeclaringType.Generics,
-            this.Method.Handle,
+            this.Method.IdentityKey,
             this.Method.Generics
         )
 

--- a/WoofWare.PawPrint/UnaryMetadataCallOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataCallOps.fs
@@ -1367,34 +1367,43 @@ module internal UnaryMetadataCallOps =
         // not comparable). For a generic target the raw signature still holds type parameters;
         // `calliStackKind` declines to classify those, so they are skipped rather than
         // spuriously rejected.
-        let calleeRaw = methodToCall.RawSignature
+        // Only a declared method has a raw signature. A synthesised target has none — there is no
+        // metadata form of a method the runtime supplies — so there is nothing to disagree with
+        // and the comparison is simply skipped. That is sound precisely because this check is a
+        // source of *refusals* and never of permission: declining to run it forfeits an error we
+        // might have caught, not a guarantee we were relying on. The slot-count and return-shape
+        // checks above, which are what guard frame integrity, apply to every target.
+        match methodToCall.TryMetadata with
+        | None -> ()
+        | Some facts ->
+            let calleeRaw = facts.RawSignature
 
-        // Positions only line up when both sides agree on who supplies `this`. When they do not
-        // (the EXPLICITTHIS / receiver-as-explicit-argument case described above) the lists are
-        // offset relative to each other and cannot be compared element-wise; the slot-count
-        // check above still guards frame integrity there.
-        let receiverConventionsAgree = callSiteHasImplicitThis = not methodToCall.IsStatic
+            // Positions only line up when both sides agree on who supplies `this`. When they do
+            // not (the EXPLICITTHIS / receiver-as-explicit-argument case described above) the
+            // lists are offset relative to each other and cannot be compared element-wise; the
+            // slot-count check above still guards frame integrity there.
+            let receiverConventionsAgree = callSiteHasImplicitThis = not methodToCall.IsStatic
 
-        if
-            receiverConventionsAgree
-            && callSiteSignature.ParameterTypes.Length = calleeRaw.ParameterTypes.Length
-        then
-            List.iteri2
-                (fun i (callSiteTy : TypeDefn) (calleeTy : TypeDefn) ->
-                    if calliKindsConflict callSiteTy calleeTy then
-                        failwith
-                            $"calli: call-site signature declares parameter %d{i} as %O{callSiteTy} but target %s{methodToCall.DeclaringType.Namespace}.%s{methodToCall.DeclaringType.Name}::%s{methodToCall.Name} declares it as %O{calleeTy}; these occupy different evaluation-stack representations, and PawPrint does not yet marshal calli arguments through the call-site signature"
-                )
-                callSiteSignature.ParameterTypes
-                calleeRaw.ParameterTypes
+            if
+                receiverConventionsAgree
+                && callSiteSignature.ParameterTypes.Length = calleeRaw.ParameterTypes.Length
+            then
+                List.iteri2
+                    (fun i (callSiteTy : TypeDefn) (calleeTy : TypeDefn) ->
+                        if calliKindsConflict callSiteTy calleeTy then
+                            failwith
+                                $"calli: call-site signature declares parameter %d{i} as %O{callSiteTy} but target %s{methodToCall.DeclaringType.Namespace}.%s{methodToCall.DeclaringType.Name}::%s{methodToCall.Name} declares it as %O{calleeTy}; these occupy different evaluation-stack representations, and PawPrint does not yet marshal calli arguments through the call-site signature"
+                    )
+                    callSiteSignature.ParameterTypes
+                    calleeRaw.ParameterTypes
 
-        match callSiteSignature.ReturnType, calleeRaw.ReturnType with
-        | MethodReturnType.Returns callSiteRet, MethodReturnType.Returns calleeRet when
-            calliKindsConflict callSiteRet calleeRet
-            ->
-            failwith
-                $"calli: call-site signature declares a return type of %O{callSiteRet} but target %s{methodToCall.DeclaringType.Namespace}.%s{methodToCall.DeclaringType.Name}::%s{methodToCall.Name} returns %O{calleeRet}; these occupy different evaluation-stack representations, and PawPrint does not yet marshal the calli result through the call-site signature"
-        | _ -> ()
+            match callSiteSignature.ReturnType, calleeRaw.ReturnType with
+            | MethodReturnType.Returns callSiteRet, MethodReturnType.Returns calleeRet when
+                calliKindsConflict callSiteRet calleeRet
+                ->
+                failwith
+                    $"calli: call-site signature declares a return type of %O{callSiteRet} but target %s{methodToCall.DeclaringType.Namespace}.%s{methodToCall.DeclaringType.Name}::%s{methodToCall.Name} returns %O{calleeRet}; these occupy different evaluation-stack representations, and PawPrint does not yet marshal the calli result through the call-site signature"
+            | _ -> ()
 
         let declaringTypeHandle =
             AllConcreteTypes.findExistingConcreteType

--- a/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
@@ -321,11 +321,16 @@ module internal UnaryMetadataObjectOps =
                 |> List.filter (fun candidate ->
                     candidate.Name = "Ctor"
                     && candidate.IsStatic
-                    && candidate.RawSignature.ParameterTypes = ctor.RawSignature.ParameterTypes
+                    && (MethodInfo.requireRawSignature "String ctor redirection" candidate).ParameterTypes = (MethodInfo.requireRawSignature
+                        "String ctor redirection"
+                        ctor)
+                        .ParameterTypes
                 )
 
             let describedSignature : string =
-                ctor.RawSignature.ParameterTypes |> List.map string |> String.concat ", "
+                (MethodInfo.requireRawSignature "String ctor redirection" ctor).ParameterTypes
+                |> List.map string
+                |> String.concat ", "
 
             let ctorImplementation =
                 match ctorImplementation with
@@ -337,7 +342,7 @@ module internal UnaryMetadataObjectOps =
                     failwith
                         $"newobj on System.String::.ctor(%s{describedSignature}) found several matching static String.Ctor overloads; the parameter signature should identify exactly one."
 
-            match ctorImplementation.RawSignature.ReturnType with
+            match (MethodInfo.requireRawSignature "String ctor redirection" ctorImplementation).ReturnType with
             | MethodReturnType.Returns (TypeDefn.PrimitiveType PrimitiveType.String) -> ()
             | other ->
                 failwith


### PR DESCRIPTION
**Stacked on #803** — review that first; this PR's own diff is the last commit,
`Separate a method's universal facts from its metadata-backed ones`.

Groundwork for letting the runtime synthesise methods. It is deliberately inert: nothing
constructs a `Synthesised` yet, so the change is behaviour-preserving by construction, and the
first consumer (porting the struct-marshal stub onto a real frame) follows separately.

## Why

#803's struct-marshal stub is driven by re-executing a `calli`, recovering "how many conversions
have completed" by counting values on CoreLib's evaluation stack. That works, and is tested, but
it is a local optimum: the idiom is borrowed from `NativeRuntimeTypeQCall`, where it is sound
because a *native frame* has its own empty evaluation stack. Transplanted onto a frame owned by
`Marshal.StructureToPtr`, it is unambiguous only by inspection. It also does not generalise —
`DateMarshaler.ConvertToNative` is the only field marshaller in CoreLib returning a non-void
value, and a conversion that returns nothing cannot be counted by a mechanism that counts stack
values. See the design note on #803 for the full argument.

The fix is to give such a stub a real frame, which needs a `MethodInfo` that no MethodDef row
backs. Three other parked features want the same thing: the JIT-helper allocator
`MarshalPtrToStructure.cs` is parked on ("CoreCLR's allocator is a JIT helper ... with no managed
MethodInfo to put in `NativeIntSource.FunctionPointer`"), delegate `BeginInvoke`/`EndInvoke`
currently sitting in `RuntimeBehaviour.Unrecognised`, and the multi-dim array helpers
`MethodBody`'s doc comment anticipates. So the capability is worth building on its own terms.

## What

`MethodInfo` becomes a two-case DU over a shared `MethodCore`:

- The **six facts every method has** — declaring type, name, body, generics, signature,
  staticness — are projected as members. The several hundred sites that only read those are
  untouched, which is what kept this to ~60 real decision points rather than a 500-site rewrite.
- The **seven that exist only because a MethodDef row does** — token, Param rows, raw signature,
  custom attributes, method and impl attributes, native import — are deliberately *not*
  projected. Reaching them requires matching.

That asymmetry is the whole point. The alternative considered was widening the identity field
alone and letting synthesised methods carry an empty Param collection and zeroed attribute flags;
that is the same class of lie as the fabricated `MethodDefinitionHandle` this design exists to
avoid, just spread thinner across more fields.

**Where the line falls on projection.** A *predicate with a genuine answer* gets a member:
`IsVirtual`, `IsNewSlot`, `IsFinal`, `IsPublic`, `TryNativeImport` are all false/None for a
synthesised method because it occupies no vtable slot, overrides nothing, and is reachable only
from the interpreter that synthesised it. Those are true answers, not fabricated ones. The *raw
attribute flags* stay behind a match, because handing the guest a zero would be inventing
metadata — so the two reflection paths that report them (`RuntimeMethodHandle.GetAttributes`, the
custom-attribute constructor lookup) now fail loudly instead, as does minting a
`RuntimeMethodHandle` for a synthesised method.

Stack-trace rendering is the one place that degrades rather than refuses: CoreCLR's own IL stubs
do appear in stack traces, so a synthesised frame renders without parameter detail rather than
killing the run.

## Incidental

The split surfaced a dozen call sites using `Parameters.Length`/`IsEmpty` as an arity check —
which that field's own doc comment warns against at length, because the Param table under-counts
(F# emits abstract members with zero Param rows regardless of declared arity). Those now use
`MethodInfo.arity`.

Two tests genuinely mean the Param table rather than the arity — *"AbstractDispatch's abstract
Combine really does have zero Param rows"* and its byref sibling — and they caught the sweep that
had converted them into the thing they are contrasted against. They keep reading the raw field,
with a comment saying why. Worth noting the compiler could not have caught that one; only running
the suite could.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
