### PR TITLE
Skip the class-init wake rewrite when nothing is blocked

### DIFF
--- a/WoofWare.PawPrint/Scheduler.fs
+++ b/WoofWare.PawPrint/Scheduler.fs
@@ -535,17 +535,8 @@ module Scheduler =
         // can branch here without a wider refactor.
         | WhatWeDid.Executed
         | WhatWeDid.VoluntaryYield ->
-            // Checked before rewriting, because this runs on every scheduler tick — once per
-            // interpreted IL instruction — and almost never has anything to do. `Map.map` has
-            // no "nothing changed, keep the old tree" path: it rebuilds the entire thread table
-            // unconditionally, and `{ state with ... }` then rebuilds the 25-field
-            // `IlMachineState` around it, to produce a value equal to the one that went in.
-            // That was ~312 bytes per tick with a single thread, and both the scan and the
-            // rebuild are O(threads), so a concurrent guest pays more.
-            //
-            // `Map.exists` short-circuits on the first match and allocates nothing, so the
-            // no-op case now costs a walk instead of a copy. When something *is* blocked on
-            // `ran` the original rewrite runs unchanged.
+            // This runs on every scheduler tick (once per interpreted IL instruction),
+            // and almost never has anything to do, so short-circuit first.
             let anyBlockedOnRan =
                 state.ThreadState
                 |> Map.exists (fun _ ts ->

--- a/WoofWare.PawPrint/Scheduler.fs
+++ b/WoofWare.PawPrint/Scheduler.fs
@@ -535,6 +535,29 @@ module Scheduler =
         // can branch here without a wider refactor.
         | WhatWeDid.Executed
         | WhatWeDid.VoluntaryYield ->
+            // Checked before rewriting, because this runs on every scheduler tick — once per
+            // interpreted IL instruction — and almost never has anything to do. `Map.map` has
+            // no "nothing changed, keep the old tree" path: it rebuilds the entire thread table
+            // unconditionally, and `{ state with ... }` then rebuilds the 25-field
+            // `IlMachineState` around it, to produce a value equal to the one that went in.
+            // That was ~312 bytes per tick with a single thread, and both the scan and the
+            // rebuild are O(threads), so a concurrent guest pays more.
+            //
+            // `Map.exists` short-circuits on the first match and allocates nothing, so the
+            // no-op case now costs a walk instead of a copy. When something *is* blocked on
+            // `ran` the original rewrite runs unchanged.
+            let anyBlockedOnRan =
+                state.ThreadState
+                |> Map.exists (fun _ ts ->
+                    match ts.Status with
+                    | ThreadStatus.BlockedOnClassInit blocker -> blocker = ran
+                    | _ -> false
+                )
+
+            if not anyBlockedOnRan then
+                state
+            else
+
             let threadState =
                 state.ThreadState
                 |> Map.map (fun _ ts ->


### PR DESCRIPTION
Companion to #839 — independent change, different file.

`Scheduler.onStepOutcome`'s `Executed`/`VoluntaryYield` arm ran `Map.map` over the whole thread table on **every scheduler tick** — once per interpreted IL instruction — to wake any thread `BlockedOnClassInit` on the thread that just ran. Almost always there is nothing to wake, but `Map.map` has no "nothing changed, keep the old tree" path: it rebuilds the entire table unconditionally, and `{ state with ThreadState = ... }` then rebuilds the 25-field `IlMachineState` around it, to produce a value equal to the one that went in.

`Map.exists` short-circuits on the first match and allocates nothing, so the no-op case now costs a walk instead of a copy. When something *is* blocked on `ran`, the original rewrite runs unchanged.

## Measurements

Allocated bytes, deterministic (wall-clock on the dev box is too noisy to A/B), toggled against `origin/main` on the same tree:

| | Before | After |
|---|---|---|
| `onStepOutcome` stage | 312 B/step | **24 B/step** |
| corelib-heavy guest, total | 12.50 GB | **11.72 GB** (−6.2%) |

Both figures come from a **single-threaded** guest, where the thread table has one entry. The `Map.exists` scan and the `Map.map` rebuild are each O(threads), so a concurrent guest — the case this project exists for — pays more and gains more. Treat 312 B as the floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)