### PR TITLE
Order NominallyEqual's cheapest discriminator first

### DIFF
--- a/WoofWare.PawPrint.Domain/TypeInfo.fs
+++ b/WoofWare.PawPrint.Domain/TypeInfo.fs
@@ -158,8 +158,22 @@ type TypeInfo<'generic, 'fieldGeneric> =
         (b : TypeInfo<'generic, 'fieldGeneric>)
         : bool
         =
-        a.Assembly.FullName = b.Assembly.FullName
-        && a.TypeDefHandle = b.TypeDefHandle
+        // Ordered cheapest-discriminator-first, because this sits on the interpreter's hot path:
+        // every `CliType.zeroOf` probe asking "is this System.String / DateTime / Decimal?"
+        // reaches it, and `AssemblyName.FullName` is by far the most expensive operand — it
+        // rebuilds the display name and SHA-1s the public key on *every* read. Measured over
+        // 1.2M calls in one guest, the `TypeDefHandle` comparison alone rejects ~86% of pairs.
+        //
+        // `&&` short-circuits and all three operands are pure reads, so the value computed is
+        // unchanged; only the evaluation order is.
+        //
+        // The reference check is strictly a fast path, not a substitute for the comparison:
+        // distinct `AssemblyName` instances can denote the same assembly (`MethodInfo.read`
+        // mints a fresh one per method it reads), so a miss must still fall through to the
+        // display-name comparison. `TestTypeResolution` pins that.
+        a.TypeDefHandle = b.TypeDefHandle
+        && (System.Object.ReferenceEquals (a.Assembly, b.Assembly)
+            || a.Assembly.FullName = b.Assembly.FullName)
         && a.Generics = b.Generics
 
 type TypeInfoEval<'ret> =

--- a/WoofWare.PawPrint.Test/TestTypeResolution.fs
+++ b/WoofWare.PawPrint.Test/TestTypeResolution.fs
@@ -31,6 +31,46 @@ module TestTypeResolution =
         |> shouldEqual [| typeof<ResolvedTypeIdentity> ; typeof<SignatureTypeKind> |]
 
     [<Test>]
+    let ``NominallyEqual sees through distinct AssemblyName instances`` () : unit =
+        // `NominallyEqual` compares assemblies by display name, but takes a reference-equality
+        // fast path first because the two sides are almost always the same `AssemblyName`
+        // object. They are not *always*: `MethodInfo.read` mints a fresh `AssemblyName` for
+        // every method it reads, so two `TypeInfo`s denoting the same type can carry different
+        // instances. This pins that the fast path falls through rather than reporting a
+        // spurious mismatch — the failure mode if the `||` were ever dropped.
+        let corelib = baseClassTypes ()
+        let stringType = corelib.String
+
+        let rehomed =
+            { stringType with
+                Assembly = System.Reflection.AssemblyName (stringType.Assembly.FullName)
+            }
+
+        System.Object.ReferenceEquals (stringType.Assembly, rehomed.Assembly)
+        |> shouldEqual false
+
+        rehomed.Assembly.FullName |> shouldEqual stringType.Assembly.FullName
+
+        TypeInfo.NominallyEqual stringType rehomed |> shouldEqual true
+        TypeInfo.NominallyEqual rehomed stringType |> shouldEqual true
+
+    [<Test>]
+    let ``NominallyEqual still separates identical rows in different assemblies`` () : unit =
+        // The mirror of the above: the same TypeDef row number in a different assembly must not
+        // compare equal. Without the display-name comparison behind it, the reference-equality
+        // fast path would be a silent identity collapse across assemblies.
+        let corelib = baseClassTypes ()
+        let stringType = corelib.String
+
+        let elsewhere =
+            { stringType with
+                Assembly = System.Reflection.AssemblyName "Some.Other.Assembly"
+            }
+
+        TypeInfo.NominallyEqual stringType elsewhere |> shouldEqual false
+        TypeInfo.NominallyEqual elsewhere stringType |> shouldEqual false
+
+    [<Test>]
     let ``nested type refs across assemblies resolve through the TypeRef parent chain`` () =
         let definingBytes =
             compileLibrary


### PR DESCRIPTION
Follow-up to #834, and the last of the per-instruction `AssemblyName.FullName` cost.

`TypeInfo.NominallyEqual` led with `a.Assembly.FullName = b.Assembly.FullName`. `AssemblyName.FullName` is not a field — every read rebuilds the display name and SHA-1s the public key. The function is on the interpreter's hot path (every `CliType.zeroOf` probe asking "is this `System.String` / `DateTime` / `Decimal`?" reaches it), and profiling attributed **7.5% of one guest's total runtime** to it, essentially all of that inside `ComputePublicKeyToken`.

## Why this ordering

I instrumented the comparison rather than guessing, on two guests — one corelib-dominated, one a purpose-built two-assembly guest (library + exe, cross-assembly virtual and interface dispatch, a cross-assembly struct, and `Box<T>` instantiated over types from both assemblies):

| | corelib guest | multi-assembly guest |
|---|---|---|
| calls | 1,204,610 | 188,905 |
| `TypeDefHandle` alone rejects the pair | 85.7% | 86.4% |
| `a.Assembly` and `b.Assembly` are the same object | 100.0% | 99.5% |
| `ReferenceEquals` disagreed with `FullName` equality | 0 | 0 |
| distinct `AssemblyName` instances seen | 2 | 3 |

The leading operand was also the worst discriminator available. So: `TypeDefHandle` first, then a reference-equality fast path on the assembly falling back to the display name, then `Generics`.

`&&` short-circuits and all three operands are pure reads, so the value computed is unchanged; only the evaluation order is.

## The fast path is a fast path, not a replacement

Distinct `AssemblyName` instances *can* denote the same assembly — `MethodInfo.read` mints a fresh one for every method it reads — so a `ReferenceEquals` miss must still fall through to the display-name comparison. Two tests pin both directions, and I mutation-tested each rather than assuming it bites:

* dropping the `||` fallback → `NominallyEqual sees through distinct AssemblyName instances` fails;
* dropping the assembly comparison entirely → `NominallyEqual still separates identical rows in different assemblies` fails.

## Measurements

Against this branch's parent, in allocated bytes (deterministic; wall-clock on the dev box is too noisy to A/B):

| Guest | Before | After |
|---|---|---|
| corelib-heavy | 13.96 GB | **12.49 GB** (−10.5%) |
| multi-assembly | 2.77 GB | **2.54 GB** (−8.3%) |

Full test suite: **2319 passed, 0 failed**. `codex review`: no actionable defects.

## One thing worth your eye

The reorder means a hypothetical null `Assembly` would now surface later, or not at all, rather than immediately. `TypeInfo.Assembly` is non-nullable and always populated from `GetAssemblyName()`, so I don't believe it is reachable — but it is a real behavioural difference in an impossible state, and I'd rather name it than let it pass silently.

## Not done here

I looked at memoising `FullName` generally (`ConditionalWeakTable`, or a domain `AssemblyIdentity` computed once at the three construction sites). After this change there is no measured `FullName` cost left outside assembly loading, so I have deliberately not done it — it is a modelling question to schedule on its own merits, not a performance one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)