### PR TITLE
Drop the vestigial option from the unchecked conversions

### DIFF
--- a/WoofWare.PawPrint.Test/TestBinaryArithmetic.fs
+++ b/WoofWare.PawPrint.Test/TestBinaryArithmetic.fs
@@ -1486,9 +1486,7 @@ module TestBinaryArithmetic =
 
     let private convU8AndAdd (state : IlMachineState) (ptr : EvalStackValue) (capacity : int64) : EvalStackValue =
         let widened : EvalStackValue =
-            match EvalStackValue.convToUInt64 ptr with
-            | Some src -> EvalStackValue.Int64 src
-            | None -> failwith $"convToUInt64 returned None for %O{ptr}"
+            EvalStackValue.convToUInt64 ptr |> EvalStackValue.Int64
 
         execute ArithmeticOperation.add state widened (EvalStackValue.Int64 (Int64Source.Verbatim capacity))
 
@@ -1498,13 +1496,11 @@ module TestBinaryArithmetic =
         let ptr = byteViewPointer arr 1 3
 
         let widened : EvalStackValue =
-            match EvalStackValue.convToUInt64 ptr with
-            | Some src -> EvalStackValue.Int64 src
-            | None -> failwith "convToUInt64 returned None"
+            EvalStackValue.convToUInt64 ptr |> EvalStackValue.Int64
 
         let recovered : NativeIntSource =
             match EvalStackValue.toUnsignedNativeInt widened with
-            | Some (UnsignedNativeIntSource.FromManagedPointer mp) -> NativeIntSource.ManagedPointer mp
+            | UnsignedNativeIntSource.FromManagedPointer mp -> NativeIntSource.ManagedPointer mp
             | other -> failwith $"expected FromManagedPointer, got %O{other}"
 
         let asNativeInt = EvalStackValue.NativeInt recovered
@@ -1518,14 +1514,9 @@ module TestBinaryArithmetic =
         let ptr = byteViewPointer arr 2 1
 
         let widened : EvalStackValue =
-            match EvalStackValue.convToInt64 ptr with
-            | Some src -> EvalStackValue.Int64 src
-            | None -> failwith "convToInt64 returned None"
+            EvalStackValue.convToInt64 ptr |> EvalStackValue.Int64
 
-        let recovered : NativeIntSource =
-            match EvalStackValue.toNativeInt widened with
-            | Some src -> src
-            | None -> failwith "toNativeInt returned None"
+        let recovered : NativeIntSource = EvalStackValue.toNativeInt widened
 
         if not (EvalStackValueComparisons.ceq ptr (EvalStackValue.NativeInt recovered)) then
             failwith $"expected Conv.I8 → Conv.I to round-trip the byref, got %O{recovered}"
@@ -1536,7 +1527,7 @@ module TestBinaryArithmetic =
         // This keeps later arithmetic on the result usable without dragging the
         // null-pointer special case through every arm.
         match EvalStackValue.convToUInt64 (EvalStackValue.ManagedPointer ManagedPointerSource.Null) with
-        | Some (Int64Source.Verbatim 0L) -> ()
+        | Int64Source.Verbatim 0L -> ()
         | other -> failwith $"expected null → verbatim 0, got %O{other}"
 
     [<Test>]
@@ -1548,7 +1539,7 @@ module TestBinaryArithmetic =
 
         let recovered : NativeIntSource =
             match EvalStackValue.toUnsignedNativeInt advanced with
-            | Some (UnsignedNativeIntSource.FromManagedPointer mp) -> NativeIntSource.ManagedPointer mp
+            | UnsignedNativeIntSource.FromManagedPointer mp -> NativeIntSource.ManagedPointer mp
             | other -> failwith $"expected FromManagedPointer after Conv.U, got %O{other}"
 
         // Original byref was at array index 1 with byte cursor 0; advancing 5 bytes
@@ -1641,7 +1632,7 @@ module TestBinaryArithmetic =
                     let advanced = convU8AndAdd state ptr (int64 capacity)
 
                     match EvalStackValue.toUnsignedNativeInt advanced with
-                    | Some (UnsignedNativeIntSource.FromManagedPointer mp) ->
+                    | UnsignedNativeIntSource.FromManagedPointer mp ->
                         EvalStackValue.NativeInt (NativeIntSource.ManagedPointer mp)
                     | other -> failwith $"unexpected: %O{other}"
 

--- a/WoofWare.PawPrint.Test/TestEvalStack.fs
+++ b/WoofWare.PawPrint.Test/TestEvalStack.fs
@@ -110,7 +110,7 @@ module TestEvalStack =
             ManagedPointerSource.Byref (ByrefRoot.PeByteRange peByteRange, [ ByrefProjection.ByteOffset 4 ])
 
         match EvalStackValue.toUnsignedNativeInt (EvalStackValue.ManagedPointer ptr) with
-        | Some (UnsignedNativeIntSource.FromManagedPointer actual) ->
+        | UnsignedNativeIntSource.FromManagedPointer actual ->
             match actual with
             | ManagedPointerSource.Byref (ByrefRoot.PeByteRange actualPeByteRange, [ ByrefProjection.ByteOffset 4 ]) when
                 actualPeByteRange = peByteRange
@@ -813,9 +813,9 @@ module TestEvalStack =
     // ---------------------------------------------------------------------------
 
     /// One of the six unchecked narrowing conversions, normalised so a single
-    /// property can range over all of them: the four sub-32-bit conversions return
-    /// `int32 option`, and `conv.i4` / `conv.u4` return an `EvalStackValue`, so both
-    /// are reduced to the int32 the opcode pushes.
+    /// property can range over all of them: the four sub-32-bit conversions return the
+    /// pushed int32 directly, while `conv.i4` / `conv.u4` return the `EvalStackValue`
+    /// they push, so the latter are unwrapped to the same int32.
     type private NarrowingConv =
         {
             Name : string
@@ -824,20 +824,16 @@ module TestEvalStack =
             Apply : EvalStackValue -> PointerHashCounters -> int32 * PointerHashCounters
         }
 
-    let private ofOptionReturning
+    let private ofInt32Returning
         (name : string)
         (destinationBits : int)
-        (f : EvalStackValue -> PointerHashCounters -> (int32 * PointerHashCounters) option)
+        (f : EvalStackValue -> PointerHashCounters -> int32 * PointerHashCounters)
         : NarrowingConv
         =
         {
             Name = name
             DestinationBits = destinationBits
-            Apply =
-                fun value counters ->
-                    match f value counters with
-                    | Some result -> result
-                    | None -> failwith $"%s{name}: conversion returned None for %O{value}"
+            Apply = f
         }
 
     let private ofEvalStackReturning
@@ -857,10 +853,10 @@ module TestEvalStack =
 
     let private narrowingConversions : NarrowingConv list =
         [
-            ofOptionReturning "conv.i1" 8 EvalStackValue.convToInt8
-            ofOptionReturning "conv.u1" 8 EvalStackValue.convToUInt8
-            ofOptionReturning "conv.i2" 16 EvalStackValue.convToInt16
-            ofOptionReturning "conv.u2" 16 EvalStackValue.convToUInt16
+            ofInt32Returning "conv.i1" 8 EvalStackValue.convToInt8
+            ofInt32Returning "conv.u1" 8 EvalStackValue.convToUInt8
+            ofInt32Returning "conv.i2" 16 EvalStackValue.convToInt16
+            ofInt32Returning "conv.u2" 16 EvalStackValue.convToUInt16
             ofEvalStackReturning "conv.i4" EvalStackValue.convToInt32
             ofEvalStackReturning "conv.u4" EvalStackValue.convToUInt32
         ]

--- a/WoofWare.PawPrint/EvalStack.fs
+++ b/WoofWare.PawPrint/EvalStack.fs
@@ -211,17 +211,17 @@ module EvalStackValue =
     let private convRUnFromInt64 (value : int64) : float = (# "conv.r.un" value : float #)
 
     /// The conversion performed by Conv_u.
-    let toUnsignedNativeInt (value : EvalStackValue) : UnsignedNativeIntSource option =
+    let toUnsignedNativeInt (value : EvalStackValue) : UnsignedNativeIntSource =
         // Table III.8. Negative inputs are bit-reinterpreted (zero-extended
         // for Int32, same bits for Int64/NativeInt); the F# `uint32`/`uint64`
         // conversions from signed already do this.
         match value with
         | EvalStackValue.Int32 int32Source ->
             let i = Int32Source.value "Conv_U" int32Source
-            Some (uint64 (uint32 i) |> UnsignedNativeIntSource.Verbatim)
-        | EvalStackValue.Int64 (Int64Source.Verbatim i) -> Some (uint64 i |> UnsignedNativeIntSource.Verbatim)
+            uint64 (uint32 i) |> UnsignedNativeIntSource.Verbatim
+        | EvalStackValue.Int64 (Int64Source.Verbatim i) -> uint64 i |> UnsignedNativeIntSource.Verbatim
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset i) ->
-            Some (UnsignedNativeIntSource.FromSyntheticCrossArrayStorage i)
+            UnsignedNativeIntSource.FromSyntheticCrossArrayStorage i
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
             // Inversion of `Conv.U8` / `Conv.I8` followed by `Conv.U`. On a
             // 64-bit interpreter the widening is bit-preserving, so the
@@ -231,23 +231,21 @@ module EvalStackValue =
             // `UnmanagedMemoryStream.Initialize` idiom checks for; modelling
             // that would require revisiting `NATIVE_INT_SIZE`.
             match src with
-            | NativeIntSource.ManagedPointer ptr -> Some (UnsignedNativeIntSource.FromManagedPointer ptr)
-            | NativeIntSource.SyntheticCrossArrayOffset s ->
-                Some (UnsignedNativeIntSource.FromSyntheticCrossArrayStorage s)
-            | NativeIntSource.Verbatim n -> Some (UnsignedNativeIntSource.Verbatim (uint64 n))
+            | NativeIntSource.ManagedPointer ptr -> UnsignedNativeIntSource.FromManagedPointer ptr
+            | NativeIntSource.SyntheticCrossArrayOffset s -> UnsignedNativeIntSource.FromSyntheticCrossArrayStorage s
+            | NativeIntSource.Verbatim n -> UnsignedNativeIntSource.Verbatim (uint64 n)
             | _ -> failwith $"TODO: Conv_U from widened native int with non-pointer source %O{src}"
         | EvalStackValue.Int64 (Int64Source.OpaqueHashBits bits) ->
             // `conv.u` narrows synthesised hash bits from int64 width back to
             // native-int width. Preserve the synthesis tag so downstream code
             // (e.g. `BitOperations.RotateLeft`'s `(nuint)` cast) sees the same
             // contract: deterministic numeric content, not a real pointer.
-            UnsignedNativeIntSource.FromOpaqueHashBits bits |> Some
+            UnsignedNativeIntSource.FromOpaqueHashBits bits
         | EvalStackValue.NativeInt i ->
             match i with
-            | NativeIntSource.Verbatim i -> uint64 i |> UnsignedNativeIntSource.Verbatim |> Some
-            | NativeIntSource.SyntheticCrossArrayOffset i ->
-                UnsignedNativeIntSource.FromSyntheticCrossArrayStorage i |> Some
-            | NativeIntSource.ManagedPointer ptr -> UnsignedNativeIntSource.FromManagedPointer ptr |> Some
+            | NativeIntSource.Verbatim i -> uint64 i |> UnsignedNativeIntSource.Verbatim
+            | NativeIntSource.SyntheticCrossArrayOffset i -> UnsignedNativeIntSource.FromSyntheticCrossArrayStorage i
+            | NativeIntSource.ManagedPointer ptr -> UnsignedNativeIntSource.FromManagedPointer ptr
             | NativeIntSource.FunctionPointer methodInfo ->
                 failwith $"Conv_U: refusing to convert function pointer %O{methodInfo} to unsigned native int"
             | NativeIntSource.FieldHandlePtr handle ->
@@ -283,38 +281,36 @@ module EvalStackValue =
                 failwith $"Conv_U: refusing to convert module handle %s{moduleName} to unsigned native int"
             | NativeIntSource.MetadataImportHandle moduleName ->
                 failwith $"Conv_U: refusing to convert metadata import handle %s{moduleName} to unsigned native int"
-            | NativeIntSource.OpaqueHashBits bits -> UnsignedNativeIntSource.FromOpaqueHashBits bits |> Some
-        | EvalStackValue.Float f -> convUFromFloat f |> UnsignedNativeIntSource.Verbatim |> Some
+            | NativeIntSource.OpaqueHashBits bits -> UnsignedNativeIntSource.FromOpaqueHashBits bits
+        | EvalStackValue.Float f -> convUFromFloat f |> UnsignedNativeIntSource.Verbatim
         | EvalStackValue.ManagedPointer managedPointerSource ->
-            UnsignedNativeIntSource.FromManagedPointer managedPointerSource |> Some
-        | EvalStackValue.NullObjectRef ->
-            ManagedPointerSource.Null |> UnsignedNativeIntSource.FromManagedPointer |> Some
+            UnsignedNativeIntSource.FromManagedPointer managedPointerSource
+        | EvalStackValue.NullObjectRef -> ManagedPointerSource.Null |> UnsignedNativeIntSource.FromManagedPointer
         | EvalStackValue.ObjectRef _
         | EvalStackValue.UserDefinedValueType _ -> failReferenceConversion "Conv_U" value
 
     /// The conversion performed by Conv_i.
-    let toNativeInt (value : EvalStackValue) : NativeIntSource option =
+    let toNativeInt (value : EvalStackValue) : NativeIntSource =
         match value with
-        | EvalStackValue.Int64 (Int64Source.Verbatim i) -> i |> convIFromInt64 |> NativeIntSource.Verbatim |> Some
-        | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset i) ->
-            NativeIntSource.SyntheticCrossArrayOffset i |> Some
+        | EvalStackValue.Int64 (Int64Source.Verbatim i) -> i |> convIFromInt64 |> NativeIntSource.Verbatim
+        | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset i) -> NativeIntSource.SyntheticCrossArrayOffset i
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
             // Inversion of `Conv.U8` / `Conv.I8` followed by `Conv.I`. See
             // the matching arm in `toUnsignedNativeInt` for the architecture
             // assumption.
-            Some src
+            src
         | EvalStackValue.Int64 (Int64Source.OpaqueHashBits bits) ->
             // `conv.i` narrows synthesised hash bits from int64 width back to
             // native-int width. The tag is preserved so the bits remain
             // distinguishable from real-pointer NativeInt sources.
-            NativeIntSource.OpaqueHashBits bits |> Some
+            NativeIntSource.OpaqueHashBits bits
         | EvalStackValue.Int32 int32Source ->
             let i = Int32Source.value "Conv_I" int32Source
-            i |> convIFromInt32 |> NativeIntSource.Verbatim |> Some
-        | EvalStackValue.NativeInt src -> Some src
-        | EvalStackValue.Float f -> f |> convIFromFloat |> NativeIntSource.Verbatim |> Some
-        | EvalStackValue.ManagedPointer ptr -> NativeIntSource.ManagedPointer ptr |> Some
-        | EvalStackValue.NullObjectRef -> ManagedPointerSource.Null |> NativeIntSource.ManagedPointer |> Some
+            i |> convIFromInt32 |> NativeIntSource.Verbatim
+        | EvalStackValue.NativeInt src -> src
+        | EvalStackValue.Float f -> f |> convIFromFloat |> NativeIntSource.Verbatim
+        | EvalStackValue.ManagedPointer ptr -> NativeIntSource.ManagedPointer ptr
+        | EvalStackValue.NullObjectRef -> ManagedPointerSource.Null |> NativeIntSource.ManagedPointer
         | EvalStackValue.ObjectRef _
         | EvalStackValue.UserDefinedValueType _ -> failReferenceConversion "Conv_I" value
 
@@ -335,38 +331,38 @@ module EvalStackValue =
     /// `(sbyte)(long)ptr` agree by construction rather than by coincidence.
     /// CoreLib chooses between those spellings with `#if TARGET_64BIT` inside
     /// `IntPtr.GetHashCode` (IntPtr.cs:90-97), so they have to.
-    let convToInt8 (value : EvalStackValue) (counters : PointerHashCounters) : (int32 * PointerHashCounters) option =
+    let convToInt8 (value : EvalStackValue) (counters : PointerHashCounters) : int32 * PointerHashCounters =
         match value with
         | EvalStackValue.Int32 int32Source ->
             let i = Int32Source.value "Conv_I1" int32Source
-            Some (convI1FromInt32 i, counters)
-        | EvalStackValue.Int64 (Int64Source.Verbatim i) -> Some (convI1FromInt64 i, counters)
+            convI1FromInt32 i, counters
+        | EvalStackValue.Int64 (Int64Source.Verbatim i) -> convI1FromInt64 i, counters
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _) -> failwith "TODO: SyntheticCrossArrayOffset"
-        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits bits) -> Some (convI1FromInt64 bits, counters)
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits bits) -> convI1FromInt64 bits, counters
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _))
         | EvalStackValue.NativeInt src ->
             let bits, counters = PointerHashSynthesis.materialiseHashBits "Conv_I1" src counters
-            Some (convI1FromInt64 bits, counters)
-        | EvalStackValue.Float f -> Some (convI1FromFloat f, counters)
+            convI1FromInt64 bits, counters
+        | EvalStackValue.Float f -> convI1FromFloat f, counters
         | EvalStackValue.ManagedPointer _
         | EvalStackValue.NullObjectRef
         | EvalStackValue.ObjectRef _
         | EvalStackValue.UserDefinedValueType _ -> failReferenceConversion "Conv_I1" value
 
     /// `conv.i2`. See `convToInt8` for why this takes `PointerHashCounters`.
-    let convToInt16 (value : EvalStackValue) (counters : PointerHashCounters) : (int32 * PointerHashCounters) option =
+    let convToInt16 (value : EvalStackValue) (counters : PointerHashCounters) : int32 * PointerHashCounters =
         match value with
         | EvalStackValue.Int32 int32Source ->
             let i = Int32Source.value "Conv_I2" int32Source
-            Some (convI2FromInt32 i, counters)
-        | EvalStackValue.Int64 (Int64Source.Verbatim i) -> Some (convI2FromInt64 i, counters)
+            convI2FromInt32 i, counters
+        | EvalStackValue.Int64 (Int64Source.Verbatim i) -> convI2FromInt64 i, counters
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _) -> failwith "TODO: SyntheticCrossArrayOffset"
-        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits bits) -> Some (convI2FromInt64 bits, counters)
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits bits) -> convI2FromInt64 bits, counters
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _))
         | EvalStackValue.NativeInt src ->
             let bits, counters = PointerHashSynthesis.materialiseHashBits "Conv_I2" src counters
-            Some (convI2FromInt64 bits, counters)
-        | EvalStackValue.Float f -> Some (convI2FromFloat f, counters)
+            convI2FromInt64 bits, counters
+        | EvalStackValue.Float f -> convI2FromFloat f, counters
         | EvalStackValue.ManagedPointer _
         | EvalStackValue.NullObjectRef
         | EvalStackValue.ObjectRef _
@@ -408,61 +404,60 @@ module EvalStackValue =
         | EvalStackValue.ObjectRef _
         | EvalStackValue.UserDefinedValueType _ -> failReferenceConversion "Conv_I4" value
 
-    let convToInt64 (value : EvalStackValue) : Int64Source option =
+    let convToInt64 (value : EvalStackValue) : Int64Source =
         match value with
         | EvalStackValue.Int32 int32Source ->
             let i = Int32Source.value "Conv_I8" int32Source
-            Some (int64<int> i |> Int64Source.Verbatim)
-        | EvalStackValue.Int64 i -> Some i
+            int64<int> i |> Int64Source.Verbatim
+        | EvalStackValue.Int64 i -> i
         | EvalStackValue.NativeInt src ->
             // `widenedNativeInt` normalises the Verbatim/SyntheticCrossArrayOffset/Null
             // cases back to canonical Int64Source variants. Non-numeric
             // sources (managed pointers, function pointers, type handles)
             // get wrapped so their provenance survives the
             // `Conv.I8 → … → Conv.I` round-trip.
-            Some (Int64Source.widenedNativeInt src true)
-        | EvalStackValue.Float f -> convI8FromFloat f |> Int64Source.Verbatim |> Some
+            Int64Source.widenedNativeInt src true
+        | EvalStackValue.Float f -> convI8FromFloat f |> Int64Source.Verbatim
         | EvalStackValue.ManagedPointer ptr ->
             // Same rationale as the NativeInt arm: keep the pointer's provenance
             // as a widened-native-int so a subsequent `Conv.U` / `Conv.I`
             // recovers the original ManagedPointer.
-            Some (Int64Source.widenedNativeInt (NativeIntSource.ManagedPointer ptr) true)
+            Int64Source.widenedNativeInt (NativeIntSource.ManagedPointer ptr) true
         | EvalStackValue.NullObjectRef ->
-            Some (Int64Source.widenedNativeInt (NativeIntSource.ManagedPointer ManagedPointerSource.Null) true)
+            Int64Source.widenedNativeInt (NativeIntSource.ManagedPointer ManagedPointerSource.Null) true
         | EvalStackValue.ObjectRef _
         | EvalStackValue.UserDefinedValueType _ -> failReferenceConversion "Conv_I8" value
 
     /// Then truncates to int64.
-    let convToUInt64 (value : EvalStackValue) : Int64Source option =
+    let convToUInt64 (value : EvalStackValue) : Int64Source =
         match value with
         | EvalStackValue.Int32 int32Source ->
             let i = Int32Source.value "Conv_U8" int32Source
-            Some (int64 (uint32 i) |> Int64Source.Verbatim)
-        | EvalStackValue.Int64 i -> Some i
-        | EvalStackValue.NativeInt src -> Some (Int64Source.widenedNativeInt src false)
-        | EvalStackValue.Float f -> convU8FromFloat f |> Int64Source.Verbatim |> Some
-        | EvalStackValue.ManagedPointer ptr ->
-            Some (Int64Source.widenedNativeInt (NativeIntSource.ManagedPointer ptr) false)
+            int64 (uint32 i) |> Int64Source.Verbatim
+        | EvalStackValue.Int64 i -> i
+        | EvalStackValue.NativeInt src -> Int64Source.widenedNativeInt src false
+        | EvalStackValue.Float f -> convU8FromFloat f |> Int64Source.Verbatim
+        | EvalStackValue.ManagedPointer ptr -> Int64Source.widenedNativeInt (NativeIntSource.ManagedPointer ptr) false
         | EvalStackValue.NullObjectRef ->
-            Some (Int64Source.widenedNativeInt (NativeIntSource.ManagedPointer ManagedPointerSource.Null) false)
+            Int64Source.widenedNativeInt (NativeIntSource.ManagedPointer ManagedPointerSource.Null) false
         | EvalStackValue.ObjectRef _
         | EvalStackValue.UserDefinedValueType _ -> failReferenceConversion "Conv_U8" value
 
     /// `conv.u1`, then truncates to int32. See `convToInt8` for why this takes
     /// `PointerHashCounters`.
-    let convToUInt8 (value : EvalStackValue) (counters : PointerHashCounters) : (int32 * PointerHashCounters) option =
+    let convToUInt8 (value : EvalStackValue) (counters : PointerHashCounters) : int32 * PointerHashCounters =
         match value with
         | EvalStackValue.Int32 int32Source ->
             let i = Int32Source.value "Conv_U1" int32Source
-            Some (convU1FromInt32 i, counters)
-        | EvalStackValue.Int64 (Int64Source.Verbatim i) -> Some (convU1FromInt64 i, counters)
+            convU1FromInt32 i, counters
+        | EvalStackValue.Int64 (Int64Source.Verbatim i) -> convU1FromInt64 i, counters
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _) -> failwith "TODO: SyntheticCrossArrayOffset"
-        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits bits) -> Some (convU1FromInt64 bits, counters)
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits bits) -> convU1FromInt64 bits, counters
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _))
         | EvalStackValue.NativeInt src ->
             let bits, counters = PointerHashSynthesis.materialiseHashBits "Conv_U1" src counters
-            Some (convU1FromInt64 bits, counters)
-        | EvalStackValue.Float f -> Some (convU1FromFloat f, counters)
+            convU1FromInt64 bits, counters
+        | EvalStackValue.Float f -> convU1FromFloat f, counters
         | EvalStackValue.ManagedPointer _
         | EvalStackValue.NullObjectRef
         | EvalStackValue.ObjectRef _
@@ -470,19 +465,19 @@ module EvalStackValue =
 
     /// `conv.u2`, then truncates to int32. See `convToInt8` for why this takes
     /// `PointerHashCounters`.
-    let convToUInt16 (value : EvalStackValue) (counters : PointerHashCounters) : (int32 * PointerHashCounters) option =
+    let convToUInt16 (value : EvalStackValue) (counters : PointerHashCounters) : int32 * PointerHashCounters =
         match value with
         | EvalStackValue.Int32 int32Source ->
             let i = Int32Source.value "Conv_U2" int32Source
-            Some (convU2FromInt32 i, counters)
-        | EvalStackValue.Int64 (Int64Source.Verbatim i) -> Some (convU2FromInt64 i, counters)
+            convU2FromInt32 i, counters
+        | EvalStackValue.Int64 (Int64Source.Verbatim i) -> convU2FromInt64 i, counters
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _) -> failwith "TODO: SyntheticCrossArrayOffset"
-        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits bits) -> Some (convU2FromInt64 bits, counters)
+        | EvalStackValue.Int64 (Int64Source.OpaqueHashBits bits) -> convU2FromInt64 bits, counters
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _))
         | EvalStackValue.NativeInt src ->
             let bits, counters = PointerHashSynthesis.materialiseHashBits "Conv_U2" src counters
-            Some (convU2FromInt64 bits, counters)
-        | EvalStackValue.Float f -> Some (convU2FromFloat f, counters)
+            convU2FromInt64 bits, counters
+        | EvalStackValue.Float f -> convU2FromFloat f, counters
         | EvalStackValue.ManagedPointer _
         | EvalStackValue.NullObjectRef
         | EvalStackValue.ObjectRef _
@@ -516,12 +511,12 @@ module EvalStackValue =
         | EvalStackValue.ObjectRef _
         | EvalStackValue.UserDefinedValueType _ -> failReferenceConversion "Conv_U4" value
 
-    let convToFloat32 (value : EvalStackValue) : float option =
+    let convToFloat32 (value : EvalStackValue) : float =
         match value with
         | EvalStackValue.Int32 int32Source ->
             let i = Int32Source.value "Conv_R4" int32Source
-            convR4FromInt32 i |> Some
-        | EvalStackValue.Int64 (Int64Source.Verbatim i) -> convR4FromInt64 i |> Some
+            convR4FromInt32 i
+        | EvalStackValue.Int64 (Int64Source.Verbatim i) -> convR4FromInt64 i
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _) ->
             failwith "Refusing to convert byte offset to float"
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
@@ -533,19 +528,19 @@ module EvalStackValue =
             // would let these bits become a float, materialising synthesised
             // pointer provenance into the float domain.
             failwith $"Refusing to convert synthesised pointer-hash bits 0x%x{bits} (native int) to float"
-        | EvalStackValue.NativeInt src -> nativeIntBitsForFloatConversion "Conv_R4" src |> convR4FromInt64 |> Some
-        | EvalStackValue.Float f -> convR4FromFloat f |> Some
+        | EvalStackValue.NativeInt src -> nativeIntBitsForFloatConversion "Conv_R4" src |> convR4FromInt64
+        | EvalStackValue.Float f -> convR4FromFloat f
         | EvalStackValue.ManagedPointer _
         | EvalStackValue.NullObjectRef
         | EvalStackValue.ObjectRef _
         | EvalStackValue.UserDefinedValueType _ -> failReferenceConversion "Conv_R4" value
 
-    let convToFloat64 (value : EvalStackValue) : float option =
+    let convToFloat64 (value : EvalStackValue) : float =
         match value with
         | EvalStackValue.Int32 int32Source ->
             let i = Int32Source.value "Conv_R8" int32Source
-            convR8FromInt32 i |> Some
-        | EvalStackValue.Int64 (Int64Source.Verbatim i) -> convR8FromInt64 i |> Some
+            convR8FromInt32 i
+        | EvalStackValue.Int64 (Int64Source.Verbatim i) -> convR8FromInt64 i
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _) ->
             failwith "Refusing to convert byte offset to float"
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
@@ -554,19 +549,19 @@ module EvalStackValue =
             failwith $"Refusing to convert synthesised pointer-hash bits 0x%x{bits} to float"
         | EvalStackValue.NativeInt (NativeIntSource.OpaqueHashBits bits) ->
             failwith $"Refusing to convert synthesised pointer-hash bits 0x%x{bits} (native int) to float"
-        | EvalStackValue.NativeInt src -> nativeIntBitsForFloatConversion "Conv_R8" src |> convR8FromInt64 |> Some
-        | EvalStackValue.Float f -> convR8FromFloat f |> Some
+        | EvalStackValue.NativeInt src -> nativeIntBitsForFloatConversion "Conv_R8" src |> convR8FromInt64
+        | EvalStackValue.Float f -> convR8FromFloat f
         | EvalStackValue.ManagedPointer _
         | EvalStackValue.NullObjectRef
         | EvalStackValue.ObjectRef _
         | EvalStackValue.UserDefinedValueType _ -> failReferenceConversion "Conv_R8" value
 
-    let convUnsignedToFloat (value : EvalStackValue) : float option =
+    let convUnsignedToFloat (value : EvalStackValue) : float =
         match value with
         | EvalStackValue.Int32 int32Source ->
             let i = Int32Source.value "Conv_R_un" int32Source
-            convRUnFromInt32 i |> Some
-        | EvalStackValue.Int64 (Int64Source.Verbatim i) -> convRUnFromInt64 i |> Some
+            convRUnFromInt32 i
+        | EvalStackValue.Int64 (Int64Source.Verbatim i) -> convRUnFromInt64 i
         | EvalStackValue.Int64 (Int64Source.SyntheticCrossArrayOffset _) ->
             failwith "Refusing to convert byte offset to float"
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
@@ -575,7 +570,7 @@ module EvalStackValue =
             failwith $"Refusing to convert synthesised pointer-hash bits 0x%x{bits} to float"
         | EvalStackValue.NativeInt (NativeIntSource.OpaqueHashBits bits) ->
             failwith $"Refusing to convert synthesised pointer-hash bits 0x%x{bits} (native int) to float"
-        | EvalStackValue.NativeInt src -> nativeIntBitsForFloatConversion "Conv_R_Un" src |> convRUnFromInt64 |> Some
+        | EvalStackValue.NativeInt src -> nativeIntBitsForFloatConversion "Conv_R_Un" src |> convRUnFromInt64
         | EvalStackValue.Float _ -> failwith "Conv_R_Un: refusing to convert an existing float as unsigned integer"
         | EvalStackValue.ManagedPointer _
         | EvalStackValue.NullObjectRef

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -521,9 +521,7 @@ module Intrinsics =
                 let valueArg, state = IlMachineState.popEvalStack currentThread state
                 let byrefArg, state = IlMachineState.popEvalStack currentThread state
 
-                let value =
-                    EvalStackValue.convToInt64 valueArg
-                    |> Option.defaultWith (fun () -> failwith $"%s{operation}: expected int64 value, got %O{valueArg}")
+                let value = EvalStackValue.convToInt64 valueArg
 
                 match popManagedByrefArgument operation byrefArg with
                 | ManagedPointerSource.Null -> interlockedNullLocation state
@@ -636,9 +634,7 @@ module Intrinsics =
                 let valueArg, state = IlMachineState.popEvalStack currentThread state
                 let byrefArg, state = IlMachineState.popEvalStack currentThread state
 
-                let value =
-                    EvalStackValue.convToInt64 valueArg
-                    |> Option.defaultWith (fun () -> failwith $"%s{operation}: expected int64 value, got %O{valueArg}")
+                let value = EvalStackValue.convToInt64 valueArg
 
                 match popManagedByrefArgument operation byrefArg with
                 | ManagedPointerSource.Null -> interlockedNullLocation state

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -2086,56 +2086,47 @@ module NullaryIlOp =
             let popped, state = IlMachineState.popEvalStack currentThread state
             let converted = EvalStackValue.toNativeInt popped
 
-            let state =
+            // Crossing from byref-world to native-pointer-world: subsequent
+            // pointer arithmetic must be byte-stride per ECMA-335 §III.1.5,
+            // so anchor a `ReinterpretAs T` projection on plain array
+            // byrefs. Plain byrefs (no anchor) keep element-stride
+            // arithmetic to match `Unsafe.Add<T>`.
+            let conv =
                 match converted with
-                | None -> failwith "TODO: Conv_I conversion failure unimplemented"
-                | Some conv ->
-                    // Crossing from byref-world to native-pointer-world: subsequent
-                    // pointer arithmetic must be byte-stride per ECMA-335 §III.1.5,
-                    // so anchor a `ReinterpretAs T` projection on plain array
-                    // byrefs. Plain byrefs (no anchor) keep element-stride
-                    // arithmetic to match `Unsafe.Add<T>`.
-                    let conv =
-                        match conv with
-                        | NativeIntSource.ManagedPointer ptr ->
-                            ManagedPointerByteView.anchorByteViewIfPlainArrayByref corelib state ptr
-                            |> NativeIntSource.ManagedPointer
-                        | other -> other
+                | NativeIntSource.ManagedPointer ptr ->
+                    ManagedPointerByteView.anchorByteViewIfPlainArrayByref corelib state ptr
+                    |> NativeIntSource.ManagedPointer
+                | other -> other
 
-                    state
-                    |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt conv) currentThread
+            let state =
+                state
+                |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt conv) currentThread
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread
 
             (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Conv_I1 ->
             let popped, state = IlMachineState.popEvalStack currentThread state
-            let converted = EvalStackValue.convToInt8 popped state.PointerHashCounters
+            let conv, counters = EvalStackValue.convToInt8 popped state.PointerHashCounters
 
             let state =
-                match converted with
-                | None -> failwith "TODO: Conv_I1 conversion failure unimplemented"
-                | Some (conv, counters) ->
-                    { state with
-                        PointerHashCounters = counters
-                    }
-                    |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 (Int32Source.Verbatim conv)) currentThread
+                { state with
+                    PointerHashCounters = counters
+                }
+                |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 (Int32Source.Verbatim conv)) currentThread
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread
 
             (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Conv_I2 ->
             let popped, state = IlMachineState.popEvalStack currentThread state
-            let converted = EvalStackValue.convToInt16 popped state.PointerHashCounters
+            let conv, counters = EvalStackValue.convToInt16 popped state.PointerHashCounters
 
             let state =
-                match converted with
-                | None -> failwith "TODO: Conv_I2 conversion failure unimplemented"
-                | Some (conv, counters) ->
-                    { state with
-                        PointerHashCounters = counters
-                    }
-                    |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 (Int32Source.Verbatim conv)) currentThread
+                { state with
+                    PointerHashCounters = counters
+                }
+                |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 (Int32Source.Verbatim conv)) currentThread
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread
 
@@ -2156,42 +2147,33 @@ module NullaryIlOp =
             (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Conv_I8 ->
             let popped, state = IlMachineState.popEvalStack currentThread state
-            let converted = EvalStackValue.convToInt64 popped
+            let conv = EvalStackValue.convToInt64 popped
 
             let state =
-                match converted with
-                | None -> failwith "TODO: Conv_I8 conversion failure unimplemented"
-                | Some conv ->
-                    state
-                    |> IlMachineState.pushToEvalStack' (EvalStackValue.Int64 conv) currentThread
+                state
+                |> IlMachineState.pushToEvalStack' (EvalStackValue.Int64 conv) currentThread
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread
 
             (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Conv_R4 ->
             let popped, state = IlMachineState.popEvalStack currentThread state
-            let converted = EvalStackValue.convToFloat32 popped
+            let conv = EvalStackValue.convToFloat32 popped
 
             let state =
-                match converted with
-                | None -> failwith "TODO: Conv_R4 conversion failure unimplemented"
-                | Some conv ->
-                    state
-                    |> IlMachineState.pushToEvalStack' (EvalStackValue.Float conv) currentThread
+                state
+                |> IlMachineState.pushToEvalStack' (EvalStackValue.Float conv) currentThread
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread
 
             (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Conv_R8 ->
             let popped, state = IlMachineState.popEvalStack currentThread state
-            let converted = EvalStackValue.convToFloat64 popped
+            let conv = EvalStackValue.convToFloat64 popped
 
             let state =
-                match converted with
-                | None -> failwith "TODO: Conv_R8 conversion failure unimplemented"
-                | Some conv ->
-                    state
-                    |> IlMachineState.pushToEvalStack' (EvalStackValue.Float conv) currentThread
+                state
+                |> IlMachineState.pushToEvalStack' (EvalStackValue.Float conv) currentThread
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread
 
@@ -2200,65 +2182,56 @@ module NullaryIlOp =
             let popped, state = IlMachineState.popEvalStack currentThread state
             let converted = EvalStackValue.toUnsignedNativeInt popped
 
-            let state =
+            // NativeIntSource.Verbatim backs the native-int stack slot with
+            // a signed int64, but the bits are what matter: signed and
+            // unsigned native-int comparisons reinterpret the slot as
+            // needed. `int64 (conv : uint64)` is a bit-exact reinterpret
+            // cast in F#, which is what ECMA-335 requires here (truncate
+            // high-order bits beyond the native word size).
+            let conv =
                 match converted with
-                | None -> failwith "TODO: Conv_U conversion failure unimplemented"
-                | Some conv ->
-                    // NativeIntSource.Verbatim backs the native-int stack slot with
-                    // a signed int64, but the bits are what matter: signed and
-                    // unsigned native-int comparisons reinterpret the slot as
-                    // needed. `int64 (conv : uint64)` is a bit-exact reinterpret
-                    // cast in F#, which is what ECMA-335 requires here (truncate
-                    // high-order bits beyond the native word size).
-                    let conv =
-                        match conv with
-                        | UnsignedNativeIntSource.Verbatim conv -> int64 conv |> NativeIntSource.Verbatim
-                        | UnsignedNativeIntSource.FromManagedPointer ptr ->
-                            // Crossing from byref-world to native-pointer-world: subsequent
-                            // pointer arithmetic must be byte-stride per ECMA-335 §III.1.5,
-                            // so anchor a `ReinterpretAs T` projection on plain array
-                            // byrefs. Plain byrefs (no anchor) keep element-stride
-                            // arithmetic to match `Unsafe.Add<T>`.
-                            ManagedPointerByteView.anchorByteViewIfPlainArrayByref corelib state ptr
-                            |> NativeIntSource.ManagedPointer
-                        | UnsignedNativeIntSource.FromSyntheticCrossArrayStorage i ->
-                            NativeIntSource.SyntheticCrossArrayOffset i
-                        | UnsignedNativeIntSource.FromOpaqueHashBits bits -> NativeIntSource.OpaqueHashBits bits
+                | UnsignedNativeIntSource.Verbatim conv -> int64 conv |> NativeIntSource.Verbatim
+                | UnsignedNativeIntSource.FromManagedPointer ptr ->
+                    // Crossing from byref-world to native-pointer-world: subsequent
+                    // pointer arithmetic must be byte-stride per ECMA-335 §III.1.5,
+                    // so anchor a `ReinterpretAs T` projection on plain array
+                    // byrefs. Plain byrefs (no anchor) keep element-stride
+                    // arithmetic to match `Unsafe.Add<T>`.
+                    ManagedPointerByteView.anchorByteViewIfPlainArrayByref corelib state ptr
+                    |> NativeIntSource.ManagedPointer
+                | UnsignedNativeIntSource.FromSyntheticCrossArrayStorage i ->
+                    NativeIntSource.SyntheticCrossArrayOffset i
+                | UnsignedNativeIntSource.FromOpaqueHashBits bits -> NativeIntSource.OpaqueHashBits bits
 
-                    state
-                    |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt conv) currentThread
+            let state =
+                state
+                |> IlMachineState.pushToEvalStack' (EvalStackValue.NativeInt conv) currentThread
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread
 
             (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Conv_U1 ->
             let popped, state = IlMachineState.popEvalStack currentThread state
-            let converted = EvalStackValue.convToUInt8 popped state.PointerHashCounters
+            let conv, counters = EvalStackValue.convToUInt8 popped state.PointerHashCounters
 
             let state =
-                match converted with
-                | None -> failwith "TODO: Conv_U1 conversion failure unimplemented"
-                | Some (conv, counters) ->
-                    { state with
-                        PointerHashCounters = counters
-                    }
-                    |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 (Int32Source.Verbatim conv)) currentThread
+                { state with
+                    PointerHashCounters = counters
+                }
+                |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 (Int32Source.Verbatim conv)) currentThread
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread
 
             (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Conv_U2 ->
             let popped, state = IlMachineState.popEvalStack currentThread state
-            let converted = EvalStackValue.convToUInt16 popped state.PointerHashCounters
+            let conv, counters = EvalStackValue.convToUInt16 popped state.PointerHashCounters
 
             let state =
-                match converted with
-                | None -> failwith "TODO: Conv_U2 conversion failure unimplemented"
-                | Some (conv, counters) ->
-                    { state with
-                        PointerHashCounters = counters
-                    }
-                    |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 (Int32Source.Verbatim conv)) currentThread
+                { state with
+                    PointerHashCounters = counters
+                }
+                |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 (Int32Source.Verbatim conv)) currentThread
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread
 
@@ -2279,14 +2252,11 @@ module NullaryIlOp =
             (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Conv_U8 ->
             let popped, state = IlMachineState.popEvalStack currentThread state
-            let converted = EvalStackValue.convToUInt64 popped
+            let conv = EvalStackValue.convToUInt64 popped
 
             let state =
-                match converted with
-                | None -> failwith "TODO: Conv_U8 conversion failure unimplemented"
-                | Some conv ->
-                    state
-                    |> IlMachineState.pushToEvalStack' (EvalStackValue.Int64 conv) currentThread
+                state
+                |> IlMachineState.pushToEvalStack' (EvalStackValue.Int64 conv) currentThread
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread
 
@@ -3139,14 +3109,11 @@ module NullaryIlOp =
         | Break -> failwith "TODO: Break unimplemented"
         | Conv_r_un ->
             let popped, state = IlMachineState.popEvalStack currentThread state
-            let converted = EvalStackValue.convUnsignedToFloat popped
+            let conv = EvalStackValue.convUnsignedToFloat popped
 
             let state =
-                match converted with
-                | None -> failwith "TODO: Conv_r_un conversion failure unimplemented"
-                | Some conv ->
-                    state
-                    |> IlMachineState.pushToEvalStack' (EvalStackValue.Float conv) currentThread
+                state
+                |> IlMachineState.pushToEvalStack' (EvalStackValue.Float conv) currentThread
 
             let state = state |> IlMachineState.advanceProgramCounter currentThread
 


### PR DESCRIPTION
Follow-up to #828, which noted the vestigial `option` in passing. Pure refactor; no behaviour change.

Thirteen conversions in `EvalStack.fs` returned an option, and **none ever returned `None`** — every arm produced `Some` or threw. So all eleven `| None -> failwith "TODO: Conv_X conversion failure unimplemented"` branches in `NullaryIlOp.fs` were unreachable, as were the two `Option.defaultWith` diagnostics at the `Interlocked` int64 sites.

Nor can they become reachable:

- Unchecked `conv.*` has no failure outcome in ECMA-335. Out-of-range float-to-integer is *unspecified* but still yields a value, which the inline-IL `convI4FromFloat` helpers already implement.
- The failure that does exist — overflow — belongs to `conv.ovf.*`, a separate family that already models it as `Result<_, unit>` and raises `OverflowException`.
- A PawPrint refusal is not a candidate either. The convention throughout is a `failwith` naming the refused shape, which says strictly more than `None` collapsing onto a generic TODO. `None` was never a slot worth filling.

So the `option` encoded an unverified claim that these conversions might fail. Removing it makes the opposite claim **compiler-checked**: the functions can no longer express failure, so no caller can pretend to handle it.

## The thirteen

`toNativeInt`, `toUnsignedNativeInt` (backing `conv.i` / `conv.u`), `convToInt8/16/64`, `convToUInt8/16/64`, `convToFloat32/64`, `convUnsignedToFloat` — plus the four narrowing conversions #828 had just changed to `(int32 * PointerHashCounters) option`, which become plain tuples.

`conv.i` and `conv.u` needed hand work rather than a mechanical pass: they carry real logic inside the `Some conv ->` arm (byte-view anchoring for the byref-to-native-pointer crossing, and the unsigned-to-signed bit reinterpret), so the surrounding `match` had to be unwrapped rather than deleted.

The `ofOptionReturning` test helper in `TestEvalStack.fs` collapses to a plain record construction, so it is now `ofInt32Returning`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
