### PR TITLE
Charge 100ns of virtual time per instruction, not a millisecond

### DIFF
--- a/WoofWare.PawPrint.Test/TestMonotonicTimestamp.fs
+++ b/WoofWare.PawPrint.Test/TestMonotonicTimestamp.fs
@@ -102,10 +102,9 @@ module TestMonotonicTimestamp =
         // high-resolution one truncated to milliseconds.
         // Neither side restates the other's arithmetic: the left is the high-resolution PAL
         // reading converted from nanoseconds to milliseconds using the BCL's own factor, the
-        // right is the low-resolution PAL reading. Before the clock was re-denominated this
-        // assertion happened to be expressible as "hi-res / 1e6 = the clock", because the clock
-        // *was* in milliseconds; at 100 ns that form degenerates into a tautology about
-        // `monotonicTimestampNanos` and stops covering the low-resolution projection at all.
+        // right is the low-resolution PAL reading. Compare the two *projections*, not a
+        // projection against the clock field — the latter is a tautology about
+        // `monotonicTimestampNanos` and covers the low-resolution one not at all.
         let property (seed : int64) : bool =
             let kernel = kernelWith (intoRange maxClockTicks seed)
 
@@ -210,14 +209,11 @@ module TestMonotonicTimestamp =
 
     [<Test>]
     let ``the reading has 100ns granularity`` () =
-        // Documented consequence of deriving from a 100 ns clock: every
-        // timestamp is a multiple of 100 ns. This assertion used to say
-        // *millisecond* granularity — a multiple of 1,000,000 — because the
-        // clock was denominated in milliseconds; re-denominating it made
-        // `Stopwatch` four orders of magnitude finer, and hence far closer to
-        // real `clock_gettime(CLOCK_MONOTONIC)`. It is still coarser than the
-        // real thing, and still not a source of unique values, which is a
-        // faithful gap rather than one to paper over.
+        // Documented consequence of deriving from a 100 ns clock: every timestamp is
+        // a multiple of 100 ns. That is coarser than real
+        // `clock_gettime(CLOCK_MONOTONIC)`, so `Stopwatch` is not a source of unique
+        // values here — a faithful gap rather than one to paper over, since the real
+        // thing makes no uniqueness guarantee either.
         let property (seed : int64) : bool =
             let nanos =
                 EmulatedKernel.monotonicTimestampNanos (kernelWith (intoRange maxClockTicks seed))

--- a/WoofWare.PawPrint.Test/TestMonotonicTimestamp.fs
+++ b/WoofWare.PawPrint.Test/TestMonotonicTimestamp.fs
@@ -305,3 +305,35 @@ module TestMonotonicTimestamp =
             |> ignore<EmulatedKernel>
 
         Assert.Throws<Exception> (TestDelegate forwardsButNegative) |> ignore<Exception>
+
+    [<Test>]
+    let ``the instruction cost is configurable and validated`` () : unit =
+        // The rate is guest-observable — a guest can measure it by counting work against
+        // `Environment.TickCount64`, and it decides whether `SpinWait` reaches its blocking
+        // rung — so it is part of the replay contract and belongs in `KernelConfig` rather than
+        // being a constant a host cannot see.
+        KernelConfig.Default.InstructionCostTicks
+        |> shouldEqual EmulatedKernel.defaultInstructionCostTicks
+
+        let configured =
+            EmulatedKernel.initial
+            |> KernelConfig.applyTo
+                { KernelConfig.Default with
+                    InstructionCostTicks = 10_000L
+                }
+
+        configured.InstructionCostTicks |> shouldEqual 10_000L
+
+        // Zero would freeze the clock, so every guest waiting for time to pass would spin
+        // forever: a hang rather than a wrong answer, and the sort of thing a host sweeping the
+        // knob could reach by off-by-one. Rejected at the setter, like `ProcessorCount`.
+        for bad in [ 0L ; -1L ] do
+            let apply () =
+                EmulatedKernel.initial
+                |> KernelConfig.applyTo
+                    { KernelConfig.Default with
+                        InstructionCostTicks = bad
+                    }
+                |> ignore<EmulatedKernel>
+
+            Assert.Throws<Exception> (TestDelegate apply) |> ignore<Exception>

--- a/WoofWare.PawPrint.Test/TestSchedulerSleepFairness.fs
+++ b/WoofWare.PawPrint.Test/TestSchedulerSleepFairness.fs
@@ -11,13 +11,13 @@ open WoofWare.PawPrint
 /// which after twenty iterations calls `Thread.Sleep(1)` forever — so this is the sleep half of
 /// the backoff, where `TestSchedulerYieldFairness` covers the yield half.
 ///
-/// Two things are asserted, and the first matters more than the numbers. Before the virtual
-/// clock's rate was made honest, `Thread.Sleep(1)` parked a thread for *zero* scheduling
-/// decisions: its deadline was one instruction away, so `fireExpiredDeadlines` woke it before
-/// the scheduler could ever see it parked. Instrumenting the driver over the original repro
-/// found 81,886 parks and not one tick at which any thread was in `BlockedOnSleep`. So the
-/// fixture watches for a parked thread directly, rather than inferring it from a step count
-/// that could improve for unrelated reasons.
+/// Two things are asserted, and the first matters more than the numbers: that a thread which
+/// has called `Thread.Sleep(1)` is *observably* parked. That fails whenever the sleep deadline
+/// falls inside the same tick the sleep was requested in, because `fireExpiredDeadlines` then
+/// wakes the thread before the scheduler can ever see it — a state in which `Sleep` costs its
+/// caller no scheduling decisions at all and the BCL's backoff does nothing. The fixture
+/// watches for a parked thread directly rather than inferring it from a step count, which
+/// could improve for unrelated reasons.
 ///
 /// Runs under `Pct`, as `TestSchedulerYieldFairness` does and for the same reason: `RoundRobin`
 /// is already maximally yield-respecting, so it is not where scheduling fixes show up.
@@ -41,8 +41,9 @@ module TestSchedulerSleepFairness =
         |> Roslyn.compile
 
     /// What one run of the guest tells us. `ParkedTicks` is the load-bearing one: the count of
-    /// driver steps at which *some* thread was observably in `BlockedOnSleep`. Before the clock
-    /// rate was made honest this was identically zero however many times the guest slept.
+    /// driver steps at which *some* thread was observably in `BlockedOnSleep`. It is zero for
+    /// any rate at which a `Sleep(1)` deadline expires before the next scheduling decision,
+    /// however many times the guest sleeps.
     type private RunMeasurement =
         {
             ExitCode : int
@@ -120,11 +121,6 @@ module TestSchedulerSleepFairness =
         // 1 reaches the sleep rung and seed 2 does not, because PCT can starve a spinner for the
         // whole run. That is PCT working as intended, not a bug, so the *qualitative* claim
         // belongs here and the statistical one belongs in the PCT test below.
-        //
-        // This is the assertion that was false before the clock rate was made honest, and
-        // starkly so: instrumenting the original repro found 81,886 `Sleep(1)` parks and not one
-        // tick out of 800,000 at which any thread was in `BlockedOnSleep`, because the deadline
-        // was one instruction away.
         let r = runOne None
 
         r.ExitCode |> shouldEqual 0

--- a/WoofWare.PawPrint.Test/TestSchedulerSleepFairness.fs
+++ b/WoofWare.PawPrint.Test/TestSchedulerSleepFairness.fs
@@ -1,0 +1,164 @@
+namespace WoofWare.PawPrint.Test
+
+open System.Collections.Immutable
+open System.IO
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.DotnetRuntimeLocator
+open WoofWare.PawPrint
+
+/// End-to-end acceptance for issue #844 itself. The guest's spinners use the BCL's `SpinWait`,
+/// which after twenty iterations calls `Thread.Sleep(1)` forever — so this is the sleep half of
+/// the backoff, where `TestSchedulerYieldFairness` covers the yield half.
+///
+/// Two things are asserted, and the first matters more than the numbers. Before the virtual
+/// clock's rate was made honest, `Thread.Sleep(1)` parked a thread for *zero* scheduling
+/// decisions: its deadline was one instruction away, so `fireExpiredDeadlines` woke it before
+/// the scheduler could ever see it parked. Instrumenting the driver over the original repro
+/// found 81,886 parks and not one tick at which any thread was in `BlockedOnSleep`. So the
+/// fixture watches for a parked thread directly, rather than inferring it from a step count
+/// that could improve for unrelated reasons.
+///
+/// Runs under `Pct`, as `TestSchedulerYieldFairness` does and for the same reason: `RoundRobin`
+/// is already maximally yield-respecting, so it is not where scheduling fixes show up.
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestSchedulerSleepFairness =
+
+    /// Anchor for locating this test assembly, whose embedded resources carry the guest source.
+    type private Marker = class end
+
+    let private testAssy = typeof<Marker>.Assembly
+
+    let private dotnetRuntimes : ImmutableArray<string> =
+        DotnetRuntime.SelectForDll testAssy.Location |> ImmutableArray.CreateRange
+
+    /// Compiled once and reused across seeds: recompiling per seed would dominate the run
+    /// without changing semantics.
+    let private image : byte[] =
+        Assembly.getEmbeddedResourceAsString "SpinWaitSpinnersDoNotStarveWorker.cs" testAssy
+        |> List.singleton
+        |> Roslyn.compile
+
+    /// What one run of the guest tells us. `ParkedTicks` is the load-bearing one: the count of
+    /// driver steps at which *some* thread was observably in `BlockedOnSleep`. Before the clock
+    /// rate was made honest this was identically zero however many times the guest slept.
+    type private RunMeasurement =
+        {
+            ExitCode : int
+            Steps : int64
+            ParkedTicks : int64
+            TotalTicks : int64
+        }
+
+    /// Run the guest to completion under one PCT seed, returning (exit code, total steps).
+    /// Drives `Program.stepPrepared` directly so the step counter is observable; `Program.run`
+    /// would hide it.
+    let private runOne (seed : uint64 option) : RunMeasurement =
+        let _messages, loggerFactory =
+            LoggerFactory.makeTestWithProperties [ "pct_seed", sprintf "%A" seed ]
+
+        use _loggerFactoryResource = loggerFactory
+        use peImage = new MemoryStream (image)
+        let logger = loggerFactory.CreateLogger "TestSchedulerSleepFairness"
+
+        match
+            Program.prepare
+                loggerFactory
+                (Some "SpinWaitSpinnersDoNotStarveWorker.cs")
+                peImage
+                { HostConfig.Default dotnetRuntimes with
+                    PctSeed = seed
+                }
+        with
+        | Program.ProgramStartResult.CompletedBeforeMain _ ->
+            failwith "guest terminated before Main; it has no static initialisers that could do that"
+        | Program.ProgramStartResult.Ready prepared ->
+            let mutable parkedTicks = 0L
+            let mutable totalTicks = 0L
+
+            let rec loop (prepared : Program.PreparedProgram) : RunMeasurement =
+                match Program.stepPrepared loggerFactory logger prepared with
+                | Program.ProgramStepOutcome.Completed (RunOutcome.NormalExit (state, thread)) ->
+                    let code =
+                        match state.ThreadState.[thread].MethodState.EvaluationStack.Values with
+                        | EvalStackValue.Int32 (Int32Source.Verbatim code) :: _ -> code
+                        | other -> failwith $"guest Main did not return an int32: %A{other}"
+
+                    {
+                        ExitCode = code
+                        Steps = state.Kernel.StepCounter
+                        ParkedTicks = parkedTicks
+                        TotalTicks = totalTicks
+                    }
+                | Program.ProgramStepOutcome.Completed other -> failwith $"unexpected guest outcome: %A{other}"
+                | Program.ProgramStepOutcome.Deadlocked (_, stuck) -> failwith $"guest deadlocked: %s{stuck}"
+                | Program.ProgramStepOutcome.InstructionStepped (p, _, _)
+                | Program.ProgramStepOutcome.WorkerTerminated (p, _) ->
+                    totalTicks <- totalTicks + 1L
+
+                    let anyParked =
+                        p.State.ThreadState
+                        |> Map.exists (fun _ ts ->
+                            match ts.Status with
+                            | ThreadStatus.BlockedOnSleep _ -> true
+                            | _ -> false
+                        )
+
+                    if anyParked then
+                        parkedTicks <- parkedTicks + 1L
+
+                    loop p
+
+            loop prepared
+
+    [<Test>]
+    let ``a SpinWait spinner is observably asleep`` () : unit =
+        // Under `RoundRobin`, so that reaching the steady state is guaranteed rather than lucky:
+        // `SpinWait` yields for twenty iterations before it ever calls `Thread.Sleep(1)`, and a
+        // fair rotation gets every spinner there. Under `Pct` it is a coin toss — measured, seed
+        // 1 reaches the sleep rung and seed 2 does not, because PCT can starve a spinner for the
+        // whole run. That is PCT working as intended, not a bug, so the *qualitative* claim
+        // belongs here and the statistical one belongs in the PCT test below.
+        //
+        // This is the assertion that was false before the clock rate was made honest, and
+        // starkly so: instrumenting the original repro found 81,886 `Sleep(1)` parks and not one
+        // tick out of 800,000 at which any thread was in `BlockedOnSleep`, because the deadline
+        // was one instruction away.
+        let r = runOne None
+
+        r.ExitCode |> shouldEqual 0
+
+        if r.ParkedTicks = 0L then
+            failwith
+                $"the guest ran %d{r.TotalTicks} ticks with six SpinWait spinners in their Sleep(1) loops, and at no tick was any thread observably parked. Thread.Sleep is not costing the sleeper any scheduling decisions."
+
+        // And not merely once: a sleeping thread should dominate the run.
+        if r.ParkedTicks * 2L < r.TotalTicks then
+            failwith
+                $"only %d{r.ParkedTicks} of %d{r.TotalTicks} ticks had a thread parked in BlockedOnSleep; the spinners are awake for most of the run despite spending every iteration in Sleep(1)."
+
+    [<Test>]
+    let ``SpinWait spinners sleep across a PCT seed sweep`` () : unit =
+        // Aggregated, because whether a given seed reaches the sleep rung at all is a property
+        // of that schedule (see above). Summing over a fixed seed set keeps the test fully
+        // deterministic while making a claim about the schedule space rather than one schedule.
+        let seeds = [ 1UL .. 10UL ]
+        let results = seeds |> List.map (fun seed -> seed, runOne (Some seed))
+
+        for seed, r in results do
+            if r.ExitCode <> 0 then
+                failwith
+                    $"guest returned %d{r.ExitCode} under PCT seed %d{seed}; it should compute 0+1+...+3999 = 7998000"
+
+        let parked = results |> List.sumBy (fun (_, r) -> r.ParkedTicks)
+        let total = results |> List.sumBy (fun (_, r) -> r.TotalTicks)
+
+        if parked * 4L < total then
+            let perSeed =
+                results
+                |> List.map (fun (seed, r) -> $"%d{seed}:%d{r.ParkedTicks}/%d{r.TotalTicks}")
+                |> String.concat " "
+
+            failwith
+                $"only %d{parked} of %d{total} ticks across the sweep had a thread parked in BlockedOnSleep. Per seed: %s{perSeed}"

--- a/WoofWare.PawPrint.Test/TestSystemTimeAsTicks.fs
+++ b/WoofWare.PawPrint.Test/TestSystemTimeAsTicks.fs
@@ -165,12 +165,11 @@ module TestSystemTimeAsTicks =
 
     [<Test>]
     let ``the reading has the full 100ns granularity of DateTime`` () =
-        // This used to assert the opposite — that every reading is a multiple of
-        // 10,000 — because the clock it derives from was denominated in whole
-        // milliseconds. Now that the clock counts 100 ns ticks, `DateTime.UtcNow`
-        // resolves every one of them, which is strictly closer to real
-        // `clock_gettime(CLOCK_REALTIME)`. Pinned as a reachability claim rather
-        // than a modulus, since "not always a multiple" needs a witness.
+        // The clock counts 100 ns ticks and `DateTime.UtcNow` resolves every one of
+        // them, which is as fine as `DateTime` itself goes and close to real
+        // `clock_gettime(CLOCK_REALTIME)`. Stated as "the reading carries the clock's
+        // sub-millisecond digits" rather than as a modulus, because the interesting
+        // claim is that nothing is being rounded away.
         let property (seeds : int64 * int64) : bool =
             let epochMs, clockTicks = reachable seeds
 

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -122,6 +122,7 @@
     <Compile Include="TestSchedulerVoluntaryYield.fs" />
     <Compile Include="TestSchedulerYieldDebt.fs" />
     <Compile Include="TestSchedulerYieldFairness.fs" />
+    <Compile Include="TestSchedulerSleepFairness.fs" />
     <Compile Include="TestSchedulerPct.fs" />
     <Compile Include="TestVariableSizeNewobj.fs" />
     <Compile Include="TestNativeMdUtf8String.fs" />

--- a/WoofWare.PawPrint.Test/sourcesConcurrencyBugs/SpinWaitSpinnersDoNotStarveWorker.cs
+++ b/WoofWare.PawPrint.Test/sourcesConcurrencyBugs/SpinWaitSpinnersDoNotStarveWorker.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading;
+
+// The guest from issue #844, shrunk. Several threads spin on a flag using the BCL's own
+// `SpinWait`, while one worker does bounded work and then sets it.
+//
+// `SpinWait.SpinOnceCore` on a single-processor kernel yields for its first 20 iterations
+// (16 `Thread.Yield()` and 4 `Thread.Sleep(0)`, measured) and then calls `Thread.Sleep(1)`
+// on every iteration forever. So this exercises the *sleep* half of the backoff, where
+// `YieldingSpinnersDoNotStarveWorker.cs` exercises the yield half.
+//
+// The point of the guest is that a sleeping thread should cost the worker almost nothing.
+// It is not a claim about PawPrint alone: on a real single-core machine these spinners are
+// asleep essentially all the time, and the worker gets the machine. The fixture measures
+// whether that is true here.
+internal static class SpinWaitSpinnersDoNotStarveWorker
+{
+    private static volatile bool ready;
+    private static volatile int result;
+
+    private static int Main()
+    {
+        const int spinners = 6;
+        // Deliberately long. `SpinWait` yields for its first twenty iterations and only then
+        // starts calling `Thread.Sleep(1)`, so a worker that finishes during that warmup never
+        // exercises the sleep path at all — measured, 150 units ended the run after ~4,000
+        // ticks with every spinner still in its yield phase, and the fixture's parked-tick
+        // assertion was vacuously false rather than meaningfully so.
+        const int workUnits = 4000;
+
+        for (int i = 0; i < spinners; i++)
+        {
+            Thread t = new Thread(() =>
+            {
+                SpinWait sw = new SpinWait();
+                while (!ready)
+                {
+                    sw.SpinOnce();
+                }
+            });
+            t.IsBackground = true;
+            t.Start();
+        }
+
+        Thread worker = new Thread(() =>
+        {
+            int sum = 0;
+            for (int j = 0; j < workUnits; j++)
+            {
+                sum += j;
+            }
+
+            result = sum;
+            ready = true;
+        });
+
+        worker.Start();
+        worker.Join();
+
+        // 0 + 1 + ... + 3999.
+        return result == 7998000 ? 0 : 1;
+    }
+}

--- a/WoofWare.PawPrint.Test/sourcesConcurrencyBugs/SpinWaitSpinnersDoNotStarveWorker.cs
+++ b/WoofWare.PawPrint.Test/sourcesConcurrencyBugs/SpinWaitSpinnersDoNotStarveWorker.cs
@@ -21,11 +21,11 @@ internal static class SpinWaitSpinnersDoNotStarveWorker
     private static int Main()
     {
         const int spinners = 6;
-        // Deliberately long. `SpinWait` yields for its first twenty iterations and only then
-        // starts calling `Thread.Sleep(1)`, so a worker that finishes during that warmup never
-        // exercises the sleep path at all — measured, 150 units ended the run after ~4,000
-        // ticks with every spinner still in its yield phase, and the fixture's parked-tick
-        // assertion was vacuously false rather than meaningfully so.
+        // Deliberately long, and do not shorten it. `SpinWait` yields for its first twenty
+        // iterations and only then starts calling `Thread.Sleep(1)`, so a worker that finishes
+        // during that warmup never exercises the sleep path and the fixture's parked-tick
+        // assertion passes vacuously. Measured: 150 units ends the run after ~4,000 ticks with
+        // every spinner still in its yield phase.
         const int workUnits = 4000;
 
         for (int i = 0; i < spinners; i++)

--- a/WoofWare.PawPrint.Test/sourcesImpure/StopwatchTimestampGranularity.cs
+++ b/WoofWare.PawPrint.Test/sourcesImpure/StopwatchTimestampGranularity.cs
@@ -55,14 +55,12 @@ namespace HelloWorldApp
             // between two high-resolution ones and its *millisecond bucket* must
             // overlap the interval they bracket.
             //
-            // Not "must fall between them", which is what this used to say. That
-            // was a theorem only while the clock was millisecond-granular and the
-            // low-resolution view was therefore exact; now it truncates, so the
-            // reading generally floors to strictly below `before`. Expanding it
-            // to the millisecond it stands for is the honest statement, and it is
-            // still enough to catch the failures worth catching: the two entry
-            // points reading different clocks, or disagreeing by more than the
-            // low-resolution quantum.
+            // Not "must fall between them": that is a theorem only for a clock whose
+            // granularity is the millisecond the low-resolution view reports, and this
+            // one is finer, so the reading generally floors to strictly below `before`.
+            // Expanding it to the millisecond it stands for is the honest statement, and
+            // still catches the failures worth catching: the two entry points reading
+            // different clocks, or disagreeing by more than the low-resolution quantum.
             long before = Stopwatch.GetTimestamp();
             long ticks = Environment.TickCount64;
             long after = Stopwatch.GetTimestamp();

--- a/WoofWare.PawPrint.Test/sourcesImpure/StopwatchTimestampGranularity.cs
+++ b/WoofWare.PawPrint.Test/sourcesImpure/StopwatchTimestampGranularity.cs
@@ -33,11 +33,11 @@ namespace HelloWorldApp
 
             long first = Stopwatch.GetTimestamp();
 
-            if (first % 1_000_000L != 0) return 2;
+            if (first % 100L != 0) return 2;
 
-            // The virtual clock advances 1ms per scheduler tick from zero, so
-            // by the time the guest reaches here the reading is positive but
-            // nowhere near a day's worth of simulated uptime. The generous
+            // The virtual clock advances from zero at a fixed cost per scheduler
+            // tick, so by the time the guest reaches here the reading is positive
+            // but nowhere near a day's worth of simulated uptime. The generous
             // headroom means this cannot be tripped merely by the interpreter
             // taking more steps than it does today.
             if (first <= 0) return 3;
@@ -47,18 +47,28 @@ namespace HelloWorldApp
             // later: elapsed-time polling loops in guest code terminate.
             long second = Stopwatch.GetTimestamp();
             if (second <= first) return 5;
-            if (second % 1_000_000L != 0) return 6;
+            if (second % 100L != 0) return 6;
 
             // `Environment.TickCount64` (SystemNative_GetLowResolutionTimestamp)
             // and `Stopwatch` (SystemNative_GetTimestamp) are two views of one
             // clock, exactly as they are upstream. Read the low-resolution one
-            // between two high-resolution ones and it must fall between them.
+            // between two high-resolution ones and its *millisecond bucket* must
+            // overlap the interval they bracket.
+            //
+            // Not "must fall between them", which is what this used to say. That
+            // was a theorem only while the clock was millisecond-granular and the
+            // low-resolution view was therefore exact; now it truncates, so the
+            // reading generally floors to strictly below `before`. Expanding it
+            // to the millisecond it stands for is the honest statement, and it is
+            // still enough to catch the failures worth catching: the two entry
+            // points reading different clocks, or disagreeing by more than the
+            // low-resolution quantum.
             long before = Stopwatch.GetTimestamp();
             long ticks = Environment.TickCount64;
             long after = Stopwatch.GetTimestamp();
 
-            if (ticks * 1_000_000L < before) return 7;
-            if (ticks * 1_000_000L > after) return 8;
+            if (ticks * 1_000_000L > after) return 7;
+            if (ticks * 1_000_000L + 1_000_000L <= before) return 8;
 
             return 0;
         }

--- a/WoofWare.PawPrint/EmulatedKernel.fs
+++ b/WoofWare.PawPrint/EmulatedKernel.fs
@@ -469,11 +469,11 @@ type EmulatedKernel =
         /// Denominated in 100 ns ticks — `DateTime`'s own quantum — so that
         /// `DateTime.UtcNow` needs no scaling and `Stopwatch` resolves finer
         /// than a millisecond. The driver loop advances it by
-        /// `instructionCostTicks` each time it increments `StepCounter`; see
+        /// `InstructionCostTicks` each time it increments `StepCounter`; see
         /// that constant for the rate and what it means as a machine speed.
         ///
         /// Elapsed-time polling loops such as `while (TickCount64 - start &lt; N)`
-        /// therefore terminate in `N * ticksPerMillisecond / instructionCostTicks`
+        /// therefore terminate in `N * ticksPerMillisecond / InstructionCostTicks`
         /// scheduler ticks, which is the cost to keep in mind when choosing the
         /// rate: it buys sleep fidelity and is paid for in run length.
         ///
@@ -602,6 +602,17 @@ type EmulatedKernel =
         /// and BCL callers divide by it, so `NativeEnvironment` asserts the
         /// invariant at the point of use rather than trusting construction.
         ProcessorCount : int
+        /// Virtual time charged for one retired IL instruction, in 100 ns ticks — how fast the
+        /// simulated machine is. Must be >= 1; a cost of zero would freeze the clock and make
+        /// every guest polling loop diverge.
+        ///
+        /// Kernel state rather than a constant because it is guest-observable: a guest can
+        /// measure it by counting work against `Environment.TickCount64`, and it decides which
+        /// BCL paths run — at a coarse enough rate `SpinWait` exhausts its spin budget in a
+        /// couple of iterations and drops to the blocking path. So it belongs to the replay
+        /// contract, alongside `WallClockEpochMs` and `ProcessorCount`, both of which are here
+        /// for the same reason. See `EmulatedKernel.defaultInstructionCostTicks`.
+        InstructionCostTicks : int64
         /// Number reported by `Thread.OptimalMaxSpinWaitsPerSpinIteration` (an
         /// `internal` property, reached only via `SpinWait.SpinOnce()` /
         /// `LowLevelSpinWaiter` in ordinary guest code). Deliberately a value
@@ -772,16 +783,33 @@ module EmulatedKernel =
     /// they say how fast the simulated machine is: at one tick per instruction it would be a
     /// self-consistent 10 MIPS machine.
     ///
-    /// Set here to a whole millisecond, which is deliberately absurd as a machine speed and is
-    /// exactly the historical behaviour — the clock advanced 1 ms per instruction when it was
-    /// denominated in milliseconds. Keeping the rate at its old value makes the re-denomination
-    /// a pure change of unit, observationally identical to what came before, so that the
-    /// separate change of *rate* is a one-line diff that can be reviewed and measured on its
-    /// own. See issue #844: at this rate the shortest sleep a guest can ask for, `Sleep(1)`,
-    /// expires within the same tick it was requested in, so it parks the caller for zero
-    /// scheduling decisions and the BCL's spin-then-sleep backoff does nothing at all.
+    /// One tick — 100 ns, a 10 MIPS machine. The value is a calibration choice, and the
+    /// quantity it calibrates is the ratio between the shortest sleep a guest can express and
+    /// the cost of one instruction, because that ratio is what decides whether the BCL's
+    /// spin-then-sleep backoff does anything at all.
+    ///
+    /// It was a whole millisecond until this constant was changed, which made that ratio 1:1:
+    /// `Thread.Sleep(1)`'s deadline expired inside the very `fireExpiredDeadlines` pass that
+    /// preceded the next scheduling decision, so the sleeper missed *zero* decisions and
+    /// `Sleep` was a no-op. Measured on issue #844's repro: 81,886 parks in one run, and not
+    /// one tick at which any thread was observably parked.
+    ///
+    /// Why 100 ns and not 1 µs, which was the other candidate. Post-backoff, a `SpinWait`
+    /// spinner's cycle is one `Sleep(1)` park plus a *measured* 67 retired instructions. Sixteen
+    /// of them therefore demand 1,072 instructions per park window, against a window of
+    /// `ticksPerMillisecond / InstructionCostTicks` instructions. At 1 µs the window is 1,000 —
+    /// smaller than the demand, so the spinners still saturate the machine and the fix does not
+    /// work at all. At 100 ns it is 10,000, leaving the producer ~89%, which is the right shape
+    /// for a single-core machine whose other threads are asleep. A further 10× buys ~10 points
+    /// and costs 10× the run length.
+    ///
+    /// The cost is paid by guests that busy-poll a clock while another thread is runnable: such
+    /// a loop waiting M ms now costs `M * 10^4` interpreted instructions, and the driver's
+    /// jump-to-deadline shortcut cannot help because the poller is runnable. That is also what
+    /// the loop would cost on a real 10 MIPS machine, and the BCL's own polling paths escalate
+    /// to `Sleep(1)`, which now parks and lets the jump engage.
     [<Literal>]
-    let instructionCostTicks : int64 = 10_000L
+    let defaultInstructionCostTicks : int64 = 1L
 
     /// Largest legal `EmulatedKernel.WallClockEpochMs`: 9999-12-31T23:59:59.999Z
     /// as milliseconds since the Unix epoch, which is the last instant
@@ -814,6 +842,7 @@ module EmulatedKernel =
 
     let initial : EmulatedKernel =
         {
+            InstructionCostTicks = defaultInstructionCostTicks
             LastPInvokeError = 0
             LastSystemError = 0
             NativeMemoryPool = NativeMemoryPool.empty
@@ -860,6 +889,18 @@ module EmulatedKernel =
     /// Set the logical-processor count the simulated process reports. Rejects
     /// non-positive values at the boundary rather than letting them reach a
     /// guest that will divide by them.
+    /// Set the virtual time charged per retired instruction. See
+    /// `EmulatedKernel.InstructionCostTicks` for what the number means and why it is
+    /// configurable; `defaultInstructionCostTicks` for how the default was calibrated.
+    let withInstructionCostTicks (cost : int64) (kernel : EmulatedKernel) : EmulatedKernel =
+        if cost < 1L then
+            failwith
+                $"InstructionCostTicks must be at least 1; got %d{cost}. A cost of zero freezes the virtual clock, so any guest waiting for time to pass would spin forever."
+
+        { kernel with
+            InstructionCostTicks = cost
+        }
+
     let withProcessorCount (count : int) (kernel : EmulatedKernel) : EmulatedKernel =
         if count < 1 then
             failwith $"ProcessorCount must be at least 1; got %d{count}"
@@ -1310,6 +1351,12 @@ type KernelConfig =
         /// Logical processor count the guest observes via
         /// `Environment.ProcessorCount`. Must be at least 1.
         ProcessorCount : int
+        /// Virtual time charged per retired IL instruction, in 100 ns ticks — the speed of the
+        /// simulated machine. Must be at least 1. See
+        /// `EmulatedKernel.InstructionCostTicks` for why this is part of the replay contract,
+        /// and `EmulatedKernel.defaultInstructionCostTicks` for the calibration behind the
+        /// default of one tick (a 10 MIPS machine).
+        InstructionCostTicks : int64
         /// Value the guest observes via the internal
         /// `Thread.OptimalMaxSpinWaitsPerSpinIteration`, consulted by
         /// `SpinWait.SpinOnce()` / `LowLevelSpinWaiter` to size each spin
@@ -1350,6 +1397,7 @@ type KernelConfig =
         {
             Environment = Map.empty
             ProcessorCount = EmulatedKernel.defaultProcessorCount
+            InstructionCostTicks = EmulatedKernel.defaultInstructionCostTicks
             OptimalMaxSpinWaitsPerSpinIteration = EmulatedKernel.defaultOptimalMaxSpinWaitsPerSpinIteration
             WallClockEpochMs = 0L
             UnixPlatform = EmulatedKernel.defaultUnixPlatform
@@ -1366,6 +1414,7 @@ module KernelConfig =
         kernel
         |> EmulatedKernel.withEnvironment config.Environment
         |> EmulatedKernel.withProcessorCount config.ProcessorCount
+        |> EmulatedKernel.withInstructionCostTicks config.InstructionCostTicks
         |> EmulatedKernel.withOptimalMaxSpinWaitsPerSpinIteration config.OptimalMaxSpinWaitsPerSpinIteration
         |> EmulatedKernel.withWallClockEpochMs config.WallClockEpochMs
         |> EmulatedKernel.withUnixPlatform config.UnixPlatform

--- a/WoofWare.PawPrint/EmulatedKernel.fs
+++ b/WoofWare.PawPrint/EmulatedKernel.fs
@@ -788,13 +788,13 @@ module EmulatedKernel =
     /// the cost of one instruction, because that ratio is what decides whether the BCL's
     /// spin-then-sleep backoff does anything at all.
     ///
-    /// It was a whole millisecond until this constant was changed, which made that ratio 1:1:
-    /// `Thread.Sleep(1)`'s deadline expired inside the very `fireExpiredDeadlines` pass that
-    /// preceded the next scheduling decision, so the sleeper missed *zero* decisions and
-    /// `Sleep` was a no-op. Measured on issue #844's repro: 81,886 parks in one run, and not
-    /// one tick at which any thread was observably parked.
+    /// A cost at or near a whole millisecond makes that ratio 1:1, at which `Thread.Sleep(1)`'s
+    /// deadline expires inside the very `fireExpiredDeadlines` pass that precedes the next
+    /// scheduling decision: the sleeper misses *zero* decisions and `Sleep` is a no-op. That is
+    /// the failure this value exists to avoid, so keep it several orders of magnitude below
+    /// `ticksPerMillisecond`.
     ///
-    /// Why 100 ns and not 1 µs, which was the other candidate. Post-backoff, a `SpinWait`
+    /// Why 100 ns and not 1 µs. Post-backoff, a `SpinWait`
     /// spinner's cycle is one `Sleep(1)` park plus a *measured* 67 retired instructions. Sixteen
     /// of them therefore demand 1,072 instructions per park window, against a window of
     /// `ticksPerMillisecond / InstructionCostTicks` instructions. At 1 µs the window is 1,000 —
@@ -1035,10 +1035,10 @@ module EmulatedKernel =
     /// `clock + timeoutMs * ticksPerMillisecond`, and `Thread.Sleep(Int32.MaxValue)` contributes
     /// about 2.1e13 ticks; with the clock bounded at 9.2e16 the sum cannot approach
     /// `Int64.MaxValue`, so the seven deadline sites need no checked arithmetic of their own.
-    /// Without the bound they would need it: the deadline jump advances the clock to a deadline
-    /// *without* retiring a step, so a loop of `Sleep(Int32.MaxValue)` reaches the wrap in about
-    /// 430,000 iterations — a few million interpreted instructions, which is minutes rather than
-    /// the unreachable 4.3 billion jumps the millisecond-denominated clock required.
+    /// Without the bound they would need it, and the horizon is close enough to matter: the
+    /// deadline jump advances the clock to a deadline *without* retiring a step, so a loop of
+    /// `Sleep(Int32.MaxValue)` reaches the wrap in about 430,000 iterations — a few million
+    /// interpreted instructions.
     let withVirtualClockTicks (ticks : int64) (kernel : EmulatedKernel) : EmulatedKernel =
         // Checked independently of the monotonicity comparison below, which on its own would
         // wave through a negative target whenever the current value is more negative still —

--- a/WoofWare.PawPrint/Native/NativeThreading.fs
+++ b/WoofWare.PawPrint/Native/NativeThreading.fs
@@ -717,7 +717,7 @@ module NativeThreading =
             // Elapsed time *is* observable to a PawPrint guest — that is what
             // `EmulatedKernel.VirtualClockTicks` is, and `Environment.TickCount64`
             // and `DateTime.UtcNow` both read it. But the driver loop advances
-            // it as a function of scheduler ticks (`instructionCostTicks` of
+            // it as a function of scheduler ticks (`InstructionCostTicks` of
             // virtual time per instruction retired), never as a function of what a given
             // instruction physically costs. So this handler doing no work does
             // not freeze the guest's clock: the `call` still retires, the clock

--- a/WoofWare.PawPrint/Native/NativeWaitHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeWaitHandle.fs
@@ -336,7 +336,7 @@ module NativeWaitHandle =
             // against the virtual clock. The guest's timeout is in
             // milliseconds and the clock counts 100 ns ticks, so it is scaled
             // by `ticksPerMillisecond` on the way in. `VirtualClockTicks`
-            // advances by `instructionCostTicks` per scheduler tick (per
+            // advances by `InstructionCostTicks` per scheduler tick (per
             // `Program.stepPrepared`), and the
             // driver loop fires `WaitHandle.fireTimeout` when the clock
             // reaches or passes a parked thread's deadline; if no other

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -376,7 +376,7 @@ module Program =
             { prepared with
                 State =
                     state.MapKernel (fun kernel ->
-                        // `EmulatedKernel.instructionCostTicks` of virtual time per scheduler
+                        // `EmulatedKernel.InstructionCostTicks` of virtual time per scheduler
                         // tick — see that constant for the rate and why it is what it is.
                         // Bumping in lock-step with `StepCounter` keeps both clocks pure
                         // functions of "how many scheduler ticks have elapsed", which is what
@@ -390,7 +390,7 @@ module Program =
                             StepCounter = kernel.StepCounter + 1L
                         }
                         |> EmulatedKernel.withVirtualClockTicks (
-                            kernel.VirtualClockTicks + EmulatedKernel.instructionCostTicks
+                            kernel.VirtualClockTicks + kernel.InstructionCostTicks
                         )
                     )
             }

--- a/docs/divergences.md
+++ b/docs/divergences.md
@@ -299,3 +299,59 @@ The same reasoning is why the case carries no `MethodTable` payload. That would 
 ```
 
 **Where this lives in code**: `FunctionPointerTarget.RuntimeAllocator` in `NativeIntSource.fs` carries the reasoning; `NativeRuntimeTypeQCall.fs` is the only producer, and `UnaryMetadataCallOps.executeAllocatorCalli` the only consumer. `CanonicalPointerKey.RuntimeAllocatorFunctionPointer` gives it a single synthesised hash-bit identity to match.
+
+## Simulated time advances per retired instruction
+
+**CoreCLR**: time is what the OS says it is. `Environment.TickCount64`, `Stopwatch` and
+`DateTime.UtcNow` read the kernel's clocks, which advance with the wall regardless of how much
+code the process runs. `Thread.Sleep(n)` blocks against an absolute deadline computed from
+`CLOCK_MONOTONIC` (`GetAbsoluteTimeout(..., fPreferMonotonicClock: TRUE)` in
+`pal/src/synchmgr/synchmanager.cpp`), and the OS wakes the thread some time at or after it —
+in practice noticeably after, since the sleep is quantised to the platform's timer granularity.
+
+**PawPrint**: the virtual clock advances `KernelConfig.InstructionCostTicks` — one 100 ns tick
+by default — for each IL instruction any thread retires, and by nothing else. A thread that is
+blocked, and a process in which nothing is runnable, experience no time at all except via the
+driver's jump to the next outstanding deadline. A `Thread.Sleep` wakes at *exactly* its
+deadline, never later.
+
+**Spec status**: outside ECMA-335, which says nothing about clocks. The .NET contract for
+`Thread.Sleep` is one-sided — "at least this long" — so waking exactly at the deadline is
+conformant. It is simply the most optimistic instant the contract permits, where a real
+scheduler is routinely far from it.
+
+**Why we chose this**: determinism is the whole point, and a clock that a replay can reproduce
+cannot be read from the host. Deriving time from retired instructions makes it a pure function
+of the execution, which is what lets a recorded trace replay bit-for-bit.
+
+The *rate* is a calibration, and the quantity it calibrates is the ratio between the shortest
+sleep a guest can express (1 ms) and the cost of one instruction — because that ratio decides
+whether the BCL's spin-then-sleep backoff does anything. Until #844 the ratio was 1:1, and
+`Thread.Sleep(1)` parked its caller for *zero* scheduling decisions: measured on that issue's
+repro, 81,886 parks and not one tick out of 800,000 at which any thread was observably
+asleep. One tick per instruction — a self-consistent 10 MIPS machine — puts the ratio at
+10,000:1, at which sleeping costs the sleeper a realistic share of the machine.
+
+Two consequences worth knowing. A guest that busy-polls a clock while another thread is
+runnable pays 10,000 interpreted instructions per simulated millisecond, and the driver's
+jump-to-deadline shortcut cannot help, because the poller is runnable. And relative timings
+between code paths are not modelled at all: every instruction costs the same, so a `call` and
+a `nop` take equally long.
+
+**Observable example**:
+
+```csharp
+// CoreCLR:  prints a number that is large and varies between runs; on Windows, a Sleep(1)
+//           typically takes ~15ms, so this is nowhere near 1.
+// PawPrint: prints exactly 1, every run, on every machine.
+long before = Environment.TickCount64;
+Thread.Sleep(1);
+Console.WriteLine(Environment.TickCount64 - before);
+```
+
+**Where this lives in code**: `EmulatedKernel.VirtualClockTicks` is the clock and
+`EmulatedKernel.InstructionCostTicks` the rate; `Program.stepPrepared` is its only writer, via
+the validating `EmulatedKernel.withVirtualClockTicks`. The three projections the guest sees are
+`systemTimeAsTicks`, `monotonicTimestampNanos` and `lowResolutionTimestampMs`, all in
+`EmulatedKernel.fs`. `TestSchedulerSleepFairness` pins that a sleeping thread is observably
+asleep.


### PR DESCRIPTION
Fixes #844.

## The calibration

The quantity being calibrated is the ratio between the shortest sleep a guest can express (1 ms) and the cost of one instruction, because that ratio decides whether the BCL's spin-then-sleep backoff does anything at all. It was **1:1**, so `Thread.Sleep(1)`'s deadline expired inside the very `fireExpiredDeadlines` pass preceding the next scheduling decision, and the sleeper missed *zero* decisions. One tick per instruction — a self-consistent 10 MIPS machine — makes it 10,000:1.

## Result

Measured on a six-spinner `SpinWait` guest, counting driver steps at which any thread was observably in `BlockedOnSleep`:

| | before | after |
|---|---|---|
| round-robin | 1.1% (5,132/454,115) | **90.0%** (69,551/77,270) |
| PCT sweep (10 seeds) | 0.77% (12,484/1,629,681) | **56.8%** (415,466/731,214) |

Run length collapses with it — round-robin 454,115 → 77,270 ticks — because the spinners stop consuming a machine they were only waiting on.

## Why 100ns and not 1µs

1 µs was the other candidate and **would not have worked**. A spinner's steady-state cycle is one `Sleep(1)` park plus a *measured* 67 retired instructions, so sixteen of them demand 1,072 instructions per park window. At 1 µs the window is 1,000 — smaller than the demand, so the spinners still saturate the machine. At 100ns it is 10,000. This only became visible by measuring the cycle instead of accepting an earlier "~30–100 instructions" estimate; anywhere in the upper half of that range and the arithmetic looks fine.

## `InstructionCostTicks` is config, not a constant

It is guest-observable — measurable against `TickCount64`, and it decides whether `SpinWait` reaches its blocking rung — so it belongs to the replay contract, exactly like `WallClockEpochMs` and `ProcessorCount`. Validated `>= 1`: zero freezes the clock and turns every guest wait into a hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)