### PR TITLE
Implement the method arm of the Signature_Init QCall

### DIFF
--- a/WoofWare.PawPrint.Test/TestFSharpPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestFSharpPureCases.fs
@@ -130,17 +130,19 @@ module TestFSharpPureCases =
             [
                 // `sprintf` reflects over the format's argument types, which walks
                 // `RuntimeType.GetMethodBase` and then asks the resulting `MethodBase` for its
-                // parameters. `GetMethodBase` itself completes; the case stops in
-                // `RuntimeMethodInfo.Signature`, at the `Signature_Init` QCall
-                // (NativeSignature.fs:223) called with a non-null `RuntimeMethodHandleInternal`:
+                // parameters. `GetMethodBase` completes, and so now does the `Signature_Init` QCall
+                // that builds the `MethodBase`'s `Signature` (its method arm landed with
+                // `sourcesPure/ReflectionMethodSignature.cs`, which covers the `ReturnType` and
+                // `CallingConvention` that arm makes readable).
                 //
-                //   TODO: Signature_Init method signature parsing is not implemented;
-                //   got non-null Numeric (NativeInt (MethodHandlePtr 25L))
-                //
-                // The handler implements the *field* arm only — `requireNullMethodHandle`
-                // (NativeSignature.fs:95) is the guard that rejects the method arm — so what is
-                // missing is parsing a MethodDef signature blob into the `Signature` object's
-                // `_returnTypeORfieldType` / `_arguments` / `_sig` fields, which is its own change.
+                // What remains is `MethodBase.GetParameters()`, which needs two further primitives,
+                // in this order:
+                //   1. `RuntimeMethodHandle.GetMethodDef` (InternalCall; CoreCLR returns
+                //      `pMethod->GetMemberDef()`), reached from `RuntimeParameterInfo.GetParameters`
+                //      via `NativeCall.failUnimplemented`;
+                //   2. with that spiked, `MetadataImport.Enum` for token type 0x08000000 (mdtParamDef)
+                //      with a MethodDef parent -- i.e. `EnumParams` -- which fails in
+                //      `NativeMetadataImport.tryExecuteQCall` with "does not yet support token type".
                 //
                 // `sourcesPure/MakeGenericMethodConstraintSatisfied.cs` covers the `GetMethodBase`
                 // walk itself and passes; it does not go on to read parameters.

--- a/WoofWare.PawPrint.Test/TestNativeSignature.fs
+++ b/WoofWare.PawPrint.Test/TestNativeSignature.fs
@@ -21,6 +21,21 @@ public sealed class GenericFieldHost<T>
 {
     public T Payload;
 }
+
+public sealed class MethodSignatureHost
+{
+    public static int Twice (int x, string s) => x * 2;
+
+    public void Instance (double d)
+    {
+    }
+
+    public static void Nothing ()
+    {
+    }
+
+    public static T Generic<T> (T t) => t;
+}
 """
 
     type private SignatureFixture =
@@ -106,6 +121,7 @@ public sealed class GenericFieldHost<T>
                  baseClassTypes.RuntimeFieldHandle
                  baseClassTypes.RuntimeFieldHandleInternal
                  baseClassTypes.RuntimeFieldInfoStub
+                 baseClassTypes.RuntimeMethodHandleInternal
              ])
             ||> List.fold (fun state typeInfo -> concretizeTypeInfo loggerFactory baseClassTypes state typeInfo |> fst)
 
@@ -340,7 +356,7 @@ public sealed class GenericFieldHost<T>
         (pCorSig : CliType)
         (cCorSig : CliType)
         (fieldHandleOverride : CliType option)
-        (methodHandle : CliType)
+        (methodHandle : IlMachineState -> CliType * IlMachineState)
         : ManagedHeapAddress * ConcreteTypeHandle * IlMachineState
         =
         let fieldHandleInternal, expectedFieldTypeHandle, state =
@@ -348,6 +364,8 @@ public sealed class GenericFieldHost<T>
 
         let fieldHandleInternal =
             fieldHandleOverride |> Option.defaultValue fieldHandleInternal
+
+        let methodHandle, state = methodHandle state
 
         let state, signatureType, signatureTypeHandle, signatureInitMethod =
             signatureInitMethod fixture state
@@ -413,7 +431,108 @@ public sealed class GenericFieldHost<T>
     let private nullPCorSig : CliType =
         CliType.RuntimePointer (CliRuntimePointer.Managed ManagedPointerSource.Null)
 
-    let private nullMethodHandle : CliType = CliType.ObjectRef None
+    /// The `RuntimeMethodHandleInternal` null sentinel. `Signature_Init`'s fourth parameter is a
+    /// struct (`default(RuntimeMethodHandleInternal)`, i.e. `m_handle == IntPtr.Zero`), unlike the
+    /// pre-.NET-10 `Signature.GetSignature` InternalCall whose corresponding argument is an
+    /// `IRuntimeMethodInfo` reference and so is null as an object reference.
+    let private nullMethodHandle (state : IlMachineState) : CliType * IlMachineState =
+        CliType.RuntimePointer (CliRuntimePointer.Verbatim 0L), state
+
+    let private methodSignatureHost (fixture : SignatureFixture) : TypeInfo<GenericParamFromMetadata, TypeDefn> =
+        requiredTopLevelType fixture.Assembly "" "MethodSignatureHost"
+
+    let private requiredHostMethod
+        (fixture : SignatureFixture)
+        (methodName : string)
+        : WoofWare.PawPrint.MethodInfo<GenericParamFromMetadata, GenericParamFromMetadata, TypeDefn>
+        =
+        (methodSignatureHost fixture).Methods
+        |> List.filter (fun method -> method.Name = methodName)
+        |> function
+            | [ method ] -> method
+            | [] -> failwith $"method %s{methodName} not found on MethodSignatureHost"
+            | methods ->
+                failwith $"method %s{methodName} was ambiguous on MethodSignatureHost: %d{methods.Length} matches"
+
+    /// A `RuntimeMethodHandleInternal` naming a fully-closed method on `MethodSignatureHost`, as
+    /// `RuntimeMethodInfo`'s handle would be by the time it reaches `Signature_Init`.
+    let private closedMethodHandle
+        (fixture : SignatureFixture)
+        (methodName : string)
+        (state : IlMachineState)
+        : CliType * IlMachineState
+        =
+        let state, _ =
+            concretizeTypeInfo fixture.LoggerFactory fixture.BaseClassTypes state (methodSignatureHost fixture)
+
+        let state, concretised, _ =
+            ExecutionConcretization.concretizeMethodWithTypeGenerics
+                fixture.LoggerFactory
+                fixture.BaseClassTypes
+                ImmutableArray.Empty
+                (requiredHostMethod fixture methodName)
+                None
+                fixture.Assembly.Name
+                ImmutableArray.Empty
+                state
+
+        let handle, methodHandles =
+            MethodHandleRegistry.getOrAllocateConcreteInternalHandle
+                fixture.BaseClassTypes
+                state.ConcreteTypes
+                concretised
+                state.MethodHandles
+
+        CliType.ValueType handle,
+        { state with
+            MethodHandles = methodHandles
+        }
+
+    /// A `RuntimeMethodHandleInternal` naming a generic method *definition* -- the shape
+    /// `RuntimeTypeHandle.GetFirstIntroducedMethod` mints, whose `MethodGenerics` is empty even
+    /// though the method declares type parameters.
+    let private openMethodHandle
+        (fixture : SignatureFixture)
+        (methodName : string)
+        (state : IlMachineState)
+        : CliType * IlMachineState
+        =
+        let state, hostHandle =
+            concretizeTypeInfo fixture.LoggerFactory fixture.BaseClassTypes state (methodSignatureHost fixture)
+
+        let declaringType =
+            AllConcreteTypes.lookup hostHandle state.ConcreteTypes
+            |> Option.defaultWith (fun () -> failwith "MethodSignatureHost was not concretized")
+
+        let handle, methodHandles =
+            MethodHandleRegistry.getOrAllocateInternalHandle
+                fixture.BaseClassTypes
+                state.ConcreteTypes
+                declaringType
+                (requiredHostMethod fixture methodName)
+                state.MethodHandles
+
+        CliType.ValueType handle,
+        { state with
+            MethodHandles = methodHandles
+        }
+
+    /// Every spelling `default(RuntimeFieldHandleInternal)` can reach a QCall as. A real guest
+    /// calling `new Signature(IRuntimeMethodInfo, RuntimeType)` produces the last of these, so a
+    /// classifier that recognises only the verbatim zeros throws on the shape that actually
+    /// arrives -- which is how `Signature_Init` broke while every unit test still passed.
+    let nullFieldHandleSpellings : CliType list =
+        [
+            CliType.RuntimePointer (CliRuntimePointer.Verbatim 0L)
+            CliType.RuntimePointer (CliRuntimePointer.Managed ManagedPointerSource.Null)
+            CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim 0L))
+            CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.ManagedPointer ManagedPointerSource.Null))
+        ]
+
+    /// The `RuntimeFieldHandleInternal` null sentinel in the shape a real guest produces, so that
+    /// `Signature_Init` dispatches on the method handle rather than refusing both-handles-non-null.
+    let private nullFieldHandle : CliType =
+        CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.ManagedPointer ManagedPointerSource.Null))
 
     [<Test>]
     let ``Signature_Init stores field RuntimeType into _returnTypeORfieldType`` () : unit =
@@ -459,13 +578,12 @@ public sealed class GenericFieldHost<T>
         |> shouldContainText "TODO: Signature_Init pCorSig blob parsing is not implemented"
 
     [<Test>]
-    let ``Signature_Init rejects mixed field handle and method handle inputs`` () : unit =
+    let ``Signature_Init rejects a field handle and a method handle together`` () : unit =
+        // CoreCLR's Signature_Init would silently prefer the method (`if (pMethodDesc != NULL) ...
+        // else if (pFieldDesc != NULL)`), but no managed Signature constructor passes both, so a
+        // value arriving here would be a PawPrint bug. Refusing is deliberately stricter than
+        // upstream: preferring one input would hide it.
         let fixture = makeSignatureFixture ()
-
-        // requireNullMethodHandle accepts ObjectRef None / null pointers / NativeInt 0; any
-        // non-null primitive triggers the TODO.
-        let nonNullMethodHandle =
-            CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim 1L))
 
         let ex =
             Assert.Throws<System.Exception> (fun () ->
@@ -474,12 +592,12 @@ public sealed class GenericFieldHost<T>
                     nullPCorSig
                     (CliType.Numeric (CliNumericType.Int32 0))
                     None
-                    nonNullMethodHandle
+                    (closedMethodHandle fixture "Twice")
                 |> ignore
             )
 
         ex.Message
-        |> shouldContainText "TODO: Signature_Init method signature parsing is not implemented"
+        |> shouldContainText "Signature_Init: got both a field handle and a method handle"
 
     [<Test>]
     let ``Signature_Init rejects mixed field handle and non-zero cCorSig`` () : unit =
@@ -516,3 +634,231 @@ public sealed class GenericFieldHost<T>
 
         ex.Message
         |> shouldContainText "TODO: Signature_Init non-field signature parsing is not implemented; fieldHandle was null"
+
+    /// Concretize a `TypeDefn` in `state` so it can be compared against a `RuntimeType` the QCall
+    /// allocated. Concretization is idempotent, so this recovers the handle the QCall used rather
+    /// than minting a second one.
+    let private expectedTarget
+        (fixture : SignatureFixture)
+        (state : IlMachineState)
+        (defn : TypeDefn)
+        : RuntimeTypeHandleTarget
+        =
+        let _, handle =
+            IlMachineState.concretizeType
+                fixture.LoggerFactory
+                fixture.BaseClassTypes
+                state
+                fixture.Assembly.Name
+                ImmutableArray.Empty
+                ImmutableArray.Empty
+                defn
+
+        RuntimeTypeHandleTarget.Closed handle
+
+    let private runtimeTypeTargetOfField
+        (state : IlMachineState)
+        (signatureAddr : ManagedHeapAddress)
+        (fieldName : string)
+        : RuntimeTypeHandleTarget
+        =
+        match signatureField state signatureAddr fieldName with
+        | CliType.ObjectRef (Some addr) ->
+            NativeCall.runtimeTypeHandleTargetOfRuntimeTypeRef
+                $"Signature_Init test (%s{fieldName})"
+                state
+                (EvalStackValue.ObjectRef addr)
+        | other -> failwith $"Expected %s{fieldName} to be a RuntimeType object ref, got %O{other}"
+
+    let private argumentTargets
+        (state : IlMachineState)
+        (signatureAddr : ManagedHeapAddress)
+        : RuntimeTypeHandleTarget list
+        =
+        let arrayAddr =
+            match signatureField state signatureAddr "_arguments" with
+            | CliType.ObjectRef (Some addr) -> addr
+            | CliType.ObjectRef None ->
+                failwith
+                    "Expected _arguments to be an allocated RuntimeType[]; CoreCLR allocates it even for a nullary method, and the managed Signature.Arguments getter asserts it is non-null"
+            | other -> failwith $"Expected _arguments to be a RuntimeType[] object ref, got %O{other}"
+
+        let array =
+            match state.ManagedHeap.Arrays.TryGetValue arrayAddr with
+            | true, array -> array
+            | false, _ -> failwith $"_arguments pointed at %O{arrayAddr}, which is not an array"
+
+        [
+            for index in 0 .. array.Length - 1 do
+                match IlMachineState.getArrayValue arrayAddr index state with
+                | CliType.ObjectRef (Some addr) ->
+                    NativeCall.runtimeTypeHandleTargetOfRuntimeTypeRef
+                        "Signature_Init test (_arguments)"
+                        state
+                        (EvalStackValue.ObjectRef addr)
+                | other -> failwith $"Expected _arguments[%d{index}] to be a RuntimeType object ref, got %O{other}"
+        ]
+
+    let private invokeMethodArm
+        (fixture : SignatureFixture)
+        (methodName : string)
+        : ManagedHeapAddress * IlMachineState
+        =
+        let signatureAddr, _, state =
+            invokeSignatureInit
+                fixture
+                nullPCorSig
+                (CliType.Numeric (CliNumericType.Int32 0))
+                (Some nullFieldHandle)
+                (closedMethodHandle fixture methodName)
+
+        signatureAddr, state
+
+    [<Test>]
+    let ``Signature_Init fills the method arm's return type and arguments`` () : unit =
+        let fixture = makeSignatureFixture ()
+        let signatureAddr, state = invokeMethodArm fixture "Twice"
+
+        runtimeTypeTargetOfField state signatureAddr "_returnTypeORfieldType"
+        |> shouldEqual (expectedTarget fixture state (TypeDefn.PrimitiveType PrimitiveType.Int32))
+
+        // Order matters: `SetArgument(i, ...)` fills index i with the i'th fixed argument, so a
+        // reversed fill would still produce a two-element array of the right types.
+        argumentTargets state signatureAddr
+        |> shouldEqual
+            [
+                expectedTarget fixture state (TypeDefn.PrimitiveType PrimitiveType.Int32)
+                expectedTarget fixture state (TypeDefn.PrimitiveType PrimitiveType.String)
+            ]
+
+    [<Test>]
+    let ``Signature_Init gives a void nullary method System.Void and an empty argument array`` () : unit =
+        let fixture = makeSignatureFixture ()
+        let signatureAddr, state = invokeMethodArm fixture "Nothing"
+
+        let voidTarget =
+            let _, _, handle =
+                NativeRuntimeTypeHelpers.concretizeNonGenericCorelibType
+                    fixture.LoggerFactory
+                    fixture.BaseClassTypes
+                    state
+                    "System"
+                    "Void"
+
+            RuntimeTypeHandleTarget.Closed handle
+
+        // CoreCLR's `msig.GetRetTypeHandleThrowing()` yields System.Void's TypeHandle for a void
+        // return rather than a null one, and the QCall asserts `_returnTypeORfieldType != NULL` on
+        // the way out.
+        runtimeTypeTargetOfField state signatureAddr "_returnTypeORfieldType"
+        |> shouldEqual voidTarget
+
+        argumentTargets state signatureAddr |> shouldEqual []
+
+    [<TestCase("Twice", 0x1)>]
+    [<TestCase("Instance", 0x21)>]
+    let ``Signature_Init translates the calling convention rather than storing the raw byte``
+        (methodName : string)
+        (expected : int)
+        : unit
+        =
+        // SignatureNative::SetCallingConvention (runtimehandles.h:455) maps the ECMA
+        // calling-convention byte onto the managed CallingConventions bits: everything that is not
+        // IMAGE_CEE_CS_CALLCONV_VARARG becomes CALLCONV_Standard (0x1), plus 0x20 for HASTHIS.
+        // Storing the raw byte would give 0x0 / 0x20 here, since IMAGE_CEE_CS_CALLCONV_DEFAULT is 0.
+        let fixture = makeSignatureFixture ()
+        let signatureAddr, state = invokeMethodArm fixture methodName
+
+        match signatureField state signatureAddr "_managedCallingConventionAndArgIteratorFlags" with
+        | CliType.Numeric (CliNumericType.Int32 actual) -> actual |> shouldEqual expected
+        | other -> failwith $"Expected _managedCallingConventionAndArgIteratorFlags to be Int32, got %O{other}"
+
+    [<Test>]
+    let ``Signature_Init points _sig at the MethodDef signature blob`` () : unit =
+        let fixture = makeSignatureFixture ()
+        let signatureAddr, state = invokeMethodArm fixture "Twice"
+
+        let expectedHandle =
+            ComparableMethodDefinitionHandle.Make (requiredHostMethod fixture "Twice").Handle
+
+        let expectedSize =
+            let mdReader = fixture.Assembly.PeReader.GetMetadataReader ()
+            let methodDef = mdReader.GetMethodDefinition expectedHandle.Get
+            mdReader.GetBlobReader(methodDef.Signature).Length
+
+        let peByteRange =
+            match signatureField state signatureAddr "_sig" |> CliType.unwrapPrimitiveLikeDeep with
+            | CliType.RuntimePointer (CliRuntimePointer.Managed (ManagedPointerSource.Byref (ByrefRoot.PeByteRange peByteRange,
+                                                                                             _))) -> peByteRange
+            | other -> failwith $"Expected _sig to be a byref over a PE byte range, got %O{other}"
+
+        peByteRange.Source
+        |> shouldEqual (PeByteRangePointerSource.MethodSignatureBlob expectedHandle)
+
+        peByteRange.Size |> shouldEqual expectedSize
+
+        // CoreCLR asserts `cCorSig > 0` on the way out, and every downstream reader
+        // (GetParameterOffsetInternal, GetCustomModifiersAtOffset) cross-checks `_csig` against the
+        // real blob length before walking it.
+        match signatureField state signatureAddr "_csig" with
+        | CliType.Numeric (CliNumericType.Int32 csig) -> csig |> shouldEqual expectedSize
+        | other -> failwith $"Expected _csig to be Int32, got %O{other}"
+
+    [<Test>]
+    let ``Signature_Init stores the method handle into _pMethod`` () : unit =
+        // `_pMethod` is what SignatureNative::GetTypeContext branches on to decide whether a
+        // signature's type context carries a method instantiation, so it has to survive the QCall.
+        let fixture = makeSignatureFixture ()
+        let expectedHandle, _ = closedMethodHandle fixture "Twice" fixture.State
+        let signatureAddr, state = invokeMethodArm fixture "Twice"
+
+        signatureField state signatureAddr "_pMethod"
+        |> CliType.unwrapPrimitiveLikeDeep
+        |> shouldEqual (CliType.unwrapPrimitiveLikeDeep expectedHandle)
+
+    [<Test>]
+    let ``Signature_Init refuses a generic method definition`` () : unit =
+        // The handle the introduced-method iterator mints for `Generic<T>` has empty MethodGenerics
+        // even though the method declares one type parameter. CoreCLR resolves the signature
+        // against the typical instantiation, whose method generic parameters a ConcreteTypeHandle
+        // cannot represent (the same limit that parks MakeGenericMethodOpenArgument.cs), so this
+        // must fail loudly rather than substitute something plausible for T.
+        let fixture = makeSignatureFixture ()
+
+        let ex =
+            Assert.Throws<System.Exception> (fun () ->
+                invokeSignatureInit
+                    fixture
+                    nullPCorSig
+                    (CliType.Numeric (CliNumericType.Int32 0))
+                    (Some nullFieldHandle)
+                    (openMethodHandle fixture "Generic")
+                |> ignore
+            )
+
+        ex.Message
+        |> shouldContainText "TODO: Signature_Init on generic method definition Generic"
+
+        ex.Message |> shouldContainText "declares 1 generic parameter"
+
+    [<TestCaseSource(nameof nullFieldHandleSpellings)>]
+    let ``Signature_Init reaches the method arm for every spelling of a null field handle``
+        (nullFieldHandle : CliType)
+        : unit
+        =
+        // The four-way dispatch classifies *both* handles before choosing an arm, so the field
+        // classifier has to answer "no field handle" for whichever zero shape the guest's
+        // `default(RuntimeFieldHandleInternal)` happens to be, rather than throwing on the ones it
+        // does not list.
+        let fixture = makeSignatureFixture ()
+
+        let signatureAddr, _, state =
+            invokeSignatureInit
+                fixture
+                nullPCorSig
+                (CliType.Numeric (CliNumericType.Int32 0))
+                (Some nullFieldHandle)
+                (closedMethodHandle fixture "Twice")
+
+        runtimeTypeTargetOfField state signatureAddr "_returnTypeORfieldType"
+        |> shouldEqual (expectedTarget fixture state (TypeDefn.PrimitiveType PrimitiveType.Int32))

--- a/WoofWare.PawPrint.Test/TestNullaryIlOp.fs
+++ b/WoofWare.PawPrint.Test/TestNullaryIlOp.fs
@@ -1175,6 +1175,31 @@ module TestNullaryIlOp =
         )
 
     [<Test>]
+    let ``a method signature blob makes no alignment claim`` () : unit =
+        // Same reasoning as the field variant below: a method's COR signature blob lives in the
+        // metadata `#Blob` heap at an offset PawPrint does not track, so its RelativeVirtualAddress
+        // is a placeholder 0 and its low bits belong to no address.
+        let method =
+            ComparableMethodDefinitionHandle.Make (
+                System.Reflection.Metadata.Ecma335.MetadataTokens.MethodDefinitionHandle 1
+            )
+
+        let blob = peByteRangeByref (PeByteRangePointerSource.MethodSignatureBlob method) 0
+
+        ManagedPointerSource.tryContainerAlignmentBits blob |> shouldEqual None
+
+        let exn =
+            Assert.Throws (fun () ->
+                runBinary
+                    NullaryIlOp.And
+                    (EvalStackValue.Int32 (Int32Source.NarrowedManagedPointer blob))
+                    (EvalStackValue.Int32 (Int32Source.Verbatim 1))
+                |> ignore<EvalStackValue>
+            )
+
+        exn.Message |> shouldContainText "claims no alignment"
+
+    [<Test>]
     let ``a field signature blob makes no alignment claim`` () : unit =
         // `FieldRva` and `ManagedResource` name real section offsets, and the image
         // base is page-aligned, so their low bits are the mapped address's low bits.

--- a/WoofWare.PawPrint.Test/sourcesPure/ReflectionMethodSignature.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/ReflectionMethodSignature.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+class Program
+{
+    // Every method here has its whole signature parsed by the Signature_Init QCall, not just the
+    // part this program can read back: the QCall fills `_arguments` eagerly (CoreCLR allocates the
+    // array even for a nullary method). So the byref and generic-instantiation parameters below are
+    // exercised even though `GetParameters()` is not reachable yet — reading `ReturnType` is enough
+    // to make the QCall concretize every parameter type, and an unsupported parameter shape would
+    // fail the run rather than go unnoticed.
+
+    static int Twice (int x, string s) => x * 2;
+
+    static string Describe (List<int> xs, out bool ok)
+    {
+        ok = true;
+        return "";
+    }
+
+    static void Bump (ref long n) => n++;
+
+    static void Nothing ()
+    {
+    }
+
+    int[] Instance (double d) => null;
+
+    static MethodInfo Get (string name)
+    {
+        MethodInfo m = typeof (Program).GetMethod (
+            name,
+            BindingFlags.Static | BindingFlags.Instance | BindingFlags.NonPublic);
+
+        if (m == null)
+            throw new Exception ("could not find " + name);
+
+        return m;
+    }
+
+    static int Main (string[] args)
+    {
+        // MethodBase.ReturnType is Signature.ReturnType, i.e. `_returnTypeORfieldType` as the
+        // Signature_Init method arm fills it.
+        if (Get ("Twice").ReturnType != typeof (int))
+            return 1;
+
+        if (Get ("Describe").ReturnType != typeof (string))
+            return 2;
+
+        if (Get ("Instance").ReturnType != typeof (int[]))
+            return 3;
+
+        // CoreCLR takes the return type from `msig.GetRetTypeHandleThrowing()`, which for a void
+        // return is System.Void's TypeHandle rather than a null one.
+        if (Get ("Nothing").ReturnType != typeof (void))
+            return 4;
+
+        if (Get ("Bump").ReturnType != typeof (void))
+            return 5;
+
+        // MethodBase.CallingConvention is Signature.CallingConvention, the low byte of
+        // `_managedCallingConventionAndArgIteratorFlags`. That field holds the *translated*
+        // CallingConventions bits SignatureNative::SetCallingConvention derives, not the raw ECMA
+        // calling-convention byte: IMAGE_CEE_CS_CALLCONV_DEFAULT is 0x0 while
+        // CallingConventions.Standard is 0x1, so a handler that stored the raw byte would report 0
+        // here for every one of these methods.
+        if (Get ("Twice").CallingConvention != CallingConventions.Standard)
+            return 6;
+
+        if (Get ("Nothing").CallingConvention != CallingConventions.Standard)
+            return 7;
+
+        if (Get ("Instance").CallingConvention != (CallingConventions.Standard | CallingConventions.HasThis))
+            return 8;
+
+        // None of these is a VarArgs method, so the VarArgs bit must never appear; a handler that
+        // inverted the VarArgs/Standard choice would pass every check above but fail this one.
+        if ((Get ("Twice").CallingConvention & CallingConventions.VarArgs) != 0)
+            return 9;
+
+        if ((Get ("Instance").CallingConvention & CallingConventions.VarArgs) != 0)
+            return 10;
+
+        // ExplicitThis never appears on a metadata method definition; only a calli site's signature
+        // can carry it.
+        if ((Get ("Instance").CallingConvention & CallingConventions.ExplicitThis) != 0)
+            return 11;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -780,6 +780,12 @@ module IlMachineManagedByref =
                 let mutable blobReader = mdReader.GetBlobReader fieldDef.Signature
                 blobReader.Offset <- byteOffset
                 blobReader.ReadBytes targetSize
+            | PeByteRangePointerSource.MethodSignatureBlob method ->
+                let mdReader = assembly.PeReader.GetMetadataReader ()
+                let methodDef = mdReader.GetMethodDefinition method.Get
+                let mutable blobReader = mdReader.GetBlobReader methodDef.Signature
+                blobReader.Offset <- byteOffset
+                blobReader.ReadBytes targetSize
 
         CliType.ofBytesLike targetTemplate bytes
 

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -55,6 +55,9 @@ module IlMachineState =
     let peByteRangeForFieldSignatureBlob =
         IlMachineTypeResolution.peByteRangeForFieldSignatureBlob
 
+    let peByteRangeForMethodSignatureBlob =
+        IlMachineTypeResolution.peByteRangeForMethodSignatureBlob
+
     let peByteRangePointer = IlMachineTypeResolution.peByteRangePointer
 
     let getFrame = IlMachineThreadState.getFrame

--- a/WoofWare.PawPrint/IlMachineTypeResolution.fs
+++ b/WoofWare.PawPrint/IlMachineTypeResolution.fs
@@ -679,6 +679,25 @@ module IlMachineTypeResolution =
             Size = blobReader.Length
         }
 
+    /// PE byte range pointer over the COR signature blob bytes for a method
+    /// definition (ECMA II.23.2.1). Same storage story as
+    /// `peByteRangeForFieldSignatureBlob`.
+    let peByteRangeForMethodSignatureBlob
+        (assembly : DumpedAssembly)
+        (methodHandle : MethodDefinitionHandle)
+        : PeByteRangePointer
+        =
+        let mdReader = assembly.PeReader.GetMetadataReader ()
+        let methodDef = mdReader.GetMethodDefinition methodHandle
+        let blobReader = mdReader.GetBlobReader methodDef.Signature
+
+        {
+            AssemblyFullName = assembly.Name.FullName
+            Source = PeByteRangePointerSource.MethodSignatureBlob (ComparableMethodDefinitionHandle.Make methodHandle)
+            RelativeVirtualAddress = 0
+            Size = blobReader.Length
+        }
+
     let peByteRangePointer
         (loggerFactory : ILoggerFactory)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)

--- a/WoofWare.PawPrint/ManagedPointerSource.fs
+++ b/WoofWare.PawPrint/ManagedPointerSource.fs
@@ -19,6 +19,9 @@ type PeByteRangePointerSource =
     /// via the assembly's `MetadataReader.GetBlobBytes` rather than through
     /// `PeReader.GetSectionData`.
     | FieldSignatureBlob of field : ComparableFieldDefinitionHandle
+    /// The COR signature blob for a method definition (ECMA II.23.2.1). Same
+    /// storage story as `FieldSignatureBlob`.
+    | MethodSignatureBlob of method : ComparableMethodDefinitionHandle
 
 type PeByteRangePointer =
     {
@@ -34,6 +37,7 @@ type PeByteRangePointer =
             | PeByteRangePointerSource.FieldRva field -> $"field %O{field.Get}"
             | PeByteRangePointerSource.ManagedResource resourceName -> $"managed resource %s{resourceName}"
             | PeByteRangePointerSource.FieldSignatureBlob field -> $"field signature blob for %O{field.Get}"
+            | PeByteRangePointerSource.MethodSignatureBlob method -> $"method signature blob for %O{method.Get}"
 
         $"<PE data %s{this.AssemblyFullName} %s{source} at %d{this.RelativeVirtualAddress} size %d{this.Size}>"
 
@@ -590,7 +594,8 @@ module ManagedPointerSource =
             match peByteRange.Source with
             | PeByteRangePointerSource.FieldRva _
             | PeByteRangePointerSource.ManagedResource _ -> Some 3
-            | PeByteRangePointerSource.FieldSignatureBlob _ -> None
+            | PeByteRangePointerSource.FieldSignatureBlob _
+            | PeByteRangePointerSource.MethodSignatureBlob _ -> None
         // Object fields, static fields, stack slots and the synthetic roots have no
         // stable in-container offset either (see `tryStableAddressBits` and
         // `NullaryIlOp.tryManagedPointerAddressBits`), so there is nothing to pair

--- a/WoofWare.PawPrint/Native/NativeCall.fs
+++ b/WoofWare.PawPrint/Native/NativeCall.fs
@@ -168,12 +168,22 @@ module NativeCall =
         | CliType.Numeric (CliNumericType.Int32 i) -> i
         | other -> failwith $"%s{operation}: expected Int32 argument, got %O{other}"
 
+    /// Extract the registry id from the m_handle of a `RuntimeFieldHandleInternal`, or `None` for
+    /// the null sentinel. The null sentinel has several spellings, because
+    /// `default(RuntimeFieldHandleInternal)` reaches PawPrint as whichever zero shape the
+    /// zero-initialising path produced -- a verbatim zero or a null managed pointer, in either the
+    /// runtime-pointer or the native-int tag. Recognise all four, exactly as
+    /// `methodHandleIdOfRuntimeMethodHandleInternal` does below: a caller that dispatches on "did
+    /// I get a field handle?" needs this to answer honestly for every spelling of null, rather than
+    /// throwing on the ones it happens not to list.
     let fieldHandleIdOfRuntimeFieldHandleInternal (operation : string) (arg : CliType) : int64 option =
         match CliType.unwrapPrimitiveLikeDeep arg with
         | CliType.RuntimePointer (CliRuntimePointer.FieldRegistryHandle id) -> Some id
         | CliType.RuntimePointer (CliRuntimePointer.Verbatim 0L) -> None
+        | CliType.RuntimePointer (CliRuntimePointer.Managed ManagedPointerSource.Null) -> None
         | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.FieldHandlePtr id)) -> Some id
         | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim 0L)) -> None
+        | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.ManagedPointer ManagedPointerSource.Null)) -> None
         | other ->
             failwith
                 $"%s{operation}: expected RuntimeFieldHandleInternal containing a field-registry handle, got %O{other}"

--- a/WoofWare.PawPrint/Native/NativeRuntimeMethodHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeMethodHandle.fs
@@ -404,7 +404,7 @@ module NativeRuntimeMethodHandle =
         )
 
     /// The metadata `MethodInfo` the given identity's MethodDef token names.
-    let private methodInfoOfMetadataIdentity
+    let methodInfoOfMetadataIdentity
         (operation : string)
         (state : IlMachineState)
         (identity : MetadataMethodIdentity)
@@ -431,7 +431,7 @@ module NativeRuntimeMethodHandle =
     /// needs one of these, and none of them has an answer for a no-metadata (`DynamicMethod`)
     /// handle -- so when that case lands, this match is one of the sites that must decide what to
     /// do rather than silently reading a token that does not exist.
-    let private resolveMetadataIdentityFromArg
+    let resolveMetadataIdentityFromArg
         (operation : string)
         (state : IlMachineState)
         (arg : CliType)

--- a/WoofWare.PawPrint/Native/NativeSignature.fs
+++ b/WoofWare.PawPrint/Native/NativeSignature.fs
@@ -14,8 +14,9 @@ module NativeSignature =
 
     /// Resolve a Signature `_sig` argument to the owning assembly plus the
     /// COR signature `BlobHandle` it points at. PawPrint installs `_sig` as a
-    /// managed byref over a field's PE-metadata signature blob; this helper
-    /// unwraps that byref. Callers that only need the raw bytes can use
+    /// managed byref over a field's or a method's PE-metadata signature blob
+    /// (see `fillFieldSignature` / `fillMethodSignature`); this helper unwraps
+    /// that byref. Callers that only need the raw bytes can use
     /// `resolveSignatureBlob`; callers that need to seek with a `BlobReader`
     /// (e.g. token-aware parsers) acquire a fresh reader from the returned
     /// handle.
@@ -31,21 +32,26 @@ module NativeSignature =
                                                                                              _))) -> peByteRange
             | other -> failwith $"%s{operation}: expected managed pointer over a PE byte range for sig, got %O{other}"
 
+        let assembly () : DumpedAssembly =
+            state.LoadedAssembly' peByteRange.AssemblyFullName
+            |> Option.defaultWith (fun () ->
+                failwith $"%s{operation}: signature blob references unloaded assembly %s{peByteRange.AssemblyFullName}"
+            )
+
         match peByteRange.Source with
         | PeByteRangePointerSource.FieldSignatureBlob field ->
-            let assembly =
-                state.LoadedAssembly' peByteRange.AssemblyFullName
-                |> Option.defaultWith (fun () ->
-                    failwith
-                        $"%s{operation}: signature blob references unloaded assembly %s{peByteRange.AssemblyFullName}"
-                )
-
+            let assembly = assembly ()
             let mdReader = assembly.PeReader.GetMetadataReader ()
             let fieldDef = mdReader.GetFieldDefinition field.Get
             assembly, fieldDef.Signature
-        | other ->
-            failwith
-                $"%s{operation}: signature `_sig` byref points at non-signature PE byte range %O{other}; only FieldSignatureBlob is currently supported"
+        | PeByteRangePointerSource.MethodSignatureBlob method ->
+            let assembly = assembly ()
+            let mdReader = assembly.PeReader.GetMetadataReader ()
+            let methodDef = mdReader.GetMethodDefinition method.Get
+            assembly, methodDef.Signature
+        | PeByteRangePointerSource.FieldRva _
+        | PeByteRangePointerSource.ManagedResource _ ->
+            failwith $"%s{operation}: signature `_sig` byref points at non-signature PE byte range %O{peByteRange}"
 
     /// Resolve a Signature `_sig` argument to the COR signature blob bytes it
     /// points at. Built on top of `resolveSignatureBlobHandle`.
@@ -207,6 +213,245 @@ module NativeSignature =
 
         state
 
+    /// ECMA II.23.2.3 calling-convention low nibble values that a *method* signature can carry.
+    let private callingConventionVarArg : int = 0x5
+
+    /// The managed `CallingConventions` bits CoreCLR's `SignatureNative::SetCallingConvention`
+    /// (runtimehandles.h:455) derives from the raw ECMA calling-convention byte. Note that this
+    /// is a translation, not the raw byte: `CallingConventions.Standard` is 0x1 while
+    /// `IMAGE_CEE_CS_CALLCONV_DEFAULT` is 0x0.
+    let private callConvStandard : int = 0x1
+    let private callConvVarArgs : int = 0x2
+    let private callConvHasThis : int = 0x20
+    let private callConvExplicitThis : int = 0x40
+
+    let private managedCallingConventionOfHeader (operation : string) (header : SignatureHeader) : int =
+        // CoreCLR dispatches on the blob's own calling convention, not on which handle it was
+        // given, so a FIELD-shaped blob reached from a method handle would take the *field* arm
+        // there. No MethodDef can carry one; assert rather than silently reporting Standard.
+        match header.Kind with
+        | SignatureKind.Method -> ()
+        | other ->
+            failwith
+                $"%s{operation}: method signature blob has signature kind %O{other}, not Method; a MethodDef cannot carry a field or local-variable calling convention"
+
+        let baseBits =
+            if int header.CallingConvention = callingConventionVarArg then
+                callConvVarArgs
+            else
+                callConvStandard
+
+        let withThis =
+            if header.IsInstance then
+                baseBits ||| callConvHasThis
+            else
+                baseBits
+
+        if header.HasExplicitThis then
+            withThis ||| callConvExplicitThis
+        else
+            withThis
+
+    /// The `SigTypeContext` a method-backed `Signature` resolves its blob against: CoreCLR builds
+    /// it from the declaring type's class instantiation plus
+    /// `pMethodDesc->LoadMethodInstantiation()` (`Signature_Init`, runtimehandles.cpp:1622, and
+    /// `SignatureNative::GetTypeContext`, runtimehandles.h:388). Returns the defining assembly too,
+    /// since token resolution against the blob needs it.
+    ///
+    /// A generic method *definition* has no representable context: the handle the introduced-method
+    /// iterator mints carries empty `MethodGenerics` while the method declares type parameters, and
+    /// CoreCLR resolves against the typical instantiation, whose method generic parameters a
+    /// `ConcreteTypeHandle` cannot name (the same limit that parks
+    /// `sourcesPure/MakeGenericMethodOpenArgument.cs`). Fail loudly rather than substitute.
+    let private methodSignatureTypeContext
+        (operation : string)
+        (state : IlMachineState)
+        (methodHandleArg : CliType)
+        : DumpedAssembly *
+          MethodInfo<GenericParamFromMetadata, GenericParamFromMetadata, TypeDefn> *
+          MetadataMethodIdentity *
+          ImmutableArray<ConcreteTypeHandle> *
+          ImmutableArray<ConcreteTypeHandle>
+        =
+        let identity =
+            NativeRuntimeMethodHandle.resolveMetadataIdentityFromArg operation state methodHandleArg
+
+        let methodInfo =
+            NativeRuntimeMethodHandle.methodInfoOfMetadataIdentity operation state identity
+
+        let assemblyFullName = identity.GetAssemblyFullName ()
+
+        let assembly =
+            state.LoadedAssembly' assemblyFullName
+            |> Option.defaultWith (fun () -> failwith $"%s{operation}: assembly %s{assemblyFullName} is not loaded")
+
+        let declaringTypeHandle = identity.GetDeclaringType ()
+
+        let typeGenerics =
+            match declaringTypeHandle with
+            | ConcreteTypeHandle.Concrete _ ->
+                match AllConcreteTypes.lookup declaringTypeHandle state.ConcreteTypes with
+                | Some declaringType -> declaringType.Generics
+                | None ->
+                    failwith
+                        $"%s{operation}: declaring type handle %O{declaringTypeHandle} was not concretized, so the method signature cannot be resolved"
+            | ConcreteTypeHandle.Byref _
+            | ConcreteTypeHandle.Pointer _
+            | ConcreteTypeHandle.FunctionPointer _
+            | ConcreteTypeHandle.OneDimArrayZero _
+            | ConcreteTypeHandle.Array _ ->
+                // CoreCLR reaches this via `declType.GetClassOrArrayInstantiation()`, which for an
+                // array type yields its element type as a one-element instantiation, so the
+                // runtime-generated array methods (Get/Set/Address/.ctor) resolve their signatures
+                // against it. PawPrint stores array element types structurally in the handle rather
+                // than as a generic argument vector, so that projection does not exist here.
+                failwith
+                    $"TODO: %s{operation} on a method whose declaring type is the structural type %O{declaringTypeHandle}; CoreCLR resolves such a signature against GetClassOrArrayInstantiation, which PawPrint does not model"
+
+        let methodGenerics = identity.GetMethodGenerics () |> ImmutableArray.CreateRange
+
+        if methodInfo.Generics.Length <> methodGenerics.Length then
+            let plural =
+                if methodInfo.Generics.Length = 1 then
+                    "generic parameter"
+                else
+                    "generic parameters"
+
+            failwith
+                $"TODO: %s{operation} on generic method definition %s{methodInfo.Name}: it declares %d{methodInfo.Generics.Length} %s{plural} but the handle carries %d{methodGenerics.Length} generic argument(s); CoreCLR resolves the signature against the typical instantiation, whose method generic parameters PawPrint's ConcreteTypeHandle cannot represent"
+
+        assembly, methodInfo, identity, typeGenerics, methodGenerics
+
+    /// Populate the Signature object's `_returnTypeORfieldType`, `_arguments`, `_sig`, `_csig`,
+    /// `_pMethod` and calling-convention fields for the method-backed path, mirroring CoreCLR's
+    /// `Signature_Init` (runtimehandles.cpp:1585) when `pMethodDesc != NULL`. `_declaringType` is
+    /// supplied by the managed constructor, so this helper only fills the runtime-derived fields.
+    ///
+    /// The types come from PawPrint's already-parsed `MethodInfo.Signature` rather than from a
+    /// second parse of the COR blob, so a method's reflected parameter types cannot disagree with
+    /// the types the interpreter binds calls against. `_sig`/`_csig` still point at the blob,
+    /// because the byte-level readers (`GetParameterOffsetInternal`,
+    /// `Signature_GetCustomModifiersAtOffset`, `Signature_AreEqual`) work from the bytes.
+    let private fillMethodSignature
+        (ctx : NativeCallContext)
+        (operation : string)
+        (signatureAddr : ManagedHeapAddress)
+        (methodHandleArg : CliType)
+        (state : IlMachineState)
+        : IlMachineState
+        =
+        let assembly, methodInfo, identity, typeGenerics, methodGenerics =
+            methodSignatureTypeContext operation state methodHandleArg
+
+        let concretize (state : IlMachineState) (defn : TypeDefn) : IlMachineState * ConcreteTypeHandle =
+            IlMachineState.concretizeType
+                ctx.LoggerFactory
+                ctx.BaseClassTypes
+                state
+                assembly.Name
+                typeGenerics
+                methodGenerics
+                defn
+
+        // CoreCLR takes the return type from `msig.GetRetTypeHandleThrowing()`, which for a void
+        // return is `System.Void`'s TypeHandle rather than a null one.
+        let state, returnTypeHandle =
+            match methodInfo.Signature.ReturnType with
+            | MethodReturnType.Void ->
+                let state, _, voidHandle =
+                    NativeRuntimeTypeHelpers.concretizeNonGenericCorelibType
+                        ctx.LoggerFactory
+                        ctx.BaseClassTypes
+                        state
+                        "System"
+                        "Void"
+
+                state, voidHandle
+            | MethodReturnType.Returns ret -> concretize state ret
+
+        let returnTypeAddr, state =
+            IlMachineState.getOrAllocateType
+                ctx.LoggerFactory
+                ctx.BaseClassTypes
+                (RuntimeTypeHandleTarget.Closed returnTypeHandle)
+                state
+
+        let state =
+            setSignatureField state signatureAddr "_returnTypeORfieldType" (CliType.ObjectRef (Some returnTypeAddr))
+
+        let state =
+            setSignatureField
+                state
+                signatureAddr
+                "_managedCallingConventionAndArgIteratorFlags"
+                (CliType.Numeric (
+                    CliNumericType.Int32 (managedCallingConventionOfHeader operation methodInfo.Signature.Header.Get)
+                ))
+
+        // CoreCLR allocates the `_arguments` array unconditionally -- `AllocateSzArray(arrayHandle,
+        // nArgs)` with nArgs possibly 0 -- and the managed `Signature.Arguments` getter asserts it
+        // is non-null, so a nullary method must still get an empty array rather than null.
+        let state, _, runtimeTypeElementHandle =
+            NativeRuntimeTypeHelpers.concretizeNonGenericCorelibType
+                ctx.LoggerFactory
+                ctx.BaseClassTypes
+                state
+                "System"
+                "RuntimeType"
+
+        // CoreCLR sizes `_arguments` with `msig.NumFixedArgs()`, i.e. the parameters before any
+        // VARARG sentinel. A MethodDef signature never carries a sentinel -- only a call site's
+        // MemberRef does -- so the two counts coincide here; assert it rather than assume it,
+        // because if they ever diverge we would silently publish the optional parameters as fixed.
+        let parameterTypes = methodInfo.Signature.ParameterTypes
+
+        if List.length parameterTypes <> methodInfo.Signature.RequiredParameterCount then
+            failwith
+                $"%s{operation}: method %s{methodInfo.Name} has %d{List.length parameterTypes} parameter types but %d{methodInfo.Signature.RequiredParameterCount} required parameters; a MethodDef signature was not expected to carry a VARARG sentinel"
+
+        let arrayAddr, state =
+            IlMachineState.allocateArray
+                (ConcreteTypeHandle.OneDimArrayZero runtimeTypeElementHandle)
+                (fun () -> CliType.ObjectRef None)
+                (List.length parameterTypes)
+                state
+
+        let state =
+            ((state, 0), parameterTypes)
+            ||> List.fold (fun (state, index) parameterType ->
+                let state, handle = concretize state parameterType
+
+                let addr, state =
+                    IlMachineState.getOrAllocateType
+                        ctx.LoggerFactory
+                        ctx.BaseClassTypes
+                        (RuntimeTypeHandleTarget.Closed handle)
+                        state
+
+                let state =
+                    IlMachineState.setArrayValue arrayAddr (CliType.ObjectRef (Some addr)) index state
+
+                state, index + 1
+            )
+            |> fst
+
+        let state =
+            setSignatureField state signatureAddr "_arguments" (CliType.ObjectRef (Some arrayAddr))
+
+        let peByteRange =
+            IlMachineState.peByteRangeForMethodSignatureBlob assembly (identity.GetMethodDefinitionHandle().Get)
+
+        let state, sigPointer =
+            IlMachineState.peByteRangePointer ctx.LoggerFactory ctx.BaseClassTypes peByteRange state
+
+        let state =
+            setSignatureField state signatureAddr "_sig" (CliType.RuntimePointer (CliRuntimePointer.Managed sigPointer))
+
+        let state =
+            setSignatureField state signatureAddr "_csig" (CliType.Numeric (CliNumericType.Int32 peByteRange.Size))
+
+        setSignatureField state signatureAddr "_pMethod" methodHandleArg
+
     let tryExecuteQCall (entryPoint : string) (ctx : NativeCallContext) : NativeHandlerResult option =
         let state = ctx.State
         let instruction = ctx.Instruction
@@ -270,29 +515,40 @@ module NativeSignature =
                 | other -> failwith $"%s{operation}: expected ObjectRef in ObjectHandleOnStack, got %O{other}"
 
             requireNullCorSig operation instruction.Arguments.[1] instruction.Arguments.[2]
-            requireNullMethodHandle operation instruction.Arguments.[4]
+
+            // CoreCLR's precedence is `if (pMethodDesc != NULL) ... else if (pFieldDesc != NULL)`,
+            // then a caller-supplied raw blob. PawPrint classifies the inputs explicitly instead,
+            // and refuses both-non-null: no managed `Signature` constructor passes both, so a value
+            // arriving that way would be a PawPrint bug, and silently preferring one would hide it.
+            let methodHandle =
+                NativeCall.methodHandleIdOfRuntimeMethodHandleInternal operation instruction.Arguments.[4]
 
             let fieldHandle =
                 NativeRuntimeFieldHandle.fieldHandleOfRuntimeFieldHandleInternal
                     operation
                     state
                     instruction.Arguments.[3]
-                |> Option.defaultWith (fun () ->
-                    failwith
-                        $"TODO: %s{operation} non-field signature parsing is not implemented; fieldHandle was null, pCorSig=%O{instruction.Arguments.[1]}, cCorSig=%O{instruction.Arguments.[2]}, methodHandle=%O{instruction.Arguments.[4]}"
-                )
 
             let state =
-                fillFieldSignature
-                    ctx
-                    operation
-                    signatureAddr
-                    fieldHandle
-                    "_returnTypeORfieldType"
-                    "_managedCallingConventionAndArgIteratorFlags"
-                    "_sig"
-                    "_csig"
-                    state
+                match methodHandle, fieldHandle with
+                | Some _, Some fieldHandle ->
+                    failwith
+                        $"%s{operation}: got both a field handle and a method handle (field %O{fieldHandle}, methodHandle=%O{instruction.Arguments.[4]}); no managed Signature constructor supplies both"
+                | Some _, None -> fillMethodSignature ctx operation signatureAddr instruction.Arguments.[4] state
+                | None, Some fieldHandle ->
+                    fillFieldSignature
+                        ctx
+                        operation
+                        signatureAddr
+                        fieldHandle
+                        "_returnTypeORfieldType"
+                        "_managedCallingConventionAndArgIteratorFlags"
+                        "_sig"
+                        "_csig"
+                        state
+                | None, None ->
+                    failwith
+                        $"TODO: %s{operation} non-field signature parsing is not implemented; fieldHandle was null, pCorSig=%O{instruction.Arguments.[1]}, cCorSig=%O{instruction.Arguments.[2]}, methodHandle=%O{instruction.Arguments.[4]}"
 
             NativeHandlerResult.completed state |> Some
         | "Signature_GetCustomModifiersAtOffset",
@@ -320,9 +576,12 @@ module NativeSignature =
             // caller `Signature.GetCustomModifiersAtOffset` asserts the result is
             // non-null even when cMods = 0, so we always allocate.
             //
-            // Today PawPrint's `_sig` byref is only populated for field-shaped
-            // signatures (see `Signature_Init` / `GetSignature` above), so we use
-            // the declaring type's instantiation as the type context.
+            // The type context follows `SignatureNative::GetTypeContext`
+            // (runtimehandles.h:388): when `_pMethod` is non-null it is the method's
+            // context (declaring-class instantiation plus method instantiation), and
+            // only otherwise is it the declaring type's alone. Both shapes of `_sig`
+            // reach here -- `Signature_Init` populates it for field-backed and
+            // method-backed signatures alike.
             // CMOD_INTERNAL (0x21) carries a `void*` that points at a runtime-only
             // TypeHandle; CoreCLR's own metadata writer never emits it from PE bytes,
             // so we fail loudly if we encounter one.
@@ -370,44 +629,62 @@ module NativeSignature =
                 | CliType.Numeric (CliNumericType.Int32 v) -> v
                 | other -> failwith $"%s{operation}: expected Int32 in Signature._csig, got %O{other}"
 
-            let declaringTypeFieldId =
-                IlMachineState.requiredOwnInstanceFieldId state signatureObj.ConcreteType "_declaringType"
+            let pMethodFieldId =
+                IlMachineState.requiredOwnInstanceFieldId state signatureObj.ConcreteType "_pMethod"
 
-            let declaringTypeAddr =
-                match AllocatedNonArrayObject.DereferenceFieldById declaringTypeFieldId signatureObj with
-                | CliType.ObjectRef (Some addr) -> addr
-                | CliType.ObjectRef None ->
-                    failwith
-                        $"%s{operation}: Signature._declaringType was null; the field-backed slice always carries a declaring RuntimeType"
-                | other ->
-                    failwith $"%s{operation}: expected RuntimeType ObjectRef in Signature._declaringType, got %O{other}"
+            let pMethod =
+                AllocatedNonArrayObject.DereferenceFieldById pMethodFieldId signatureObj
 
-            let declaringTypeObj = ManagedHeap.get declaringTypeAddr state.ManagedHeap
+            let typeGenerics, methodGenerics =
+                match NativeCall.methodHandleIdOfRuntimeMethodHandleInternal operation pMethod with
+                | Some _ ->
+                    let _, _, _, typeGenerics, methodGenerics =
+                        methodSignatureTypeContext operation state pMethod
 
-            let handleFieldId =
-                IlMachineState.requiredOwnInstanceFieldId state declaringTypeObj.ConcreteType "m_handle"
+                    typeGenerics, methodGenerics
+                | None ->
 
-            let declaringTarget =
-                match
-                    AllocatedNonArrayObject.DereferenceFieldById handleFieldId declaringTypeObj
-                    |> CliType.unwrapPrimitiveLike
-                with
-                | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.TypeHandlePtr target)) -> target
-                | other -> failwith $"%s{operation}: expected TypeHandlePtr in RuntimeType.m_handle, got %O{other}"
+                let declaringTypeFieldId =
+                    IlMachineState.requiredOwnInstanceFieldId state signatureObj.ConcreteType "_declaringType"
 
-            let typeGenerics =
-                match declaringTarget with
-                | RuntimeTypeHandleTarget.Closed handle ->
-                    match AllConcreteTypes.lookup handle state.ConcreteTypes with
-                    | Some ct -> ct.Generics
-                    | None ->
+                let declaringTypeAddr =
+                    match AllocatedNonArrayObject.DereferenceFieldById declaringTypeFieldId signatureObj with
+                    | CliType.ObjectRef (Some addr) -> addr
+                    | CliType.ObjectRef None ->
                         failwith
-                            $"%s{operation}: declaring type handle %O{handle} was not concretized, so custom modifiers cannot be resolved"
-                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ -> ImmutableArray.Empty
-                | RuntimeTypeHandleTarget.GenericParameter _
-                | RuntimeTypeHandleTarget.MethodGenericParameter _ ->
-                    failwith
-                        $"%s{operation}: declaring type %O{declaringTarget} is a generic parameter; the field-backed slice expects a real declaring type"
+                            $"%s{operation}: Signature._declaringType was null; the field-backed slice always carries a declaring RuntimeType"
+                    | other ->
+                        failwith
+                            $"%s{operation}: expected RuntimeType ObjectRef in Signature._declaringType, got %O{other}"
+
+                let declaringTypeObj = ManagedHeap.get declaringTypeAddr state.ManagedHeap
+
+                let handleFieldId =
+                    IlMachineState.requiredOwnInstanceFieldId state declaringTypeObj.ConcreteType "m_handle"
+
+                let declaringTarget =
+                    match
+                        AllocatedNonArrayObject.DereferenceFieldById handleFieldId declaringTypeObj
+                        |> CliType.unwrapPrimitiveLike
+                    with
+                    | CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.TypeHandlePtr target)) -> target
+                    | other -> failwith $"%s{operation}: expected TypeHandlePtr in RuntimeType.m_handle, got %O{other}"
+
+                let typeGenerics =
+                    match declaringTarget with
+                    | RuntimeTypeHandleTarget.Closed handle ->
+                        match AllConcreteTypes.lookup handle state.ConcreteTypes with
+                        | Some ct -> ct.Generics
+                        | None ->
+                            failwith
+                                $"%s{operation}: declaring type handle %O{handle} was not concretized, so custom modifiers cannot be resolved"
+                    | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ -> ImmutableArray.Empty
+                    | RuntimeTypeHandleTarget.GenericParameter _
+                    | RuntimeTypeHandleTarget.MethodGenericParameter _ ->
+                        failwith
+                            $"%s{operation}: declaring type %O{declaringTarget} is a generic parameter; the field-backed slice expects a real declaring type"
+
+                typeGenerics, ImmutableArray.Empty
 
             let assembly, blobHandle = resolveSignatureBlobHandle operation state sigCliValue
             let mdReader = assembly.PeReader.GetMetadataReader ()
@@ -491,7 +768,7 @@ module NativeSignature =
                             state
                             resolvedAssy.Name
                             typeGenerics
-                            ImmutableArray.Empty
+                            methodGenerics
                             typeDefn
 
                     let runtimeTypeAddr, state =

--- a/docs/plans/2026-08-08-signature-init-method-arm.md
+++ b/docs/plans/2026-08-08-signature-init-method-arm.md
@@ -1,0 +1,259 @@
+# The method arm of the `Signature_Init` QCall
+
+## What is blocked, verified rather than assumed
+
+`SprintfBasic` is parked (`TestFSharpPureCases.unimplemented`) on
+
+```
+TODO: Signature_Init method signature parsing is not implemented;
+got non-null Numeric (NativeInt (MethodHandlePtr 25L))
+```
+
+thrown by `requireNullMethodHandle` (`Native/NativeSignature.fs:95`) from the `Signature_Init`
+handler (`:273`). Un-parking and running confirms that this is still where it stops
+(`F# pure tests("SprintfBasic")`, 8 other cases in the fixture pass).
+
+The blocker is not F#-specific. A four-line C# guest
+
+```csharp
+MethodInfo m = typeof (Program).GetMethod ("Twice", ...);
+if (m.ReturnType != typeof (int)) return 2;
+```
+
+stops at exactly the same `failwith`, so the gap is reachable in isolation and does not need
+`sprintf` to exercise it.
+
+## Where the chain actually goes
+
+`RuntimeMethodInfo.Signature` (`RuntimeMethodInfo.CoreCLR.cs:87`) lazily builds
+`new Signature(this, m_declaringType)`, the two-argument constructor that leaves
+`_returnTypeORfieldType` null, so the QCall must run the *full* parse arm: calling convention,
+return type, and the `_arguments` array.
+
+Spiking the method arm (working tree of this branch, uncommitted) shows what each further
+reflection member costs:
+
+| Guest expression | Verdict after this change |
+| --- | --- |
+| `m.ReturnType` (incl. `void`) | passes |
+| `m.CallingConvention` (`Standard`, `Standard\|HasThis`) | passes |
+| `m.GetParameters()` | next blocker: `RuntimeMethodHandle.GetMethodDef` (InternalCall, unimplemented) |
+| ... with that spiked too | next blocker: `MetadataImport.Enum` for token type `0x08000000` (mdtParamDef) with a MethodDef parent — i.e. `EnumParams` |
+
+So **`SprintfBasic` stays parked**; its park comment gets rewritten to name `GetMethodDef` and
+`EnumParams` instead of `Signature_Init`. Those are two further primitives and belong in their own
+changes (`GetMethodDef` is a near-trivial FCall; `EnumParams` is a new `MetadataImport.Enum` token
+type). This PR ships the `Signature_Init` method arm plus a guest test that covers exactly what it
+buys.
+
+## Upstream shape being mirrored
+
+`Signature_Init` (`src/coreclr/vm/runtimehandles.cpp:1585`):
+
+```c
+if (pMethodDesc != NULL)      pMethodDesc->GetSig(&pCorSig, &cCorSig);
+else if (pFieldDesc != NULL)  pFieldDesc->GetSig(&pCorSig, &cCorSig);
+_ASSERTE(pCorSig != NULL && cCorSig > 0);
+gc.pSig->_sig = pCorSig; gc.pSig->_csig = cCorSig; gc.pSig->_pMethod = pMethodDesc;
+if (gc.pSig->_returnTypeORfieldType == NULL) {
+    // SigTypeContext = declType's class instantiation + pMethodDesc->LoadMethodInstantiation()
+    if (callConv == IMAGE_CEE_CS_CALLCONV_FIELD) { ...field arm... }
+    else {
+        gc.pSig->SetCallingConvention(msig.GetCallingConventionInfo());
+        gc.pSig->SetReturnType(msig.GetRetTypeHandleThrowing().GetManagedClassObject());
+        // AllocateSzArray(RuntimeType[], msig.NumFixedArgs()) -- allocated even for 0 args
+        for each fixed arg: gc.pSig->SetArgument(i, ...);
+    }
+}
+```
+
+Two details worth pinning down because they are easy to get wrong:
+
+* `SetCallingConvention` (`runtimehandles.h:455`) is a **translation**, not the raw ECMA byte:
+  `IMAGE_CEE_CS_CALLCONV_VARARG` → `CALLCONV_VarArgs` (0x2), everything else →
+  `CALLCONV_Standard` (0x1), then `|= 0x20` for HASTHIS and `|= 0x40` for EXPLICITTHIS. Note
+  `IMAGE_CEE_CS_CALLCONV_DEFAULT` is 0x0 while `CallingConventions.Standard` is 0x1.
+* the field arm never calls `SetCallingConvention` at all, so a field-backed `Signature` leaves
+  `_managedCallingConventionAndArgIteratorFlags` at 0 (see "pre-existing divergence" below).
+
+## Decisions
+
+### 1. Where do the parameter and return types come from?
+
+* **A (chosen): PawPrint's already-parsed `MethodInfo.Signature`** — `ParameterTypes : TypeDefn list`
+  and `ReturnType : MethodReturnType<TypeDefn>` — fed through `IlMachineState.concretizeType` and
+  `getOrAllocateType`, exactly as `runtimeTypeForField` already does for the field arm.
+* B: parse the COR blob bytes with a `BlobReader`, mirroring `MetaSig`.
+
+A is the "transform canonical data into the right form" option: it reuses the one signature parser
+the interpreter already trusts, so a method's reflected parameter types cannot disagree with the
+types the interpreter binds calls against. B would create a second, independently-drifting
+signature interpretation for the sake of surface similarity to C++. B is genuinely needed one day
+for `Signature(void* pCorSig, int cCorSig, RuntimeType)` (a raw blob with no MethodDesc), which is
+a separate, currently-unreached constructor that keeps failing loudly.
+
+### 2. `_sig` / `_csig`
+
+* **A (chosen): add `PeByteRangePointerSource.MethodSignatureBlob of ComparableMethodDefinitionHandle`**
+  and point `_sig` at the MethodDef's signature blob, mirroring `peByteRangeForFieldSignatureBlob`.
+  The compiler then forces the three existing match sites to be revisited
+  (`ManagedPointerSource.tryContainerAlignmentBits`, `readPeByteRangeBytesAs`,
+  `NativeSignature.resolveSignatureBlobHandle`); alignment bits stay `None` for the same reason the
+  field variant does (a `#Blob`-heap offset PawPrint does not track).
+* B: leave `_sig` null / `_csig` 0.
+
+B is smaller but stores a value real .NET asserts cannot occur (`_ASSERTE(pCorSig != NULL && cCorSig > 0)`),
+and would make the downstream readers (`GetParameterOffsetInternal`, `Signature_AreEqual`,
+`GetCustomModifiersAtOffset`) fail with "not a PE byte range" instead of their own honest
+"non-FIELD calling convention" TODO. A keeps every diagnostic pointing at the real gap.
+
+### 3. Generic methods
+
+`MetadataMethodIdentity` carries `DeclaringType : ConcreteTypeHandle` and
+`MethodGenerics : ConcreteTypeHandle list`, which is the `SigTypeContext` we need — for *closed*
+instantiations. For a generic method **definition** (the handle the introduced-method iterator
+mints, `MethodGenerics = []`), CoreCLR resolves the signature against the typical instantiation,
+whose method generic parameters a `ConcreteTypeHandle` cannot represent — the same limit that parks
+`MakeGenericMethodOpenArgument.cs`.
+
+* **A (chosen): fail loudly** when `methodInfo.Generics.Length <> MethodGenerics.Length`, naming the
+  method and both counts.
+* B: substitute something plausible (e.g. `System.Object`) so the call succeeds.
+
+B would silently hand the guest wrong `RuntimeType`s for `T`. A is "prefer crashing over documented
+divergence", and the failure names the representational gap rather than a symptom.
+
+### 4. Dispatch between the three input shapes
+
+CoreCLR's precedence is `pMethodDesc`, then `pFieldDesc`, then a caller-supplied raw blob. PawPrint
+should classify explicitly:
+
+```
+match methodHandle, fieldHandle with
+| Some m, None    -> method arm
+| None,   Some f  -> field arm
+| Some _, Some _  -> failwith (both non-null; no managed caller does this)
+| None,   None    -> failwith (TODO: raw pCorSig blob, as today)
+```
+
+Refusing "both non-null" is deliberately *stricter* than CoreCLR, which would silently prefer the
+method. No managed constructor passes both, so a value that reached here would be a PawPrint bug,
+and preferring one input would hide it.
+
+This changes one existing test. `TestNativeSignature.fs:462`, ``Signature_Init rejects mixed field
+handle and method handle inputs``, currently passes `NativeInt (Verbatim 1L)` as a "non-null method
+handle" and asserts the `requireNullMethodHandle` message. Its *intent* (both handles non-null is
+refused) survives; it needs a genuine registry handle and the new message. Flagging this because
+changing an existing test deserves scrutiny: the assertion being relaxed is
+"method-shaped input is unimplemented", which is precisely what this change implements.
+
+### 5. `Signature_GetCustomModifiersAtOffset`
+
+That handler builds its type context from `_declaringType` alone and passes empty method generics,
+under a comment saying "`_sig` byref is only populated for field-shaped signatures" — which this
+change falsifies. It stays unreachable from a guest until `GetMethodDef`/`EnumParams` land, so:
+
+* **A (chosen): read `_pMethod`; when non-null, resolve it and pass its method generics**, mirroring
+  `SignatureNative::GetTypeContext` (`runtimehandles.h:388`), and drop the stale comment.
+* B: keep it as-is and only fix the comment, letting a generic method's modifier token fault inside
+  `concretizeType` with an index error.
+
+A is ~10 lines and is what the C++ does; B leaves a knowingly-wrong type context behind a comment.
+Confirmed against the C++ rather than inferred: `Signature_GetCustomModifiersAtOffset`
+(`runtimehandles.cpp:1484`) opens with `gc.pSig->GetTypeContext(&typeContext)`, and that method
+(`runtimehandles.h:388`) branches on `_pMethod` exactly as A does.
+
+## Non-goals
+
+* `RuntimeMethodHandle.GetMethodDef` and `MetadataImport`'s mdtParamDef enumeration — the next two
+  blockers, each its own change.
+* `Signature.GetParameterOffsetInternal`'s non-FIELD calling conventions (already a loud TODO).
+* The raw-blob `Signature(void*, int, RuntimeType)` constructor arm.
+* `_keepAlive`: CoreCLR sets it only for a collectible `LoaderAllocator`, and PawPrint has no
+  collectible assemblies.
+
+## Pre-existing divergence found while reading (deliberately deferred to its own PR)
+
+`fillFieldSignature` writes the **raw ECMA byte** 0x6 into
+`_managedCallingConventionAndArgIteratorFlags`, but CoreCLR's field arm never calls
+`SetCallingConvention`, so a real field-backed `Signature` leaves that field 0. `(CallingConventions)6`
+is `VarArgs | 0x4`, which is not a legal value. It is unobservable today — `FieldInfo` exposes no
+`CallingConvention`, and neither `HasThis()` (6 & 0x20 = 0) nor `GetArgIteratorFlags()` (6 >> 8 = 0)
+changes — so there is no guest-visible test for it, only a `TestNativeSignature` unit assertion.
+Worth fixing; agreed to be its own PR rather than smuggled in here.
+
+## Test plan
+
+Unit (`TestNativeSignature.fs`), driving `tryExecuteQCall` directly — this is the only level at
+which `_arguments`, `_sig` and `_pMethod` are observable at all today:
+
+* a static two-parameter method: `_returnTypeORfieldType`, each `_arguments` element, `_csig`
+  matching the MethodDef blob length, `_sig` resolving back through `resolveSignatureBlobHandle`,
+  `_pMethod` echoing the input handle;
+* a void, zero-argument method: `_arguments` is an allocated length-0 array, not null (CoreCLR
+  always allocates), and `_returnTypeORfieldType` is `System.Void`;
+* the calling-convention translation across static / instance;
+* both-handles-non-null is refused;
+* a generic method definition is refused with the counts in the message.
+
+End-to-end (`sourcesPure/`), covering exactly what the spike proved reachable: `ReturnType` for a
+value type, a reference type and `void`, and `CallingConvention` for a static and an instance
+method. Deliberately no `GetParameters()` — that would park the file on the *next* primitive and
+stop checking this one.
+
+Mutation checks to run before calling it done: swap `callConvStandard`/`callConvVarArgs`, drop the
+`HasThis` bit, return `_arguments` as null, and reverse the parameter fill order — each must kill at
+least one test.
+
+## Results
+
+Shipped as planned, with one addition the mutation pass forced out (below).
+
+Guest coverage: `sourcesPure/ReflectionMethodSignature.cs`, differential against real .NET via
+`TestPureCases.runTest`. It reads `ReturnType` for a value type, a reference type, an array and
+`void`, and `CallingConvention` for a static and an instance method, plus negative controls on the
+VarArgs and ExplicitThis bits. Its methods also carry `ref`/`out` and generic-instantiation
+parameters: `_arguments` is filled eagerly by the QCall, so those parameter shapes are concretized
+on every one of these calls even though `GetParameters()` is not reachable yet.
+
+Unit coverage: `TestNativeSignature.fs` gained a `MethodSignatureHost` type in its fixture source
+plus 11 cases (return type and per-index argument types, void/nullary, the calling-convention
+translation, `_sig`/`_csig`, `_pMethod`, the generic-method-definition refusal, both-handles-non-null,
+and the null-field-handle spellings below). `TestNullaryIlOp.fs` pins `MethodSignatureBlob`'s
+"no alignment claim", matching the field variant.
+
+### Mutation results
+
+| Mutant | Killed by |
+| --- | --- |
+| swap `callConvStandard` / `callConvVarArgs` | both unit calling-convention cases + guest (returns 6) |
+| drop the `HasThis` bit | unit `Instance` case + guest (returns 8) |
+| leave `_arguments` null | two unit cases + guest |
+| reverse the parameter fill order | unit argument-order case + guest |
+| skip the `_pMethod` write-back | unit `_pMethod` case + guest |
+| write 0 into `_csig` | unit `_sig`/`_csig` case + guest |
+| drop the generic-method-definition guard | unit refusal case + guest |
+| narrow `fieldHandleIdOfRuntimeFieldHandleInternal` back | 8 unit cases + guest |
+
+### A bug the guest test caught that the unit tests could not
+
+Switching to the explicit four-way dispatch (decision 4) means classifying *both* handles before
+choosing an arm, where the earlier shape only looked at the field handle if the method handle was
+absent. `NativeCall.fieldHandleIdOfRuntimeFieldHandleInternal` recognised only two of the four
+spellings of a null `RuntimeFieldHandleInternal` — and the one a real guest produces for
+`default(RuntimeFieldHandleInternal)`, `NativeInt (ManagedPointer Null)`, was not among them, so it
+threw instead of answering "no field handle". Its sibling
+`methodHandleIdOfRuntimeMethodHandleInternal` already accepted all four; the asymmetry was latent
+until a caller classified a field handle it was not going to use.
+
+Fixed by widening the field classifier to match its sibling, which is the "keep the classifier's
+contract truthful and load-bearing" rule: a caller dispatching on "did I get a field handle?" needs
+an honest answer for every spelling of null. Every caller already treats `None` as "null handle" and
+fails with its own diagnostic, so nothing else changes.
+
+Two things are worth recording about how this was found. The unit tests all passed with the bug
+present, because the fixture's null field handle used a spelling the classifier happened to list —
+a unit test is only as faithful as the value it feeds in. And the end-to-end case was passing when
+last run *before* the dispatch rewrite; it was the mutation pass, which re-ran it, that surfaced
+the regression. `nullFieldHandleSpellings` now drives a test over all four shapes so the gap cannot
+reopen silently.


### PR DESCRIPTION
`RuntimeMethodInfo.Signature` builds `new Signature(this, m_declaringType)`, the constructor that leaves `_returnTypeORfieldType` null, so its QCall must run the full parse arm against a `MethodDesc`.

## What lands

`fillMethodSignature` fills `_returnTypeORfieldType` (`System.Void` for a void return, as `msig.GetRetTypeHandleThrowing()` yields rather than null), the translated `CallingConventions` bits, an always-allocated `RuntimeType[]` of parameter types, `_sig`/`_csig` over the MethodDef signature blob, and `_pMethod`.

Decisions, with the rejected alternatives recorded in `docs/plans/2026-08-08-signature-init-method-arm.md`:

- **Types come from PawPrint's already-parsed `MethodInfo.Signature`**, not a second `BlobReader` parse of the COR blob. A method's reflected parameter types then cannot disagree with the types the interpreter binds calls against; parsing the blob again would create a second, independently-drifting signature interpretation.
- **`_sig` points at the real blob**, via a new `PeByteRangePointerSource.MethodSignatureBlob`, because the byte-level readers work from bytes. The compiler forces the three existing match sites on that DU to be revisited. Leaving `_sig` null would store a value real .NET asserts cannot occur (`_ASSERTE(pCorSig != NULL && cCorSig > 0)`) and would misdirect every downstream diagnostic.
- **A generic method *definition* is refused.** Its handle carries empty `MethodGenerics` while the method declares type parameters; CoreCLR resolves against the typical instantiation, whose method generic parameters a `ConcreteTypeHandle` cannot name — the same limit that parks `MakeGenericMethodOpenArgument.cs`. Substituting something plausible for `T` would hand the guest wrong `RuntimeType`s.
- **`Signature_GetCustomModifiersAtOffset` now derives its type context from `_pMethod`** when non-null, mirroring `SignatureNative::GetTypeContext` (`runtimehandles.h:388`, called at `runtimehandles.cpp:1484`). Its previous comment claimed `_sig` was only ever field-shaped, which this change falsifies.
- **Dispatch classifies both handles and refuses both-non-null** — stricter than CoreCLR's silent `pMethodDesc`-then-`pFieldDesc` precedence, because no managed constructor passes both, so such a value would be a PawPrint bug that preferring one input would hide.

Two invariants are now machine-checked rather than assumed: the blob's `SignatureKind` must be `Method`, and its parameter count must equal `RequiredParameterCount` (a MethodDef carries no VARARG sentinel).

## Deliberately not here

- **`SprintfBasic` stays parked.** `GetParameters()` next needs `RuntimeMethodHandle.GetMethodDef`, and then `MetadataImport.Enum` for mdtParamDef tokens (`EnumParams`) — both spiked to confirm the order. Its park comment now names those instead of `Signature_Init`.
- A **pre-existing field-arm divergence** found while reading: `fillFieldSignature` writes the raw ECMA byte `0x6` into `_managedCallingConventionAndArgIteratorFlags`, where CoreCLR's field arm never calls `SetCallingConvention` and leaves it `0`. `(CallingConventions)6` is not a legal value. Unobservable from a guest, so it gets its own PR rather than being smuggled in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)