### PR TITLE
Fold the expired-deadline scan instead of piping it through Seq

### DIFF
--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -177,15 +177,25 @@ module Program =
     let private fireExpiredDeadlines (state : IlMachineState) : IlMachineState =
         let now = state.Kernel.VirtualClockMs
 
+        // Written as a fold rather than `Map.toSeq |> Seq.choose |> Seq.toList`, because this
+        // runs on every scheduler tick — i.e. once per interpreted IL instruction — and on the
+        // overwhelmingly common tick nothing has expired at all. That pipeline still allocates
+        // to say so: `Map.toSeq` builds a tree-walking enumerator carrying its own stack,
+        // `Seq.choose` wraps it in a second enumerator plus a closure, and `Seq.toList`
+        // allocates a builder, all to produce an empty list. Measured at ~505 bytes per tick on
+        // a single-threaded guest, and it grows with the thread count.
+        //
+        // `Map.foldBack` visits keys in descending order, so consing during the fold yields the
+        // very same ascending-`ThreadId` list the `Map.toSeq` pipeline produced — which is what
+        // makes this substitution behaviour-preserving outright, rather than only up to the
+        // `sortKey` ordering applied below.
         let expired =
-            state.ThreadState
-            |> Map.toSeq
-            |> Seq.choose (fun (tid, ts) ->
+            (state.ThreadState, [])
+            ||> Map.foldBack (fun tid ts acc ->
                 match waitDeadline ts.Status with
-                | Some (kind, deadline) when deadline <= now -> Some (tid, kind)
-                | _ -> None
+                | Some (kind, deadline) when deadline <= now -> (tid, kind) :: acc
+                | _ -> acc
             )
-            |> Seq.toList
 
         let monitorQueuePosition (LowLevelMonitorId mid as monitorId : LowLevelMonitorId) (thread : ThreadId) : int =
             let monitor = Map.find monitorId state.Kernel.LowLevelMonitors

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -177,18 +177,8 @@ module Program =
     let private fireExpiredDeadlines (state : IlMachineState) : IlMachineState =
         let now = state.Kernel.VirtualClockMs
 
-        // Written as a fold rather than `Map.toSeq |> Seq.choose |> Seq.toList`, because this
-        // runs on every scheduler tick — i.e. once per interpreted IL instruction — and on the
-        // overwhelmingly common tick nothing has expired at all. That pipeline still allocates
-        // to say so: `Map.toSeq` builds a tree-walking enumerator carrying its own stack,
-        // `Seq.choose` wraps it in a second enumerator plus a closure, and `Seq.toList`
-        // allocates a builder, all to produce an empty list. Measured at ~505 bytes per tick on
-        // a single-threaded guest, and it grows with the thread count.
-        //
-        // `Map.foldBack` visits keys in descending order, so consing during the fold yields the
-        // very same ascending-`ThreadId` list the `Map.toSeq` pipeline produced — which is what
-        // makes this substitution behaviour-preserving outright, rather than only up to the
-        // `sortKey` ordering applied below.
+        // `Map.foldBack` visits keys in descending order, so the resulting list is sorted by
+        // thread ID.
         let expired =
             (state.ThreadState, [])
             ||> Map.foldBack (fun tid ts acc ->


### PR DESCRIPTION
`fireExpiredDeadlines` runs on **every scheduler tick** — once per interpreted IL instruction — and on the overwhelmingly common tick nothing has expired at all. It still allocated to say so: `Map.toSeq` builds a tree-walking enumerator carrying its own stack, `Seq.choose` wraps that in a second enumerator plus a closure, and `Seq.toList` allocates a builder, all to produce an empty list.

## Why this shape

`Map.foldBack` visits keys in descending order, so consing during the fold yields the *very same* ascending-`ThreadId` list the old pipeline produced. That is what makes the substitution behaviour-preserving outright, rather than only up to the `sortKey` ordering applied immediately below — worth being precise about, because fire order is guest-observable.

(I originally wrote a comment claiming the input order breaks `sortKey` ties. That was wrong and I removed it: `sortKey` is injective over distinct threads — queue positions are unique within a queue, and the WaitHandle/Join/Sleep arms break by `ThreadId` — so no ties can arise.)

I also first guessed the cost was the four local helper closures (`monitorQueuePosition` and friends) being allocated before the empty-list check. **That was wrong too** — early-outing ahead of them saved 24 B of 505. It is the enumerator chain.

## Measurements

Allocated bytes, deterministic (wall-clock on the dev box is too noisy to A/B), toggled against `origin/main` on the same tree:

| | Before | After |
|---|---|---|
| `fireExpiredDeadlines` stage | 505 B/step | **25 B/step** |
| corelib-heavy guest, total | 12.50 GB | **11.27 GB** (−9.8%) |

Both figures are from a **single-threaded** guest. The scan is O(threads), so a concurrent guest — the case this project exists for — pays more, and this is worth more there. Treat 505 B as the floor.

## Verification

* Full test suite: **2337 passed, 0 failed**.
* I checked the existing suite pins this code path *before* touching it: stubbing `fireExpiredDeadlines` out entirely makes the suite hang rather than fail, because timeout-parked threads then never wake. So the path is covered, if by timeout rather than assertion.
* `codex review`: no actionable defects.

Companion PR (independent, different file) does the same for `Scheduler.onStepOutcome`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)