### PR TITLE
Honour the guest's yield declarations in the scheduler

### DIFF
--- a/WoofWare.PawPrint.App/DebuggerServer.fs
+++ b/WoofWare.PawPrint.App/DebuggerServer.fs
@@ -370,7 +370,7 @@ module DebuggerServer =
                 match whatWeDid with
                 | WhatWeDid.BlockedOnClassInit blocker -> Some (threadIdValue blocker)
                 | WhatWeDid.Executed
-                | WhatWeDid.VoluntaryYield
+                | WhatWeDid.VoluntaryYield _
                 | WhatWeDid.SuspendedForClassInit
                 | WhatWeDid.SuspendedForManagedCall
                 | WhatWeDid.ThrowingTypeInitializationException -> None

--- a/WoofWare.PawPrint.Test/TestLowLevelMonitor.fs
+++ b/WoofWare.PawPrint.Test/TestLowLevelMonitor.fs
@@ -40,6 +40,7 @@ module TestLowLevelMonitor =
     let private stubThreadState (status : ThreadStatus) : ThreadState =
         {
             MethodStates = Map.empty
+            YieldDebt = Set.empty
             NextFrameId = 0
             ActiveMethodState = FrameId -1
             Status = status

--- a/WoofWare.PawPrint.Test/TestNativeThreadYield.fs
+++ b/WoofWare.PawPrint.Test/TestNativeThreadYield.fs
@@ -121,20 +121,31 @@ public static class Entry
 
         let stateAfter =
             match NativeThreading.tryExecuteQCall "ThreadNative_YieldThread" ctx with
-            | Some (NativeHandlerResult.Yielded (state, effect)) ->
+            | Some (NativeHandlerResult.Yielded (state, reportsSwitch, effect)) ->
                 // The handler must not emit any externally-observable effect — Thread.Yield is
                 // a scheduler hint, not an I/O operation. The dispatcher will translate
-                // `Yielded` into `ExecutionResult.Stepped (_, WhatWeDid.VoluntaryYield, effect)`,
+                // `Yielded` into `ExecutionResult.Stepped (_, WhatWeDid.VoluntaryYield _, effect)`,
                 // so any non-`NoEffect` here would leak through to the driver.
                 effect |> shouldEqual StepEffect.NoEffect
+                // `Thread.Yield()` returns Interop.BOOL, so the handler owes the scheduler an
+                // optimistic slot to rewrite with the real answer. Asserting the flag here
+                // pins the half of the contract that lives on this side of the seam.
+                reportsSwitch |> shouldEqual true
                 state
             | Some other -> failwith $"unexpected ThreadNative_YieldThread execution result: %O{other}"
             | None -> failwith "ThreadNative_YieldThread QCall did not match"
 
         let returnValue, _ = IlMachineState.popEvalStack prepared.EntryThread stateAfter
 
-        // Interop.BOOL.FALSE is Int32 0; pushed by the handler so the IL caller's
-        // `YieldInternal() != Interop.BOOL.FALSE` evaluates to `false`. Returning TRUE here
-        // would lie under the current `Scheduler.chooseNext` contract (no guarantee a
-        // different thread will run before the yielder observes the return).
+        // Interop.BOOL.FALSE is Int32 0, so the IL caller's
+        // `YieldInternal() != Interop.BOOL.FALSE` evaluates to `false`.
+        //
+        // This is the handler's *optimistic* push, not the final answer: the handler cannot
+        // know whether a switch will happen, so it pushes FALSE and
+        // `Scheduler.onStepOutcome` rewrites the slot to TRUE iff it charges a yield debt.
+        // Here that rewrite has deliberately not run — we invoked the QCall directly rather
+        // than going through the driver — so FALSE is what we must see. It is also the
+        // correct *final* answer for this state, since the entry thread is the only Runnable
+        // thread and a yield with nobody to yield to switches to nobody.
+        // `TestSchedulerYieldDebt` covers the TRUE case, where a peer is Runnable.
         returnValue |> shouldEqual (EvalStackValue.Int32 (Int32Source.Verbatim 0))

--- a/WoofWare.PawPrint.Test/TestSchedulerPct.fs
+++ b/WoofWare.PawPrint.Test/TestSchedulerPct.fs
@@ -147,6 +147,7 @@ module TestSchedulerPct =
     let private stubThreadState (status : ThreadStatus) : ThreadState =
         {
             MethodStates = Map.empty
+            YieldDebt = Set.empty
             NextFrameId = 0
             ActiveMethodState = FrameId -1
             Status = status

--- a/WoofWare.PawPrint.Test/TestSchedulerVoluntaryYield.fs
+++ b/WoofWare.PawPrint.Test/TestSchedulerVoluntaryYield.fs
@@ -34,6 +34,7 @@ module TestSchedulerVoluntaryYield =
     let private stubThreadState (status : ThreadStatus) : ThreadState =
         {
             MethodStates = Map.empty
+            YieldDebt = Set.empty
             NextFrameId = 0
             ActiveMethodState = FrameId -1
             Status = status
@@ -73,7 +74,7 @@ module TestSchedulerVoluntaryYield =
                     t2, ThreadStatus.BlockedOnClassInit t0
                 ]
 
-        let after = Scheduler.onStepOutcome t0 WhatWeDid.VoluntaryYield state
+        let after = Scheduler.onStepOutcome t0 (WhatWeDid.VoluntaryYield false) state
 
         // Yielder's own status is untouched — VoluntaryYield is a hint, not a self-block.
         statusOf t0 after |> shouldEqual ThreadStatus.Runnable
@@ -94,19 +95,23 @@ module TestSchedulerVoluntaryYield =
                     t2, ThreadStatus.BlockedOnClassInit t1
                 ]
 
-        let after = Scheduler.onStepOutcome t0 WhatWeDid.VoluntaryYield state
+        let after = Scheduler.onStepOutcome t0 (WhatWeDid.VoluntaryYield false) state
 
         statusOf t0 after |> shouldEqual ThreadStatus.Runnable
         statusOf t1 after |> shouldEqual ThreadStatus.Runnable
         statusOf t2 after |> shouldEqual (ThreadStatus.BlockedOnClassInit t1)
 
     [<Test>]
-    let ``VoluntaryYield wakes match Executed exactly`` () : unit =
-        // Belt-and-braces: the scheduler comment promises VoluntaryYield is identical to
-        // Executed for wake-up purposes today. Compare both outcomes on the same input
-        // so a future divergence is caught even if the explicit assertions above are
-        // edited around. Snapshot all three threads' statuses to keep the assertion
-        // total rather than spot-checking.
+    let ``VoluntaryYield wakes match Executed exactly, and only the wakes`` () : unit =
+        // VoluntaryYield used to be *wholly* identical to Executed; it no longer is, because
+        // a yield now also charges the yielder a `YieldDebt`. What must stay identical is the
+        // class-init wake behaviour: yielding is still forward progress, so the same threads
+        // wake either way. Pinning both halves separately is the point — the wake logic must
+        // not drift, and the debt must be the *only* difference, so a future change that
+        // (say) parked the yielder would fail here rather than passing a statuses-only check.
+        //
+        // Snapshot all three threads' statuses to keep the wake assertion total rather than
+        // spot-checking.
         let state =
             baseState ()
             |> withThreads
@@ -116,13 +121,26 @@ module TestSchedulerVoluntaryYield =
                     t2, ThreadStatus.BlockedOnClassInit t1
                 ]
 
-        let afterYield = Scheduler.onStepOutcome t0 WhatWeDid.VoluntaryYield state
+        let afterYield = Scheduler.onStepOutcome t0 (WhatWeDid.VoluntaryYield false) state
         let afterExecuted = Scheduler.onStepOutcome t0 WhatWeDid.Executed state
 
         let statuses (s : IlMachineState) =
             [ t0 ; t1 ; t2 ] |> List.map (fun tid -> statusOf tid s)
 
         statuses afterYield |> shouldEqual (statuses afterExecuted)
+
+        // The debt names t1: it was woken by this very step, so it is part of the run queue
+        // the yielder goes to the back of. t2 is still blocked behind t1 and so is not owed a
+        // turn. Executed charges nothing.
+        let debtOf (tid : ThreadId) (s : IlMachineState) : Set<ThreadId> = s.ThreadState.[tid].YieldDebt
+
+        debtOf t0 afterYield |> shouldEqual (Set.ofList [ t1 ])
+        debtOf t0 afterExecuted |> shouldEqual Set.empty
+
+        // Nobody else is charged anything, either way.
+        for tid in [ t1 ; t2 ] do
+            debtOf tid afterYield |> shouldEqual Set.empty
+            debtOf tid afterExecuted |> shouldEqual Set.empty
 
     [<Test>]
     let ``onWorkerSpawned treats VoluntaryYield init outcome as Runnable`` () : unit =
@@ -136,6 +154,6 @@ module TestSchedulerVoluntaryYield =
             baseState ()
             |> withThreads [ t0, ThreadStatus.Runnable ; t1, ThreadStatus.Runnable ]
 
-        let after = Scheduler.onWorkerSpawned t1 WhatWeDid.VoluntaryYield state
+        let after = Scheduler.onWorkerSpawned t1 (WhatWeDid.VoluntaryYield false) state
 
         statusOf t1 after |> shouldEqual ThreadStatus.Runnable

--- a/WoofWare.PawPrint.Test/TestSchedulerYieldDebt.fs
+++ b/WoofWare.PawPrint.Test/TestSchedulerYieldDebt.fs
@@ -432,3 +432,38 @@ module TestSchedulerYieldDebt =
             ||> List.fold (fun s tid -> Scheduler.onStepOutcome tid WhatWeDid.Executed s)
 
         after.Scheduling |> shouldEqual (SchedulerState.Pct (PctState.ofSeed 99UL))
+
+    [<Test>]
+    let ``a terminating thread is pruned from every outstanding debt`` () : unit =
+        // A thread's final step is its bottom-frame `Ret`, which the driver routes through
+        // `onThreadTerminated` rather than `onStepOutcome` — so the one step that most
+        // conclusively satisfies "I am waiting to see you run" is the one step that would
+        // otherwise discharge nothing.
+        //
+        // Correctness does not depend on this (a Terminated thread is never in the Runnable
+        // set, so `candidates` ignores it either way, and the two assertions on `chooseNext`
+        // below pass with or without the pruning). Cost does: a debt that keeps a
+        // permanently-unrunnable member never goes empty, so its owner misses the `IsEmpty`
+        // fast path in `debtDischarged` for the rest of the run and scans the runnable list on
+        // every scheduling decision. Assert on the debt itself, not just on the choice, or the
+        // regression is invisible.
+        let state = baseState () |> withThreads (runnable 3)
+
+        let state =
+            Scheduler.onStepOutcome (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
+
+        debtOf (ThreadId 0) state
+        |> shouldEqual (Set.ofList [ ThreadId 1 ; ThreadId 2 ])
+
+        let state = Scheduler.onThreadTerminated (ThreadId 1) state
+
+        debtOf (ThreadId 0) state |> shouldEqual (Set.ofList [ ThreadId 2 ])
+
+        // Thread 2 still owes a step, so thread 0 stays excluded; once it runs, the debt is
+        // empty rather than merely ignorable.
+        Scheduler.chooseNext (ThreadId 2) state
+        |> snd
+        |> shouldEqual (Some (ThreadId 2))
+
+        let state = Scheduler.onStepOutcome (ThreadId 2) WhatWeDid.Executed state
+        debtOf (ThreadId 0) state |> shouldEqual Set.empty

--- a/WoofWare.PawPrint.Test/TestSchedulerYieldDebt.fs
+++ b/WoofWare.PawPrint.Test/TestSchedulerYieldDebt.fs
@@ -1,0 +1,434 @@
+namespace WoofWare.PawPrint.Test
+
+open System.Collections.Immutable
+open FsCheck
+open FsCheck.FSharp
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+/// Pins the yield-debt fairness filter: an honoured `Thread.Yield()` / `Thread.Sleep(0)`
+/// sends the caller to the back of the run queue, and the scheduler holds it out of the
+/// candidate set until the threads that were Runnable alongside it have each taken a step.
+///
+/// The two defects this fixture exists to prevent are both liveness bugs that a
+/// weaker-but-plausible design walks straight into, so they are pinned as properties rather
+/// than as examples:
+///
+///   * *Exclusion bounded by other threads **yielding** rather than **running**.* A rule that
+///     re-admits a yielder only once every runnable thread has also yielded lets one
+///     non-yielding busy-waiter exclude it forever: `Thread.Yield(); f = true;` racing
+///     `while (!f) {}` livelocks, where today it terminates. `bounded exclusion under
+///     RoundRobin` is the property that catches this — note its generators deliberately
+///     include threads that never yield.
+///   * *Debt surviving a park/wake cycle.* A yielder that blocks and later wakes must not
+///     still be held out by peers that have since run or blocked themselves. Rather than
+///     clear debt in every wake path, membership is filtered against the live Runnable set at
+///     read time, so a member that stops being Runnable stops counting.
+///
+/// `chooseNext`'s `Pct` branch calls `ThreadState.peekNextOp`, which needs a live frame, so
+/// the properties here drive `RoundRobin` (whose choice rule is total over frameless stubs)
+/// and cover `Pct` through `onStepOutcome`, which touches no frames. That split mirrors
+/// `TestSchedulerPct`.
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestSchedulerYieldDebt =
+
+    let private corelib : DumpedAssembly =
+        let corelibPath = typeof<obj>.Assembly.Location
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        Assembly.readFile loggerFactory corelibPath
+
+    let private baseState () : IlMachineState =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        IlMachineState.initial loggerFactory ImmutableArray.Empty corelib
+
+    /// Frame-less stub thread state. See `TestSchedulerVoluntaryYield.stubThreadState`: the
+    /// paths under test here read `Status` and `YieldDebt` only, so a sentinel FrameId that
+    /// would crash loudly on dereference is the right stub.
+    let private stubThreadState (status : ThreadStatus) : ThreadState =
+        {
+            MethodStates = Map.empty
+            YieldDebt = Set.empty
+            NextFrameId = 0
+            ActiveMethodState = FrameId -1
+            Status = status
+            IsBackground = false
+            Name = None
+            Cpu = CpuId 0
+            OsThreadId = OsThreadId 1u
+        }
+
+    let private withThreads (threads : (ThreadId * ThreadStatus) list) (state : IlMachineState) : IlMachineState =
+        { state with
+            ThreadState =
+                threads
+                |> List.map (fun (tid, status) -> tid, stubThreadState status)
+                |> Map.ofList
+        }
+
+    let private debtOf (tid : ThreadId) (state : IlMachineState) : Set<ThreadId> = state.ThreadState.[tid].YieldDebt
+
+    let private runnable (n : int) : (ThreadId * ThreadStatus) list =
+        List.init n (fun i -> ThreadId i, ThreadStatus.Runnable)
+
+    // ---------------- Charging ----------------
+
+    [<Test>]
+    let ``an honoured yield charges a debt naming every other Runnable thread`` () : unit =
+        // Blocked threads are not in the run queue, so the yielder owes them nothing — it is
+        // not waiting for them, and waiting would be a liveness bug if they never wake.
+        let state =
+            baseState ()
+            |> withThreads
+                [
+                    ThreadId 0, ThreadStatus.Runnable
+                    ThreadId 1, ThreadStatus.Runnable
+                    ThreadId 2, ThreadStatus.BlockedOnJoin (ThreadId 0, None)
+                ]
+
+        let after =
+            Scheduler.onStepOutcome (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
+
+        debtOf (ThreadId 0) after |> shouldEqual (Set.ofList [ ThreadId 1 ])
+        debtOf (ThreadId 1) after |> shouldEqual Set.empty
+        debtOf (ThreadId 2) after |> shouldEqual Set.empty
+
+    [<Test>]
+    let ``yielding with no other Runnable thread charges nothing`` () : unit =
+        // There is nobody to go to the back of the queue behind. This is the case that makes
+        // `Thread.Yield()` honestly return FALSE, and it must not produce an empty-but-present
+        // debt that `candidates` would then have to reason about.
+        let state =
+            baseState ()
+            |> withThreads
+                [
+                    ThreadId 0, ThreadStatus.Runnable
+                    ThreadId 1, ThreadStatus.BlockedOnSleep (Some 100L)
+                ]
+
+        let after =
+            Scheduler.onStepOutcome (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
+
+        debtOf (ThreadId 0) after |> shouldEqual Set.empty
+
+    // ---------------- Filtering and discharge ----------------
+
+    [<Test>]
+    let ``a thread with outstanding debt is not chosen`` () : unit =
+        let state = baseState () |> withThreads (runnable 3)
+
+        let state =
+            Scheduler.onStepOutcome (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
+
+        // Round-robin from `lastRan = 2` would wrap to thread 0; the debt must override that.
+        Scheduler.chooseNext (ThreadId 2) state
+        |> snd
+        |> shouldEqual (Some (ThreadId 1))
+
+    [<Test>]
+    let ``debt is discharged by its members running, re-admitting the yielder`` () : unit =
+        let state = baseState () |> withThreads (runnable 3)
+
+        let state =
+            Scheduler.onStepOutcome (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
+
+        debtOf (ThreadId 0) state
+        |> shouldEqual (Set.ofList [ ThreadId 1 ; ThreadId 2 ])
+
+        let state = Scheduler.onStepOutcome (ThreadId 1) WhatWeDid.Executed state
+        debtOf (ThreadId 0) state |> shouldEqual (Set.ofList [ ThreadId 2 ])
+        // Still excluded: thread 2 has not had its turn.
+        Scheduler.chooseNext (ThreadId 2) state
+        |> snd
+        |> shouldEqual (Some (ThreadId 1))
+
+        let state = Scheduler.onStepOutcome (ThreadId 2) WhatWeDid.Executed state
+        debtOf (ThreadId 0) state |> shouldEqual Set.empty
+
+        Scheduler.chooseNext (ThreadId 2) state
+        |> snd
+        |> shouldEqual (Some (ThreadId 0))
+
+    [<Test>]
+    let ``a debt member that stops being Runnable stops counting`` () : unit =
+        // The park/wake defect, pinned directly: thread 1 blocks without ever taking another
+        // step, so it can never discharge the debt by running. It must stop holding thread 0
+        // out anyway, or thread 0 waits on a thread that will never satisfy it.
+        let state = baseState () |> withThreads (runnable 2)
+
+        let state =
+            Scheduler.onStepOutcome (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
+
+        debtOf (ThreadId 0) state |> shouldEqual (Set.ofList [ ThreadId 1 ])
+
+        let state = Scheduler.blockOnJoin (ThreadId 1) (ThreadId 0) None state
+
+        // The debt still names thread 1 — we do not rewrite it — but the filter ignores it.
+        debtOf (ThreadId 0) state |> shouldEqual (Set.ofList [ ThreadId 1 ])
+
+        Scheduler.chooseNext (ThreadId 0) state
+        |> snd
+        |> shouldEqual (Some (ThreadId 0))
+
+    [<Test>]
+    let ``a yielder that is the only Runnable thread is still chosen`` () : unit =
+        // Degenerate case of the never-empty invariant: `candidates` must not starve the
+        // machine when the sole runnable thread has just yielded.
+        let state = baseState () |> withThreads (runnable 2)
+
+        let state =
+            Scheduler.onStepOutcome (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
+
+        let state = Scheduler.blockOnJoin (ThreadId 1) (ThreadId 0) None state
+
+        Scheduler.chooseNext (ThreadId 0) state
+        |> snd
+        |> shouldEqual (Some (ThreadId 0))
+
+    [<Test>]
+    let ``lockstep yielders alternate rather than deadlocking`` () : unit =
+        // Two threads that do nothing but yield at each other. Under one-core `sched_yield`
+        // this is strict alternation; under a rule that waited for mutual yields it would be
+        // fine too, which is why this case alone is not enough — see the property below.
+        let mutable state = baseState () |> withThreads (runnable 2)
+        let mutable lastRan = ThreadId 1
+        let chosen = ResizeArray ()
+
+        for _ in 1..6 do
+            let s, choice = Scheduler.chooseNext lastRan state
+            let choice = Option.get choice
+            chosen.Add choice
+            lastRan <- choice
+            state <- Scheduler.onStepOutcome choice (WhatWeDid.VoluntaryYield false) s
+
+        chosen
+        |> List.ofSeq
+        |> shouldEqual [ ThreadId 0 ; ThreadId 1 ; ThreadId 0 ; ThreadId 1 ; ThreadId 0 ; ThreadId 1 ]
+
+    // ---------------- Properties ----------------
+
+    /// One thread's behaviour in a generated schedule. `NeverYields` is the load-bearing case:
+    /// the livelock the epoch design suffered needs a peer that only ever executes.
+    type private Behaviour =
+        | AlwaysYields
+        | NeverYields
+        | YieldsThenExecutes
+
+    let private behaviourGen : Gen<Behaviour> =
+        Gen.elements
+            [
+                Behaviour.AlwaysYields
+                Behaviour.NeverYields
+                Behaviour.YieldsThenExecutes
+            ]
+
+    let private scheduleGen : Gen<Behaviour list> =
+        gen {
+            let! n = Gen.choose (1, 5)
+            return! Gen.listOfLength n behaviourGen
+        }
+
+    [<Test>]
+    let ``bounded exclusion under RoundRobin`` () : unit =
+        // The property the epoch design fails. Every thread stays Runnable throughout, so any
+        // thread that goes unchosen for more than `n` consecutive decisions is being starved
+        // by the filter itself rather than by the policy.
+        //
+        // `n` (not `n + 1`) is the right bound: with every thread Runnable, round-robin's
+        // sweep visits each candidate once, and a debt charged during that sweep names only
+        // threads that are themselves in it.
+        let config = Config.QuickThrowOnFailure
+
+        let property (behaviours : Behaviour list) : unit =
+            let n = behaviours.Length
+            let mutable state = baseState () |> withThreads (runnable n)
+            let mutable lastRan = ThreadId (n - 1)
+            let lastChosenAt = System.Collections.Generic.Dictionary<ThreadId, int> ()
+
+            for i in 0 .. n - 1 do
+                lastChosenAt.[ThreadId i] <- -1
+
+            for step in 0 .. (6 * n) - 1 do
+                let s, choice = Scheduler.chooseNext lastRan state
+
+                match choice with
+                | None -> failwith "every thread is Runnable, so a choice must exist"
+                | Some choice ->
+
+                lastChosenAt.[choice] <- step
+                lastRan <- choice
+
+                let outcome =
+                    match behaviours.[let (ThreadId i) = choice in i] with
+                    | Behaviour.AlwaysYields -> WhatWeDid.VoluntaryYield false
+                    | Behaviour.NeverYields -> WhatWeDid.Executed
+                    | Behaviour.YieldsThenExecutes ->
+                        if step % 2 = 0 then
+                            WhatWeDid.VoluntaryYield false
+                        else
+                            WhatWeDid.Executed
+
+                state <- Scheduler.onStepOutcome choice outcome s
+
+                // Everyone that has already had a turn must have had one within the last `n`
+                // decisions. Threads not yet chosen at all are covered by the end-state check.
+                for KeyValue (tid, at) in lastChosenAt do
+                    if at >= 0 && step - at > n then
+                        failwith
+                            $"thread %O{tid} was continuously Runnable but went unchosen for %d{step - at} decisions (bound %d{n}); behaviours %A{behaviours}"
+
+            // And nobody was excluded for the whole run.
+            for KeyValue (tid, at) in lastChosenAt do
+                if at < 0 then
+                    failwith $"thread %O{tid} was continuously Runnable but never chosen; behaviours %A{behaviours}"
+
+        Check.One (config, Prop.forAll (Arb.fromGen scheduleGen) property)
+
+    [<Test>]
+    let ``chooseNext returns a choice whenever any thread is Runnable`` () : unit =
+        // `candidates` promises never to empty a non-empty Runnable set; if it could, the
+        // driver would report a spurious deadlock. Threads block and wake during the run so
+        // that debts routinely name threads that are no longer Runnable.
+        let config = Config.QuickThrowOnFailure
+
+        let property (behaviours : Behaviour list) : unit =
+            let n = behaviours.Length
+            let mutable state = baseState () |> withThreads (runnable n)
+            let mutable lastRan = ThreadId (n - 1)
+
+            for step in 0 .. (6 * n) - 1 do
+                // Park and wake a thread on alternating rounds to churn the Runnable set.
+                if n > 1 && step % 3 = 0 then
+                    let victim = ThreadId (step % n)
+
+                    state <-
+                        if
+                            state.ThreadState.[victim].Status = ThreadStatus.Runnable
+                            && Scheduler.hasAnyRunnable (Scheduler.blockOnSleep victim (Some 1L) state)
+                        then
+                            Scheduler.blockOnSleep victim (Some 1L) state
+                        else
+                            state
+
+                if step % 5 = 0 then
+                    let sleeper = ThreadId (step % n)
+
+                    state <-
+                        match state.ThreadState.[sleeper].Status with
+                        | ThreadStatus.BlockedOnSleep (Some _) -> Scheduler.fireSleepTimeout sleeper state
+                        | _ -> state
+
+                let s, choice = Scheduler.chooseNext lastRan state
+
+                Scheduler.hasAnyRunnable s |> shouldEqual choice.IsSome
+
+                match choice with
+                | None -> ()
+                | Some choice ->
+                    lastRan <- choice
+
+                    let outcome =
+                        match behaviours.[let (ThreadId i) = choice in i] with
+                        | Behaviour.NeverYields -> WhatWeDid.Executed
+                        | _ -> WhatWeDid.VoluntaryYield false
+
+                    state <- Scheduler.onStepOutcome choice outcome s
+
+        Check.One (config, Prop.forAll (Arb.fromGen scheduleGen) property)
+
+    // ---------------- Pct: the honour coin ----------------
+
+    /// Seeds chosen by enumeration so that the first `nextDouble` lands either side of
+    /// `P_HONOUR_YIELD`. Pinning concrete seeds rather than sampling keeps this a
+    /// deterministic test of a deterministic function — the coin is a pure function of the
+    /// splitmix64 state — and gives a two-sided assertion: a regression to *always* honouring
+    /// fails the decline case, and one to *never* honouring fails the honour case.
+    let private seedWhere (wantHonour : bool) : uint64 =
+        let rec go (seed : uint64) : uint64 =
+            if seed > 10000UL then
+                failwith $"no seed below 10000 produces honour=%b{wantHonour}"
+            else
+
+            let sample, _ = NonCryptoRandom.nextDouble seed
+
+            if (sample < 0.9) = wantHonour then
+                seed
+            else
+                go (seed + 1UL)
+
+        go 0UL
+
+    let private pctYield (seed : uint64) : Set<ThreadId> =
+        let state =
+            baseState () |> withThreads (runnable 2) |> IlMachineState.withPctSeed seed
+
+        Scheduler.onStepOutcome (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
+        |> debtOf (ThreadId 0)
+
+    [<Test>]
+    let ``Pct honours a yield on one seed and declines on another`` () : unit =
+        pctYield (seedWhere true) |> shouldEqual (Set.ofList [ ThreadId 1 ])
+
+        // The decline is the point: schedules in which a yield is *not* respected are real
+        // executions — it is why `Thread.Yield()` returns a bool — so the exploration policy
+        // must be able to produce them. Without this half, a regression to honouring
+        // unconditionally would pass every other test in this fixture.
+        pctYield (seedWhere false) |> shouldEqual Set.empty
+
+    [<Test>]
+    let ``RoundRobin honours every yield and consumes no randomness`` () : unit =
+        // RoundRobin is the reproducible baseline and is documented as drawing no random
+        // numbers at all, so it takes no coin: it always honours. The asymmetry with Pct is
+        // deliberate, and this pins it against a well-meaning refactor that unified the two
+        // through a shared sampling path with p = 1.0.
+        let state = baseState () |> withThreads (runnable 2)
+
+        let after =
+            Scheduler.onStepOutcome (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
+
+        debtOf (ThreadId 0) after |> shouldEqual (Set.ofList [ ThreadId 1 ])
+        after.Scheduling |> shouldEqual SchedulerState.RoundRobin
+
+    [<Test>]
+    let ``Pct burns exactly one draw per yield, regardless of the Runnable set`` () : unit =
+        // Matching the always-burn Bernoulli in `chooseNext`: the seed must be consumed at a
+        // rate that depends only on the sequence of yields, so that a replay does not diverge
+        // because a thread happened to be blocked at one of them.
+        let rngAfter (threads : (ThreadId * ThreadStatus) list) : uint64 =
+            let state =
+                baseState () |> withThreads threads |> IlMachineState.withPctSeed 12345UL
+
+            let after =
+                Scheduler.onStepOutcome (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
+
+            match after.Scheduling with
+            | SchedulerState.Pct pct -> pct.Rng
+            | other -> failwith $"expected Pct scheduling, got %O{other}"
+
+        let withPeer = rngAfter (runnable 2)
+
+        let alone =
+            rngAfter
+                [
+                    ThreadId 0, ThreadStatus.Runnable
+                    ThreadId 1, ThreadStatus.BlockedOnSleep (Some 5L)
+                ]
+
+        withPeer |> shouldEqual alone
+
+        let _, expected = NonCryptoRandom.nextDouble 12345UL
+        withPeer |> shouldEqual expected
+
+    [<Test>]
+    let ``a Pct run with no yields consumes the RNG exactly as before`` () : unit =
+        // Property 4 from the plan: the filter itself must draw nothing, so a guest that never
+        // yields replays bit-identically against seeds recorded before this change.
+        let state =
+            baseState () |> withThreads (runnable 3) |> IlMachineState.withPctSeed 99UL
+
+        let after =
+            (state, [ ThreadId 0 ; ThreadId 1 ; ThreadId 2 ; ThreadId 0 ])
+            ||> List.fold (fun s tid -> Scheduler.onStepOutcome tid WhatWeDid.Executed s)
+
+        after.Scheduling |> shouldEqual (SchedulerState.Pct (PctState.ofSeed 99UL))

--- a/WoofWare.PawPrint.Test/TestSchedulerYieldFairness.fs
+++ b/WoofWare.PawPrint.Test/TestSchedulerYieldFairness.fs
@@ -1,0 +1,122 @@
+namespace WoofWare.PawPrint.Test
+
+open System.Collections.Immutable
+open System.IO
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.DotnetRuntimeLocator
+open WoofWare.PawPrint
+
+/// End-to-end acceptance for the yield-debt fairness filter: a guest in which several threads
+/// spin on a flag, yielding every iteration, while one worker does bounded work and sets it.
+///
+/// The measurement is the total scheduler step count for the run. The worker's own work is
+/// fixed, so the step count is a direct measure of how much of the machine the spinners took
+/// while contributing nothing.
+///
+/// **This fixture runs under `Pct`, not `RoundRobin`, and that is the honest scope of the
+/// change.** `RoundRobin` picks the lowest id strictly greater than `lastRan` and wraps, so it
+/// already never re-picks the thread that just ran while another is Runnable — it is already
+/// maximally yield-respecting, and the filter provably cannot improve it. (Measured: this guest
+/// costs 22,900 steps under `RoundRobin` both with and without the filter, to the step.) `Pct`
+/// is the policy that sticks to a high-priority thread until a demotion draw succeeds, so it is
+/// the policy a yield has something to say to.
+///
+/// Related, and deliberately out of scope here: the `SpinWait`-based guest from issue #844
+/// escalates to `Thread.Sleep(1)` after twenty iterations and spends the rest of its life
+/// there. A `Sleep(1)` currently parks a thread for less than one scheduler decision, so no
+/// amount of yield fairness helps it; that needs virtual time to cost something.
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestSchedulerYieldFairness =
+
+    /// Anchor for locating this test assembly, whose embedded resources carry the guest source.
+    type private Marker = class end
+
+    let private testAssy = typeof<Marker>.Assembly
+
+    let private dotnetRuntimes : ImmutableArray<string> =
+        DotnetRuntime.SelectForDll testAssy.Location |> ImmutableArray.CreateRange
+
+    /// Compiled once and reused across seeds: recompiling per seed would dominate the run
+    /// without changing semantics.
+    let private image : byte[] =
+        Assembly.getEmbeddedResourceAsString "YieldingSpinnersDoNotStarveWorker.cs" testAssy
+        |> List.singleton
+        |> Roslyn.compile
+
+    /// Run the guest to completion under one PCT seed, returning (exit code, total steps).
+    /// Drives `Program.stepPrepared` directly so the step counter is observable; `Program.run`
+    /// would hide it.
+    let private runOne (seed : uint64) : int * int64 =
+        let _messages, loggerFactory =
+            LoggerFactory.makeTestWithProperties [ "pct_seed", string seed ]
+
+        use _loggerFactoryResource = loggerFactory
+        use peImage = new MemoryStream (image)
+        let logger = loggerFactory.CreateLogger "TestSchedulerYieldFairness"
+
+        match
+            Program.prepare
+                loggerFactory
+                (Some "YieldingSpinnersDoNotStarveWorker.cs")
+                peImage
+                { HostConfig.Default dotnetRuntimes with
+                    PctSeed = Some seed
+                }
+        with
+        | Program.ProgramStartResult.CompletedBeforeMain _ ->
+            failwith "guest terminated before Main; it has no static initialisers that could do that"
+        | Program.ProgramStartResult.Ready prepared ->
+            let rec loop (prepared : Program.PreparedProgram) : int * int64 =
+                match Program.stepPrepared loggerFactory logger prepared with
+                | Program.ProgramStepOutcome.Completed (RunOutcome.NormalExit (state, thread)) ->
+                    let code =
+                        match state.ThreadState.[thread].MethodState.EvaluationStack.Values with
+                        | EvalStackValue.Int32 (Int32Source.Verbatim code) :: _ -> code
+                        | other -> failwith $"guest Main did not return an int32: %A{other}"
+
+                    code, state.Kernel.StepCounter
+                | Program.ProgramStepOutcome.Completed other -> failwith $"unexpected guest outcome: %A{other}"
+                | Program.ProgramStepOutcome.Deadlocked (_, stuck) -> failwith $"guest deadlocked: %s{stuck}"
+                | Program.ProgramStepOutcome.InstructionStepped (p, _, _) -> loop p
+                | Program.ProgramStepOutcome.WorkerTerminated (p, _) -> loop p
+
+            loop prepared
+
+    /// Six spinners plus the worker and the entry thread.
+    ///
+    /// Aggregated over a fixed seed set rather than asserted per seed, because the effect is
+    /// statistical and the per-seed numbers are not monotone. `Pct`'s residency is a random
+    /// walk over priorities, and charging a yield debt perturbs the RNG stream, so an
+    /// individual seed can land on a *worse* interleaving than it did before — measured, seed 7
+    /// goes 5,464 → 11,349 while seed 42 goes 16,593 → 4,421. Pinning any single seed would be
+    /// pinning luck, and pinning the sum measures the thing the change is actually for.
+    ///
+    /// The seeds are fixed, so this is fully deterministic despite being a statistical claim:
+    /// no flakiness, and a failure reproduces exactly.
+    ///
+    /// Measured totals over these twenty seeds: 601,789 steps without the yield-debt filter,
+    /// 151,253 with it — a 4x reduction. The bound below sits between the two, so it is not a
+    /// change-detector on exact interleavings: a scheduler tweak that shuffles individual seeds
+    /// around is free to pass, and only losing the fairness effect itself fails.
+    [<Test>]
+    let ``yielding spinners do not starve the worker under Pct`` () : unit =
+        let seeds = [ 1UL .. 20UL ]
+
+        let results = seeds |> List.map (fun seed -> seed, runOne seed)
+
+        for seed, (exitCode, _) in results do
+            if exitCode <> 0 then
+                failwith $"guest returned %d{exitCode} under PCT seed %d{seed}; it should compute 0+1+...+149 = 11175"
+
+        let total = results |> List.sumBy (fun (_, (_, steps)) -> steps)
+
+        if total > 300_000L then
+            let perSeed =
+                results
+                |> List.map (fun (seed, (_, steps)) -> $"%d{seed}:%d{steps}")
+                |> String.concat " "
+
+            failwith
+                $"guest took %d{total} scheduler steps in total across %d{seeds.Length} PCT seeds (budget 300000); the yielding spinners are consuming the machine despite having declared they have nothing to do. Per seed: %s{perSeed}"

--- a/WoofWare.PawPrint.Test/TestSignalDispatch.fs
+++ b/WoofWare.PawPrint.Test/TestSignalDispatch.fs
@@ -126,6 +126,7 @@ module TestSignalDispatch =
     let private stubThreadState (status : ThreadStatus) : ThreadState =
         {
             MethodStates = Map.empty
+            YieldDebt = Set.empty
             NextFrameId = 0
             ActiveMethodState = FrameId -1
             Status = status

--- a/WoofWare.PawPrint.Test/TestSignalDispatcherThread.fs
+++ b/WoofWare.PawPrint.Test/TestSignalDispatcherThread.fs
@@ -32,6 +32,7 @@ module TestSignalDispatcherThread =
     let private stubThreadState (status : ThreadStatus) : ThreadState =
         {
             MethodStates = Map.empty
+            YieldDebt = Set.empty
             NextFrameId = 0
             ActiveMethodState = FrameId -1
             Status = status

--- a/WoofWare.PawPrint.Test/TestSyncBlockMonitor.fs
+++ b/WoofWare.PawPrint.Test/TestSyncBlockMonitor.fs
@@ -42,6 +42,7 @@ module TestSyncBlockMonitor =
     let private stubThreadState (status : ThreadStatus) : ThreadState =
         {
             MethodStates = Map.empty
+            YieldDebt = Set.empty
             NextFrameId = 0
             ActiveMethodState = FrameId -1
             Status = status

--- a/WoofWare.PawPrint.Test/TestWaitHandle.fs
+++ b/WoofWare.PawPrint.Test/TestWaitHandle.fs
@@ -35,6 +35,7 @@ module TestWaitHandle =
     let private stubThreadState (status : ThreadStatus) : ThreadState =
         {
             MethodStates = Map.empty
+            YieldDebt = Set.empty
             NextFrameId = 0
             ActiveMethodState = FrameId -1
             Status = status

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -120,6 +120,8 @@
     <Compile Include="TestNativeThreadSpinWait.fs" />
     <Compile Include="TestNativeEventSource.fs" />
     <Compile Include="TestSchedulerVoluntaryYield.fs" />
+    <Compile Include="TestSchedulerYieldDebt.fs" />
+    <Compile Include="TestSchedulerYieldFairness.fs" />
     <Compile Include="TestSchedulerPct.fs" />
     <Compile Include="TestVariableSizeNewobj.fs" />
     <Compile Include="TestNativeMdUtf8String.fs" />

--- a/WoofWare.PawPrint.Test/sourcesConcurrencyBugs/YieldingSpinnersDoNotStarveWorker.cs
+++ b/WoofWare.PawPrint.Test/sourcesConcurrencyBugs/YieldingSpinnersDoNotStarveWorker.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Threading;
+
+// Several threads spin on a flag, yielding on every iteration, while one worker does bounded
+// real work and then sets the flag. On a real machine the yielders cost the worker almost
+// nothing. PawPrint serialises every thread onto one virtual CPU, so the worker cannot have
+// the machine to itself — but a scheduler that honours the yields must not let the spinners
+// take a proportional share of it either, because a yielding thread has explicitly said it
+// has nothing to do.
+//
+// The assertion that matters is not in this file: the harness pins the total scheduler step
+// count for the run (see TestImpureCases). This guest only has to (a) terminate, and (b) do a
+// fixed, known amount of real work, so that the step count is a meaningful measure of how much
+// of the machine the spinners consumed.
+//
+// Deliberately `Thread.Yield()` rather than `SpinWait`: SpinWait escalates to `Thread.Sleep(1)`
+// after 20 iterations and spends the rest of its life there, and making a sleep cost the
+// sleeper any virtual time is a separate piece of work. This guest is scoped to the part the
+// yield-debt filter actually fixes.
+internal static class YieldingSpinnersDoNotStarveWorker
+{
+    private static volatile bool ready;
+    private static volatile int result;
+
+    private static int Main()
+    {
+        const int spinners = 6;
+        const int workUnits = 150;
+
+        for (int i = 0; i < spinners; i++)
+        {
+            Thread t = new Thread(() =>
+            {
+                while (!ready)
+                {
+                    Thread.Yield();
+                }
+            });
+            t.IsBackground = true;
+            t.Start();
+        }
+
+        Thread worker = new Thread(() =>
+        {
+            int sum = 0;
+            for (int j = 0; j < workUnits; j++)
+            {
+                sum += j;
+            }
+
+            result = sum;
+            ready = true;
+        });
+
+        worker.Start();
+        worker.Join();
+
+        // 0 + 1 + ... + 149.
+        return result == 11175 ? 0 : 1;
+    }
+}

--- a/WoofWare.PawPrint/AbstractMachine.fs
+++ b/WoofWare.PawPrint/AbstractMachine.fs
@@ -60,13 +60,17 @@ module AbstractMachine =
                 match IlMachineState.returnStackFrame loggerFactory baseClassTypes thread state with
                 | ReturnFrameResult.NormalReturn state -> ExecutionResult.Stepped (state, WhatWeDid.Executed, effect)
                 | result -> failwith $"unexpected ReturnFrameResult from extern method return: %A{result}"
-            | NativeHandlerResult.Yielded (state, effect) ->
+            | NativeHandlerResult.Yielded (state, reportsSwitch, effect) ->
                 // Native handler ran to completion AND requested a scheduler yield. Frame
                 // management is identical to Completed (pop the native frame); the
-                // distinction is carried in `WhatWeDid.VoluntaryYield` for the Scheduler.
+                // distinction is carried in `WhatWeDid.VoluntaryYield` for the Scheduler,
+                // which is where the yield is actually acted on. Note the frame pop happens
+                // *before* the Scheduler sees the outcome, which is what puts any optimistic
+                // return value the handler pushed onto the caller's eval stack in time for
+                // `Scheduler.onStepOutcome` to rewrite it.
                 match IlMachineState.returnStackFrame loggerFactory baseClassTypes thread state with
                 | ReturnFrameResult.NormalReturn state ->
-                    ExecutionResult.Stepped (state, WhatWeDid.VoluntaryYield, effect)
+                    ExecutionResult.Stepped (state, WhatWeDid.VoluntaryYield reportsSwitch, effect)
                 | result -> failwith $"unexpected ReturnFrameResult from yielding extern method return: %A{result}"
             | NativeHandlerResult.PushedManagedCallee (state, effect) ->
                 // The handler pushed a managed callee on top of itself for re-entry: leave

--- a/WoofWare.PawPrint/IlMachineStateExecution.fs
+++ b/WoofWare.PawPrint/IlMachineStateExecution.fs
@@ -1934,7 +1934,7 @@ module IlMachineStateExecution =
                     // `TypeInitState.Failed` cached-cctor path, which we pre-handle above.
                     failwith
                         "logic error: ensureTypeInitialised should not reach the cached-failure path inside Activator.CreateInstance<T>() (handled separately above)"
-                | WhatWeDid.VoluntaryYield ->
+                | WhatWeDid.VoluntaryYield _ ->
                     failwith
                         "logic error: ensureTypeInitialised inside Activator.CreateInstance<T>() cannot produce a VoluntaryYield (cctor execution has no path to a yield primitive)"
             else

--- a/WoofWare.PawPrint/IlMachineStateModel.fs
+++ b/WoofWare.PawPrint/IlMachineStateModel.fs
@@ -242,15 +242,24 @@ type WhatWeDid =
     | ThrowingTypeInitializationException
     /// The thread completed a step (no frame change, no suspension) and the guest explicitly
     /// requested that the scheduler consider running another thread before resuming this one
-    /// (e.g. `Thread.Yield()`). Under today's scheduling policy this has the same observable
-    /// effect as `Executed`: `Scheduler.chooseNext`'s signature is `(lastRan, state)` and does
-    /// not consume the previous outcome, so the round-robin policy is hint-insensitive. The
-    /// variant exists so a future fuzz/pruning policy at the driver/scheduler boundary can
-    /// distinguish voluntary yields from forced context switches (e.g. for coverage weighting,
-    /// or to constrain the next-thread choice). Surfacing the hint to `chooseNext` itself is
-    /// a separate later change — either widen its signature, or carry the last outcome on
-    /// the state — neither of which this variant alone prescribes.
-    | VoluntaryYield
+    /// (`Thread.Yield()` and `Thread.Sleep(0)`).
+    ///
+    /// `Scheduler.onStepOutcome` is the *only* place that acts on this: it draws the policy's
+    /// honour-the-yield coin and, if honoured, charges the yielder a `ThreadState.YieldDebt`
+    /// so the scheduler holds it out of the candidate set until its contemporaries have run.
+    /// Concentrating that here rather than at the QCall handler is deliberate and load-bearing:
+    /// the driver routes every `ExecutionResult.Stepped` through `onStepOutcome`, so it is
+    /// impossible to emit a yield signal without the scheduler's bookkeeping happening. A
+    /// handler that returns `NativeHandlerResult.yielded` cannot forget to consult the
+    /// scheduler, because it never consults the scheduler itself.
+    ///
+    /// `reportsSwitch` says whether the yielding call reports the outcome back to the guest.
+    /// `Thread.Yield()` returns `Interop.BOOL` (CoreCLR's `SwitchToThread` reports whether it
+    /// actually switched away), so its handler leaves an optimistic FALSE on the eval stack
+    /// which `onStepOutcome` rewrites to TRUE iff a switch is now guaranteed — the same
+    /// optimistic-push-then-rewrite contract `Scheduler.fireJoinTimeout` uses. `Thread.Sleep(0)`
+    /// returns `void` and so has no slot to rewrite; it passes `false`.
+    | VoluntaryYield of reportsSwitch : bool
 
 /// An externally-observable side-effect that a single interpreter step requests
 /// from the driver (the imperative shell around the functional core). The
@@ -372,7 +381,7 @@ type NativeHandlerResult =
     /// equivalent to `Completed` for frame-management purposes; distinct so the guest's
     /// yield intent reaches the scheduler boundary unmangled — see `WhatWeDid.VoluntaryYield`
     /// for the longer-term motivation.
-    | Yielded of IlMachineState * StepEffect
+    | Yielded of IlMachineState * reportsSwitch : bool * StepEffect
     /// Native handler synchronously pushed a managed callee on top of itself for re-entry:
     /// the handler will be invoked again after the callee returns, typically via re-entry
     /// markers placed on the eval stack so the handler can distinguish first entry from
@@ -506,14 +515,20 @@ module NativeHandlerResult =
     let completedWith (effect : StepEffect) (state : IlMachineState) : NativeHandlerResult =
         NativeHandlerResult.Completed (state, effect)
 
-    /// Native handler completed normally AND requested a scheduler yield. Use this only
-    /// for genuine yield primitives (today: `ThreadNative_YieldThread`). The dispatcher
-    /// pops the native frame and reports `WhatWeDid.VoluntaryYield`. Handlers that simply
-    /// finish — even ones that touched shared state — should use `completed`; the yield
-    /// signal is reserved for the guest-requested hint, not derived from the handler's
-    /// side-effects.
-    let yielded (state : IlMachineState) : NativeHandlerResult =
-        NativeHandlerResult.Yielded (state, StepEffect.NoEffect)
+    /// Native handler completed normally AND requested a scheduler yield. Use this only for
+    /// genuine yield primitives (today: `ThreadNative_YieldThread` and `ThreadNative_Sleep`
+    /// with a zero timeout). The dispatcher pops the native frame and reports
+    /// `WhatWeDid.VoluntaryYield`, which is where the scheduler charges the yield debt.
+    /// Handlers that simply finish — even ones that touched shared state — should use
+    /// `completed`; the yield signal is reserved for the guest-requested hint, not derived
+    /// from the handler's side-effects.
+    ///
+    /// `reportsSwitch` must be `true` exactly when the handler has left an optimistic
+    /// `Interop.BOOL.FALSE` on the eval stack for `Scheduler.onStepOutcome` to rewrite — i.e.
+    /// when the guest-visible signature returns whether the switch happened. See
+    /// `WhatWeDid.VoluntaryYield`.
+    let yielded (reportsSwitch : bool) (state : IlMachineState) : NativeHandlerResult =
+        NativeHandlerResult.Yielded (state, reportsSwitch, StepEffect.NoEffect)
 
     /// Native handler pushed a managed callee on top of itself for re-entry. The
     /// handler will be re-invoked on a future step (typically distinguishing first
@@ -570,7 +585,7 @@ module NativeHandlerResult =
         // bubble up as a sub-call control-flow signal because the handler's own
         // outcome is what the dispatcher records, and the handler can decide for
         // itself whether to yield (via `NativeHandlerResult.yielded`) when it returns.
-        | WhatWeDid.VoluntaryYield -> None
+        | WhatWeDid.VoluntaryYield _ -> None
         | WhatWeDid.SuspendedForClassInit -> Some (suspendedForClassInit state)
         | WhatWeDid.BlockedOnClassInit blockedBy -> Some (blockedOnClassInit blockedBy state)
         | WhatWeDid.ThrowingTypeInitializationException -> Some (throwingTypeInitializationException state)

--- a/WoofWare.PawPrint/IlMachineThreadState.fs
+++ b/WoofWare.PawPrint/IlMachineThreadState.fs
@@ -359,6 +359,7 @@ module IlMachineThreadState =
                 // it therefore still consumes a rotation slot.
                 Cpu = EmulatedKernel.cpuForRotation state.NextCpuRotation state.Kernel
                 OsThreadId = EmulatedKernel.osThreadId thread
+                YieldDebt = Set.empty
             }
 
         let newState =
@@ -415,6 +416,7 @@ module IlMachineThreadState =
                 // `osThreadId` is a function of the `ThreadId` allocated just
                 // above, which is unique to this thread like any other's.
                 OsThreadId = EmulatedKernel.osThreadId thread
+                YieldDebt = Set.empty
             }
 
         let newState =
@@ -513,6 +515,7 @@ module IlMachineThreadState =
                 // field is copied like every other per-thread fact rather than
                 // recomputed, so it stays correct if that ever stops holding.)
                 OsThreadId = existing.OsThreadId
+                YieldDebt = Set.empty
             }
 
         { state with

--- a/WoofWare.PawPrint/Native/NativeCustomAttribute.fs
+++ b/WoofWare.PawPrint/Native/NativeCustomAttribute.fs
@@ -358,7 +358,7 @@ module NativeCustomAttribute =
                     NativeHandlerResult.throwingTypeInitializationException state |> Some
                 | WhatWeDid.SuspendedForManagedCall ->
                     failwith "logic error: ensureTypeInitialised cannot suspend for an arbitrary managed call"
-                | WhatWeDid.VoluntaryYield ->
+                | WhatWeDid.VoluntaryYield _ ->
                     failwith "logic error: ensureTypeInitialised cannot produce a VoluntaryYield"
                 | WhatWeDid.Executed ->
 

--- a/WoofWare.PawPrint/Native/NativeRuntimeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeHelpers.fs
@@ -75,7 +75,7 @@ module NativeRuntimeHelpers =
                         // Another thread owns this type's .cctor lock. Yield so the scheduler
                         // can run that thread to completion before re-entering.
                         NativeHandlerResult.blockedOnClassInit blockedBy state |> Some
-                    | WhatWeDid.VoluntaryYield ->
+                    | WhatWeDid.VoluntaryYield _ ->
                         failwith "logic error: ensureTypeInitialised cannot produce a VoluntaryYield"
         | _ -> None
 

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
@@ -727,7 +727,7 @@ module NativeRuntimeTypeQCall =
                     NativeHandlerResult.throwingTypeInitializationException state |> Some
                 | WhatWeDid.SuspendedForManagedCall ->
                     failwith "logic error: ensureTypeInitialised cannot suspend for an arbitrary managed call"
-                | WhatWeDid.VoluntaryYield ->
+                | WhatWeDid.VoluntaryYield _ ->
                     failwith "logic error: ensureTypeInitialised cannot produce a VoluntaryYield"
                 | WhatWeDid.Executed ->
 

--- a/WoofWare.PawPrint/Native/NativeThreading.fs
+++ b/WoofWare.PawPrint/Native/NativeThreading.fs
@@ -602,10 +602,16 @@ module NativeThreading =
             if instruction.Arguments.Length <> 0 then
                 failwith $"%s{operation}: expected zero native arguments, got %d{instruction.Arguments.Length}"
 
+            // Optimistic `Interop.BOOL.FALSE`. We cannot know here whether the switch will
+            // happen: that is the scheduler's decision, taken in `Scheduler.onStepOutcome`
+            // when it sees our `WhatWeDid.VoluntaryYield true` and either charges a yield debt
+            // or declines. It rewrites this slot to TRUE iff a switch is now guaranteed, the
+            // same optimistic-push-then-rewrite contract `Scheduler.fireJoinTimeout` uses for
+            // `Thread.Join`'s return value.
             let state =
                 IlMachineState.pushToEvalStack (CliType.Numeric (CliNumericType.Int32 0)) ctx.Thread state
 
-            NativeHandlerResult.yielded state |> Some
+            NativeHandlerResult.yielded true state |> Some
         | "ThreadNative_Sleep",
           "System.Private.CoreLib",
           "System.Threading",
@@ -642,10 +648,24 @@ module NativeThreading =
                 | CliType.Numeric (CliNumericType.Int32 i) -> i
                 | other -> failwith $"%s{operation}: expected int32 millisecondsTimeout, got %O{other}"
 
+            if millisecondsTimeout = 0 then
+                // `Thread.Sleep(0)` does not park: CoreCLR's `SleepEx(0, ...)` relinquishes
+                // the remainder of the caller's time slice to a ready thread of equal
+                // priority and returns immediately, without waiting for the clock. So it
+                // costs no virtual time — but it *is* a yield, and the BCL treats it as one:
+                // `SpinWait.SpinOnceCore` uses it as one of its backoff rungs, alternating it
+                // with `Thread.Yield()` for the first 20 iterations.
+                //
+                // Reporting it as a yield rather than as `completed` is what lets
+                // `Scheduler.onStepOutcome` charge the caller a yield debt. `reportsSwitch`
+                // is `false`: unlike `Thread.Yield()`, `Thread.Sleep(int)` returns `void`,
+                // so there is no eval-stack slot for the scheduler to rewrite with the
+                // outcome, and the guest cannot observe whether the switch happened.
+                NativeHandlerResult.yielded false state |> Some
+            else
+
             let state =
-                if millisecondsTimeout = 0 then
-                    state
-                elif millisecondsTimeout = System.Threading.Timeout.Infinite then
+                if millisecondsTimeout = System.Threading.Timeout.Infinite then
                     Scheduler.blockOnSleep ctx.Thread None state
                 elif millisecondsTimeout < 0 then
                     failwith

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -318,7 +318,7 @@ module Program =
                 "Executed one step; active assembly: {ActiveAssembly}",
                 state.ActiveAssembly(thread).Name.Name
             )
-        | WhatWeDid.VoluntaryYield ->
+        | WhatWeDid.VoluntaryYield _ ->
             logger.LogTrace (
                 "Executed one step (voluntary yield requested); active assembly: {ActiveAssembly}",
                 state.ActiveAssembly(thread).Name.Name
@@ -501,6 +501,14 @@ module Program =
                     // terminated, the dispatcher is just between handler
                     // invocations.
                     let state = SignalDispatch.reParkAfterHandler terminatingThread state
+
+                    // Route through the scheduler like every other stepped outcome. This
+                    // branch reports `WhatWeDid.Executed` — the dispatcher did retire a step —
+                    // and the scheduler's per-step bookkeeping (discharging yield debts that
+                    // name this thread) has to see it. Skipping the call would leave the
+                    // dispatcher named in an outstanding debt it can never discharge, which
+                    // `Scheduler.candidates` relies on being impossible.
+                    let state = Scheduler.onStepOutcome terminatingThread WhatWeDid.Executed state
 
                     ProgramStepOutcome.InstructionStepped (
                         { prepared with
@@ -967,7 +975,7 @@ module Program =
         | WhatWeDid.BlockedOnClassInit _ -> failwith "logic error: surely this thread can't be blocked on class init"
         | WhatWeDid.ThrowingTypeInitializationException ->
             failwith "TypeInitializationException during entry point type initialisation"
-        | WhatWeDid.VoluntaryYield ->
+        | WhatWeDid.VoluntaryYield _ ->
             // ensureTypeInitialised drives cctor execution, which has no path to a
             // yield primitive: voluntary yields are produced by native handlers like
             // `ThreadNative_YieldThread`, never by a synthetic cctor step. If this

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -490,6 +490,25 @@ module Program =
             match AbstractMachine.executeOneStep loggerFactory prepared.BaseClassTypes prepared.State nextThread with
             | ExecutionResult.Terminated (state, terminatingThread) ->
                 if terminatingThread = prepared.EntryThread then
+                    // Discharge before reporting. This looks like the end of the run, and for
+                    // the post-`Main` pump it is — but the *pre*-`Main` cctor pump reports
+                    // `NormalExit` too, when the synthetic `onlyRet` frame returns, and then
+                    // `Program.run` resurrects this very thread with the real `Main` frame and
+                    // keeps stepping. A worker spawned by an entry-type cctor that yielded just
+                    // before that synthetic `ret` would otherwise carry a debt naming the entry
+                    // thread across the resurrection, and be held out for a decision even
+                    // though the thread it is waiting on has already run.
+                    //
+                    // Routed through `onStepOutcome` rather than a discharge-only helper for
+                    // the same reason as the dispatcher branch below: one entry point for
+                    // "a thread retired a step" is one fewer thing a future path can half-do.
+                    // Its other effect here — waking threads BlockedOnClassInit on the entry
+                    // thread — is right in the pre-`Main` case (those cctors have just
+                    // finished) and inert in the post-`Main` one (nothing is scheduled again).
+                    // Deliberately does *not* mark the entry thread Terminated: it may yet run
+                    // `Main`.
+                    let state = Scheduler.onStepOutcome terminatingThread WhatWeDid.Executed state
+
                     ProgramStepOutcome.Completed (RunOutcome.NormalExit (state, prepared.EntryThread))
                 elif SignalState.signalThread state.Kernel.Signals = Some terminatingThread then
                     // The kernel-owned signal-dispatch thread's handler frame

--- a/WoofWare.PawPrint/Scheduler.fs
+++ b/WoofWare.PawPrint/Scheduler.fs
@@ -28,6 +28,26 @@ module Scheduler =
     /// surface as a knob if a future harness needs to fuzz the constant itself.
     let private P_BASE : double = 0.01
 
+    /// Probability that the `Pct` policy honours a guest yield (`Thread.Yield()`,
+    /// `Thread.Sleep(0)`) by charging the yielder a `ThreadState.YieldDebt`. On the
+    /// complementary draw the yield is declined: nothing happens, exactly as when a real
+    /// `SwitchToThread` returns without switching.
+    ///
+    /// Declines exist for *reachability*, not for frequency. A schedule in which a yield is
+    /// not respected is a real execution — it is why `Thread.Yield()` returns a `bool` at all
+    /// — so a scheduler that honoured every yield would delete those schedules from the space
+    /// a fuzzing harness can explore. But the common real-world decline, "no other thread was
+    /// ready", is already modelled exactly and deterministically by the empty-debt branch of
+    /// `chargeYieldDebt`; what this constant buys is the *rarer* case where a peer was ready
+    /// and the OS declined anyway. Hence a value near 1: at 0.9 the fairness effect engages
+    /// within a couple of yields, while a spinner's measured 16-yield `SpinWait` warmup phase
+    /// contains at least one decline with probability ~0.81.
+    ///
+    /// `RoundRobin` does not draw at all — see `chargeYieldDebt`. Like `P_BASE` this is a
+    /// hand-calibrated constant rather than a derived one; deriving it from the runnable-set
+    /// size buys nothing, since retries are geometric at any constant rate.
+    let private P_HONOUR_YIELD : double = 0.9
+
     /// Enumerate the Runnable threads in ascending id order. Used by every
     /// policy: the set of candidates is policy-independent, only the choice
     /// among them differs. Kept private so policies stay enumerable here.
@@ -46,6 +66,85 @@ module Scheduler =
             | ThreadStatus.Runnable -> tid :: acc
             | _ -> acc
         )
+
+    /// Is `thread`'s yield debt discharged, given the currently-Runnable set? A debt member
+    /// that is no longer Runnable has left the run queue and cannot be waited for, so it stops
+    /// counting; this is what makes the debt self-clearing across park/wake and termination,
+    /// with no cleanup pass anywhere.
+    let private debtDischarged (runnable : ThreadId list) (ts : ThreadState) : bool =
+        ts.YieldDebt.IsEmpty
+        || not (runnable |> List.exists (fun tid -> ts.YieldDebt |> Set.contains tid))
+
+    /// The Runnable threads the policy may choose among: those whose yield debt is discharged.
+    /// Every policy filters through here, so fairness is a property of the schedule space
+    /// rather than of any one policy.
+    ///
+    /// **This is never empty when `runnableThreads` is non-empty**, which is what keeps
+    /// `chooseNext`'s deadlock contract (`None` iff nothing is Runnable) intact. Proof: a debt
+    /// is only ever charged to a thread during that thread's own step, so any thread holding
+    /// one has run at least once; and every live member of that debt was Runnable when the
+    /// debt was charged and has not run since (a member that ran was discharged by
+    /// `dischargeYieldDebts`). So a thread with live debt necessarily ran more recently than
+    /// every live member of its debt. Now take the Runnable thread whose last run is least
+    /// recent, counting "never ran" as least recent of all — a never-run thread has an empty
+    /// debt by construction, and any other candidate for that position cannot hold live debt,
+    /// since its members would have to be Runnable and yet less recent still. Either way that
+    /// thread is a candidate.
+    ///
+    /// The proof leans on the discharge lemma — *if a thread ran, it left every debt* — which
+    /// in turn requires every step to reach `onStepOutcome`. Rather than trust that, we check
+    /// the conclusion and fail loudly: a silent fallback to the unfiltered set would convert a
+    /// structural bug into a subtle fairness anomaly, and this project would rather crash.
+    let private candidates (state : IlMachineState) : ThreadId list =
+        let runnable = runnableThreads state
+
+        match runnable with
+        | [] -> []
+        | _ ->
+
+        let eligible =
+            runnable
+            |> List.filter (fun tid -> debtDischarged runnable (Map.find tid state.ThreadState))
+
+        match eligible with
+        | [] ->
+            let debts =
+                runnable
+                |> List.map (fun tid -> tid, (Map.find tid state.ThreadState).YieldDebt)
+
+            failwith
+                $"Scheduler.candidates: every Runnable thread has an outstanding yield debt (%A{debts}), which the debt invariant makes impossible — a thread's debt can only name threads that were Runnable when it was charged, and members are discharged as they run. Reaching here means some execution path retired a step without routing its outcome through Scheduler.onStepOutcome, so debts are no longer being discharged."
+        | _ -> eligible
+
+    /// Remove `ran` from every outstanding yield debt: it has taken its step, so anyone waiting
+    /// to see it run has been satisfied. Called for every step outcome, since every step
+    /// discharges, not just yields.
+    ///
+    /// Short-circuits on the common path the way the `BlockedOnClassInit` wake scan next door
+    /// does: this runs once per interpreted IL instruction and almost never has anything to do,
+    /// because outstanding debts exist only during yield bursts.
+    let private dischargeYieldDebts (ran : ThreadId) (state : IlMachineState) : IlMachineState =
+        let anyDebtNames =
+            state.ThreadState |> Map.exists (fun _ ts -> ts.YieldDebt |> Set.contains ran)
+
+        if not anyDebtNames then
+            state
+        else
+
+        { state with
+            ThreadState =
+                state.ThreadState
+                |> Map.map (fun _ ts ->
+                    // Guard the rewrite so untouched threads keep their existing record rather
+                    // than being reallocated with an identical debt.
+                    if ts.YieldDebt |> Set.contains ran then
+                        { ts with
+                            YieldDebt = ts.YieldDebt |> Set.remove ran
+                        }
+                    else
+                        ts
+                )
+        }
 
     /// Does any thread currently have status `Runnable`? Used by the
     /// deadline-advance loop in `Program.fs` to decide whether jumping the
@@ -79,7 +178,7 @@ module Scheduler =
     let chooseNext (lastRan : ThreadId) (state : IlMachineState) : IlMachineState * ThreadId option =
         match state.Scheduling with
         | SchedulerState.RoundRobin ->
-            let runnable = runnableThreads state
+            let runnable = candidates state
 
             let chosen =
                 match runnable with
@@ -93,7 +192,13 @@ module Scheduler =
 
             state, chosen
         | SchedulerState.Pct pct ->
+            // Priorities are sampled over the *unfiltered* Runnable set, but the argmax runs
+            // over the candidates. Keeping the sampling domain unfiltered preserves the
+            // documented invariant that the sampling sequence is a function of the seed plus
+            // the set of threads ever seen Runnable — if the filter drove it, the RNG stream
+            // would depend on yield timing.
             let runnable = runnableThreads state
+            let eligible = candidates state
 
             match runnable with
             | [] ->
@@ -110,13 +215,15 @@ module Scheduler =
                 // in which they were created.
                 let pct = PctState.ensurePriorityFor runnable pct
 
-                // Deterministic argmax over `runnable`. F#'s `List.maxBy` keeps
-                // the first element on ties (it uses strict `>`); `runnable`
+                // Deterministic argmax over `eligible`. F#'s `List.maxBy` keeps
+                // the first element on ties (it uses strict `>`); `eligible`
                 // is sorted by ThreadId ascending, so ties resolve to the
                 // lowest id — purely for reproducibility, since with `nextDouble`
                 // sampling from a 53-bit mantissa a tie is astronomically rare.
+                // `Map.find` is total here: `eligible` is a subset of `runnable`,
+                // which `ensurePriorityFor` has just covered.
                 let argmax (priorities : Map<ThreadId, double>) : ThreadId =
-                    runnable |> List.maxBy (fun tid -> Map.find tid priorities)
+                    eligible |> List.maxBy (fun tid -> Map.find tid priorities)
 
                 let current = argmax pct.Priorities
 
@@ -478,7 +585,7 @@ module Scheduler =
     let onWorkerSpawned (worker : ThreadId) (initOutcome : WhatWeDid) (state : IlMachineState) : IlMachineState =
         match initOutcome with
         | WhatWeDid.Executed
-        | WhatWeDid.VoluntaryYield
+        | WhatWeDid.VoluntaryYield _
         | WhatWeDid.SuspendedForClassInit
         | WhatWeDid.SuspendedForManagedCall
         | WhatWeDid.ThrowingTypeInitializationException ->
@@ -524,17 +631,78 @@ module Scheduler =
     /// cctor hasn't completed. This is correct but wasteful;
     /// it's cheap to fix once the scheduler owns the
     /// policy, which is only true after this refactor.
+    /// Act on a guest yield by `ran`: draw the policy's honour coin and, if it comes up
+    /// honoured, charge `ran` a yield debt naming every *other* currently-Runnable thread, so
+    /// `candidates` holds it out until they have each taken a step. Returns the new state and
+    /// whether a switch away from `ran` is now guaranteed.
+    ///
+    /// That returned flag is an exact iff, not an approximation, and it is what
+    /// `Thread.Yield()` reports to the guest: a non-empty debt excludes `ran` from
+    /// `candidates` until its members run, so under *any* policy somebody else runs first;
+    /// an empty debt (nobody else was Runnable, or the coin declined) excludes nothing, so
+    /// nothing is guaranteed. This is why the debt lives in `ThreadState` rather than the
+    /// yield being a transient hint — the guarantee has to be inspectable to be reported.
+    ///
+    /// `RoundRobin` takes no draw at all and always honours. That is a deliberate asymmetry
+    /// rather than `P_HONOUR_YIELD = 1.0` through a shared path: `RoundRobin` is the
+    /// reproducible baseline and is documented as consuming no randomness whatsoever, so
+    /// introducing a draw there would break that contract for every existing run. `Pct` is the
+    /// exploration policy, and "the OS declined to switch" is an exploration feature.
+    ///
+    /// Under `Pct` the draw is unconditional — burned even when `ran` is the only Runnable
+    /// thread and the outcome cannot matter — matching the always-burn Bernoulli in
+    /// `chooseNext`, so the seed is consumed at a rate that depends only on the sequence of
+    /// yields and not on how many threads happened to be Runnable at each one.
+    let private chargeYieldDebt (ran : ThreadId) (state : IlMachineState) : IlMachineState * bool =
+        let others = runnableThreads state |> List.filter (fun tid -> tid <> ran)
+
+        let state, honour =
+            match state.Scheduling with
+            | SchedulerState.RoundRobin -> state, true
+            | SchedulerState.Pct pct ->
+                let sample, rng = NonCryptoRandom.nextDouble pct.Rng
+
+                let state =
+                    { state with
+                        Scheduling =
+                            SchedulerState.Pct
+                                { pct with
+                                    Rng = rng
+                                }
+                    }
+
+                state, sample < P_HONOUR_YIELD
+
+        if not honour || List.isEmpty others then
+            state, false
+        else
+
+        let state =
+            { state with
+                ThreadState =
+                    state.ThreadState
+                    |> Map.change
+                        ran
+                        (Option.map (fun ts ->
+                            { ts with
+                                YieldDebt = Set.ofList others
+                            }
+                        ))
+            }
+
+        state, true
+
     let onStepOutcome (ran : ThreadId) (outcome : WhatWeDid) (state : IlMachineState) : IlMachineState =
-        match outcome with
-        // VoluntaryYield is identical in its scheduler effect to Executed: the yielder
-        // made forward progress, so any thread parked BlockedOnClassInit on `ran` must
-        // be woken to re-check its blocker. The hint (that the guest *asked* to yield)
-        // is preserved for the driver-loop boundary — `chooseNext`'s current signature
-        // doesn't consume the previous outcome, so the round-robin policy is hint-
-        // insensitive today, but the variant exists so a future fuzz/pruning policy
-        // can branch here without a wider refactor.
-        | WhatWeDid.Executed
-        | WhatWeDid.VoluntaryYield ->
+        // Every step discharges, whatever else it did: `ran` has taken its turn, so any thread
+        // waiting to see it run is satisfied. Must happen for all outcomes, including the
+        // blocking ones — a thread that blocks has still run, and `candidates`' non-emptiness
+        // proof depends on that being true without exception.
+        let state = dischargeYieldDebts ran state
+
+        // A yielder made forward progress just as an ordinary `Executed` step does, so both
+        // wake any thread parked BlockedOnClassInit on `ran`. They diverge only afterwards:
+        // a yield additionally goes to the back of the run queue.
+        let wakeClassInitWaiters (state : IlMachineState) : IlMachineState =
             // This runs on every scheduler tick (once per interpreted IL instruction),
             // and almost never has anything to do, so short-circuit first.
             let anyBlockedOnRan =
@@ -563,6 +731,37 @@ module Scheduler =
             { state with
                 ThreadState = threadState
             }
+
+        match outcome with
+        | WhatWeDid.Executed -> wakeClassInitWaiters state
+        | WhatWeDid.VoluntaryYield reportsSwitch ->
+            // Wake first, then charge: the run queue the yielder goes to the back of is the
+            // one that exists at the end of its step, so a thread this very step unblocked is
+            // owed a turn too. If it promptly re-blocks it drops out of the debt anyway.
+            let state = wakeClassInitWaiters state
+            let state, switched = chargeYieldDebt ran state
+
+            if not reportsSwitch then
+                state
+            else
+
+            // Optimistic-push-then-rewrite, as `fireJoinTimeout` does for Join's return value:
+            // the handler could not know whether the switch would happen (that is the
+            // scheduler's decision, taken here), so it left `Interop.BOOL.FALSE` behind for us
+            // to correct. Pop-and-repush unconditionally, checking what we find, so that a
+            // handler which sets `reportsSwitch` without leaving the slot fails loudly rather
+            // than silently corrupting its caller's eval stack.
+            let popped, state = IlMachineState.popEvalStack ran state
+
+            match popped with
+            | EvalStackValue.Int32 _ -> ()
+            | other ->
+                failwith
+                    $"Scheduler.onStepOutcome: thread %O{ran} reported a VoluntaryYield with reportsSwitch=true, so the yield handler should have left an optimistic Interop.BOOL.FALSE on its eval stack for rewriting, but the top of stack was %O{other}. Either the handler failed to push, or a handler that returns void passed reportsSwitch=true."
+
+            let result = if switched then 1 else 0
+
+            IlMachineState.pushToEvalStack' (EvalStackValue.Int32 (Int32Source.Verbatim result)) ran state
         | WhatWeDid.SuspendedForClassInit
         | WhatWeDid.SuspendedForManagedCall ->
             // Mid-call work: another frame is now on top of `ran` and will run on its next turn.

--- a/WoofWare.PawPrint/Scheduler.fs
+++ b/WoofWare.PawPrint/Scheduler.fs
@@ -69,8 +69,13 @@ module Scheduler =
 
     /// Is `thread`'s yield debt discharged, given the currently-Runnable set? A debt member
     /// that is no longer Runnable has left the run queue and cannot be waited for, so it stops
-    /// counting; this is what makes the debt self-clearing across park/wake and termination,
-    /// with no cleanup pass anywhere.
+    /// counting; this is what makes the debt self-clearing across a park/wake cycle, with no
+    /// hook in any wake path.
+    ///
+    /// The `IsEmpty` test is not merely a fast path for its own sake — it is the common case,
+    /// and keeping it reachable is why `onThreadTerminated` prunes rather than relying on this
+    /// filter alone. A debt holding a permanently-unrunnable member would answer correctly
+    /// here forever while scanning the whole runnable list to do it.
     let private debtDischarged (runnable : ThreadId list) (ts : ThreadState) : bool =
         ts.YieldDebt.IsEmpty
         || not (runnable |> List.exists (fun tid -> ts.YieldDebt |> Set.contains tid))
@@ -568,10 +573,26 @@ module Scheduler =
             | SchedulerState.RoundRobin -> SchedulerState.RoundRobin
             | SchedulerState.Pct pct -> SchedulerState.Pct (PctState.removeThread terminated pct)
 
-        { state with
-            ThreadState = threadState
-            Scheduling = scheduling
-        }
+        let state =
+            { state with
+                ThreadState = threadState
+                Scheduling = scheduling
+            }
+
+        // Discharge `terminated` from every outstanding yield debt. A thread's *final* step is
+        // its bottom-frame `Ret`, which the driver surfaces as `ExecutionResult.Terminated` and
+        // routes here rather than through `onStepOutcome` — so without this, the one step that
+        // most conclusively satisfies "I am waiting to see you run" would be the one step that
+        // never discharges anything.
+        //
+        // Not needed for correctness: `candidates` intersects each debt with the live Runnable
+        // set, and a Terminated thread is never in it, so a stale member could not hold anyone
+        // out. It is needed for cost. A debt containing a terminated id never becomes empty, so
+        // its owner permanently misses the `IsEmpty` fast path in `debtDischarged` and pays a
+        // scan of the runnable list on every scheduling decision for the rest of the run —
+        // turning candidate selection from O(R) into O(R²) once a few threads have yielded and
+        // a peer has exited. Pruning here keeps the fast path reachable.
+        dischargeYieldDebts terminated state
 
     /// Apply the init outcome of a freshly-spawned worker to its own ThreadStatus.
     /// Called once from `Thread.StartInternal` after `ensureTypeInitialised` has run

--- a/WoofWare.PawPrint/ThreadState.fs
+++ b/WoofWare.PawPrint/ThreadState.fs
@@ -337,6 +337,31 @@ type ThreadState =
         /// and here the lie would be an *aliased* id, which is precisely the
         /// failure this type exists to prevent.
         OsThreadId : OsThreadId
+        /// Threads this one must see run — or see leave the Runnable set — before the
+        /// scheduler will choose it again. Empty for every thread that has not just yielded,
+        /// and empty means eligible; `Scheduler.candidates` filters out any Runnable thread
+        /// whose debt is still outstanding.
+        ///
+        /// This is `sched_yield(2)` semantics stated as data: an honoured `Thread.Yield()` /
+        /// `Thread.Sleep(0)` sends the caller to the back of the run queue, and the queue is
+        /// "everyone who was Runnable alongside me at that moment".
+        /// `Scheduler.onStepOutcome` charges the debt (see `WhatWeDid.VoluntaryYield`) and
+        /// discharges members as they run.
+        ///
+        /// Bounded and self-clearing by construction, which is the whole point of the
+        /// representation. The set only ever shrinks: members are removed as they run, and
+        /// `Scheduler.candidates` additionally intersects it with the live Runnable set at
+        /// read time, so a member that blocks, parks or terminates stops counting without any
+        /// cleanup pass — in particular there is nothing to prune in
+        /// `Scheduler.onThreadTerminated` (contrast `PctState.removeThread`, which exists
+        /// precisely because a map keyed on live threads *does* need pruning).
+        ///
+        /// The consequence worth stating explicitly, because the obvious alternative design
+        /// gets it wrong: a peer that never yields *discharges* the debt by running. A rule
+        /// that instead held a yielder out until its peers also yielded would let a single
+        /// non-yielding busy-waiter exclude a yielder forever — `Thread.Yield(); f = true;`
+        /// racing `while (!f) {}` would livelock, where today it does not.
+        YieldDebt : Set<ThreadId>
     }
 
     // --- Frame resolution primitives ---
@@ -432,6 +457,7 @@ type ThreadState =
             Name = None
             Cpu = cpu
             OsThreadId = osThreadId
+            YieldDebt = Set.empty
         }
 
     static member peekEvalStack (state : ThreadState) : EvalStackValue option =

--- a/WoofWare.PawPrint/ThreadState.fs
+++ b/WoofWare.PawPrint/ThreadState.fs
@@ -351,10 +351,14 @@ type ThreadState =
         /// Bounded and self-clearing by construction, which is the whole point of the
         /// representation. The set only ever shrinks: members are removed as they run, and
         /// `Scheduler.candidates` additionally intersects it with the live Runnable set at
-        /// read time, so a member that blocks, parks or terminates stops counting without any
-        /// cleanup pass — in particular there is nothing to prune in
-        /// `Scheduler.onThreadTerminated` (contrast `PctState.removeThread`, which exists
-        /// precisely because a map keyed on live threads *does* need pruning).
+        /// read time, so for *correctness* a member that blocks, parks or terminates stops
+        /// counting with no cleanup pass at all.
+        ///
+        /// `Scheduler.onThreadTerminated` nonetheless prunes the terminated thread, for cost
+        /// rather than correctness: a debt that retains a permanently-unrunnable member never
+        /// becomes empty, so its owner misses the cheap `IsEmpty` test forever after and pays
+        /// a runnable-set scan on every scheduling decision. See that function for the
+        /// argument in full.
         ///
         /// The consequence worth stating explicitly, because the obvious alternative design
         /// gets it wrong: a peer that never yields *discharges* the debt by running. A rule

--- a/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
@@ -276,7 +276,7 @@ module internal UnaryMetadataObjectOps =
         | WhatWeDid.SuspendedForManagedCall ->
             failwith "logic error: ensureTypeInitialised cannot suspend for an arbitrary managed call"
         | WhatWeDid.ThrowingTypeInitializationException -> state, WhatWeDid.ThrowingTypeInitializationException
-        | WhatWeDid.VoluntaryYield -> failwith "logic error: ensureTypeInitialised cannot produce a VoluntaryYield"
+        | WhatWeDid.VoluntaryYield _ -> failwith "logic error: ensureTypeInitialised cannot produce a VoluntaryYield"
         | WhatWeDid.Executed ->
 
         let ctorAssembly = state.LoadedAssembly ctor.DeclaringType.Assembly |> Option.get


### PR DESCRIPTION
First of three planned changes for #844. Consulted with Fable on the design (two review rounds, which killed the first mechanism outright), then Codex on the implementation (two rounds, two findings, both fixed).

## What the measurements said

I instrumented the driver loop and ran the issue's repro (16 SpinWait spinners + a producer). This changed the diagnosis:

- **The PCT weight is not inverted in practice.** Mean `ContextSwitchPrior` weight is *identical* across spinners (0.277) and producer (0.269) — the BCL spin path is call- and volatile-read-heavy, so spinners take demotion draws at the same rate as real work. The hypothesis that spin loops dodge demotion is false for this guest.
- **The guest announces its futility thousands of times and we discard all of it.** Per spinner, exactly: 16 `Thread.Yield()` calls (reaching `onStepOutcome` as `VoluntaryYield` and treated identically to `Executed`), 4 `Thread.Sleep(0)` calls (a literal no-op that doesn't even signal a yield), and then `Thread.Sleep(1)` forever — 81,886 parks in one run, with **zero** ticks out of 800,000 at which any thread was observably parked.
- Shares: RoundRobin producer 5.76% (fair 5.88%); PCT seed 1 producer 1.04% at 800k steps, top spinner 16.6–24.9%.

## What this PR does

A yield now means what `sched_yield(2)` means: go to the back of the run queue. `ThreadState.YieldDebt` records the threads a yielder must see run before being chosen again; `Scheduler.candidates` filters the runnable set for every policy, so fairness is a property of the schedule space rather than of one policy.

The debt is bounded and self-clearing: it only shrinks, and membership is intersected with the live Runnable set at read time, so a member that blocks or parks stops counting with no hook in any wake path. Crucially **a peer that never yields discharges the debt by running.**

Yields are honoured only probabilistically under PCT (p = 0.9). A schedule where a yield isn't respected is a real execution — it's why `Thread.Yield()` returns a bool — so honouring unconditionally would delete those schedules from the space a harness can explore. RoundRobin takes no draw at all, preserving its documented determinism.

The coin, the debt and the return-value rewrite all live in `onStepOutcome`, the chokepoint every step already routes through, so a handler cannot emit a yield without the bookkeeping. `Thread.Yield()` accordingly stops returning hardcoded FALSE and reports the truth, as CoreCLR's `SwitchToThread` does. `Thread.Sleep(0)` now signals a yield.

## Scope — stated plainly

**This does not fix #844's repro**, whose steady state is `Sleep(1)`, and it does not change RoundRobin, which already never re-picks the thread that just ran while another is Runnable (measured: the acceptance guest costs 22,900 steps under RoundRobin with and without the filter, to the step). The beneficiary is PCT: **601,789 → 151,253** total scheduler steps across 20 fixed seeds. Making a sleep cost the sleeper virtual time is the next change.

## A rejected design, and why

The first plan used a global epoch: a yielder is re-admitted once every runnable thread has also yielded. Fable found it livelocks — `Thread.Yield(); f = true;` racing `while (!f) {}` hangs under that rule, where today it terminates, because one non-yielding peer excludes the yielder forever. It also let debt survive park/wake, so a thread that woke *holding* a lock could be held out indefinitely by an unflagged poller. Both are pinned as tests; both mutate back to failure.

## Testing

- Property tests over generated schedules (deliberately including threads that **never** yield — the case the epoch design died on), plus unit tests for charging, discharge, filtering, and the PCT coin on pinned seeds either side of the threshold.
- **Every new test was mutation-checked.** Re-introducing the epoch defect fails `bounded exclusion under RoundRobin` with the minimal counterexample `[NeverYields; NeverYields; AlwaysYields]`. Re-introducing the park/wake defect trips the `candidates` loud-failure assertion in three tests.
- The end-to-end test aggregates over a fixed seed set rather than asserting per seed: charging a debt perturbs the RNG stream, so individual seeds are not monotone (seed 7 gets *worse*, seed 42 improves 3.8×). Fixed seeds keep it fully deterministic despite being a statistical claim. My first two attempts at this test were vacuous and I only caught that by mutation.
- Full suite: 2,395 pass.

## Codex findings, both fixed

1. A thread's final `ret` routes through `onThreadTerminated`, not `onStepOutcome`, so terminated IDs stayed in debts forever — no correctness impact, but the `IsEmpty` fast path becomes unreachable and candidate selection degrades to O(R²).
2. The same shape on the entry-thread branch, which matters in the pre-`Main` pump where the thread is resurrected. Bounded at one scheduling decision; shipped without a direct regression test, and the commit says so.

Both were the same class of defect — a driver path retiring a step without routing through `onStepOutcome`. That invariant is currently spread across four branches of `stepPrepared` rather than enforced in one place, which is worth addressing when A and C land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)