### PR TITLE
Discharge yield debts once, at the driver's step seam

### DIFF
--- a/WoofWare.PawPrint.Test/TestSchedulerVoluntaryYield.fs
+++ b/WoofWare.PawPrint.Test/TestSchedulerVoluntaryYield.fs
@@ -103,12 +103,12 @@ module TestSchedulerVoluntaryYield =
 
     [<Test>]
     let ``VoluntaryYield wakes match Executed exactly, and only the wakes`` () : unit =
-        // VoluntaryYield used to be *wholly* identical to Executed; it no longer is, because
-        // a yield now also charges the yielder a `YieldDebt`. What must stay identical is the
-        // class-init wake behaviour: yielding is still forward progress, so the same threads
-        // wake either way. Pinning both halves separately is the point — the wake logic must
-        // not drift, and the debt must be the *only* difference, so a future change that
-        // (say) parked the yielder would fail here rather than passing a statuses-only check.
+        // VoluntaryYield differs from Executed in exactly one respect: it also charges the
+        // yielder a `YieldDebt`. The class-init wake behaviour must be identical, because
+        // yielding is forward progress just as an ordinary step is, so the same threads wake
+        // either way. Pinning both halves separately is the point — the wake logic must not
+        // drift, and the debt must be the *only* difference, so a change that (say) parked the
+        // yielder would fail here rather than passing a statuses-only check.
         //
         // Snapshot all three threads' statuses to keep the wake assertion total rather than
         // spot-checking.

--- a/WoofWare.PawPrint.Test/TestSchedulerYieldDebt.fs
+++ b/WoofWare.PawPrint.Test/TestSchedulerYieldDebt.fs
@@ -72,6 +72,21 @@ module TestSchedulerYieldDebt =
     let private runnable (n : int) : (ThreadId * ThreadStatus) list =
         List.init n (fun i -> ThreadId i, ThreadStatus.Runnable)
 
+    /// Mirror of what the driver does when a thread retires a step: discharge every yield debt
+    /// naming the runner, then apply the consequences specific to the outcome. The two halves
+    /// live in different places on purpose — the discharge is applied once at
+    /// `Program.stepPrepared`'s single `executeOneStep` seam so that it cannot be forgotten for
+    /// an outcome, while `onStepOutcome` sees only the `Stepped` family — so a test that wants
+    /// to model "a step happened" has to compose them.
+    ///
+    /// Note what this helper cannot catch: it re-implements the driver, so it stays green if
+    /// the driver itself stops discharging. `TestSchedulerYieldFairness` closes that gap by
+    /// asserting the invariant against a real run.
+    let private retireStep (ran : ThreadId) (outcome : WhatWeDid) (state : IlMachineState) : IlMachineState =
+        state
+        |> Scheduler.dischargeYieldDebts ran
+        |> Scheduler.onStepOutcome ran outcome
+
     // ---------------- Charging ----------------
 
     [<Test>]
@@ -87,8 +102,7 @@ module TestSchedulerYieldDebt =
                     ThreadId 2, ThreadStatus.BlockedOnJoin (ThreadId 0, None)
                 ]
 
-        let after =
-            Scheduler.onStepOutcome (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
+        let after = retireStep (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
 
         debtOf (ThreadId 0) after |> shouldEqual (Set.ofList [ ThreadId 1 ])
         debtOf (ThreadId 1) after |> shouldEqual Set.empty
@@ -107,8 +121,7 @@ module TestSchedulerYieldDebt =
                     ThreadId 1, ThreadStatus.BlockedOnSleep (Some 100L)
                 ]
 
-        let after =
-            Scheduler.onStepOutcome (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
+        let after = retireStep (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
 
         debtOf (ThreadId 0) after |> shouldEqual Set.empty
 
@@ -118,8 +131,7 @@ module TestSchedulerYieldDebt =
     let ``a thread with outstanding debt is not chosen`` () : unit =
         let state = baseState () |> withThreads (runnable 3)
 
-        let state =
-            Scheduler.onStepOutcome (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
+        let state = retireStep (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
 
         // Round-robin from `lastRan = 2` would wrap to thread 0; the debt must override that.
         Scheduler.chooseNext (ThreadId 2) state
@@ -130,20 +142,19 @@ module TestSchedulerYieldDebt =
     let ``debt is discharged by its members running, re-admitting the yielder`` () : unit =
         let state = baseState () |> withThreads (runnable 3)
 
-        let state =
-            Scheduler.onStepOutcome (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
+        let state = retireStep (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
 
         debtOf (ThreadId 0) state
         |> shouldEqual (Set.ofList [ ThreadId 1 ; ThreadId 2 ])
 
-        let state = Scheduler.onStepOutcome (ThreadId 1) WhatWeDid.Executed state
+        let state = retireStep (ThreadId 1) WhatWeDid.Executed state
         debtOf (ThreadId 0) state |> shouldEqual (Set.ofList [ ThreadId 2 ])
         // Still excluded: thread 2 has not had its turn.
         Scheduler.chooseNext (ThreadId 2) state
         |> snd
         |> shouldEqual (Some (ThreadId 1))
 
-        let state = Scheduler.onStepOutcome (ThreadId 2) WhatWeDid.Executed state
+        let state = retireStep (ThreadId 2) WhatWeDid.Executed state
         debtOf (ThreadId 0) state |> shouldEqual Set.empty
 
         Scheduler.chooseNext (ThreadId 2) state
@@ -157,8 +168,7 @@ module TestSchedulerYieldDebt =
         // out anyway, or thread 0 waits on a thread that will never satisfy it.
         let state = baseState () |> withThreads (runnable 2)
 
-        let state =
-            Scheduler.onStepOutcome (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
+        let state = retireStep (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
 
         debtOf (ThreadId 0) state |> shouldEqual (Set.ofList [ ThreadId 1 ])
 
@@ -177,8 +187,7 @@ module TestSchedulerYieldDebt =
         // machine when the sole runnable thread has just yielded.
         let state = baseState () |> withThreads (runnable 2)
 
-        let state =
-            Scheduler.onStepOutcome (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
+        let state = retireStep (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
 
         let state = Scheduler.blockOnJoin (ThreadId 1) (ThreadId 0) None state
 
@@ -200,7 +209,7 @@ module TestSchedulerYieldDebt =
             let choice = Option.get choice
             chosen.Add choice
             lastRan <- choice
-            state <- Scheduler.onStepOutcome choice (WhatWeDid.VoluntaryYield false) s
+            state <- retireStep choice (WhatWeDid.VoluntaryYield false) s
 
         chosen
         |> List.ofSeq
@@ -269,7 +278,7 @@ module TestSchedulerYieldDebt =
                         else
                             WhatWeDid.Executed
 
-                state <- Scheduler.onStepOutcome choice outcome s
+                state <- retireStep choice outcome s
 
                 // Everyone that has already had a turn must have had one within the last `n`
                 // decisions. Threads not yet chosen at all are covered by the end-state check.
@@ -333,7 +342,7 @@ module TestSchedulerYieldDebt =
                         | Behaviour.NeverYields -> WhatWeDid.Executed
                         | _ -> WhatWeDid.VoluntaryYield false
 
-                    state <- Scheduler.onStepOutcome choice outcome s
+                    state <- retireStep choice outcome s
 
         Check.One (config, Prop.forAll (Arb.fromGen scheduleGen) property)
 
@@ -363,7 +372,7 @@ module TestSchedulerYieldDebt =
         let state =
             baseState () |> withThreads (runnable 2) |> IlMachineState.withPctSeed seed
 
-        Scheduler.onStepOutcome (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
+        retireStep (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
         |> debtOf (ThreadId 0)
 
     [<Test>]
@@ -384,8 +393,7 @@ module TestSchedulerYieldDebt =
         // through a shared sampling path with p = 1.0.
         let state = baseState () |> withThreads (runnable 2)
 
-        let after =
-            Scheduler.onStepOutcome (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
+        let after = retireStep (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
 
         debtOf (ThreadId 0) after |> shouldEqual (Set.ofList [ ThreadId 1 ])
         after.Scheduling |> shouldEqual SchedulerState.RoundRobin
@@ -399,8 +407,7 @@ module TestSchedulerYieldDebt =
             let state =
                 baseState () |> withThreads threads |> IlMachineState.withPctSeed 12345UL
 
-            let after =
-                Scheduler.onStepOutcome (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
+            let after = retireStep (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
 
             match after.Scheduling with
             | SchedulerState.Pct pct -> pct.Rng
@@ -434,28 +441,30 @@ module TestSchedulerYieldDebt =
         after.Scheduling |> shouldEqual (SchedulerState.Pct (PctState.ofSeed 99UL))
 
     [<Test>]
-    let ``a terminating thread is pruned from every outstanding debt`` () : unit =
-        // A thread's final step is its bottom-frame `Ret`, which the driver routes through
-        // `onThreadTerminated` rather than `onStepOutcome` — so the one step that most
-        // conclusively satisfies "I am waiting to see you run" is the one step that would
-        // otherwise discharge nothing.
+    let ``a terminating thread is discharged from every outstanding debt`` () : unit =
+        // A thread's final step is its bottom-frame `Ret`, which reaches the driver as
+        // `ExecutionResult.Terminated` rather than `Stepped` — so the one step that most
+        // conclusively satisfies "I am waiting to see you run" is the one that is easiest to
+        // forget. It is discharged at the seam, like every other retired step, so the sequence
+        // modelled here is "the step was retired, *and* it happened to be a termination".
         //
-        // Correctness does not depend on this (a Terminated thread is never in the Runnable
-        // set, so `candidates` ignores it either way, and the two assertions on `chooseNext`
-        // below pass with or without the pruning). Cost does: a debt that keeps a
-        // permanently-unrunnable member never goes empty, so its owner misses the `IsEmpty`
-        // fast path in `debtDischarged` for the rest of the run and scans the runnable list on
-        // every scheduling decision. Assert on the debt itself, not just on the choice, or the
-        // regression is invisible.
+        // Correctness does not depend on it (a Terminated thread is never in the Runnable set,
+        // so `candidates` ignores it either way, and the two `chooseNext` assertions below pass
+        // regardless). Cost does: a debt keeping a permanently-unrunnable member never goes
+        // empty, so its owner misses the `IsEmpty` fast path in `debtDischarged` for the rest of
+        // the run and scans the runnable list on every scheduling decision. Assert on the debt
+        // itself, not just on the choice, or the regression is invisible.
         let state = baseState () |> withThreads (runnable 3)
 
-        let state =
-            Scheduler.onStepOutcome (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
+        let state = retireStep (ThreadId 0) (WhatWeDid.VoluntaryYield false) state
 
         debtOf (ThreadId 0) state
         |> shouldEqual (Set.ofList [ ThreadId 1 ; ThreadId 2 ])
 
-        let state = Scheduler.onThreadTerminated (ThreadId 1) state
+        let state =
+            state
+            |> Scheduler.dischargeYieldDebts (ThreadId 1)
+            |> Scheduler.onThreadTerminated (ThreadId 1)
 
         debtOf (ThreadId 0) state |> shouldEqual (Set.ofList [ ThreadId 2 ])
 
@@ -465,5 +474,45 @@ module TestSchedulerYieldDebt =
         |> snd
         |> shouldEqual (Some (ThreadId 2))
 
-        let state = Scheduler.onStepOutcome (ThreadId 2) WhatWeDid.Executed state
+        let state = retireStep (ThreadId 2) WhatWeDid.Executed state
         debtOf (ThreadId 0) state |> shouldEqual Set.empty
+
+    [<Test>]
+    let ``mapState reaches the state of every ExecutionResult variant`` () : unit =
+        // The seam's totality is the enforcement mechanism: `Program.stepPrepared` discharges by
+        // mapping over whatever `executeOneStep` returned, so an outcome whose state `mapState`
+        // failed to touch would silently skip the per-step bookkeeping. The compiler catches a
+        // *missing* variant; this catches one that is present but wired to the wrong field, and
+        // pins that no variant is deliberately exempted later.
+        let marked = baseState () |> withThreads (runnable 1)
+
+        let mark (_ : IlMachineState) : IlMachineState = marked
+
+        let sentinel = baseState ()
+        let thread = ThreadId 0
+
+        let variants : ExecutionResult list =
+            [
+                ExecutionResult.Terminated (sentinel, thread)
+                ExecutionResult.ProcessExit (sentinel, thread)
+                ExecutionResult.FailFast (sentinel, thread, Some "m")
+                ExecutionResult.SignalTerminated (sentinel, Signal.SIGINT)
+                ExecutionResult.Stepped (sentinel, WhatWeDid.Executed, StepEffect.NoEffect)
+            ]
+
+        for variant in variants do
+            let mapped = ExecutionResult.mapState mark variant
+
+            let state =
+                match mapped with
+                | ExecutionResult.Terminated (s, _)
+                | ExecutionResult.ProcessExit (s, _)
+                | ExecutionResult.FailFast (s, _, _)
+                | ExecutionResult.SignalTerminated (s, _)
+                | ExecutionResult.Stepped (s, _, _)
+                | ExecutionResult.UnhandledException (s, _, _) -> s
+
+            // Reference equality would be ideal but `IlMachineState` is a large record; the
+            // thread map is enough to tell the marked state from the sentinel.
+            state.ThreadState.Count |> shouldEqual marked.ThreadState.Count
+            state.ThreadState.Count |> shouldNotEqual sentinel.ThreadState.Count

--- a/WoofWare.PawPrint.Test/TestSchedulerYieldDebt.fs
+++ b/WoofWare.PawPrint.Test/TestSchedulerYieldDebt.fs
@@ -1,6 +1,7 @@
 namespace WoofWare.PawPrint.Test
 
 open System.Collections.Immutable
+open Microsoft.FSharp.Reflection
 open FsCheck
 open FsCheck.FSharp
 open FsUnitTyped
@@ -491,6 +492,12 @@ module TestSchedulerYieldDebt =
         let sentinel = baseState ()
         let thread = ThreadId 0
 
+        let guestException : CliException<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle> =
+            {
+                ExceptionObject = ManagedHeapAddress 1
+                StackTrace = []
+            }
+
         let variants : ExecutionResult list =
             [
                 ExecutionResult.Terminated (sentinel, thread)
@@ -498,7 +505,16 @@ module TestSchedulerYieldDebt =
                 ExecutionResult.FailFast (sentinel, thread, Some "m")
                 ExecutionResult.SignalTerminated (sentinel, Signal.SIGINT)
                 ExecutionResult.Stepped (sentinel, WhatWeDid.Executed, StepEffect.NoEffect)
+                ExecutionResult.UnhandledException (sentinel, thread, guestException)
             ]
+
+        // The table above is hand-written, so it can fall behind the type — which is the exact
+        // failure this test would then hide, since a variant that is never constructed is never
+        // checked no matter how thoroughly the assertions below are written. Tie the two
+        // together: adding a variant to `ExecutionResult` fails here until it is listed.
+        FSharpType.GetUnionCases typeof<ExecutionResult>
+        |> Array.length
+        |> shouldEqual variants.Length
 
         for variant in variants do
             let mapped = ExecutionResult.mapState mark variant

--- a/WoofWare.PawPrint.Test/TestSchedulerYieldFairness.fs
+++ b/WoofWare.PawPrint.Test/TestSchedulerYieldFairness.fs
@@ -76,6 +76,30 @@ module TestSchedulerYieldFairness =
                         | EvalStackValue.Int32 (Int32Source.Verbatim code) :: _ -> code
                         | other -> failwith $"guest Main did not return an int32: %A{other}"
 
+                    // The discharge lemma, checked against a real run rather than a model of
+                    // one: no thread may hold a yield debt naming a thread that has already
+                    // terminated. A terminating thread retires a step like any other (its
+                    // bottom-frame `Ret`), so the driver's seam must have discharged it; and
+                    // nothing can be charged into a debt after it stops being Runnable, since
+                    // `chargeYieldDebt` only names Runnable threads. So a violation here means
+                    // the driver skipped `Scheduler.dischargeYieldDebts` for some outcome.
+                    //
+                    // This is the assertion the unit tests structurally cannot make: their
+                    // `retireStep` helper re-implements the driver, so it stays green if the
+                    // driver itself drops the seam call.
+                    let terminated =
+                        state.ThreadState
+                        |> Map.filter (fun _ ts -> ts.Status = ThreadStatus.Terminated)
+                        |> Map.keys
+                        |> Set.ofSeq
+
+                    for KeyValue (tid, ts) in state.ThreadState do
+                        let stale = Set.intersect ts.YieldDebt terminated
+
+                        if not stale.IsEmpty then
+                            failwith
+                                $"thread %O{tid} ended the run holding a yield debt naming terminated thread(s) %A{stale}; the driver failed to discharge a retired step."
+
                     code, state.Kernel.StepCounter
                 | Program.ProgramStepOutcome.Completed other -> failwith $"unexpected guest outcome: %A{other}"
                 | Program.ProgramStepOutcome.Deadlocked (_, stuck) -> failwith $"guest deadlocked: %s{stuck}"

--- a/WoofWare.PawPrint/IlMachineStateModel.fs
+++ b/WoofWare.PawPrint/IlMachineStateModel.fs
@@ -503,6 +503,32 @@ module ExecutionResult =
     let steppedWith (effect : StepEffect) ((state, whatWeDid) : IlMachineState * WhatWeDid) : ExecutionResult =
         ExecutionResult.Stepped (state, whatWeDid, effect)
 
+    /// Apply `f` to the machine state carried by any outcome, preserving the variant and its
+    /// other payload.
+    ///
+    /// Every `ExecutionResult` carries a state because every one of them describes a step that
+    /// was actually retired — that is the whole reason this function can be total. It exists so
+    /// that per-step bookkeeping which must happen *whatever the step turned out to be* can be
+    /// written once, at the driver's single call site of `AbstractMachine.executeOneStep`,
+    /// rather than being repeated in each arm of the driver's match on the outcome.
+    ///
+    /// The match is deliberately written out rather than expressed with a wildcard: adding a
+    /// variant must fail to compile here, so that whoever adds it has to decide whether their
+    /// new outcome represents a retired step. That compile error is the enforcement mechanism —
+    /// the reason to prefer this over a hand-written call in each arm, where a new arm silently
+    /// inherits nothing.
+    let mapState (f : IlMachineState -> IlMachineState) (result : ExecutionResult) : ExecutionResult =
+        match result with
+        | ExecutionResult.Terminated (state, terminatingThread) ->
+            ExecutionResult.Terminated (f state, terminatingThread)
+        | ExecutionResult.ProcessExit (state, exitingThread) -> ExecutionResult.ProcessExit (f state, exitingThread)
+        | ExecutionResult.FailFast (state, abortingThread, message) ->
+            ExecutionResult.FailFast (f state, abortingThread, message)
+        | ExecutionResult.SignalTerminated (state, signal) -> ExecutionResult.SignalTerminated (f state, signal)
+        | ExecutionResult.Stepped (state, whatWeDid, effect) -> ExecutionResult.Stepped (f state, whatWeDid, effect)
+        | ExecutionResult.UnhandledException (state, terminatingThread, exn) ->
+            ExecutionResult.UnhandledException (f state, terminatingThread, exn)
+
 [<RequireQualifiedAccess>]
 module NativeHandlerResult =
     /// Native handler completed normally with no externally-observable effect.

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -494,10 +494,9 @@ module Program =
             // per-step scheduler bookkeeping that holds regardless of outcome is applied here,
             // once, before we look at which outcome we got.
             //
-            // This used to be done in the individual arms, and the two arms above were both
-            // missed; see `Scheduler.dischargeYieldDebts` for what that cost. `mapState` is
-            // exhaustive over `ExecutionResult`, so a new outcome cannot quietly skip it.
-            // Outcome-*specific* consequences still belong in the arms, via
+            // Doing it here rather than in the individual arms is what makes it hard to get
+            // wrong: `mapState` is exhaustive over `ExecutionResult`, so a new outcome cannot
+            // quietly skip it. Outcome-*specific* consequences still belong in the arms, via
             // `Scheduler.onStepOutcome` and `Scheduler.onThreadTerminated`.
             let stepResult =
                 AbstractMachine.executeOneStep loggerFactory prepared.BaseClassTypes prepared.State nextThread

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -487,28 +487,25 @@ module Program =
             // remaining thread is blocked, so progress is impossible.
             ProgramStepOutcome.Deadlocked (prepared, deadlockDescription prepared.State)
         | Some nextThread ->
-            match AbstractMachine.executeOneStep loggerFactory prepared.BaseClassTypes prepared.State nextThread with
+            // `nextThread` has now retired a step, and that is true of *every* outcome below —
+            // including the ones that do not look like ordinary progress: a thread's final
+            // `Ret` arrives as `Terminated`, and the entry thread's synthetic `onlyRet` frame
+            // arrives as a `NormalExit` that the pre-`Main` pump then continues past. So the
+            // per-step scheduler bookkeeping that holds regardless of outcome is applied here,
+            // once, before we look at which outcome we got.
+            //
+            // This used to be done in the individual arms, and the two arms above were both
+            // missed; see `Scheduler.dischargeYieldDebts` for what that cost. `mapState` is
+            // exhaustive over `ExecutionResult`, so a new outcome cannot quietly skip it.
+            // Outcome-*specific* consequences still belong in the arms, via
+            // `Scheduler.onStepOutcome` and `Scheduler.onThreadTerminated`.
+            let stepResult =
+                AbstractMachine.executeOneStep loggerFactory prepared.BaseClassTypes prepared.State nextThread
+                |> ExecutionResult.mapState (Scheduler.dischargeYieldDebts nextThread)
+
+            match stepResult with
             | ExecutionResult.Terminated (state, terminatingThread) ->
                 if terminatingThread = prepared.EntryThread then
-                    // Discharge before reporting. This looks like the end of the run, and for
-                    // the post-`Main` pump it is — but the *pre*-`Main` cctor pump reports
-                    // `NormalExit` too, when the synthetic `onlyRet` frame returns, and then
-                    // `Program.run` resurrects this very thread with the real `Main` frame and
-                    // keeps stepping. A worker spawned by an entry-type cctor that yielded just
-                    // before that synthetic `ret` would otherwise carry a debt naming the entry
-                    // thread across the resurrection, and be held out for a decision even
-                    // though the thread it is waiting on has already run.
-                    //
-                    // Routed through `onStepOutcome` rather than a discharge-only helper for
-                    // the same reason as the dispatcher branch below: one entry point for
-                    // "a thread retired a step" is one fewer thing a future path can half-do.
-                    // Its other effect here — waking threads BlockedOnClassInit on the entry
-                    // thread — is right in the pre-`Main` case (those cctors have just
-                    // finished) and inert in the post-`Main` one (nothing is scheduled again).
-                    // Deliberately does *not* mark the entry thread Terminated: it may yet run
-                    // `Main`.
-                    let state = Scheduler.onStepOutcome terminatingThread WhatWeDid.Executed state
-
                     ProgramStepOutcome.Completed (RunOutcome.NormalExit (state, prepared.EntryThread))
                 elif SignalState.signalThread state.Kernel.Signals = Some terminatingThread then
                     // The kernel-owned signal-dispatch thread's handler frame
@@ -521,12 +518,10 @@ module Program =
                     // invocations.
                     let state = SignalDispatch.reParkAfterHandler terminatingThread state
 
-                    // Route through the scheduler like every other stepped outcome. This
-                    // branch reports `WhatWeDid.Executed` — the dispatcher did retire a step —
-                    // and the scheduler's per-step bookkeeping (discharging yield debts that
-                    // name this thread) has to see it. Skipping the call would leave the
-                    // dispatcher named in an outstanding debt it can never discharge, which
-                    // `Scheduler.candidates` relies on being impossible.
+                    // The dispatcher retired a step and this branch reports it as
+                    // `WhatWeDid.Executed`, so give it that outcome's consequences — waking
+                    // anything parked BlockedOnClassInit behind it. (The yield-debt half of
+                    // the bookkeeping has already happened at the seam above.)
                     let state = Scheduler.onStepOutcome terminatingThread WhatWeDid.Executed state
 
                     ProgramStepOutcome.InstructionStepped (

--- a/WoofWare.PawPrint/Scheduler.fs
+++ b/WoofWare.PawPrint/Scheduler.fs
@@ -122,13 +122,30 @@ module Scheduler =
         | _ -> eligible
 
     /// Remove `ran` from every outstanding yield debt: it has taken its step, so anyone waiting
-    /// to see it run has been satisfied. Called for every step outcome, since every step
-    /// discharges, not just yields.
+    /// to see it run has been satisfied.
     ///
-    /// Short-circuits on the common path the way the `BlockedOnClassInit` wake scan next door
-    /// does: this runs once per interpreted IL instruction and almost never has anything to do,
-    /// because outstanding debts exist only during yield bursts.
-    let private dischargeYieldDebts (ran : ThreadId) (state : IlMachineState) : IlMachineState =
+    /// **This must be applied to every retired step, whatever that step turned out to be**, and
+    /// there is exactly one caller: the driver applies it to the result of
+    /// `AbstractMachine.executeOneStep` via `ExecutionResult.mapState`, before it looks at which
+    /// outcome it got. Do not add a second call site. The reason is not tidiness — it is that
+    /// the discharge used to live in the driver's per-outcome arms, and both of the arms that
+    /// did not obviously look like "a thread ran" were missed, in both cases only being caught
+    /// in review:
+    ///
+    ///   * a thread's *final* step leaves the driver as `ExecutionResult.Terminated`, so the one
+    ///     step that most conclusively satisfies "I am waiting to see you run" discharged
+    ///     nothing, and the terminated id sat in debts forever;
+    ///   * the entry thread's synthetic `onlyRet` frame reports `NormalExit` even in the
+    ///     pre-`Main` pump, after which that same thread is resurrected and keeps running.
+    ///
+    /// Neither was a correctness bug, because `candidates` filters debts against the live
+    /// Runnable set — but both broke the discharge lemma that `candidates`' non-emptiness proof
+    /// rests on, and the first one made the `IsEmpty` fast path permanently unreachable.
+    ///
+    /// Short-circuits on the common path the way the `BlockedOnClassInit` wake scan does: this
+    /// runs once per interpreted IL instruction and almost never has anything to do, because
+    /// outstanding debts exist only during yield bursts.
+    let dischargeYieldDebts (ran : ThreadId) (state : IlMachineState) : IlMachineState =
         let anyDebtNames =
             state.ThreadState |> Map.exists (fun _ ts -> ts.YieldDebt |> Set.contains ran)
 
@@ -573,26 +590,13 @@ module Scheduler =
             | SchedulerState.RoundRobin -> SchedulerState.RoundRobin
             | SchedulerState.Pct pct -> SchedulerState.Pct (PctState.removeThread terminated pct)
 
-        let state =
-            { state with
-                ThreadState = threadState
-                Scheduling = scheduling
-            }
-
-        // Discharge `terminated` from every outstanding yield debt. A thread's *final* step is
-        // its bottom-frame `Ret`, which the driver surfaces as `ExecutionResult.Terminated` and
-        // routes here rather than through `onStepOutcome` — so without this, the one step that
-        // most conclusively satisfies "I am waiting to see you run" would be the one step that
-        // never discharges anything.
-        //
-        // Not needed for correctness: `candidates` intersects each debt with the live Runnable
-        // set, and a Terminated thread is never in it, so a stale member could not hold anyone
-        // out. It is needed for cost. A debt containing a terminated id never becomes empty, so
-        // its owner permanently misses the `IsEmpty` fast path in `debtDischarged` and pays a
-        // scan of the runnable list on every scheduling decision for the rest of the run —
-        // turning candidate selection from O(R) into O(R²) once a few threads have yielded and
-        // a peer has exited. Pruning here keeps the fast path reachable.
-        dischargeYieldDebts terminated state
+        // No yield-debt pruning here: the driver has already discharged `terminated` at the
+        // seam, because a thread's final `Ret` is a retired step like any other. See
+        // `dischargeYieldDebts`.
+        { state with
+            ThreadState = threadState
+            Scheduling = scheduling
+        }
 
     /// Apply the init outcome of a freshly-spawned worker to its own ThreadStatus.
     /// Called once from `Thread.StartInternal` after `ensureTypeInitialised` has run
@@ -713,13 +717,11 @@ module Scheduler =
 
         state, true
 
+    /// Apply the consequences that depend on *which* outcome the step produced. The
+    /// consequences that apply to every retired step regardless — currently just discharging
+    /// yield debts — deliberately do not live here, because this function only sees the
+    /// `Stepped` family of outcomes; they live at the driver seam. See `dischargeYieldDebts`.
     let onStepOutcome (ran : ThreadId) (outcome : WhatWeDid) (state : IlMachineState) : IlMachineState =
-        // Every step discharges, whatever else it did: `ran` has taken its turn, so any thread
-        // waiting to see it run is satisfied. Must happen for all outcomes, including the
-        // blocking ones — a thread that blocks has still run, and `candidates`' non-emptiness
-        // proof depends on that being true without exception.
-        let state = dischargeYieldDebts ran state
-
         // A yielder made forward progress just as an ordinary `Executed` step does, so both
         // wake any thread parked BlockedOnClassInit on `ran`. They diverge only afterwards:
         // a yield additionally goes to the back of the run queue.

--- a/WoofWare.PawPrint/Scheduler.fs
+++ b/WoofWare.PawPrint/Scheduler.fs
@@ -127,20 +127,19 @@ module Scheduler =
     /// **This must be applied to every retired step, whatever that step turned out to be**, and
     /// there is exactly one caller: the driver applies it to the result of
     /// `AbstractMachine.executeOneStep` via `ExecutionResult.mapState`, before it looks at which
-    /// outcome it got. Do not add a second call site. The reason is not tidiness — it is that
-    /// the discharge used to live in the driver's per-outcome arms, and both of the arms that
-    /// did not obviously look like "a thread ran" were missed, in both cases only being caught
-    /// in review:
+    /// outcome it got. Do not add a second call site, and in particular do not move it into the
+    /// driver's per-outcome arms. Two outcomes there do not look like "a thread ran" and are
+    /// easy to overlook:
     ///
-    ///   * a thread's *final* step leaves the driver as `ExecutionResult.Terminated`, so the one
-    ///     step that most conclusively satisfies "I am waiting to see you run" discharged
-    ///     nothing, and the terminated id sat in debts forever;
+    ///   * a thread's *final* step leaves the driver as `ExecutionResult.Terminated`, though it
+    ///     is the step that most conclusively satisfies "I am waiting to see you run";
     ///   * the entry thread's synthetic `onlyRet` frame reports `NormalExit` even in the
     ///     pre-`Main` pump, after which that same thread is resurrected and keeps running.
     ///
-    /// Neither was a correctness bug, because `candidates` filters debts against the live
-    /// Runnable set — but both broke the discharge lemma that `candidates`' non-emptiness proof
-    /// rests on, and the first one made the `IsEmpty` fast path permanently unreachable.
+    /// Missing either does not break correctness, because `candidates` filters debts against the
+    /// live Runnable set — but it breaks the discharge lemma that `candidates`' non-emptiness
+    /// proof rests on, and missing the first also makes the `IsEmpty` fast path below
+    /// permanently unreachable for any thread that yielded before a peer exited.
     ///
     /// Short-circuits on the common path the way the `BlockedOnClassInit` wake scan does: this
     /// runs once per interpreted IL instruction and almost never has anything to do, because

--- a/WoofWare.PawPrint/ThreadState.fs
+++ b/WoofWare.PawPrint/ThreadState.fs
@@ -345,26 +345,21 @@ type ThreadState =
         /// This is `sched_yield(2)` semantics stated as data: an honoured `Thread.Yield()` /
         /// `Thread.Sleep(0)` sends the caller to the back of the run queue, and the queue is
         /// "everyone who was Runnable alongside me at that moment".
-        /// `Scheduler.onStepOutcome` charges the debt (see `WhatWeDid.VoluntaryYield`) and
-        /// discharges members as they run.
+        /// `Scheduler.onStepOutcome` charges the debt (see `WhatWeDid.VoluntaryYield`);
+        /// `Scheduler.dischargeYieldDebts`, applied to every retired step at the driver's
+        /// single step seam, removes members as they run.
         ///
         /// Bounded and self-clearing by construction, which is the whole point of the
-        /// representation. The set only ever shrinks: members are removed as they run, and
-        /// `Scheduler.candidates` additionally intersects it with the live Runnable set at
-        /// read time, so for *correctness* a member that blocks, parks or terminates stops
-        /// counting with no cleanup pass at all.
+        /// representation. The set only ever shrinks, and `Scheduler.candidates` additionally
+        /// intersects it with the live Runnable set at read time, so a member that blocks,
+        /// parks or terminates stops counting even before its id is removed — no wake path
+        /// needs a cleanup hook.
         ///
-        /// `Scheduler.onThreadTerminated` nonetheless prunes the terminated thread, for cost
-        /// rather than correctness: a debt that retains a permanently-unrunnable member never
-        /// becomes empty, so its owner misses the cheap `IsEmpty` test forever after and pays
-        /// a runnable-set scan on every scheduling decision. See that function for the
-        /// argument in full.
-        ///
-        /// The consequence worth stating explicitly, because the obvious alternative design
-        /// gets it wrong: a peer that never yields *discharges* the debt by running. A rule
-        /// that instead held a yielder out until its peers also yielded would let a single
-        /// non-yielding busy-waiter exclude a yielder forever — `Thread.Yield(); f = true;`
-        /// racing `while (!f) {}` would livelock, where today it does not.
+        /// A peer that never yields nonetheless *discharges* the debt by running, and that is
+        /// load-bearing rather than incidental. A rule that instead held a yielder out until
+        /// its peers also yielded would let one non-yielding busy-waiter exclude it forever:
+        /// `Thread.Yield(); f = true;` racing `while (!f) {}` would livelock under such a
+        /// rule.
         YieldDebt : Set<ThreadId>
     }
 


### PR DESCRIPTION
Follow-up to #846, which left an invariant maintained by hand in several places.

## The problem

"Every retired step discharges the runner from outstanding yield debts" was enforced by a call in each arm of `Program.stepPrepared`'s match on the step outcome. Both arms that don't *look* like "a thread ran" were missed, and both were caught only in review of #846.

## The change

Every `ExecutionResult` variant carries a state, precisely because every one describes a step that was actually retired. So the discharge now happens once, via a total `ExecutionResult.mapState`, applied to whatever `executeOneStep` returned *before* the driver looks at which outcome it got. The match is written out rather than using a wildcard, so adding a variant fails to compile until its author decides whether it represents a retired step.

Both earlier patches delete as a result: `onThreadTerminated` no longer prunes debts, and the entry-thread arm no longer has a bespoke discharge. `onStepOutcome` is left doing only work that genuinely depends on *which* outcome occurred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)