### PR TITLE
Denominate the virtual clock in 100ns ticks

### DIFF
--- a/WoofWare.PawPrint.App/DebuggerServer.fs
+++ b/WoofWare.PawPrint.App/DebuggerServer.fs
@@ -74,14 +74,14 @@ module DebuggerServer =
         match status with
         | ThreadStatus.Runnable -> writer.WriteStringValue "runnable"
         | ThreadStatus.NotStarted -> writer.WriteStringValue "notStarted"
-        | ThreadStatus.BlockedOnJoin (target, deadlineMs) ->
+        | ThreadStatus.BlockedOnJoin (target, deadlineTicks) ->
             writer.WriteStartObject ()
             writer.WriteString ("kind", "blockedOnJoin")
             writer.WriteNumber ("targetThread", threadIdValue target)
 
-            match deadlineMs with
+            match deadlineTicks with
             | None -> ()
-            | Some ms -> writer.WriteNumber ("deadlineMs", ms)
+            | Some ticks -> writer.WriteNumber ("deadlineTicks", ticks)
 
             writer.WriteEndObject ()
         | ThreadStatus.BlockedOnClassInit blocker ->
@@ -94,47 +94,47 @@ module DebuggerServer =
             writer.WriteString ("kind", "blockedOnMonitorAcquire")
             writer.WriteNumber ("monitor", monitor)
             writer.WriteEndObject ()
-        | ThreadStatus.BlockedOnMonitorWait (LowLevelMonitorId monitor, deadlineMs) ->
+        | ThreadStatus.BlockedOnMonitorWait (LowLevelMonitorId monitor, deadlineTicks) ->
             writer.WriteStartObject ()
             writer.WriteString ("kind", "blockedOnMonitorWait")
             writer.WriteNumber ("monitor", monitor)
 
-            match deadlineMs with
+            match deadlineTicks with
             | None -> ()
-            | Some ms -> writer.WriteNumber ("deadlineMs", ms)
+            | Some ticks -> writer.WriteNumber ("deadlineTicks", ticks)
 
             writer.WriteEndObject ()
-        | ThreadStatus.BlockedOnSyncBlockAcquire (lockObject, deadlineMs) ->
+        | ThreadStatus.BlockedOnSyncBlockAcquire (lockObject, deadlineTicks) ->
             writer.WriteStartObject ()
             writer.WriteString ("kind", "blockedOnSyncBlockAcquire")
             writer.WriteNumber ("lockObject", heapAddressValue lockObject)
 
-            match deadlineMs with
+            match deadlineTicks with
             | None -> ()
-            | Some ms -> writer.WriteNumber ("deadlineMs", ms)
+            | Some ticks -> writer.WriteNumber ("deadlineTicks", ticks)
 
             writer.WriteEndObject ()
-        | ThreadStatus.BlockedOnSyncBlockWait (lockObject, deadlineMs) ->
+        | ThreadStatus.BlockedOnSyncBlockWait (lockObject, deadlineTicks) ->
             writer.WriteStartObject ()
             writer.WriteString ("kind", "blockedOnSyncBlockWait")
             writer.WriteNumber ("lockObject", heapAddressValue lockObject)
 
-            match deadlineMs with
+            match deadlineTicks with
             | None -> ()
-            | Some ms -> writer.WriteNumber ("deadlineMs", ms)
+            | Some ticks -> writer.WriteNumber ("deadlineTicks", ticks)
 
             writer.WriteEndObject ()
-        | ThreadStatus.BlockedOnWaitHandle (WaitHandleId handle, deadlineMs) ->
+        | ThreadStatus.BlockedOnWaitHandle (WaitHandleId handle, deadlineTicks) ->
             writer.WriteStartObject ()
             writer.WriteString ("kind", "blockedOnWaitHandle")
             writer.WriteNumber ("handle", handle)
 
-            match deadlineMs with
+            match deadlineTicks with
             | None -> ()
-            | Some ms -> writer.WriteNumber ("deadlineMs", ms)
+            | Some ticks -> writer.WriteNumber ("deadlineTicks", ticks)
 
             writer.WriteEndObject ()
-        | ThreadStatus.BlockedOnWaitHandles (handles, waitAll, deadlineMs) ->
+        | ThreadStatus.BlockedOnWaitHandles (handles, waitAll, deadlineTicks) ->
             writer.WriteStartObject ()
             writer.WriteString ("kind", "blockedOnWaitHandles")
             writer.WriteBoolean ("waitAll", waitAll)
@@ -145,18 +145,18 @@ module DebuggerServer =
 
             writer.WriteEndArray ()
 
-            match deadlineMs with
+            match deadlineTicks with
             | None -> ()
-            | Some ms -> writer.WriteNumber ("deadlineMs", ms)
+            | Some ticks -> writer.WriteNumber ("deadlineTicks", ticks)
 
             writer.WriteEndObject ()
-        | ThreadStatus.BlockedOnSleep deadlineMs ->
+        | ThreadStatus.BlockedOnSleep deadlineTicks ->
             writer.WriteStartObject ()
             writer.WriteString ("kind", "blockedOnSleep")
 
-            match deadlineMs with
+            match deadlineTicks with
             | None -> ()
-            | Some ms -> writer.WriteNumber ("deadlineMs", ms)
+            | Some ticks -> writer.WriteNumber ("deadlineTicks", ticks)
 
             writer.WriteEndObject ()
         | ThreadStatus.Terminated -> writer.WriteStringValue "terminated"

--- a/WoofWare.PawPrint.Test/TestCpuPlacement.fs
+++ b/WoofWare.PawPrint.Test/TestCpuPlacement.fs
@@ -273,7 +273,7 @@ module TestCpuPlacement =
 
             let busy =
                 { plain with
-                    VirtualClockMs = 1234L
+                    VirtualClockTicks = 1234L
                     StepCounter = 5678L
                     NonCryptoRandomState = 0xDEADBEEFUL
                 }

--- a/WoofWare.PawPrint.Test/TestImpureCases.fs
+++ b/WoofWare.PawPrint.Test/TestImpureCases.fs
@@ -273,8 +273,11 @@ module TestImpureCases =
             }
             {
                 // The monotonic clock the guest observes through `Stopwatch`
-                // boots at zero and moves in whole milliseconds, and is the same
-                // clock `Environment.TickCount64` reads. Those are
+                // boots at zero, and is the same clock `Environment.TickCount64`
+                // reads. It moves in whole milliseconds at the current
+                // instruction cost — a property of the rate rather than of the
+                // clock's 100 ns unit; see the guest for what that means for
+                // these assertions. Those are
                 // replay-contract facts the pure `StopwatchElapsed.cs` cannot
                 // pin: it is cross-checked against the real runtime, whose
                 // CLOCK_MONOTONIC counts from an unspecified origin at

--- a/WoofWare.PawPrint.Test/TestLowLevelMonitor.fs
+++ b/WoofWare.PawPrint.Test/TestLowLevelMonitor.fs
@@ -935,7 +935,7 @@ module TestLowLevelMonitor =
     let private parkInTimedWait
         (thread : ThreadId)
         (id : LowLevelMonitorId)
-        (deadlineMs : int64)
+        (deadlineTicks : int64)
         (state : IlMachineState)
         : IlMachineState
         =
@@ -945,7 +945,7 @@ module TestLowLevelMonitor =
             state
             |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 (Int32Source.Verbatim 1)) thread
 
-        LowLevelMonitor.wait thread id (Some deadlineMs) state
+        LowLevelMonitor.wait thread id (Some deadlineTicks) state
 
     [<Test>]
     let ``fireTimeout on free monitor grants ownership and rewrites Int32 1 to Int32 0`` () : unit =

--- a/WoofWare.PawPrint.Test/TestMonotonicTimestamp.fs
+++ b/WoofWare.PawPrint.Test/TestMonotonicTimestamp.fs
@@ -1,5 +1,6 @@
 namespace WoofWare.PawPrint.Test
 
+open System
 open FsCheck
 open FsCheck.FSharp
 open FsUnitTyped
@@ -221,3 +222,44 @@ module TestMonotonicTimestamp =
             succeeds (fun () -> EmulatedKernel.monotonicTimestampNanos (kernelWith clockMs)) = derivable
 
         Check.One (propertyConfig, Prop.forAll int64s property)
+
+    [<Test>]
+    let ``the clock writer rejects moving past the representable horizon`` () : unit =
+        // Regression guard for an overflow the re-denomination made reachable. A finite deadline
+        // is `clock + timeoutMs * ticksPerMillisecond`; `Thread.Sleep(Int32.MaxValue)` adds about
+        // 2.1e13 ticks, and the driver's deadline jump advances the clock to a deadline *without*
+        // retiring a step. So a guest looping on that sleep reaches `Int64.MaxValue` in ~430,000
+        // cheap iterations, where the millisecond-denominated clock needed 4.3 billion. Wrapping
+        // would hand the next sleeper a negative deadline that fires immediately, and time would
+        // stop advancing — a silent wrong answer, so the writer faults instead.
+        let atHorizon =
+            { EmulatedKernel.initial with
+                VirtualClockTicks = EmulatedKernel.maxMonotonicTimestampClockTicks
+            }
+
+        // The horizon itself is legal: a reading can still be derived from it.
+        EmulatedKernel.monotonicTimestampNanos atHorizon |> shouldBeGreaterThan 0L
+
+        let beyond () =
+            EmulatedKernel.withVirtualClockTicks (EmulatedKernel.maxMonotonicTimestampClockTicks + 1L) atHorizon
+            |> ignore<EmulatedKernel>
+
+        Assert.Throws<Exception> (TestDelegate beyond) |> ignore<Exception>
+
+    [<Test>]
+    let ``the clock writer rejects moving backwards`` () : unit =
+        // Monotonicity is the one guarantee every derived clock rests on, and `MapKernel` makes
+        // it easy for a future caller to compute a smaller value by accident (a `min` for a
+        // `max`, say). Cheap to assert at the writer.
+        let kernel =
+            { EmulatedKernel.initial with
+                VirtualClockTicks = 5_000L
+            }
+
+        EmulatedKernel.withVirtualClockTicks 5_000L kernel
+        |> fun k -> k.VirtualClockTicks |> shouldEqual 5_000L
+
+        let backwards () =
+            EmulatedKernel.withVirtualClockTicks 4_999L kernel |> ignore<EmulatedKernel>
+
+        Assert.Throws<Exception> (TestDelegate backwards) |> ignore<Exception>

--- a/WoofWare.PawPrint.Test/TestMonotonicTimestamp.fs
+++ b/WoofWare.PawPrint.Test/TestMonotonicTimestamp.fs
@@ -100,14 +100,38 @@ module TestMonotonicTimestamp =
         // compares `Environment.TickCount64` against a `Stopwatch` must not see
         // them disagree, so the low-resolution reading has to be exactly the
         // high-resolution one truncated to milliseconds.
+        // Neither side restates the other's arithmetic: the left is the high-resolution PAL
+        // reading converted from nanoseconds to milliseconds using the BCL's own factor, the
+        // right is the low-resolution PAL reading. Before the clock was re-denominated this
+        // assertion happened to be expressible as "hi-res / 1e6 = the clock", because the clock
+        // *was* in milliseconds; at 100 ns that form degenerates into a tautology about
+        // `monotonicTimestampNanos` and stops covering the low-resolution projection at all.
         let property (seed : int64) : bool =
-            let clockMs = intoRange maxClockTicks seed
-            let kernel = kernelWith clockMs
+            let kernel = kernelWith (intoRange maxClockTicks seed)
 
-            EmulatedKernel.monotonicTimestampNanos kernel
-            / EmulatedKernel.nanosecondsPerTick = kernel.VirtualClockTicks
+            let hiResMs = EmulatedKernel.monotonicTimestampNanos kernel / 1_000_000L
+
+            hiResMs = EmulatedKernel.lowResolutionTimestampMs kernel
 
         Check.One (propertyConfig, Prop.forAll int64s property)
+
+    [<Test>]
+    let ``the low-resolution reading is the clock truncated to milliseconds`` () =
+        // Sub-millisecond clock values are the interesting ones: they are unreachable at the
+        // current instruction cost but reachable at any finer one, and they are what the
+        // agreement property above cannot distinguish if the conversion factor is wrong in a
+        // way that happens to preserve whole milliseconds.
+        for ticks, expected in
+            [
+                0L, 0L
+                1L, 0L
+                EmulatedKernel.ticksPerMillisecond - 1L, 0L
+                EmulatedKernel.ticksPerMillisecond, 1L
+                EmulatedKernel.ticksPerMillisecond + 1L, 1L
+                7L * EmulatedKernel.ticksPerMillisecond - 1L, 6L
+            ] do
+            EmulatedKernel.lowResolutionTimestampMs (kernelWith ticks)
+            |> shouldEqual expected
 
     [<Test>]
     let ``the wall-clock epoch cannot perturb the monotonic clock`` () =
@@ -263,3 +287,21 @@ module TestMonotonicTimestamp =
             EmulatedKernel.withVirtualClockTicks 4_999L kernel |> ignore<EmulatedKernel>
 
         Assert.Throws<Exception> (TestDelegate backwards) |> ignore<Exception>
+
+    [<Test>]
+    let ``the clock writer rejects negative targets even when moving forwards`` () : unit =
+        // The monotonicity check alone waves this through: -10,000 is *greater* than -20,000, so
+        // the move is forwards and only an independent non-negativity check catches it. Reachable
+        // because a kernel assembled by record-copy never passed through the writer, which is the
+        // same reason the per-reader guards exist. Left untested, the writer would enforce a
+        // narrower range than its own doc comment claims.
+        let negativeKernel =
+            { EmulatedKernel.initial with
+                VirtualClockTicks = -20_000L
+            }
+
+        let forwardsButNegative () =
+            EmulatedKernel.withVirtualClockTicks -10_000L negativeKernel
+            |> ignore<EmulatedKernel>
+
+        Assert.Throws<Exception> (TestDelegate forwardsButNegative) |> ignore<Exception>

--- a/WoofWare.PawPrint.Test/TestMonotonicTimestamp.fs
+++ b/WoofWare.PawPrint.Test/TestMonotonicTimestamp.fs
@@ -24,7 +24,7 @@ module TestMonotonicTimestamp =
 
     let private propertyConfig : Config = Config.QuickThrowOnFailure.WithMaxTest 500
 
-    let private maxClockMs : int64 = EmulatedKernel.maxMonotonicTimestampClockMs
+    let private maxClockTicks : int64 = EmulatedKernel.maxMonotonicTimestampClockTicks
 
     /// Fold an arbitrary int64 into `[0, bound]`. Deliberately not `abs`, which
     /// throws on `Int64.MinValue` — a value FsCheck does generate.
@@ -36,7 +36,7 @@ module TestMonotonicTimestamp =
     /// record-copy because the driver loop is its only production writer.
     let private kernelWith (clockMs : int64) : EmulatedKernel =
         { EmulatedKernel.initial with
-            VirtualClockMs = clockMs
+            VirtualClockTicks = clockMs
         }
 
     let private int64s = ArbMap.defaults |> ArbMap.arbitrary<int64>
@@ -51,21 +51,21 @@ module TestMonotonicTimestamp =
         EmulatedKernel.monotonicTimestampNanos EmulatedKernel.initial |> shouldEqual 0L
 
     [<Test>]
-    let ``maxMonotonicTimestampClockMs is the last non-overflowing millisecond`` () =
+    let ``maxMonotonicTimestampClockTicks is the last non-overflowing millisecond`` () =
         // Pinned against int64 arithmetic rather than against the literal, so a
         // slip in the literal is caught here.
-        System.Int64.MaxValue / EmulatedKernel.nanosecondsPerMillisecond
-        |> shouldEqual EmulatedKernel.maxMonotonicTimestampClockMs
+        System.Int64.MaxValue / EmulatedKernel.nanosecondsPerTick
+        |> shouldEqual EmulatedKernel.maxMonotonicTimestampClockTicks
 
         // The bound is tight, not merely safe: the boundary itself is
         // representable...
-        maxClockMs * EmulatedKernel.nanosecondsPerMillisecond |> shouldBeGreaterThan 0L
+        maxClockTicks * EmulatedKernel.nanosecondsPerTick |> shouldBeGreaterThan 0L
 
         // ...and one millisecond further is not. The assertion is on the
         // wrapped int64 product itself, because a negative product is precisely
         // the failure the bound exists to prevent: a monotonic clock that had
         // run backwards.
-        (maxClockMs + 1L) * EmulatedKernel.nanosecondsPerMillisecond
+        (maxClockTicks + 1L) * EmulatedKernel.nanosecondsPerTick
         |> shouldBeSmallerThan 0L
 
     [<Test>]
@@ -73,19 +73,21 @@ module TestMonotonicTimestamp =
         // A virtual-clock reading `systemTimeAsTicks` still accepts can be too
         // large for the nanosecond derivation. This is a real asymmetry between
         // the two clock views, not an oversight, and the guard exists precisely
-        // because of it.
-        maxClockMs < EmulatedKernel.maxWallClockEpochMs |> shouldEqual true
+        // because of it. Compared against the wall clock's ceiling in the same
+        // unit — both are now 100 ns ticks, where the wall-clock bound used to
+        // be stated in milliseconds.
+        maxClockTicks < EmulatedKernel.maxWallClockTicks |> shouldEqual true
 
     [<Test>]
     let ``the timestamp is the virtual clock scaled to nanoseconds`` () =
         // The oracle is decimal arithmetic (exact for these magnitudes), so a
         // slip in the int64 multiply is not restated as its own oracle.
         let property (seed : int64) : bool =
-            let clockMs = intoRange maxClockMs seed
+            let clockTicks = intoRange maxClockTicks seed
 
-            let expected = decimal clockMs * 1_000_000M
+            let expected = decimal clockTicks * 100M
 
-            decimal (EmulatedKernel.monotonicTimestampNanos (kernelWith clockMs)) = expected
+            decimal (EmulatedKernel.monotonicTimestampNanos (kernelWith clockTicks)) = expected
 
         Check.One (propertyConfig, Prop.forAll int64s property)
 
@@ -98,11 +100,11 @@ module TestMonotonicTimestamp =
         // them disagree, so the low-resolution reading has to be exactly the
         // high-resolution one truncated to milliseconds.
         let property (seed : int64) : bool =
-            let clockMs = intoRange maxClockMs seed
+            let clockMs = intoRange maxClockTicks seed
             let kernel = kernelWith clockMs
 
             EmulatedKernel.monotonicTimestampNanos kernel
-            / EmulatedKernel.nanosecondsPerMillisecond = kernel.VirtualClockMs
+            / EmulatedKernel.nanosecondsPerTick = kernel.VirtualClockTicks
 
         Check.One (propertyConfig, Prop.forAll int64s property)
 
@@ -116,7 +118,7 @@ module TestMonotonicTimestamp =
         // zero.
         let property (epochSeed : int64, clockSeed : int64) : bool =
             let epochMs = intoRange EmulatedKernel.maxWallClockEpochMs epochSeed
-            let clockMs = intoRange maxClockMs clockSeed
+            let clockMs = intoRange maxClockTicks clockSeed
 
             let shifted =
                 { kernelWith clockMs with
@@ -139,7 +141,7 @@ module TestMonotonicTimestamp =
         let property (firstSeed : int64, secondSeed : int64) : bool =
             // Constrained to the range legal for *both* clocks; the asymmetry
             // between their bounds has its own test above.
-            let bound = min maxClockMs EmulatedKernel.maxWallClockEpochMs
+            let bound = min maxClockTicks EmulatedKernel.maxWallClockEpochMs
             let first = intoRange bound firstSeed
             let second = intoRange bound secondSeed
 
@@ -161,8 +163,8 @@ module TestMonotonicTimestamp =
         // monotonic clock moves: guest code that polls until elapsed time
         // exceeds a threshold must make progress.
         let property (firstSeed : int64, secondSeed : int64) : bool =
-            let first = intoRange maxClockMs firstSeed
-            let second = intoRange maxClockMs secondSeed
+            let first = intoRange maxClockTicks firstSeed
+            let second = intoRange maxClockTicks secondSeed
 
             let firstNanos = EmulatedKernel.monotonicTimestampNanos (kernelWith first)
             let secondNanos = EmulatedKernel.monotonicTimestampNanos (kernelWith second)
@@ -176,23 +178,26 @@ module TestMonotonicTimestamp =
         // The guard's whole purpose: a wrapped negative timestamp would make
         // every `Stopwatch` in the guest report a negative elapsed time.
         let property (seed : int64) : bool =
-            EmulatedKernel.monotonicTimestampNanos (kernelWith (intoRange maxClockMs seed))
+            EmulatedKernel.monotonicTimestampNanos (kernelWith (intoRange maxClockTicks seed))
             >= 0L
 
         Check.One (propertyConfig, Prop.forAll int64s property)
 
     [<Test>]
-    let ``the reading has millisecond granularity`` () =
-        // Documented consequence of deriving from a millisecond clock: every
-        // timestamp is a multiple of 1,000,000 ns, so `Stopwatch` is not a
-        // source of unique values here. Real `clock_gettime(CLOCK_MONOTONIC)`
-        // makes no uniqueness guarantee either, so this is a faithful gap
-        // rather than one to paper over.
+    let ``the reading has 100ns granularity`` () =
+        // Documented consequence of deriving from a 100 ns clock: every
+        // timestamp is a multiple of 100 ns. This assertion used to say
+        // *millisecond* granularity — a multiple of 1,000,000 — because the
+        // clock was denominated in milliseconds; re-denominating it made
+        // `Stopwatch` four orders of magnitude finer, and hence far closer to
+        // real `clock_gettime(CLOCK_MONOTONIC)`. It is still coarser than the
+        // real thing, and still not a source of unique values, which is a
+        // faithful gap rather than one to paper over.
         let property (seed : int64) : bool =
             let nanos =
-                EmulatedKernel.monotonicTimestampNanos (kernelWith (intoRange maxClockMs seed))
+                EmulatedKernel.monotonicTimestampNanos (kernelWith (intoRange maxClockTicks seed))
 
-            nanos % EmulatedKernel.nanosecondsPerMillisecond = 0L
+            nanos % EmulatedKernel.nanosecondsPerTick = 0L
 
         Check.One (propertyConfig, Prop.forAll int64s property)
 
@@ -211,7 +216,7 @@ module TestMonotonicTimestamp =
         // is the only place the invariant can be asserted. It must fail loudly
         // rather than quietly wrapping.
         let property (clockMs : int64) : bool =
-            let derivable = clockMs >= 0L && clockMs <= maxClockMs
+            let derivable = clockMs >= 0L && clockMs <= maxClockTicks
 
             succeeds (fun () -> EmulatedKernel.monotonicTimestampNanos (kernelWith clockMs)) = derivable
 

--- a/WoofWare.PawPrint.Test/TestSyncBlockMonitor.fs
+++ b/WoofWare.PawPrint.Test/TestSyncBlockMonitor.fs
@@ -1208,7 +1208,7 @@ module TestSyncBlockMonitor =
         (thread : ThreadId)
         (depth : int)
         (addr : ManagedHeapAddress)
-        (deadlineMs : int64)
+        (deadlineTicks : int64)
         (state : IlMachineState)
         : IlMachineState
         =
@@ -1218,16 +1218,16 @@ module TestSyncBlockMonitor =
             state
             |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 (Int32Source.Verbatim 1)) thread
 
-        SyncBlockMonitor.wait thread addr (Some deadlineMs) state
+        SyncBlockMonitor.wait thread addr (Some deadlineTicks) state
 
     let private parkInTimedWait
         (thread : ThreadId)
         (addr : ManagedHeapAddress)
-        (deadlineMs : int64)
+        (deadlineTicks : int64)
         (state : IlMachineState)
         : IlMachineState
         =
-        parkInTimedWaitAtDepth thread 1 addr deadlineMs state
+        parkInTimedWaitAtDepth thread 1 addr deadlineTicks state
 
     [<Test>]
     let ``fireTimeout on free SyncBlock takes ownership at snapshot depth and rewrites Int32 1 to Int32 0`` () : unit =
@@ -1493,7 +1493,7 @@ module TestSyncBlockMonitor =
     // fireAcquireTimeout — Monitor.TryEnter(obj, ms) slowpath deadlines
     // -------------------------------------------------------------------
 
-    /// Drive `acquirer` into `BlockedOnSyncBlockAcquire (addr, Some deadlineMs)`,
+    /// Drive `acquirer` into `BlockedOnSyncBlockAcquire (addr, Some deadlineTicks)`,
     /// queued behind `owner`, with the optimistic `Int32 1` on `acquirer`'s eval
     /// stack — mirroring the state `TryEnter_Slowpath` leaves the caller in when
     /// the lock was contended.
@@ -1501,7 +1501,7 @@ module TestSyncBlockMonitor =
         (owner : ThreadId)
         (acquirer : ThreadId)
         (addr : ManagedHeapAddress)
-        (deadlineMs : int64)
+        (deadlineTicks : int64)
         (state : IlMachineState)
         : IlMachineState
         =
@@ -1526,7 +1526,7 @@ module TestSyncBlockMonitor =
                 WaitQueue = block.WaitQueue
             }
         |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 (Int32Source.Verbatim 1)) acquirer
-        |> Scheduler.setThreadStatus acquirer (ThreadStatus.BlockedOnSyncBlockAcquire (addr, Some deadlineMs))
+        |> Scheduler.setThreadStatus acquirer (ThreadStatus.BlockedOnSyncBlockAcquire (addr, Some deadlineTicks))
 
     [<Test>]
     let ``fireAcquireTimeout dequeues without transferring ownership and rewrites Int32 1 to Int32 0`` () : unit =

--- a/WoofWare.PawPrint.Test/TestSystemTimeAsTicks.fs
+++ b/WoofWare.PawPrint.Test/TestSystemTimeAsTicks.fs
@@ -30,13 +30,15 @@ module TestSystemTimeAsTicks =
         ((seed % modulus) + modulus) % modulus
 
     /// A kernel booting at `epochMs` whose virtual clock has since advanced to
-    /// `clockMs`. The clock is set by record-copy because the driver loop is its
-    /// only production writer.
-    let private kernelWith (epochMs : int64) (clockMs : int64) : EmulatedKernel =
+    /// `clockTicks` — note the units differ: the boot instant is a millisecond
+    /// offset (that is what `KernelConfig` takes), while the clock is in the
+    /// 100 ns ticks it is denominated in. The clock is set by record-copy
+    /// because the driver loop is its only production writer.
+    let private kernelWith (epochMs : int64) (clockTicks : int64) : EmulatedKernel =
         let kernel = EmulatedKernel.initial |> EmulatedKernel.withWallClockEpochMs epochMs
 
         { kernel with
-            VirtualClockMs = clockMs
+            VirtualClockTicks = clockTicks
         }
 
     /// The guest-visible instant, computed exactly as CoreLib does but through
@@ -45,13 +47,16 @@ module TestSystemTimeAsTicks =
     let private guestUtcNow (kernel : EmulatedKernel) : DateTime =
         DateTime (DateTime.UnixEpoch.Ticks + EmulatedKernel.systemTimeAsTicks kernel, DateTimeKind.Utc)
 
-    /// Draw an epoch and a virtual-clock reading whose sum is still
-    /// representable — i.e. exactly the states a legally-configured kernel can
-    /// reach.
+    /// Draw an epoch (ms) and a virtual-clock reading (100 ns ticks) whose
+    /// combination is still representable — i.e. exactly the states a
+    /// legally-configured kernel can reach.
     let private reachable (epochSeed : int64, clockSeed : int64) : int64 * int64 =
         let epochMs = intoRange maxEpochMs epochSeed
-        let clockMs = intoRange (maxEpochMs - epochMs) clockSeed
-        epochMs, clockMs
+
+        let clockTicks =
+            intoRange ((maxEpochMs - epochMs) * EmulatedKernel.ticksPerMillisecond) clockSeed
+
+        epochMs, clockTicks
 
     let private int64Pairs = ArbMap.defaults |> ArbMap.arbitrary<int64 * int64>
 
@@ -76,8 +81,8 @@ module TestSystemTimeAsTicks =
     [<Test>]
     let ``every reachable reading names a representable UTC instant`` () =
         let property (seeds : int64 * int64) : bool =
-            let epochMs, clockMs = reachable seeds
-            let now = guestUtcNow (kernelWith epochMs clockMs)
+            let epochMs, clockTicks = reachable seeds
+            let now = guestUtcNow (kernelWith epochMs clockTicks)
 
             now.Kind = DateTimeKind.Utc
             && now >= DateTime.UnixEpoch
@@ -90,11 +95,11 @@ module TestSystemTimeAsTicks =
         // The oracle is the BCL's own date arithmetic rather than a restatement
         // of the implementation's multiply.
         let property (seeds : int64 * int64) : bool =
-            let epochMs, clockMs = reachable seeds
+            let epochMs, clockTicks = reachable seeds
 
-            guestUtcNow (kernelWith epochMs clockMs) = DateTime.UnixEpoch
+            guestUtcNow (kernelWith epochMs clockTicks) = DateTime.UnixEpoch
                 .AddTicks(epochMs * EmulatedKernel.ticksPerMillisecond)
-                .AddTicks (clockMs * EmulatedKernel.ticksPerMillisecond)
+                .AddTicks (clockTicks)
 
         Check.One (propertyConfig, Prop.forAll int64Pairs property)
 
@@ -104,11 +109,18 @@ module TestSystemTimeAsTicks =
         // "booted at E+C, ran for nothing". This is what makes the wall clock a
         // pure view of the monotonic one rather than an independent axis, and it
         // is the property that would have to be given up to model NTP steps.
+        //
+        // Only a *whole millisecond* of elapsed time can be moved, because the
+        // boot instant is denominated in milliseconds and the clock is not. The
+        // sub-millisecond remainder has to stay on the clock; that it does, and
+        // that the reading is unchanged, is the substance of the property now.
         let property (seeds : int64 * int64) : bool =
-            let epochMs, clockMs = reachable seeds
+            let epochMs, clockTicks = reachable seeds
+            let wholeMs = clockTicks / EmulatedKernel.ticksPerMillisecond
+            let remainder = clockTicks % EmulatedKernel.ticksPerMillisecond
 
-            EmulatedKernel.systemTimeAsTicks (kernelWith epochMs clockMs) = EmulatedKernel.systemTimeAsTicks (
-                kernelWith (epochMs + clockMs) 0L
+            EmulatedKernel.systemTimeAsTicks (kernelWith epochMs clockTicks) = EmulatedKernel.systemTimeAsTicks (
+                kernelWith (epochMs + wholeMs) remainder
             )
 
         Check.One (propertyConfig, Prop.forAll int64Pairs property)
@@ -132,17 +144,18 @@ module TestSystemTimeAsTicks =
         Check.One (propertyConfig, Prop.forAll (ArbMap.defaults |> ArbMap.arbitrary<int64 * int64 * int64>) property)
 
     [<Test>]
-    let ``the reading has millisecond granularity`` () =
-        // Documented consequence of deriving from a millisecond clock: every
-        // tick value is a multiple of 10,000, so `DateTime.UtcNow` is not a
-        // source of unique values. Real `clock_gettime(CLOCK_REALTIME)` makes no
-        // uniqueness guarantee either, so this is a faithful gap rather than one
-        // to paper over.
+    let ``the reading has the full 100ns granularity of DateTime`` () =
+        // This used to assert the opposite — that every reading is a multiple of
+        // 10,000 — because the clock it derives from was denominated in whole
+        // milliseconds. Now that the clock counts 100 ns ticks, `DateTime.UtcNow`
+        // resolves every one of them, which is strictly closer to real
+        // `clock_gettime(CLOCK_REALTIME)`. Pinned as a reachability claim rather
+        // than a modulus, since "not always a multiple" needs a witness.
         let property (seeds : int64 * int64) : bool =
-            let epochMs, clockMs = reachable seeds
+            let epochMs, clockTicks = reachable seeds
 
-            let ticks = EmulatedKernel.systemTimeAsTicks (kernelWith epochMs clockMs)
-            ticks % EmulatedKernel.ticksPerMillisecond = 0L
+            let ticks = EmulatedKernel.systemTimeAsTicks (kernelWith epochMs clockTicks)
+            ticks % EmulatedKernel.ticksPerMillisecond = clockTicks % EmulatedKernel.ticksPerMillisecond
 
         Check.One (propertyConfig, Prop.forAll int64Pairs property)
 
@@ -174,14 +187,15 @@ module TestSystemTimeAsTicks =
         // `DateTime`, and it must fail loudly rather than quietly wrapping.
         let property (epochSeed : int64, overshootSeed : int64) : bool =
             let epochMs = intoRange maxEpochMs epochSeed
-            let headroom = maxEpochMs - epochMs
+
+            let headroom = (maxEpochMs - epochMs) * EmulatedKernel.ticksPerMillisecond
             // Strictly past the representable end of time.
-            let clockMs = headroom + 1L + intoRange 1_000_000L overshootSeed
+            let clockTicks = headroom + 1L + intoRange 1_000_000L overshootSeed
 
             let kernel =
                 { EmulatedKernel.initial with
                     WallClockEpochMs = epochMs
-                    VirtualClockMs = clockMs
+                    VirtualClockTicks = clockTicks
                 }
 
             not (succeeds (fun () -> EmulatedKernel.systemTimeAsTicks kernel))

--- a/WoofWare.PawPrint.Test/TestSystemTimeAsTicks.fs
+++ b/WoofWare.PawPrint.Test/TestSystemTimeAsTicks.fs
@@ -72,6 +72,26 @@ module TestSystemTimeAsTicks =
         |> shouldEqual (DateTime (9999, 12, 31, 23, 59, 59, 999, DateTimeKind.Utc))
 
     [<Test>]
+    let ``maxWallClockTicks is the last tick DateTime can represent`` () =
+        // Also pinned against the BCL. The tempting derivation
+        // `maxWallClockEpochMs * ticksPerMillisecond` is wrong by 9,999 ticks:
+        // that is the last whole *millisecond*, and the clock resolves finer
+        // than that, so deriving it would reject the finalsub-millisecond of
+        // representable time.
+        DateTime.MaxValue.Ticks - DateTime.UnixEpoch.Ticks
+        |> shouldEqual EmulatedKernel.maxWallClockTicks
+
+        EmulatedKernel.maxWallClockTicks
+        - maxEpochMs * EmulatedKernel.ticksPerMillisecond
+        |> shouldEqual (EmulatedKernel.ticksPerMillisecond - 1L)
+
+        // The last representable instant really is accepted, not rejected one
+        // sub-millisecond early: this is the exact case the derived ceiling got
+        // wrong, so assert the boundary itself rather than only the constant.
+        guestUtcNow (kernelWith maxEpochMs (EmulatedKernel.ticksPerMillisecond - 1L))
+        |> shouldEqual DateTime.MaxValue
+
+    [<Test>]
     let ``a default kernel boots at the Unix epoch`` () =
         // The replay contract: change this and every recorded trace's timestamps
         // change with it.
@@ -188,7 +208,8 @@ module TestSystemTimeAsTicks =
         let property (epochSeed : int64, overshootSeed : int64) : bool =
             let epochMs = intoRange maxEpochMs epochSeed
 
-            let headroom = (maxEpochMs - epochMs) * EmulatedKernel.ticksPerMillisecond
+            let headroom =
+                EmulatedKernel.maxWallClockTicks - epochMs * EmulatedKernel.ticksPerMillisecond
             // Strictly past the representable end of time.
             let clockTicks = headroom + 1L + intoRange 1_000_000L overshootSeed
 

--- a/WoofWare.PawPrint.Test/sourcesImpure/StopwatchTimestampGranularity.cs
+++ b/WoofWare.PawPrint.Test/sourcesImpure/StopwatchTimestampGranularity.cs
@@ -8,12 +8,24 @@ namespace HelloWorldApp
         static int Main(string[] args)
         {
             // PawPrint's high-resolution clock is the virtual clock scaled to
-            // nanoseconds, so it boots at zero and only ever takes values that
-            // are whole milliseconds. Both are part of the replay contract, and
-            // neither can be pinned by the sibling pure case
-            // `StopwatchElapsed.cs`, which is cross-checked against the real
-            // runtime (whose CLOCK_MONOTONIC counts from an unspecified origin
-            // at nanosecond resolution).
+            // nanoseconds, so it boots at zero. Both that and the granularity
+            // asserted below are part of the replay contract, and neither can
+            // be pinned by the sibling pure case `StopwatchElapsed.cs`, which
+            // is cross-checked against the real runtime (whose CLOCK_MONOTONIC
+            // counts from an unspecified origin at nanosecond resolution).
+            //
+            // Note what the whole-millisecond assertions below actually pin.
+            // The clock itself counts 100 ns ticks and can represent any of
+            // them; readings come out as whole milliseconds only because
+            // `EmulatedKernel.instructionCostTicks` currently charges exactly
+            // one millisecond per retired instruction, so every reachable
+            // value is a multiple of 10,000 ticks. These assertions therefore
+            // track the *rate*, not the unit, and are expected to change when
+            // the rate does. The same caveat applies with more force to the
+            // containment check at the end of this file: `TickCount64 * 1e6`
+            // lying inside a hi-res interval is a theorem only while readings
+            // are millisecond-granular — at a finer rate the millisecond
+            // reading floors below `before`.
 
             // On Unix `Stopwatch.Frequency` is a hard-coded 1e9, which is what
             // fixes our unit as the nanosecond.

--- a/WoofWare.PawPrint/EmulatedKernel.fs
+++ b/WoofWare.PawPrint/EmulatedKernel.fs
@@ -973,14 +973,43 @@ module EmulatedKernel =
     /// The bound is *tighter* than `maxWallClockTicks` by a factor of about
     /// 27, so there is a band of clock readings from which `DateTime.UtcNow`
     /// and `Environment.TickCount64` are derivable but `Stopwatch.GetTimestamp`
-    /// is not. Nothing bounds `VirtualClockTicks` at its write sites, so each
-    /// clock-derived PAL entry enforces its own ceiling lazily, at the moment
-    /// the guest reads that particular clock — `systemTimeAsTicks` has the same
-    /// shape. Bounding the field centrally at the scheduler, its sole writer,
-    /// would collapse these into one invariant and fault at the wait that
-    /// pushed time past the horizon rather than at an arbitrary later read.
+    /// is not. `withVirtualClockTicks` bounds the field centrally at the
+    /// scheduler, its sole writer, using *this* ceiling because it is the
+    /// tightest; the per-reader guards remain because a kernel assembled by
+    /// record-copy can bypass the writer, and `systemTimeAsTicks` has the same
+    /// shape for the same reason.
     [<Literal>]
     let maxMonotonicTimestampClockTicks : int64 = 92233720368547758L
+
+    /// Advance the virtual clock to `ticks`, which must not move it backwards and must keep it
+    /// inside the range every clock-derived reading can be computed from.
+    ///
+    /// The bound is `maxMonotonicTimestampClockTicks` — the tightest of the per-reader ceilings
+    /// — so this is deliberately stricter than any individual reader requires. Enforcing it at
+    /// the writer means a guest that runs the clock off the end faults at the wait that did it,
+    /// naming the operation responsible, rather than at whichever unlucky later `Stopwatch` read
+    /// happens to trip over the value.
+    ///
+    /// It also keeps deadline arithmetic total. A finite deadline is
+    /// `clock + timeoutMs * ticksPerMillisecond`, and `Thread.Sleep(Int32.MaxValue)` contributes
+    /// about 2.1e13 ticks; with the clock bounded at 9.2e16 the sum cannot approach
+    /// `Int64.MaxValue`, so the seven deadline sites need no checked arithmetic of their own.
+    /// Without the bound they would need it: the deadline jump advances the clock to a deadline
+    /// *without* retiring a step, so a loop of `Sleep(Int32.MaxValue)` reaches the wrap in about
+    /// 430,000 iterations — a few million interpreted instructions, which is minutes rather than
+    /// the unreachable 4.3 billion jumps the millisecond-denominated clock required.
+    let withVirtualClockTicks (ticks : int64) (kernel : EmulatedKernel) : EmulatedKernel =
+        if ticks < kernel.VirtualClockTicks then
+            failwith
+                $"virtual clock would move backwards, from %d{kernel.VirtualClockTicks} to %d{ticks} ticks; it is monotonic by construction and every guest-visible clock derives from it"
+
+        if ticks > maxMonotonicTimestampClockTicks then
+            failwith
+                $"simulated uptime has reached %d{ticks} ticks (100 ns each), past the %d{maxMonotonicTimestampClockTicks} from which a monotonic nanosecond timestamp can still be derived — about 292 years. The guest has almost certainly been jumping the clock with long timed waits; PawPrint cannot represent time beyond this."
+
+        { kernel with
+            VirtualClockTicks = ticks
+        }
 
     /// Monotonic time since the simulated process booted, in nanoseconds:
     /// exactly what `SystemNative_GetTimestamp` returns, and hence what

--- a/WoofWare.PawPrint/EmulatedKernel.fs
+++ b/WoofWare.PawPrint/EmulatedKernel.fs
@@ -753,10 +753,18 @@ module EmulatedKernel =
     let ticksPerMillisecond : int64 = 10_000L
 
     /// Largest legal wall-clock reading, in 100 ns ticks since the Unix epoch:
-    /// `maxWallClockEpochMs` expressed in the clock's own unit. `DateTime`
-    /// cannot name an instant beyond it.
+    /// `DateTime.MaxValue.Ticks - DateTime.UnixEpoch.Ticks`. `DateTime` cannot
+    /// name an instant beyond it.
+    ///
+    /// Deliberately *not* `maxWallClockEpochMs * ticksPerMillisecond`, which is
+    /// 9,999 ticks smaller. The two differ because they bound different things:
+    /// `maxWallClockEpochMs` is the last whole millisecond, which is the right
+    /// ceiling for `KernelConfig.WallClockEpochMs` because that knob is
+    /// denominated in milliseconds, while the clock resolves every 100 ns tick
+    /// up to the end of `DateTime`'s range. Deriving this one from the other
+    /// would reject the final sub-millisecond of representable time.
     [<Literal>]
-    let maxWallClockTicks : int64 = 2534023007999990000L
+    let maxWallClockTicks : int64 = 2534023007999999999L
 
     /// Virtual time charged for one retired IL instruction, in 100 ns ticks.
     ///

--- a/WoofWare.PawPrint/EmulatedKernel.fs
+++ b/WoofWare.PawPrint/EmulatedKernel.fs
@@ -999,6 +999,13 @@ module EmulatedKernel =
     /// 430,000 iterations — a few million interpreted instructions, which is minutes rather than
     /// the unreachable 4.3 billion jumps the millisecond-denominated clock required.
     let withVirtualClockTicks (ticks : int64) (kernel : EmulatedKernel) : EmulatedKernel =
+        // Checked independently of the monotonicity comparison below, which on its own would
+        // wave through a negative target whenever the current value is more negative still —
+        // reachable because a kernel assembled by record-copy never passed through here.
+        if ticks < 0L then
+            failwith
+                $"virtual clock would be set to %d{ticks} ticks; simulated uptime starts at zero and cannot be negative"
+
         if ticks < kernel.VirtualClockTicks then
             failwith
                 $"virtual clock would move backwards, from %d{kernel.VirtualClockTicks} to %d{ticks} ticks; it is monotonic by construction and every guest-visible clock derives from it"
@@ -1049,6 +1056,24 @@ module EmulatedKernel =
                 $"kernel VirtualClockTicks is %d{kernel.VirtualClockTicks}, which is outside the range [0, %d{maxMonotonicTimestampClockTicks}] a nanosecond monotonic timestamp can be derived from without overflowing int64"
 
         kernel.VirtualClockTicks * nanosecondsPerTick
+
+    /// The guest-visible `Environment.TickCount64`, in whole milliseconds:
+    /// `SystemNative_GetLowResolutionTimestamp`'s reading.
+    ///
+    /// Lives here beside `monotonicTimestampNanos` and `systemTimeAsTicks` rather than inline in
+    /// the PAL handler, so that all three projections of the one clock sit together and can be
+    /// checked against each other without a test having to restate the arithmetic of any of
+    /// them. Upstream these two monotonic entry points (`minipal_lowres_ticks` and
+    /// `minipal_hires_ticks`) read the same clock at two resolutions, and the contract a guest
+    /// depends on is that they never disagree — so this must be exactly the high-resolution
+    /// reading truncated to milliseconds.
+    ///
+    /// Truncating rather than rounding is faithful: upstream's coarse clock truncates too.
+    /// Unguarded, unlike its siblings, because dividing a clock already bounded below
+    /// `Int64.MaxValue` cannot overflow or go negative.
+    let lowResolutionTimestampMs (kernel : EmulatedKernel) : int64 =
+        kernel.VirtualClockTicks / ticksPerMillisecond
+
 
     /// Largest value CoreCLR will accept from the processor-count
     /// configuration knob (`MAX_PROCESSOR_COUNT` in

--- a/WoofWare.PawPrint/EmulatedKernel.fs
+++ b/WoofWare.PawPrint/EmulatedKernel.fs
@@ -466,13 +466,16 @@ type EmulatedKernel =
         /// `EmulatedKernel.monotonicTimestampNanos` — rather than either
         /// maintaining a parallel clock.
         ///
-        /// The driver loop advances this by 1 ms each time it increments
-        /// `StepCounter`, so the guest sees one wall-clock millisecond per
-        /// scheduler tick. That makes elapsed-time polling loops like
-        /// `while (TickCount64 - start &lt; N)` terminate in O(N) ticks —
-        /// the absolute rate is "very slow computer" by wall-clock
-        /// standards but exact bit-for-bit reproducibility is the goal,
-        /// not realism.
+        /// Denominated in 100 ns ticks — `DateTime`'s own quantum — so that
+        /// `DateTime.UtcNow` needs no scaling and `Stopwatch` resolves finer
+        /// than a millisecond. The driver loop advances it by
+        /// `instructionCostTicks` each time it increments `StepCounter`; see
+        /// that constant for the rate and what it means as a machine speed.
+        ///
+        /// Elapsed-time polling loops such as `while (TickCount64 - start &lt; N)`
+        /// therefore terminate in `N * ticksPerMillisecond / instructionCostTicks`
+        /// scheduler ticks, which is the cost to keep in mind when choosing the
+        /// rate: it buys sleep fidelity and is paid for in run length.
         ///
         /// Reading the field never mutates it: the BCL's `TickCount64`
         /// observers stay pure, and the consistency property "two threads
@@ -483,15 +486,15 @@ type EmulatedKernel =
         /// no thread is Runnable, and that jump must not require a
         /// matching jump in `StepCounter` (which would skew the spurious-
         /// wakeup schedule).
-        VirtualClockMs : int64
+        VirtualClockTicks : int64
         /// Wall-clock time, in milliseconds since the Unix epoch, that the
         /// simulated process boots at — i.e. the wall-clock reading that
-        /// corresponds to `VirtualClockMs = 0`. The realtime clock the guest
+        /// corresponds to `VirtualClockTicks = 0`. The realtime clock the guest
         /// observes is the affine image of the monotonic one:
-        /// `systemTimeAsTicks = (WallClockEpochMs + VirtualClockMs) * 10_000`.
+        /// `systemTimeAsTicks = (WallClockEpochMs + VirtualClockTicks) * 10_000`.
         ///
         /// Deliberately *not* a second mutable clock advanced alongside
-        /// `VirtualClockMs`. A parallel field would be behaviourally identical
+        /// `VirtualClockTicks`. A parallel field would be behaviourally identical
         /// today while silently drifting out of step the first time someone
         /// adds a new way for the monotonic clock to advance (the driver's
         /// deadline jump is exactly such a path) and forgets to update both.
@@ -742,11 +745,35 @@ module EmulatedKernel =
     /// 100ns ticks per millisecond. The `SystemNative_GetSystemTime*` family
     /// speaks in ticks while PawPrint's virtual clock speaks in milliseconds,
     /// so every wall-clock derivation goes through this factor. A consequence
-    /// is that every tick value the guest ever observes is a multiple of
-    /// 10,000: `DateTime.UtcNow` has millisecond granularity here, where real
-    /// `clock_gettime(CLOCK_REALTIME)` is far finer.
+    /// is the unit `VirtualClockTicks` itself is denominated in, so no scaling
+    /// is applied to the clock when deriving `DateTime.UtcNow`; the factor
+    /// converts the *epoch* offset, and converts guest millisecond timeouts
+    /// into deadlines.
     [<Literal>]
     let ticksPerMillisecond : int64 = 10_000L
+
+    /// Largest legal wall-clock reading, in 100 ns ticks since the Unix epoch:
+    /// `maxWallClockEpochMs` expressed in the clock's own unit. `DateTime`
+    /// cannot name an instant beyond it.
+    [<Literal>]
+    let maxWallClockTicks : int64 = 2534023007999990000L
+
+    /// Virtual time charged for one retired IL instruction, in 100 ns ticks.
+    ///
+    /// This is the *rate* half of the clock; `ticksPerMillisecond` is the unit half. Together
+    /// they say how fast the simulated machine is: at one tick per instruction it would be a
+    /// self-consistent 10 MIPS machine.
+    ///
+    /// Set here to a whole millisecond, which is deliberately absurd as a machine speed and is
+    /// exactly the historical behaviour — the clock advanced 1 ms per instruction when it was
+    /// denominated in milliseconds. Keeping the rate at its old value makes the re-denomination
+    /// a pure change of unit, observationally identical to what came before, so that the
+    /// separate change of *rate* is a one-line diff that can be reviewed and measured on its
+    /// own. See issue #844: at this rate the shortest sleep a guest can ask for, `Sleep(1)`,
+    /// expires within the same tick it was requested in, so it parks the caller for zero
+    /// scheduling decisions and the BCL's spin-then-sleep backoff does nothing at all.
+    [<Literal>]
+    let instructionCostTicks : int64 = 10_000L
 
     /// Largest legal `EmulatedKernel.WallClockEpochMs`: 9999-12-31T23:59:59.999Z
     /// as milliseconds since the Unix epoch, which is the last instant
@@ -791,7 +818,7 @@ module EmulatedKernel =
             SpuriousWakeup = SpuriousWakeupStrategy.Disabled
             SyncBlockSpuriousWakeup = SyncBlockSpuriousWakeupStrategy.Disabled
             StepCounter = 0L
-            VirtualClockMs = 0L
+            VirtualClockTicks = 0L
             WallClockEpochMs = 0L
             NonCryptoRandomState = NonCryptoRandom.initialState
             CryptoRandomState = cryptoRandomInitialState
@@ -874,7 +901,7 @@ module EmulatedKernel =
     ///
     /// Pure: reading the clock never advances it, so two threads reading on the
     /// same scheduler tick observe the same instant — the same property
-    /// `VirtualClockMs` guarantees for `Environment.TickCount64`, and the
+    /// `VirtualClockTicks` guarantees for `Environment.TickCount64`, and the
     /// reason this is a plain derivation rather than an advance-on-read
     /// counter. That does mean `DateTime.UtcNow` is only *weakly* monotonic
     /// here: repeated reads within one scheduler tick are equal, so it is not
@@ -884,62 +911,68 @@ module EmulatedKernel =
     let systemTimeAsTicks (kernel : EmulatedKernel) : int64 =
         // A kernel built by record-copy can bypass `withWallClockEpochMs`, so
         // re-assert the invariant here: the guest must never observe a tick
-        // count that names no `DateTime`. Checking both operands first also
-        // establishes that neither the addition nor the multiplication below
-        // can overflow (each is at most `maxWallClockEpochMs`, whose doubled
-        // value scaled by `ticksPerMillisecond` still fits in an int64).
+        // count that names no `DateTime`.
+        //
+        // The association matters. `WallClockEpochMs` is milliseconds and
+        // `VirtualClockTicks` is already in `DateTime`'s own 100 ns unit, so the
+        // scaling applies to the epoch alone: scaling their *sum* would first
+        // have to convert the clock back to milliseconds and would throw away
+        // its sub-millisecond digits. Doing it this way is also what keeps the
+        // arithmetic in range — the guards below bound each operand, and
+        // `maxWallClockEpochMs * ticksPerMillisecond` is 2.53e18, comfortably
+        // inside int64, where the same bound expressed in nanoseconds
+        // (2.53e20) would not be.
         if kernel.WallClockEpochMs < 0L || kernel.WallClockEpochMs > maxWallClockEpochMs then
             failwith
                 $"kernel WallClockEpochMs is %d{kernel.WallClockEpochMs}, which is outside the range [0, %d{maxWallClockEpochMs}] that System.DateTime can represent"
 
-        if kernel.VirtualClockMs < 0L || kernel.VirtualClockMs > maxWallClockEpochMs then
+        if kernel.VirtualClockTicks < 0L || kernel.VirtualClockTicks > maxWallClockTicks then
             failwith
-                $"kernel VirtualClockMs is %d{kernel.VirtualClockMs}, which is outside the range [0, %d{maxWallClockEpochMs}] a wall-clock reading can be derived from"
+                $"kernel VirtualClockTicks is %d{kernel.VirtualClockTicks}, which is outside the range [0, %d{maxWallClockTicks}] a wall-clock reading can be derived from"
 
-        let ms = kernel.WallClockEpochMs + kernel.VirtualClockMs
+        let ticks = kernel.WallClockEpochMs * ticksPerMillisecond + kernel.VirtualClockTicks
 
-        if ms > maxWallClockEpochMs then
+        if ticks > maxWallClockTicks then
             failwith
-                $"simulated wall clock has reached %d{ms} ms since the Unix epoch, past the %d{maxWallClockEpochMs} ms that System.DateTime can represent; lower KernelConfig.WallClockEpochMs"
+                $"simulated wall clock has reached %d{ticks} ticks since the Unix epoch, past the %d{maxWallClockTicks} that System.DateTime can represent; lower KernelConfig.WallClockEpochMs"
 
-        ms * ticksPerMillisecond
+        ticks
 
     /// Nanoseconds per millisecond. `SystemNative_GetTimestamp` speaks in
-    /// nanoseconds while PawPrint's virtual clock speaks in milliseconds, so
-    /// the high-resolution timestamp derivation goes through this factor. A
-    /// consequence is that every timestamp the guest ever observes is a
-    /// multiple of 1,000,000: `Stopwatch` has millisecond granularity here,
-    /// where real `clock_gettime(CLOCK_MONOTONIC)` is far finer.
+    /// nanoseconds while PawPrint's virtual clock speaks in 100 ns ticks, so
+    /// the high-resolution timestamp derivation goes through this factor. Every
+    /// timestamp the guest observes is therefore a multiple of 100 — `Stopwatch`
+    /// has 100 ns granularity here, matching `DateTime`'s quantum, where real
+    /// `clock_gettime(CLOCK_MONOTONIC)` is finer still.
     [<Literal>]
-    let nanosecondsPerMillisecond : int64 = 1_000_000L
+    let nanosecondsPerTick : int64 = 100L
 
-    /// Largest `VirtualClockMs` from which a nanosecond timestamp can be
+    /// Largest `VirtualClockTicks` from which a nanosecond timestamp can be
     /// derived without overflowing the `int64` the PAL entry point returns:
-    /// `Int64.MaxValue / nanosecondsPerMillisecond`, i.e. about 292 years of
-    /// simulated uptime.
+    /// `Int64.MaxValue / nanosecondsPerTick`, i.e. about 29 years of simulated
+    /// uptime.
     ///
     /// The horizon is reachable by ordinary guest code, not merely in
-    /// principle. A sleep deadline is `VirtualClockMs + timeout` with no cap,
+    /// principle. A sleep deadline is `VirtualClockTicks + timeout` with no cap,
     /// and when no thread is Runnable the driver's deadline jump moves the
     /// clock the whole way there, so each `Thread.Sleep(Int32.MaxValue)`
-    /// advances it by about 2.1e9 ms: eight of them advance it by
-    /// 17,179,869,451 ms, and roughly 4,300 cross this bound. So
+    /// advances it by about 2.1e13 ticks, and roughly 4,300 cross this bound. So
     /// `monotonicTimestampNanos` checks rather than assumes — silently wrapping
     /// into a negative timestamp would hand the guest a monotonic clock that
     /// had run backwards, which is the one guarantee the primitive exists to
     /// provide.
     ///
-    /// The bound is *tighter* than `maxWallClockEpochMs` by a factor of about
+    /// The bound is *tighter* than `maxWallClockTicks` by a factor of about
     /// 27, so there is a band of clock readings from which `DateTime.UtcNow`
     /// and `Environment.TickCount64` are derivable but `Stopwatch.GetTimestamp`
-    /// is not. Nothing bounds `VirtualClockMs` at its write sites, so each
+    /// is not. Nothing bounds `VirtualClockTicks` at its write sites, so each
     /// clock-derived PAL entry enforces its own ceiling lazily, at the moment
     /// the guest reads that particular clock — `systemTimeAsTicks` has the same
     /// shape. Bounding the field centrally at the scheduler, its sole writer,
     /// would collapse these into one invariant and fault at the wait that
     /// pushed time past the horizon rather than at an arbitrary later read.
     [<Literal>]
-    let maxMonotonicTimestampClockMs : int64 = 9223372036854L
+    let maxMonotonicTimestampClockTicks : int64 = 92233720368547758L
 
     /// Monotonic time since the simulated process booted, in nanoseconds:
     /// exactly what `SystemNative_GetTimestamp` returns, and hence what
@@ -948,7 +981,7 @@ module EmulatedKernel =
     /// Real CoreCLR answers this from `minipal_hires_ticks()`
     /// (`clock_gettime_nsec_np(CLOCK_UPTIME_RAW)` on macOS,
     /// `clock_gettime(CLOCK_MONOTONIC)` on Linux). PawPrint derives it from
-    /// the same `VirtualClockMs` that already backs
+    /// the same `VirtualClockTicks` that already backs
     /// `SystemNative_GetLowResolutionTimestamp` — which upstream is
     /// `minipal_lowres_ticks()`, *the same clock* read in milliseconds. Making
     /// both PawPrint entry points views of one field is therefore not merely
@@ -967,18 +1000,18 @@ module EmulatedKernel =
     /// reads within one tick are equal, so a zero-length measured interval is
     /// normal). Real `CLOCK_MONOTONIC` makes no uniqueness guarantee either.
     let monotonicTimestampNanos (kernel : EmulatedKernel) : int64 =
-        // The driver loop is the only production writer of `VirtualClockMs`
+        // The driver loop is the only production writer of `VirtualClockTicks`
         // and only ever advances it from zero, but a kernel built by
         // record-copy (as tests do) can bypass that, so re-assert here rather
         // than trusting construction.
         if
-            kernel.VirtualClockMs < 0L
-            || kernel.VirtualClockMs > maxMonotonicTimestampClockMs
+            kernel.VirtualClockTicks < 0L
+            || kernel.VirtualClockTicks > maxMonotonicTimestampClockTicks
         then
             failwith
-                $"kernel VirtualClockMs is %d{kernel.VirtualClockMs}, which is outside the range [0, %d{maxMonotonicTimestampClockMs}] a nanosecond monotonic timestamp can be derived from without overflowing int64"
+                $"kernel VirtualClockTicks is %d{kernel.VirtualClockTicks}, which is outside the range [0, %d{maxMonotonicTimestampClockTicks}] a nanosecond monotonic timestamp can be derived from without overflowing int64"
 
-        kernel.VirtualClockMs * nanosecondsPerMillisecond
+        kernel.VirtualClockTicks * nanosecondsPerTick
 
     /// Largest value CoreCLR will accept from the processor-count
     /// configuration knob (`MAX_PROCESSOR_COUNT` in

--- a/WoofWare.PawPrint/ExternImplementations/System.Threading.Monitor.fs
+++ b/WoofWare.PawPrint/ExternImplementations/System.Threading.Monitor.fs
@@ -47,10 +47,10 @@ module System_Threading_Monitor =
     /// ownership-transfer model so the IL after the `Enter` call site is correctly
     /// held.
     ///
-    /// `deadlineMs = None` is an infinite acquire (`Monitor.Enter(obj)` /
+    /// `deadlineTicks = None` is an infinite acquire (`Monitor.Enter(obj)` /
     /// `Monitor.TryEnter(obj, Timeout.Infinite)`); `Some ms` is a finite
     /// positive timeout from the `TryEnter_Slowpath` route, expressed as
-    /// the absolute virtual-clock millisecond at which the timed acquire
+    /// the absolute virtual-clock tick at which the timed acquire
     /// expires. If the deadline fires while still queued,
     /// `SyncBlockMonitor.fireAcquireTimeout` dequeues the thread without
     /// transferring ownership.
@@ -59,7 +59,7 @@ module System_Threading_Monitor =
         (thread : ThreadId)
         (block : SyncBlock)
         (locked : LockedSyncBlock)
-        (deadlineMs : int64 option)
+        (deadlineTicks : int64 option)
         (state : IlMachineState)
         : IlMachineState
         =
@@ -70,7 +70,7 @@ module System_Threading_Monitor =
 
         state
         |> writeHeld addr block.WaitQueue locked
-        |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnSyncBlockAcquire (addr, deadlineMs))
+        |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnSyncBlockAcquire (addr, deadlineTicks))
 
     /// .NET 10 InternalCall: Monitor.TryEnter_FastPath(obj) -> bool.
     /// Backs `Monitor.Enter(obj)`: the BCL's IL is "if (!TryEnter_FastPath(obj)) Enter_Slowpath(obj)",
@@ -285,11 +285,13 @@ module System_Threading_Monitor =
                     // via either ownership transfer (Exit_FastPath head dequeue) or
                     // deadline fire (`SyncBlockMonitor.fireAcquireTimeout` rewrites
                     // to `Int32 0`).
-                    let deadlineMs = state.Kernel.VirtualClockMs + int64 timeout
+                    let deadlineTicks =
+                        state.Kernel.VirtualClockTicks
+                        + int64 timeout * EmulatedKernel.ticksPerMillisecond
 
                     state
                     |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 (Int32Source.Verbatim 1)) currentThread
-                    |> parkOnAcquireQueue addr currentThread block locked (Some deadlineMs)
+                    |> parkOnAcquireQueue addr currentThread block locked (Some deadlineTicks)
 
         state
 

--- a/WoofWare.PawPrint/LowLevelMonitor.fs
+++ b/WoofWare.PawPrint/LowLevelMonitor.fs
@@ -40,7 +40,7 @@ namespace WoofWare.PawPrint
 /// BCL.
 ///
 /// Timeouts: `wait` accepts an optional absolute virtual-clock
-/// `deadlineMs`. `None` is the infinite-wait shape used by the void
+/// `deadlineTicks`. `None` is the infinite-wait shape used by the void
 /// `SystemNative_LowLevelMonitor_Wait` entry point; `Some ms` is the
 /// finite-deadline shape used by `TimedWait`. The deadline is recorded
 /// on the waiter's `BlockedOnMonitorWait` status, where the driver
@@ -257,7 +257,7 @@ module LowLevelMonitor =
     /// monitor but has not yet been parked, because both happen in a single
     /// `wait` call.
     ///
-    /// `deadlineMs = None` mirrors the infinite-timeout
+    /// `deadlineTicks = None` mirrors the infinite-timeout
     /// `SystemNative_LowLevelMonitor_Wait` entry point: the thread will
     /// only wake from a `Signal_Release` or a spurious wake. `Some ms`
     /// is the finite-deadline shape used by `TimedWait`: the driver
@@ -266,7 +266,7 @@ module LowLevelMonitor =
     let wait
         (thread : ThreadId)
         (id : LowLevelMonitorId)
-        (deadlineMs : int64 option)
+        (deadlineTicks : int64 option)
         (state : IlMachineState)
         : IlMachineState
         =
@@ -291,7 +291,7 @@ module LowLevelMonitor =
 
             state
             |> writeMonitor id monitor
-            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnMonitorWait (id, deadlineMs))
+            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnMonitorWait (id, deadlineTicks))
 
         | head :: rest ->
             // Transfer ownership to the AcquireQueue head and park the
@@ -306,7 +306,7 @@ module LowLevelMonitor =
             state
             |> writeMonitor id monitor
             |> Scheduler.setThreadStatus head ThreadStatus.Runnable
-            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnMonitorWait (id, deadlineMs))
+            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnMonitorWait (id, deadlineTicks))
 
     /// `Signal_Release` is the wakeup half of the condvar protocol. The
     /// caller must hold the monitor; the call wakes at most one thread

--- a/WoofWare.PawPrint/Native/NativeLowLevelMonitor.fs
+++ b/WoofWare.PawPrint/Native/NativeLowLevelMonitor.fs
@@ -113,7 +113,7 @@ module NativeLowLevelMonitor =
             let id = monitorOfArgument operation instruction.Arguments.[0]
             let timeout = NativeCall.int32Argument operation instruction.Arguments.[1]
 
-            let deadlineMs =
+            let deadlineTicks =
                 if timeout = System.Threading.Timeout.Infinite then
                     // The managed `LowLevelMonitor.Wait(int)` wrapper
                     // routes `-1 → Wait()` rather than calling TimedWait,
@@ -139,7 +139,10 @@ module NativeLowLevelMonitor =
                     // immediate timeout against signal-poll-then-park.
                     // `int64` keeps the addition safe for `Int32.MaxValue`
                     // timeouts against a long-running clock.
-                    Some (state.Kernel.VirtualClockMs + int64 timeout)
+                    Some (
+                        state.Kernel.VirtualClockTicks
+                        + int64 timeout * EmulatedKernel.ticksPerMillisecond
+                    )
 
             // Push the optimistic `Int32 1` (signalled) onto the calling
             // thread's eval stack *before* parking. Park flips the
@@ -153,7 +156,7 @@ module NativeLowLevelMonitor =
                 state
                 |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 (Int32Source.Verbatim 1)) ctx.Thread
 
-            let state = LowLevelMonitor.wait ctx.Thread id deadlineMs state
+            let state = LowLevelMonitor.wait ctx.Thread id deadlineTicks state
             NativeHandlerResult.completed state |> Some
 
         | Some "SystemNative_LowLevelMonitor_Signal_Release",

--- a/WoofWare.PawPrint/Native/NativeMonitor.fs
+++ b/WoofWare.PawPrint/Native/NativeMonitor.fs
@@ -137,7 +137,7 @@ module NativeMonitor =
                 | CliType.Numeric (CliNumericType.Int32 i) -> i
                 | other -> failwith $"%s{operation}: expected int32 timeout, got %O{other}"
 
-            let deadlineMs =
+            let deadlineTicks =
                 if timeout = System.Threading.Timeout.Infinite then
                     // The managed `Monitor.Wait(obj)` overload routes through the same QCall
                     // with `millisecondsTimeout = -1`; an infinite wait has no deadline and
@@ -156,7 +156,10 @@ module NativeMonitor =
                     // driver tick's `fireExpiredDeadlines` pass — observably an immediate
                     // timeout. `int64` keeps the addition safe for `Int32.MaxValue`
                     // timeouts against a long-running clock.
-                    Some (state.Kernel.VirtualClockMs + int64 timeout)
+                    Some (
+                        state.Kernel.VirtualClockTicks
+                        + int64 timeout * EmulatedKernel.ticksPerMillisecond
+                    )
 
             // Push the optimistic `Int32 1` (signalled) onto the calling thread's eval stack
             // *before* parking. Park flips the thread's status; the IL site advances past
@@ -168,7 +171,7 @@ module NativeMonitor =
                 state
                 |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 (Int32Source.Verbatim 1)) ctx.Thread
 
-            let state = SyncBlockMonitor.wait ctx.Thread addr deadlineMs state
+            let state = SyncBlockMonitor.wait ctx.Thread addr deadlineTicks state
 
             NativeHandlerResult.completed state |> Some
 

--- a/WoofWare.PawPrint/Native/NativeSystemNative.fs
+++ b/WoofWare.PawPrint/Native/NativeSystemNative.fs
@@ -376,9 +376,7 @@ module NativeSystemNative =
             // scheduler is the sole writer of `VirtualClockTicks`.
             state
             |> IlMachineState.pushToEvalStack'
-                (EvalStackValue.Int64 (
-                    Int64Source.Verbatim (state.Kernel.VirtualClockTicks / EmulatedKernel.ticksPerMillisecond)
-                ))
+                (EvalStackValue.Int64 (Int64Source.Verbatim (EmulatedKernel.lowResolutionTimestampMs state.Kernel)))
                 ctx.Thread
             |> NativeHandlerResult.completed
             |> Some

--- a/WoofWare.PawPrint/Native/NativeSystemNative.fs
+++ b/WoofWare.PawPrint/Native/NativeSystemNative.fs
@@ -369,11 +369,16 @@ module NativeSystemNative =
             // CoreCLR returns `clock_gettime(CLOCK_MONOTONIC_COARSE)`
             // converted to milliseconds; PawPrint substitutes the
             // deterministic virtual clock the scheduler maintains so the
-            // result is bit-for-bit reproducible. Read-only: the
-            // scheduler is the sole writer of `VirtualClockMs`.
+            // result is bit-for-bit reproducible. The clock counts 100 ns
+            // ticks, so the conversion to the milliseconds this entry point
+            // returns is an explicit divide — truncating, which is faithful:
+            // upstream's coarse clock truncates too. Read-only: the
+            // scheduler is the sole writer of `VirtualClockTicks`.
             state
             |> IlMachineState.pushToEvalStack'
-                (EvalStackValue.Int64 (Int64Source.Verbatim state.Kernel.VirtualClockMs))
+                (EvalStackValue.Int64 (
+                    Int64Source.Verbatim (state.Kernel.VirtualClockTicks / EmulatedKernel.ticksPerMillisecond)
+                ))
                 ctx.Thread
             |> NativeHandlerResult.completed
             |> Some
@@ -519,7 +524,7 @@ module NativeSystemNative =
             // on Unix (Stopwatch.Unix.cs) — so the units here are pinned by
             // CoreLib rather than chosen.
             //
-            // The reading derives from the same `VirtualClockMs` that backs
+            // The reading derives from the same `VirtualClockTicks` that backs
             // `SystemNative_GetLowResolutionTimestamp` above, because upstream
             // *that* entry point is `minipal_lowres_ticks()`, which reads the
             // very same monotonic clock in milliseconds. One field for both
@@ -529,7 +534,7 @@ module NativeSystemNative =
             // `EmulatedKernel.monotonicTimestampNanos`.
             //
             // Read-only, like every other clock observer: the scheduler is the
-            // sole writer of `VirtualClockMs`.
+            // sole writer of `VirtualClockTicks`.
             state
             |> IlMachineState.pushToEvalStack'
                 (EvalStackValue.Int64 (Int64Source.Verbatim (EmulatedKernel.monotonicTimestampNanos state.Kernel)))
@@ -546,7 +551,7 @@ module NativeSystemNative =
             // from the same deterministic virtual clock that backs
             // `Environment.TickCount64`, offset by the kernel's boot-time
             // wall-clock reading. Read-only, like every other clock observer:
-            // the scheduler is the sole writer of `VirtualClockMs`, and
+            // the scheduler is the sole writer of `VirtualClockTicks`, and
             // `WallClockEpochMs` never changes after configuration.
             state
             |> IlMachineState.pushToEvalStack'

--- a/WoofWare.PawPrint/Native/NativeThreading.fs
+++ b/WoofWare.PawPrint/Native/NativeThreading.fs
@@ -101,7 +101,7 @@ module NativeThreading =
         (timeout : int)
         : IlMachineState * bool
         =
-        let deadlineMs : int64 option option =
+        let deadlineTicks : int64 option option =
             // `None` = caller passed `0` (non-blocking poll, no block at all).
             // `Some None` = caller passed `-1` (infinite wait, block with no deadline).
             // `Some (Some ms)` = caller passed `> 0` (finite timeout, block with deadline).
@@ -122,7 +122,12 @@ module NativeThreading =
                 // `timeout > 0` is the finite-wait case. `int64` keeps the addition
                 // safe against an `Int32.MaxValue` timeout against a long-running
                 // virtual clock.
-                Some (Some (state.Kernel.VirtualClockMs + int64 timeout))
+                Some (
+                    Some (
+                        state.Kernel.VirtualClockTicks
+                        + int64 timeout * EmulatedKernel.ticksPerMillisecond
+                    )
+                )
 
         let targetThreadId = threadIdFromThreadAddr state "Thread.Join" threadAddr
 
@@ -140,7 +145,7 @@ module NativeThreading =
         // waits 50 ms and returns false. The non-blocking poll (`timeout = 0`)
         // is also fine for self: `targetTerminated` is false for a running self,
         // so we return false immediately without any status transition.
-        match deadlineMs with
+        match deadlineTicks with
         | Some None when targetThreadId = ctx.Thread ->
             failwith
                 $"Thread.Join: thread {ctx.Thread} is attempting to join itself with an infinite timeout, which would deadlock. The real CLR also hangs on infinite self-join; PawPrint reports this at the call site rather than as a downstream deadlock. Use Thread.Join(int) with a finite timeout (or 0) if you want the call to return."
@@ -168,7 +173,7 @@ module NativeThreading =
 
         let targetTerminated = targetState.Status = ThreadStatus.Terminated
 
-        match deadlineMs with
+        match deadlineTicks with
         | None ->
             // timeout = 0: non-blocking poll. Result is whether the target is
             // already terminated; no status transition.
@@ -630,7 +635,7 @@ module NativeThreading =
             // `WaitHandle.ToTimeoutMilliseconds`, so this single arm covers
             // both overloads.
             //
-            // PawPrint's deterministic scheduler advances `VirtualClockMs`
+            // PawPrint's deterministic scheduler advances `VirtualClockTicks`
             // one tick at a time; the actual wait is implemented by parking
             // the thread in `BlockedOnSleep` with an absolute deadline
             // (or `None` for `Timeout.Infinite`) and letting
@@ -671,7 +676,10 @@ module NativeThreading =
                     failwith
                         $"%s{operation}: negative timeout %d{millisecondsTimeout} ms is not Infinite (-1); the BCL Thread.Sleep call site is required to pre-validate this. Reaching here means the validation was bypassed (e.g. by a synthesised IL call) — bug in the caller."
                 else
-                    let deadline = state.Kernel.VirtualClockMs + int64 millisecondsTimeout
+                    let deadline =
+                        state.Kernel.VirtualClockTicks
+                        + int64 millisecondsTimeout * EmulatedKernel.ticksPerMillisecond
+
                     Scheduler.blockOnSleep ctx.Thread (Some deadline) state
 
             NativeHandlerResult.completed state |> Some
@@ -707,16 +715,16 @@ module NativeThreading =
             // wall-clock time proportional to `iterations`.
             //
             // Elapsed time *is* observable to a PawPrint guest — that is what
-            // `EmulatedKernel.VirtualClockMs` is, and `Environment.TickCount64`
+            // `EmulatedKernel.VirtualClockTicks` is, and `Environment.TickCount64`
             // and `DateTime.UtcNow` both read it. But the driver loop advances
-            // it as a function of scheduler ticks (one tick, one millisecond,
-            // per instruction retired), never as a function of what a given
+            // it as a function of scheduler ticks (`instructionCostTicks` of
+            // virtual time per instruction retired), never as a function of what a given
             // instruction physically costs. So this handler doing no work does
             // not freeze the guest's clock: the `call` still retires, the clock
             // still moves, and a guest delay loop such as
-            // `while (TickCount64 - start < N) Thread.SpinWait(k);` terminates —
-            // in fact almost immediately, since a millisecond per instruction is
-            // a generous rate to be billed at.
+            // `while (TickCount64 - start < N) Thread.SpinWait(k);` terminates,
+            // after about `N * ticksPerMillisecond / instructionCostTicks`
+            // iterations.
             //
             // What is deliberately not modelled is the *proportionality* to
             // `iterations`: `SpinWait(1)` and `SpinWait(10_000_000)` each cost
@@ -729,7 +737,7 @@ module NativeThreading =
             // days of virtual time, firing every outstanding timeout in the
             // process — strictly worse for guest fidelity than under-charging.
             // And it would make a native handler a second writer of
-            // `VirtualClockMs`, which `EmulatedKernel` documents as
+            // `VirtualClockTicks`, which `EmulatedKernel` documents as
             // scheduler-only; the property that two threads reading on the same
             // tick observe the same value is stated there and relied on by the
             // `SystemNative_GetLowResolutionTimestamp` and

--- a/WoofWare.PawPrint/Native/NativeWaitHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeWaitHandle.fs
@@ -274,7 +274,7 @@ module NativeWaitHandle =
     ///  - `timeout = 0`: the non-blocking probe `WaitOne(0)` issues —
     ///    routed through `tryWait`, which never parks and returns
     ///    `WAIT_OBJECT_0` / `WAIT_ABANDONED` / `WAIT_TIMEOUT` inline.
-    ///  - `timeout > 0`: compute an absolute deadline as `VirtualClockMs
+    ///  - `timeout > 0`: compute an absolute deadline as `VirtualClockTicks
     ///    + timeout` and thread it through `blockingWait`. The fast
     ///    paths ignore the deadline; the slow path records it on the
     ///    parked thread's `BlockedOnWaitHandle` status, and the driver
@@ -333,17 +333,22 @@ module NativeWaitHandle =
                 $"%s{operation}: negative timeout %d{timeout} ms is not Infinite (-1); the BCL's WaitHandle.WaitOne(int) validates this argument before the QCall, so reaching here means the wrapper was bypassed."
         else
             // Finite positive timeout: compute an absolute deadline
-            // against the virtual clock. `VirtualClockMs` advances 1 ms
-            // per scheduler tick (per `Program.stepPrepared`), and the
+            // against the virtual clock. The guest's timeout is in
+            // milliseconds and the clock counts 100 ns ticks, so it is scaled
+            // by `ticksPerMillisecond` on the way in. `VirtualClockTicks`
+            // advances by `instructionCostTicks` per scheduler tick (per
+            // `Program.stepPrepared`), and the
             // driver loop fires `WaitHandle.fireTimeout` when the clock
             // reaches or passes a parked thread's deadline; if no other
             // thread is Runnable, the driver also jumps the clock to
             // the nearest pending deadline so the wait can resolve.
             // `int64` keeps the addition safe even for
             // `Int32.MaxValue` timeouts against a long-running clock.
-            let deadlineMs = state.Kernel.VirtualClockMs + int64 timeout
+            let deadlineTicks =
+                state.Kernel.VirtualClockTicks
+                + int64 timeout * EmulatedKernel.ticksPerMillisecond
 
-            match blockingWait (Some deadlineMs) state with
+            match blockingWait (Some deadlineTicks) state with
             | WaitHandle.WaitOutcome.Acquired state -> state, waitObjectZero
             | WaitHandle.WaitOutcome.AcquiredAbandoned state -> state, waitAbandoned
             | WaitHandle.WaitOutcome.Blocked state -> state, waitObjectZero
@@ -715,9 +720,11 @@ module NativeWaitHandle =
                 failwith
                     $"%s{operation}: negative timeout %d{timeout} ms is not Infinite (-1); WaitHandle.WaitMultiple validates this argument before the QCall, so reaching here means the wrapper was bypassed."
             else
-                let deadlineMs = state.Kernel.VirtualClockMs + int64 timeout
+                let deadlineTicks =
+                    state.Kernel.VirtualClockTicks
+                    + int64 timeout * EmulatedKernel.ticksPerMillisecond
 
-                match WaitHandle.waitMultiple ctx.Thread handles waitAll (Some deadlineMs) state with
+                match WaitHandle.waitMultiple ctx.Thread handles waitAll (Some deadlineTicks) state with
                 | WaitHandle.MultiWaitOutcome.Acquired (index, abandoned, state) ->
                     completeWith state (multiWaitResult waitAll index abandoned)
                 | WaitHandle.MultiWaitOutcome.Blocked state -> completeWith state waitObjectZero

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -114,7 +114,7 @@ module Program =
     /// Project a thread status into its finite-timeout deadline against
     /// the virtual clock, if any. Threads with no deadline (Runnable,
     /// non-timed blocks, infinite waits) return `None`; threads parked
-    /// with a finite timeout return `Some (kind, absoluteVirtualClockMs)`.
+    /// with a finite timeout return `Some (kind, absoluteVirtualClockTicks)`.
     /// The `kind` is what tells the deadline-firing path which
     /// subsystem's fire function to invoke.
     let private waitDeadline (status : ThreadStatus) : (FiredDeadline * int64) option =
@@ -144,7 +144,7 @@ module Program =
         | ThreadStatus.Parked -> None
 
     /// Fire a timeout wake for every blocked-with-deadline thread whose
-    /// deadline is `<= state.Kernel.VirtualClockMs`. Each fire routes
+    /// deadline is `<= state.Kernel.VirtualClockTicks`. Each fire routes
     /// through a per-subsystem fire function (WaitHandle dequeues from
     /// the handle's wait queue and rewrites `WAIT_OBJECT_0 → WAIT_TIMEOUT`;
     /// LowLevelMonitor moves the waiter from `WaitQueue` to `AcquireQueue`
@@ -175,7 +175,7 @@ module Program =
     /// Queue positions are computed against the input state, before any
     /// fires mutate `WaitQueue`s.
     let private fireExpiredDeadlines (state : IlMachineState) : IlMachineState =
-        let now = state.Kernel.VirtualClockMs
+        let now = state.Kernel.VirtualClockTicks
 
         // `Map.foldBack` visits keys in descending order, so the resulting list is sorted by
         // thread ID.
@@ -278,13 +278,13 @@ module Program =
     /// `None` if no thread is parked with a finite timeout. Used by the
     /// driver loop's jump-to-deadline fallback: if no thread is Runnable
     /// but at least one has a finite-timeout wait outstanding, advance
-    /// `VirtualClockMs` to the nearest such deadline so the wait can
+    /// `VirtualClockTicks` to the nearest such deadline so the wait can
     /// resolve on the next pass.
     ///
     /// The clock-jump must not bump `StepCounter` — the spurious-wakeup
     /// schedules are keyed on `StepCounter`, and a jump-driven tick is
     /// deliberately *not* a real scheduler tick. Keeping the two clocks
-    /// separate is exactly why `VirtualClockMs` is its own field rather
+    /// separate is exactly why `VirtualClockTicks` is its own field rather
     /// than derived from `StepCounter`.
     let private nextDeadline (state : IlMachineState) : int64 option =
         state.ThreadState
@@ -378,22 +378,21 @@ module Program =
                     state.MapKernel (fun kernel ->
                         { kernel with
                             StepCounter = kernel.StepCounter + 1L
-                            // One wall-clock millisecond per scheduler
-                            // tick — see `EmulatedKernel.VirtualClockMs`
-                            // for why the rate is "very slow computer"
-                            // by realism standards but bit-for-bit
-                            // deterministic. Bumping in lock-step with
+                            // `EmulatedKernel.instructionCostTicks` of virtual
+                            // time per scheduler tick — see that constant for
+                            // the rate and why it is what it is. Bumping in
+                            // lock-step with
                             // `StepCounter` keeps both clocks pure
                             // functions of "how many scheduler ticks
                             // have elapsed", which is what tests rely
                             // on when driving the strategies without a
                             // real driver.
-                            VirtualClockMs = kernel.VirtualClockMs + 1L
+                            VirtualClockTicks = kernel.VirtualClockTicks + EmulatedKernel.instructionCostTicks
                         }
                     )
             }
 
-        // After advancing `VirtualClockMs`, fire any wait deadlines that
+        // After advancing `VirtualClockTicks`, fire any wait deadlines that
         // are now in the past. This runs every tick (not just on
         // deadlock) so a timeout against a thread holding a release lock
         // can still expire while other threads make progress: e.g.
@@ -419,11 +418,11 @@ module Program =
 
         // Jump-to-deadline fallback: if no thread is Runnable but at
         // least one is parked with a finite-timeout wait outstanding,
-        // advance `VirtualClockMs` to the nearest pending deadline and
+        // advance `VirtualClockTicks` to the nearest pending deadline and
         // fire it. This is what keeps a guest like `WaitOne(50)` against
         // an unsignalled handle from deadlocking — without the jump, the
-        // clock would advance 1 ms per tick *only when there's something
-        // to step*, but there is nothing to step.
+        // clock would advance only when there's something to step, and
+        // there is nothing to step.
         //
         // The fallback loops because a single fire may not make any
         // thread Runnable: `LowLevelMonitor.fireTimeout` moves a waiter
@@ -434,12 +433,12 @@ module Program =
         // declare deadlock even though the owner's later finite wait can
         // still resolve and release the monitor. Each iteration either
         // produces a Runnable thread (terminating the loop) or strictly
-        // advances `VirtualClockMs` to the next outstanding deadline; the
+        // advances `VirtualClockTicks` to the next outstanding deadline; the
         // set of finite-deadline threads is finite and monotonically
         // shrinks (no fire creates a new deadline), so the loop
         // terminates.
         //
-        // Only `VirtualClockMs` is advanced (not `StepCounter`), so the
+        // Only `VirtualClockTicks` is advanced (not `StepCounter`), so the
         // spurious-wakeup schedule is untouched. A jump-driven wake is
         // not a scheduler tick — it is the resolution of a timeout that
         // would otherwise be invisible.
@@ -458,7 +457,7 @@ module Program =
                     let state =
                         state.MapKernel (fun kernel ->
                             { kernel with
-                                VirtualClockMs = max kernel.VirtualClockMs target
+                                VirtualClockTicks = max kernel.VirtualClockTicks target
                             }
                         )
 

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -376,19 +376,22 @@ module Program =
             { prepared with
                 State =
                     state.MapKernel (fun kernel ->
+                        // `EmulatedKernel.instructionCostTicks` of virtual time per scheduler
+                        // tick — see that constant for the rate and why it is what it is.
+                        // Bumping in lock-step with `StepCounter` keeps both clocks pure
+                        // functions of "how many scheduler ticks have elapsed", which is what
+                        // tests rely on when driving the strategies without a real driver.
+                        //
+                        // Through `withVirtualClockTicks` so that the horizon is enforced at
+                        // the writer; this path cannot realistically reach it (it would take
+                        // ~9.2e12 retired instructions) but going around the validating setter
+                        // would leave the invariant true only by coincidence.
                         { kernel with
                             StepCounter = kernel.StepCounter + 1L
-                            // `EmulatedKernel.instructionCostTicks` of virtual
-                            // time per scheduler tick — see that constant for
-                            // the rate and why it is what it is. Bumping in
-                            // lock-step with
-                            // `StepCounter` keeps both clocks pure
-                            // functions of "how many scheduler ticks
-                            // have elapsed", which is what tests rely
-                            // on when driving the strategies without a
-                            // real driver.
-                            VirtualClockTicks = kernel.VirtualClockTicks + EmulatedKernel.instructionCostTicks
                         }
+                        |> EmulatedKernel.withVirtualClockTicks (
+                            kernel.VirtualClockTicks + EmulatedKernel.instructionCostTicks
+                        )
                     )
             }
 
@@ -455,10 +458,14 @@ module Program =
                 | None -> state
                 | Some target ->
                     let state =
-                        state.MapKernel (fun kernel ->
-                            { kernel with
-                                VirtualClockTicks = max kernel.VirtualClockTicks target
-                            }
+                        // The path that *can* reach the horizon: this jumps the clock straight
+                        // to a deadline without retiring a step, so a guest looping on
+                        // `Thread.Sleep(Int32.MaxValue)` advances it ~2.1e13 ticks per cheap
+                        // iteration. `withVirtualClockTicks` faults here, naming the wait that
+                        // ran time off the end, instead of letting the addition wrap and hand
+                        // some later sleeper a negative deadline that fires immediately.
+                        state.MapKernel (
+                            EmulatedKernel.withVirtualClockTicks (max state.Kernel.VirtualClockTicks target)
                         )
 
                     advanceUntilRunnableOrQuiescent (fireExpiredDeadlines state)

--- a/WoofWare.PawPrint/Scheduler.fs
+++ b/WoofWare.PawPrint/Scheduler.fs
@@ -320,19 +320,19 @@ module Scheduler =
                     ))
         }
 
-    /// Transition `blocked` from Runnable to `BlockedOnJoin (target, deadlineMs)`.
+    /// Transition `blocked` from Runnable to `BlockedOnJoin (target, deadlineTicks)`.
     /// Called from the `Thread.Join` intrinsic; exposed here so the set of places
     /// that mutate `ThreadStatus` stays small and auditable.
     ///
-    /// `deadlineMs = None` is an infinite wait (`Thread.Join()` /
+    /// `deadlineTicks = None` is an infinite wait (`Thread.Join()` /
     /// `Thread.Join(-1)`); `Some ms` is a finite timeout, expressed as the
-    /// absolute virtual-clock millisecond at which the wait expires. The
+    /// absolute virtual-clock tick at which the wait expires. The
     /// deadline-firing path in `Program.fireExpiredDeadlines` routes such
     /// threads through `fireJoinTimeout` below.
     let blockOnJoin
         (blocked : ThreadId)
         (target : ThreadId)
-        (deadlineMs : int64 option)
+        (deadlineTicks : int64 option)
         (state : IlMachineState)
         : IlMachineState
         =
@@ -343,7 +343,7 @@ module Scheduler =
                     blocked
                     (Option.map (fun s ->
                         { s with
-                            Status = ThreadStatus.BlockedOnJoin (target, deadlineMs)
+                            Status = ThreadStatus.BlockedOnJoin (target, deadlineTicks)
                         }
                     ))
         }
@@ -391,7 +391,7 @@ module Scheduler =
     /// Park `blocked` in `BlockedOnSleep`, transitioning out of `Runnable`.
     /// Mirrors `blockOnJoin` but with no per-primitive wait queue: sleeping
     /// is purely time-driven, the wake comes from `Scheduler.fireSleepTimeout`
-    /// when the virtual clock crosses the deadline. `deadlineMs = None` is
+    /// when the virtual clock crosses the deadline. `deadlineTicks = None` is
     /// an infinite sleep (`Thread.Sleep(-1)` / `Timeout.Infinite`); `Some _`
     /// is a finite timeout. No optimistic eval-stack push is performed
     /// because `Thread.Sleep` returns `void`.
@@ -400,7 +400,7 @@ module Scheduler =
     /// `Sleep` call site before parking (so the wake resumes after the
     /// call), matching the contract used by every other QCall handler that
     /// blocks.
-    let blockOnSleep (blocked : ThreadId) (deadlineMs : int64 option) (state : IlMachineState) : IlMachineState =
+    let blockOnSleep (blocked : ThreadId) (deadlineTicks : int64 option) (state : IlMachineState) : IlMachineState =
         { state with
             ThreadState =
                 state.ThreadState
@@ -408,7 +408,7 @@ module Scheduler =
                     blocked
                     (Option.map (fun s ->
                         { s with
-                            Status = ThreadStatus.BlockedOnSleep deadlineMs
+                            Status = ThreadStatus.BlockedOnSleep deadlineTicks
                         }
                     ))
         }

--- a/WoofWare.PawPrint/SyncBlockMonitor.fs
+++ b/WoofWare.PawPrint/SyncBlockMonitor.fs
@@ -82,9 +82,9 @@ module SyncBlockMonitor =
     /// of which moves the waiter to the AcquireQueue carrying the snapshot
     /// for depth restoration on re-acquire.
     ///
-    /// `deadlineMs = None` is `Monitor.Wait(obj)` (infinite); `Some ms` is
+    /// `deadlineTicks = None` is `Monitor.Wait(obj)` (infinite); `Some ms` is
     /// `Monitor.Wait(obj, timeout)` (finite). The deadline is the absolute
-    /// virtual-clock millisecond at which the wait expires; on expiry the
+    /// virtual-clock tick at which the wait expires; on expiry the
     /// driver fires `fireWaitTimeout` which routes the waiter through the same
     /// reacquire path and rewrites the optimistic `Int32 1` slot pushed at
     /// park time to `Int32 0` (timed out).
@@ -95,7 +95,7 @@ module SyncBlockMonitor =
     let wait
         (thread : ThreadId)
         (addr : ManagedHeapAddress)
-        (deadlineMs : int64 option)
+        (deadlineTicks : int64 option)
         (state : IlMachineState)
         : IlMachineState
         =
@@ -141,7 +141,7 @@ module SyncBlockMonitor =
             | None -> state
             | Some nextOwner -> Scheduler.setThreadStatus nextOwner ThreadStatus.Runnable state
 
-        Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnSyncBlockWait (addr, deadlineMs)) state
+        Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnSyncBlockWait (addr, deadlineTicks)) state
 
     /// `Monitor.Pulse`: caller must hold the lock; wakes at most one waiter
     /// from the FIFO head of `WaitQueue`. The woken waiter is moved to the

--- a/WoofWare.PawPrint/ThreadState.fs
+++ b/WoofWare.PawPrint/ThreadState.fs
@@ -28,11 +28,11 @@ type ThreadStatus =
     /// `BlockedOnJoin (target, _)` whose `target` matches the terminating
     /// thread and flips them back to `Runnable`.
     ///
-    /// `deadlineMs = None` is an infinite wait (`Thread.Join()` /
+    /// `deadlineTicks = None` is an infinite wait (`Thread.Join()` /
     /// `Thread.Join(-1)` / `Timeout.Infinite`); `Some ms` is a finite
     /// timeout (`Thread.Join(int)` with a non-zero positive value),
-    /// expressed as the absolute virtual-clock millisecond at which the
-    /// wait expires. When `VirtualClockMs` advances past the deadline and
+    /// expressed as the absolute virtual-clock tick at which the
+    /// wait expires. When `VirtualClockTicks` advances past the deadline and
     /// the thread is still parked, the driver fires a timeout wake
     /// (`Scheduler.fireJoinTimeout`): the optimistic `Int32 1` slot
     /// pushed at park time by the Join handler is rewritten to `Int32 0`
@@ -43,7 +43,7 @@ type ThreadStatus =
     /// `Thread.Join(0)` is a non-blocking poll handled at the call site
     /// (no `BlockedOnJoin` transition); only `> 0` finite timeouts and
     /// `-1` infinite reach this variant.
-    | BlockedOnJoin of target : ThreadId * deadlineMs : int64 option
+    | BlockedOnJoin of target : ThreadId * deadlineTicks : int64 option
     /// This thread tried to access a type whose .cctor is currently being run by another
     /// thread. Per ECMA-335 II.10.5.3.3 it must wait for that thread to finish initialising
     /// the type before it can proceed.
@@ -63,9 +63,9 @@ type ThreadStatus =
     /// `BlockedOnMonitorAcquire`; reacquisition then runs through the
     /// normal acquire path.
     ///
-    /// `deadlineMs = None` is an infinite wait; `Some ms` is a finite
-    /// timeout, expressed as the absolute virtual-clock millisecond at
-    /// which the wait expires. When `VirtualClockMs` advances to that
+    /// `deadlineTicks = None` is an infinite wait; `Some ms` is a finite
+    /// timeout, expressed as the absolute virtual-clock tick at
+    /// which the wait expires. When `VirtualClockTicks` advances to that
     /// point and the thread is still parked, the driver fires a timeout
     /// wake (`LowLevelMonitor.fireTimeout`): the thread is dequeued from
     /// the monitor's `WaitQueue`, moved to the `AcquireQueue` tail (or
@@ -75,7 +75,7 @@ type ThreadStatus =
     /// Storing the deadline in the status itself (rather than alongside
     /// in a separate map) makes "no deadline once the wake has fired"
     /// structural — the new status carries no deadline field.
-    | BlockedOnMonitorWait of monitor : LowLevelMonitorId * deadlineMs : int64 option
+    | BlockedOnMonitorWait of monitor : LowLevelMonitorId * deadlineTicks : int64 option
     /// This thread called `Monitor.Enter` (or its `TryEnter` cousin with a non-zero
     /// timeout) on an object whose SyncBlock is `Held` by a different thread, and
     /// is parked at the SyncBlock's `AcquireQueue`. The lock owner's eventual
@@ -84,13 +84,13 @@ type ThreadStatus =
     /// the `LowLevelMonitor` ownership-transfer model so the resumed thread's IL
     /// continues past the `Enter` call site already owning the SyncBlock.
     ///
-    /// `deadlineMs = None` is an infinite acquire (`Monitor.Enter(obj)` /
+    /// `deadlineTicks = None` is an infinite acquire (`Monitor.Enter(obj)` /
     /// `Monitor.TryEnter(obj, Timeout.Infinite)`); `Some ms` is a finite
     /// timeout (`Monitor.TryEnter(obj, ms)` with `ms > 0`), expressed as the
-    /// absolute virtual-clock millisecond at which the timed acquire expires.
+    /// absolute virtual-clock tick at which the timed acquire expires.
     /// Only the `TryEnter_Slowpath` path produces `Some _` — the fast-path
     /// short-circuits zero-timeout contention and parks infinite-timeout
-    /// contention with `None` directly. When `VirtualClockMs` advances past
+    /// contention with `None` directly. When `VirtualClockTicks` advances past
     /// the deadline and the thread is still parked, the driver fires
     /// `SyncBlockMonitor.fireAcquireTimeout`: the thread is dequeued from the
     /// SyncBlock's `AcquireQueue`, the optimistic `Int32 1` (acquired) slot
@@ -98,7 +98,7 @@ type ThreadStatus =
     /// status flips back to `Runnable`. Storing the deadline in the status
     /// itself rather than in a parallel map makes the invariant "no deadline
     /// once Runnable again" structural — a wake naturally forgets it.
-    | BlockedOnSyncBlockAcquire of lockObject : ManagedHeapAddress * deadlineMs : int64 option
+    | BlockedOnSyncBlockAcquire of lockObject : ManagedHeapAddress * deadlineTicks : int64 option
     /// This thread called `Monitor.Wait` on an object's SyncBlock and is parked at
     /// the SyncBlock's `WaitQueue` with the lock fully released. A subsequent
     /// `Monitor.Pulse` / `PulseAll` from another thread (or a spurious wake)
@@ -110,10 +110,10 @@ type ThreadStatus =
     /// re-owning the lock. Parallel with `BlockedOnMonitorWait` but for managed
     /// SyncBlocks rather than `LowLevelMonitor`.
     ///
-    /// `deadlineMs = None` is an infinite wait (`Monitor.Wait(obj)` / managed
+    /// `deadlineTicks = None` is an infinite wait (`Monitor.Wait(obj)` / managed
     /// `Timeout.Infinite`); `Some ms` is a finite timeout
     /// (`Monitor.Wait(obj, ms)`), expressed as the absolute virtual-clock
-    /// millisecond at which the wait expires. When `VirtualClockMs` advances
+    /// millisecond at which the wait expires. When `VirtualClockTicks` advances
     /// past the deadline and the thread is still parked, the driver fires a
     /// timeout wake (`SyncBlockMonitor.fireWaitTimeout`): the thread is dequeued
     /// from the SyncBlock's `WaitQueue`, routed through the same reacquire
@@ -123,7 +123,7 @@ type ThreadStatus =
     /// (timed out). Storing the deadline in the status itself rather than
     /// in a parallel map makes the invariant "no deadline once Runnable
     /// again" structural — a wake naturally forgets it.
-    | BlockedOnSyncBlockWait of lockObject : ManagedHeapAddress * deadlineMs : int64 option
+    | BlockedOnSyncBlockWait of lockObject : ManagedHeapAddress * deadlineTicks : int64 option
     /// This thread called `WaitHandle.WaitOne` (via the `WaitHandle_WaitOneCore`
     /// QCall) on a wait handle whose count was zero / unsignalled, and is
     /// parked at the handle's FIFO `WaitQueue`. A subsequent state change that
@@ -134,10 +134,10 @@ type ThreadStatus =
     /// Single-handle blocking only; `BlockedOnWaitHandles` is the multi-handle
     /// counterpart.
     ///
-    /// `deadlineMs = None` is an infinite wait (Win32 `INFINITE` / managed
+    /// `deadlineTicks = None` is an infinite wait (Win32 `INFINITE` / managed
     /// `Timeout.Infinite`); `Some ms` is a finite timeout, expressed as the
-    /// absolute virtual-clock millisecond at which the wait expires. When
-    /// `VirtualClockMs` advances to that point and the thread is still
+    /// absolute virtual-clock tick at which the wait expires. When
+    /// `VirtualClockTicks` advances to that point and the thread is still
     /// parked, the driver fires a timeout wake (`WaitHandle.fireTimeout`):
     /// the thread is dequeued from the handle's `WaitQueue`, the
     /// `WAIT_OBJECT_0` slot pushed at park time is rewritten to
@@ -145,7 +145,7 @@ type ThreadStatus =
     /// deadline in the status itself (rather than alongside in a separate
     /// map) makes the invariant "no deadline once Runnable again" structural
     /// — a wake naturally forgets it.
-    | BlockedOnWaitHandle of handle : WaitHandleId * deadlineMs : int64 option
+    | BlockedOnWaitHandle of handle : WaitHandleId * deadlineTicks : int64 option
     /// This thread called `WaitHandle.WaitAny` / `WaitAll` (via the
     /// `WaitHandle_WaitMultipleIgnoringSyncContext` QCall) and could not be
     /// satisfied immediately, so it is parked at the FIFO tail of *every* named
@@ -172,16 +172,16 @@ type ThreadStatus =
     /// other waiters — see the weakened queue invariants documented on
     /// `SemaphoreState` / `MutexState` / `EventState`.
     ///
-    /// `deadlineMs` has the same meaning as on `BlockedOnWaitHandle`: `None`
+    /// `deadlineTicks` has the same meaning as on `BlockedOnWaitHandle`: `None`
     /// for `INFINITE`, `Some ms` for an absolute virtual-clock deadline, at
     /// which `WaitHandle.fireMultipleTimeout` dequeues the thread from every
     /// handle it is registered on and rewrites its slot to `WAIT_TIMEOUT`.
-    | BlockedOnWaitHandles of handles : WaitHandleId list * waitAll : bool * deadlineMs : int64 option
+    | BlockedOnWaitHandles of handles : WaitHandleId list * waitAll : bool * deadlineTicks : int64 option
     /// This thread called `Thread.Sleep` (routed via the `ThreadNative_Sleep`
     /// QCall) and is parked against the virtual clock with no associated
     /// wait-queue or signalling primitive. There is no per-primitive FIFO
     /// here because the wake is purely time-driven: the scheduler advances
-    /// `VirtualClockMs` one tick at a time, and once it crosses the deadline
+    /// `VirtualClockTicks` one tick at a time, and once it crosses the deadline
     /// the driver fires `Scheduler.fireSleepTimeout`, which flips the status
     /// back to `Runnable`. The IL `Sleep(int)` call site has already
     /// advanced past itself (Sleep returns `void`, so there is no
@@ -189,20 +189,20 @@ type ThreadStatus =
     /// `BlockedOnJoin`/`BlockedOnSyncBlockWait` et al., which use the
     /// optimistic-push-then-rewrite pattern).
     ///
-    /// `deadlineMs = None` is an infinite sleep (`Thread.Sleep(-1)` /
+    /// `deadlineTicks = None` is an infinite sleep (`Thread.Sleep(-1)` /
     /// `Timeout.Infinite`), which currently parks the thread forever
     /// because `Thread.Interrupt` is not yet implemented (a future slice
     /// that wires interrupt will be the only way out of an infinite
     /// sleep — matching real CoreCLR semantics). `Some ms` is a finite
     /// timeout (`Thread.Sleep(ms)` with `ms > 0`), expressed as the
-    /// absolute virtual-clock millisecond at which the sleep expires.
+    /// absolute virtual-clock tick at which the sleep expires.
     /// `Thread.Sleep(0)` does not produce a `BlockedOnSleep` transition
     /// at all: it is a no-op handled inline at the call site (the BCL
     /// uses it as a yield hint; PawPrint has no preemption to invoke).
     /// Storing the deadline in the status itself rather than in a
     /// parallel map makes the invariant "no deadline once Runnable
     /// again" structural — a wake naturally forgets it.
-    | BlockedOnSleep of deadlineMs : int64 option
+    | BlockedOnSleep of deadlineTicks : int64 option
     /// This thread has executed its final `ret`; it will never run again. Its state is kept
     /// only so other threads can observe termination (e.g. to satisfy Join).
     | Terminated

--- a/WoofWare.PawPrint/WaitHandle.fs
+++ b/WoofWare.PawPrint/WaitHandle.fs
@@ -51,9 +51,9 @@ namespace WoofWare.PawPrint
 ///
 /// Timeouts: finite timeouts on `WaitHandle_WaitOneCore` /
 /// `WaitHandle_WaitOnePrioritized` are supported through the
-/// virtual-clock plumbing in `EmulatedKernel.VirtualClockMs`. The
+/// virtual-clock plumbing in `EmulatedKernel.VirtualClockTicks`. The
 /// native handler converts a millisecond timeout into an absolute
-/// deadline against `VirtualClockMs` and threads it through `waitOne` /
+/// deadline against `VirtualClockTicks` and threads it through `waitOne` /
 /// `waitOnePrioritized`; if the slow path fires, the deadline is
 /// recorded on the parked thread's `BlockedOnWaitHandle` status. The
 /// driver loop fires `fireTimeout` for any thread whose deadline has
@@ -574,7 +574,7 @@ module WaitHandle =
 
     /// Internal: kind-private semaphore waitOne. Used by the kind
     /// dispatcher in `waitOne` and the property tests that exercise the
-    /// semaphore path directly. `deadlineMs` is the absolute virtual-clock
+    /// semaphore path directly. `deadlineTicks` is the absolute virtual-clock
     /// millisecond at which the wait expires (or `None` for an infinite
     /// wait); the value is recorded on the parked thread's `BlockedOn
     /// WaitHandle` status when the slow path fires, so the driver loop's
@@ -582,7 +582,7 @@ module WaitHandle =
     let private waitOneSemaphore
         (thread : ThreadId)
         (id : WaitHandleId)
-        (deadlineMs : int64 option)
+        (deadlineTicks : int64 option)
         (semaphore : SemaphoreState)
         (state : IlMachineState)
         : WaitOutcome
@@ -612,18 +612,18 @@ module WaitHandle =
 
             state
             |> writeHandle id (WaitHandleState.Semaphore semaphore)
-            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnWaitHandle (id, deadlineMs))
+            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnWaitHandle (id, deadlineTicks))
             |> WaitOutcome.Blocked
 
     /// Internal: kind-private mutex waitOne. Re-entrant on owner; the
     /// `Free wasAbandoned=true` transition produces `AcquiredAbandoned`
-    /// and clears the flag. `deadlineMs` is recorded on the parked
+    /// and clears the flag. `deadlineTicks` is recorded on the parked
     /// thread's status when the slow path fires (held by another thread);
     /// the fast paths do not consult it.
     let private waitOneMutex
         (thread : ThreadId)
         (id : WaitHandleId)
-        (deadlineMs : int64 option)
+        (deadlineTicks : int64 option)
         (mutex : MutexState)
         (state : IlMachineState)
         : WaitOutcome
@@ -659,18 +659,18 @@ module WaitHandle =
 
             state
             |> writeHandle id (WaitHandleState.Mutex mutex)
-            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnWaitHandle (id, deadlineMs))
+            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnWaitHandle (id, deadlineTicks))
             |> WaitOutcome.Blocked
 
     /// Internal: kind-private event waitOne. Acquiring a signalled `Auto`
     /// event consumes the signal (clears `Signaled`); acquiring a
     /// signalled `Manual` event leaves it signalled (every concurrent
     /// waiter passes through). On an unsignalled event the thread parks
-    /// at the FIFO tail with `deadlineMs` recorded on its status.
+    /// at the FIFO tail with `deadlineTicks` recorded on its status.
     let private waitOneEvent
         (thread : ThreadId)
         (id : WaitHandleId)
-        (deadlineMs : int64 option)
+        (deadlineTicks : int64 option)
         (event : EventState)
         (state : IlMachineState)
         : WaitOutcome
@@ -697,7 +697,7 @@ module WaitHandle =
 
             state
             |> writeHandle id (WaitHandleState.Event event)
-            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnWaitHandle (id, deadlineMs))
+            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnWaitHandle (id, deadlineTicks))
             |> WaitOutcome.Blocked
 
     /// Try to take ownership of `id` on behalf of `thread`. Dispatches
@@ -705,14 +705,14 @@ module WaitHandle =
     ///
     ///  - Semaphore: decrement the count if positive; otherwise park at
     ///    the FIFO tail of `WaitQueue` and flip the thread's status to
-    ///    `BlockedOnWaitHandle (id, deadlineMs)`.
+    ///    `BlockedOnWaitHandle (id, deadlineTicks)`.
     ///  - Mutex: re-entrant fast path on the owning thread; take the
     ///    free mutex (producing `AcquiredAbandoned` iff the abandoned
     ///    flag was set, clearing it); otherwise park at the FIFO tail.
     ///  - Event: signalled events fast-path (consuming the signal for
     ///    `Auto`); unsignalled events park at the FIFO tail.
     ///
-    /// `deadlineMs` is the absolute virtual-clock millisecond at which a
+    /// `deadlineTicks` is the absolute virtual-clock tick at which a
     /// finite timeout expires, or `None` for an infinite wait. The fast
     /// paths ignore it; only the slow paths thread it through to the
     /// parked thread's status, where the driver loop's deadline-firing
@@ -728,16 +728,16 @@ module WaitHandle =
     let waitOne
         (thread : ThreadId)
         (id : WaitHandleId)
-        (deadlineMs : int64 option)
+        (deadlineTicks : int64 option)
         (state : IlMachineState)
         : WaitOutcome
         =
         let handle = lookup id state
 
         match handle with
-        | WaitHandleState.Semaphore semaphore -> waitOneSemaphore thread id deadlineMs semaphore state
-        | WaitHandleState.Mutex mutex -> waitOneMutex thread id deadlineMs mutex state
-        | WaitHandleState.Event event -> waitOneEvent thread id deadlineMs event state
+        | WaitHandleState.Semaphore semaphore -> waitOneSemaphore thread id deadlineTicks semaphore state
+        | WaitHandleState.Mutex mutex -> waitOneMutex thread id deadlineTicks mutex state
+        | WaitHandleState.Event event -> waitOneEvent thread id deadlineTicks event state
 
     /// Non-blocking probe used to model the zero-timeout `WaitOne(0)`
     /// path. CoreCLR's contract for a zero millisecond timeout: try the
@@ -841,13 +841,13 @@ module WaitHandle =
     /// fairness contract is LIFO over the kernel semaphore's FIFO base.
     ///
     /// The fast path is identical to `waitOne`: priority only matters
-    /// when the call has to block. `deadlineMs` propagates to the parked
+    /// when the call has to block. `deadlineTicks` propagates to the parked
     /// thread's status when the slow path fires, and is ignored on the
     /// fast path for the same reason as `waitOne`.
     let waitOnePrioritized
         (thread : ThreadId)
         (id : WaitHandleId)
-        (deadlineMs : int64 option)
+        (deadlineTicks : int64 option)
         (state : IlMachineState)
         : WaitOutcome
         =
@@ -875,7 +875,7 @@ module WaitHandle =
 
             state
             |> writeHandle id (WaitHandleState.Semaphore semaphore)
-            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnWaitHandle (id, deadlineMs))
+            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnWaitHandle (id, deadlineTicks))
             |> WaitOutcome.Blocked
 
     /// Increment the semaphore by `releaseCount`, waking up to that many
@@ -1199,7 +1199,7 @@ module WaitHandle =
     /// Enqueuing twice would let one signal wake it and leave a stale entry
     /// behind.
     ///
-    /// `deadlineMs` is the absolute virtual-clock millisecond at which a
+    /// `deadlineTicks` is the absolute virtual-clock tick at which a
     /// finite timeout expires, or `None` for `INFINITE`. As on the
     /// single-handle path the IL call site advances in every case, and the
     /// slow path pushes an optimistic `WAIT_OBJECT_0` that the eventual wake
@@ -1208,7 +1208,7 @@ module WaitHandle =
         (thread : ThreadId)
         (handles : WaitHandleId list)
         (waitAll : bool)
-        (deadlineMs : int64 option)
+        (deadlineTicks : int64 option)
         (state : IlMachineState)
         : MultiWaitOutcome
         =
@@ -1231,7 +1231,7 @@ module WaitHandle =
                     state
 
             state
-            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnWaitHandles (handles, waitAll, deadlineMs))
+            |> Scheduler.setThreadStatus thread (ThreadStatus.BlockedOnWaitHandles (handles, waitAll, deadlineTicks))
             |> MultiWaitOutcome.Blocked
 
     /// Wake `thread` because its finite-timeout multi-handle wait has expired


### PR DESCRIPTION
Change **A** of #844, part one of two. Design run past Fable (two memos: options, and blast radius/calibration).

**This PR changes only the unit.** The rate stays at a whole millisecond per retired instruction — exactly what it was — so every run is observationally identical and the suite passes untouched. Part two flips one constant, which is then a diff that can be reviewed and measured on its own.

## Why the clock has to move

Measured on the issue's repro with an instrumented driver loop: each spinner calls `Thread.Sleep(1)` forever — 81,886 parks in one run — and **not once** was any thread observed parked. The deadline is `now + 1ms`, the clock advances 1ms per instruction, and `fireExpiredDeadlines` runs every tick, so the sleeper wakes before any scheduling decision can see it. The shortest sleep a guest can express costs it zero scheduling decisions.

## Why 100ns ticks and not nanoseconds

Nanoseconds was the obvious choice and is wrong. `DateTime`'s quantum is 100ns, so `systemTimeAsTicks` becomes an addition rather than a `/ 100` — and that division truncates, letting two distinct clock readings collapse onto one `DateTime` tick and breaking the strict monotonicity `TestSystemTimeAsTicks` pins. The scaling also has to sit on the *epoch* side of the sum rather than the total: scaling the total would first have to round the clock back to milliseconds, and `maxWallClockEpochMs` in nanoseconds is 2.53e20, about 27× past `Int64.MaxValue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)