### PR TITLE
Record pointer-hash bit assignment as an explicit choice

### DIFF
--- a/WoofWare.PawPrint.Domain/ContextSwitchPrior.fs
+++ b/WoofWare.PawPrint.Domain/ContextSwitchPrior.fs
@@ -10,7 +10,7 @@ namespace WoofWare.PawPrint
 ///
 /// The motivation is that under a strict one-sided POR contract, nearly
 /// every op in this interpreter ends up classified as visible (because the
-/// interpreter mutates internal bookkeeping — `PointerHashCounters`,
+/// interpreter mutates internal bookkeeping — `PointerHashState`,
 /// `ConcreteTypes`, the runtime-handle cache — from ops the guest can't
 /// directly address). PCT decouples "could in principle have a cross-thread
 /// effect" from "almost always has one", and lets the scheduler spend its
@@ -28,7 +28,7 @@ type ContextSwitchPrior =
     /// pure comparisons, non-trapping non-pointer conversions, branches.
     | Never
     /// Touches only interpreter-internal mutable bookkeeping
-    /// (`PointerHashCounters`, the concretisation cache, the interning
+    /// (`PointerHashState`, the concretisation cache, the interning
     /// table). Guest IL has no opcode that directly addresses these
     /// structures; the only path to guest visibility is through opaque
     /// hash bits / handle identities, which are usually deterministic
@@ -89,7 +89,7 @@ module ContextSwitchPrior =
         | NullaryIlOp.LdcI4_m1
         | NullaryIlOp.LdNull
         // Comparisons read both operands but don't materialise pointer-hash
-        // bits, so they don't mutate `PointerHashCounters`.
+        // bits, so they don't mutate `PointerHashState`.
         | NullaryIlOp.Ceq
         | NullaryIlOp.Cgt
         | NullaryIlOp.Cgt_un
@@ -129,7 +129,7 @@ module ContextSwitchPrior =
         // ---- InterpreterOnly: bookkeeping mutation ----
         // Arithmetic on a `WidenedNativeInt` operand materialises hash bits
         // via `PointerHashSynthesis.materialiseHashBits`, which mutates
-        // `state.PointerHashCounters`. The counter assignment is observable
+        // `state.PointerHashState`. The counter assignment is observable
         // by another thread that subsequently consumes a `OpaqueHashBits`
         // value derived from the same pointer, but only through that
         // indirect channel. In typical numeric code these operands aren't

--- a/WoofWare.PawPrint.Test/PointerHashTestHelpers.fs
+++ b/WoofWare.PawPrint.Test/PointerHashTestHelpers.fs
@@ -1,0 +1,27 @@
+namespace WoofWare.PawPrint.Test
+
+open WoofWare.PawPrint
+
+/// Accessors onto the state carried by `PointerHashCounters.SequentialFirstTouch`.
+///
+/// These live in the test project rather than beside the type because they are
+/// counter-scheme-specific: a keyed assignment rule has no counter and no memo
+/// table, so there is nothing for them to return under such a case. Tests that use
+/// them are asserting the counter scheme's contract specifically, and the match
+/// below will fail to compile the moment a second case lands — which is correct,
+/// because those assertions would not describe the new case either.
+[<RequireQualifiedAccess>]
+module PointerHashTestHelpers =
+    /// Counter that will be spent on the next not-yet-seen canonical key.
+    let nextCounter (counters : PointerHashCounters) : uint64 =
+        match counters with
+        | PointerHashCounters.SequentialFirstTouch (nextCounter, _) -> nextCounter
+
+    /// Address bits assigned so far, keyed by canonical pointer identity. Tag bits
+    /// are not in here; `materialiseHashBits` ORs those on per source.
+    let assigned (counters : PointerHashCounters) : Map<CanonicalPointerKey, uint64> =
+        match counters with
+        | PointerHashCounters.SequentialFirstTouch (_, assigned) -> assigned
+
+    /// How many distinct canonical keys have been assigned bits.
+    let assignedCount (counters : PointerHashCounters) : int = (assigned counters).Count

--- a/WoofWare.PawPrint.Test/PointerHashTestHelpers.fs
+++ b/WoofWare.PawPrint.Test/PointerHashTestHelpers.fs
@@ -2,7 +2,7 @@ namespace WoofWare.PawPrint.Test
 
 open WoofWare.PawPrint
 
-/// Accessors onto the state carried by `PointerHashCounters.SequentialFirstTouch`.
+/// Accessors onto the state carried by `PointerHashState.SequentialFirstTouch`.
 ///
 /// These live in the test project rather than beside the type because they are
 /// counter-scheme-specific: a keyed assignment rule has no counter and no memo
@@ -13,15 +13,15 @@ open WoofWare.PawPrint
 [<RequireQualifiedAccess>]
 module PointerHashTestHelpers =
     /// Counter that will be spent on the next not-yet-seen canonical key.
-    let nextCounter (counters : PointerHashCounters) : uint64 =
+    let nextCounter (counters : PointerHashState) : uint64 =
         match counters with
-        | PointerHashCounters.SequentialFirstTouch (nextCounter, _) -> nextCounter
+        | PointerHashState.SequentialFirstTouch (nextCounter, _) -> nextCounter
 
     /// Address bits assigned so far, keyed by canonical pointer identity. Tag bits
     /// are not in here; `materialiseHashBits` ORs those on per source.
-    let assigned (counters : PointerHashCounters) : Map<CanonicalPointerKey, uint64> =
+    let assigned (counters : PointerHashState) : Map<CanonicalPointerKey, uint64> =
         match counters with
-        | PointerHashCounters.SequentialFirstTouch (_, assigned) -> assigned
+        | PointerHashState.SequentialFirstTouch (_, assigned) -> assigned
 
     /// How many distinct canonical keys have been assigned bits.
-    let assignedCount (counters : PointerHashCounters) : int = (assigned counters).Count
+    let assignedCount (counters : PointerHashState) : int = (assigned counters).Count

--- a/WoofWare.PawPrint.Test/TestContextSwitchPrior.fs
+++ b/WoofWare.PawPrint.Test/TestContextSwitchPrior.fs
@@ -102,7 +102,7 @@ module TestContextSwitchPrior =
         ]
 
     /// Ops whose only effect is on interpreter-internal mutable bookkeeping
-    /// (`PointerHashCounters` or `ManagedHeap.Arrays` reads via the byte-view
+    /// (`PointerHashState` or `ManagedHeap.Arrays` reads via the byte-view
     /// anchor path). Guest IL has no opcode that directly addresses these
     /// structures.
     let private nullaryInterpreterOnly : NullaryIlOp list =

--- a/WoofWare.PawPrint.Test/TestEvalStack.fs
+++ b/WoofWare.PawPrint.Test/TestEvalStack.fs
@@ -224,7 +224,7 @@ module TestEvalStack =
         // Under the counter-based pointer-hash scheme, an identity bit op such as `x ^ 0UL`
         // materialises the WidenedNativeInt's bits into OpaqueHashBits. A subsequent
         // `x == y` would then ask: do `WidenedNativeInt x`'s materialised bits equal `b`?
-        // Answering that requires the PointerHashCounters map which ceq does not currently
+        // Answering that requires the PointerHashState map which ceq does not currently
         // thread; the silent-false answer that prior versions returned is wrong under
         // identity ops, so this case fails loudly until ceq is taught to look it up.
         let widened =
@@ -242,13 +242,13 @@ module TestEvalStack =
 
         ex.Message |> shouldContainText "WidenedNativeInt"
         ex.Message |> shouldContainText "OpaqueHashBits"
-        ex.Message |> shouldContainText "PointerHashCounters"
+        ex.Message |> shouldContainText "PointerHashState"
 
         // And symmetrically the other direction.
         let exSym =
             Assert.Throws<System.Exception> (fun () -> EvalStackValueComparisons.ceq hashBits widened |> ignore)
 
-        exSym.Message |> shouldContainText "PointerHashCounters"
+        exSym.Message |> shouldContainText "PointerHashState"
 
     [<Test>]
     let ``ceq of SyntheticCrossArrayOffset vs OpaqueHashBits returns false (cross-shape)`` () : unit =
@@ -821,13 +821,13 @@ module TestEvalStack =
             Name : string
             /// Width of the destination in bits, for the cross-width coherence property.
             DestinationBits : int
-            Apply : EvalStackValue -> PointerHashCounters -> int32 * PointerHashCounters
+            Apply : EvalStackValue -> PointerHashState -> int32 * PointerHashState
         }
 
     let private ofInt32Returning
         (name : string)
         (destinationBits : int)
-        (f : EvalStackValue -> PointerHashCounters -> int32 * PointerHashCounters)
+        (f : EvalStackValue -> PointerHashState -> int32 * PointerHashState)
         : NarrowingConv
         =
         {
@@ -838,7 +838,7 @@ module TestEvalStack =
 
     let private ofEvalStackReturning
         (name : string)
-        (f : EvalStackValue -> PointerHashCounters -> EvalStackValue * PointerHashCounters)
+        (f : EvalStackValue -> PointerHashState -> EvalStackValue * PointerHashState)
         : NarrowingConv
         =
         {
@@ -924,10 +924,10 @@ module TestEvalStack =
         // arm that already handled synthesised bits.
         let property ((conv, src) : NarrowingConv * NativeIntSource) : unit =
             let viaWidened, countersAfter =
-                conv.Apply (EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, true))) PointerHashCounters.empty
+                conv.Apply (EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, true))) PointerHashState.empty
 
             let bits, expectedCounters =
-                PointerHashSynthesis.materialiseHashBits "oracle" src PointerHashCounters.empty
+                PointerHashSynthesis.materialiseHashBits "oracle" src PointerHashState.empty
 
             let viaHashBits, _ =
                 conv.Apply (EvalStackValue.Int64 (Int64Source.OpaqueHashBits bits)) expectedCounters
@@ -950,10 +950,10 @@ module TestEvalStack =
         // between the spellings by `#if TARGET_64BIT` inside `IntPtr.GetHashCode`.
         let property ((conv, src) : NarrowingConv * NativeIntSource) : unit =
             let direct, directCounters =
-                conv.Apply (EvalStackValue.NativeInt src) PointerHashCounters.empty
+                conv.Apply (EvalStackValue.NativeInt src) PointerHashState.empty
 
             let widened, widenedCounters =
-                conv.Apply (EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, true))) PointerHashCounters.empty
+                conv.Apply (EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, true))) PointerHashState.empty
 
             if direct <> widened then
                 failwith $"%s{conv.Name} of %O{src} gave %i{direct} in the native-int slot but %i{widened} once widened"
@@ -964,7 +964,7 @@ module TestEvalStack =
             // Signedness of the widening is a property of the int64 slot, not of the
             // pointer, so it cannot change the bits.
             let widenedUnsigned, _ =
-                conv.Apply (EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, false))) PointerHashCounters.empty
+                conv.Apply (EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, false))) PointerHashState.empty
 
             widenedUnsigned |> shouldEqual widened
 
@@ -974,7 +974,7 @@ module TestEvalStack =
     let ``narrowing the same pointer twice is stable and assigns no second counter`` () : unit =
         let property ((conv, src) : NarrowingConv * NativeIntSource) : unit =
             let first, counters =
-                conv.Apply (EvalStackValue.NativeInt src) PointerHashCounters.empty
+                conv.Apply (EvalStackValue.NativeInt src) PointerHashState.empty
 
             let second, counters' = conv.Apply (EvalStackValue.NativeInt src) counters
 
@@ -995,7 +995,7 @@ module TestEvalStack =
         // widths deliberately make no such claim: a byte cannot hold 2^30 identities.
         let property ((a, b) : NativeIntSource * NativeIntSource) : unit =
             let bitsA, counters =
-                PointerHashSynthesis.materialiseHashBits "oracle" a PointerHashCounters.empty
+                PointerHashSynthesis.materialiseHashBits "oracle" a PointerHashState.empty
 
             let bitsB, _ = PointerHashSynthesis.materialiseHashBits "oracle" b counters
 
@@ -1004,7 +1004,7 @@ module TestEvalStack =
             // alias deliberately, and share bits.
             if bitsA <> bitsB then
                 let narrowedA, counters =
-                    EvalStackValue.convToInt32 (EvalStackValue.NativeInt a) PointerHashCounters.empty
+                    EvalStackValue.convToInt32 (EvalStackValue.NativeInt a) PointerHashState.empty
 
                 let narrowedB, _ = EvalStackValue.convToInt32 (EvalStackValue.NativeInt b) counters
 
@@ -1020,7 +1020,7 @@ module TestEvalStack =
     let ``narrow widths are the low bytes of the int32 narrowing`` () : unit =
         let property (src : NativeIntSource) : unit =
             let asInt32, _ =
-                EvalStackValue.convToInt32 (EvalStackValue.NativeInt src) PointerHashCounters.empty
+                EvalStackValue.convToInt32 (EvalStackValue.NativeInt src) PointerHashState.empty
 
             let full =
                 match asInt32 with
@@ -1028,8 +1028,7 @@ module TestEvalStack =
                 | other -> failwith $"expected verbatim int32, got %O{other}"
 
             for conv in narrowingConversions do
-                let narrowed, _ =
-                    conv.Apply (EvalStackValue.NativeInt src) PointerHashCounters.empty
+                let narrowed, _ = conv.Apply (EvalStackValue.NativeInt src) PointerHashState.empty
 
                 let mask =
                     if conv.DestinationBits = 32 then
@@ -1061,18 +1060,18 @@ module TestEvalStack =
                     EvalStackValue.convToInt32, "conv.i4"
                     EvalStackValue.convToUInt32, "conv.u4"
                 ] do
-                match conv value PointerHashCounters.empty with
+                match conv value PointerHashState.empty with
                 | EvalStackValue.Int32 (Int32Source.NarrowedManagedPointer p), counters ->
                     p |> shouldEqual byref
                     // No identity was registered: a byref is not a synthesisable handle.
-                    counters |> shouldEqual PointerHashCounters.empty
+                    counters |> shouldEqual PointerHashState.empty
                 | other, _ -> failwith $"%s{expected} of %O{value} should keep byref provenance, got %O{other}"
 
             // Below 32 bits there is no representation for a narrowed byref, so the
             // conversion must refuse rather than invent bits.
             for conv in narrowingConversions |> List.filter (fun c -> c.DestinationBits < 32) do
                 let exn =
-                    Assert.Throws<System.Exception> (fun () -> conv.Apply value PointerHashCounters.empty |> ignore)
+                    Assert.Throws<System.Exception> (fun () -> conv.Apply value PointerHashState.empty |> ignore)
 
                 exn.Message |> shouldContainText "refusing"
 
@@ -1090,7 +1089,7 @@ module TestEvalStack =
                 Assert.Throws<System.Exception> (fun () ->
                     conv.Apply
                         (EvalStackValue.NativeInt (NativeIntSource.SyntheticCrossArrayOffset offset))
-                        PointerHashCounters.empty
+                        PointerHashState.empty
                     |> ignore
                 )
 
@@ -1108,8 +1107,8 @@ module TestEvalStack =
                         EvalStackValue.NativeInt (NativeIntSource.Verbatim i)
                         EvalStackValue.Int64 (Int64Source.Verbatim i)
                     ] do
-                    let _, counters = conv.Apply value PointerHashCounters.empty
-                    counters |> shouldEqual PointerHashCounters.empty
+                    let _, counters = conv.Apply value PointerHashState.empty
+                    counters |> shouldEqual PointerHashState.empty
 
         Check.One (narrowingPropertyConfig, Prop.forAll (ArbMap.defaults |> ArbMap.arbitrary<int64>) property)
 
@@ -1125,18 +1124,18 @@ module TestEvalStack =
                 NativeIntSource.ManagedPointer (ManagedPointerSource.NativeIntPlaceholder bits)
 
             let narrowed, counters =
-                EvalStackValue.convToInt32 (EvalStackValue.NativeInt placeholder) PointerHashCounters.empty
+                EvalStackValue.convToInt32 (EvalStackValue.NativeInt placeholder) PointerHashState.empty
 
             narrowed
             |> shouldEqual (EvalStackValue.Int32 (Int32Source.Verbatim (int32 (uint32 (uint64 bits)))))
 
-            counters |> shouldEqual PointerHashCounters.empty
+            counters |> shouldEqual PointerHashState.empty
 
             let viaHash, hashCounters =
-                PointerHashSynthesis.materialiseHashBits "placeholder" placeholder PointerHashCounters.empty
+                PointerHashSynthesis.materialiseHashBits "placeholder" placeholder PointerHashState.empty
 
             viaHash |> shouldEqual bits
-            hashCounters |> shouldEqual PointerHashCounters.empty
+            hashCounters |> shouldEqual PointerHashState.empty
 
         Check.One (narrowingPropertyConfig, Prop.forAll (ArbMap.defaults |> ArbMap.arbitrary<int64>) property)
 
@@ -1150,7 +1149,7 @@ module TestEvalStack =
         let widened = EvalStackValue.Int64 (Int64Source.WidenedNativeInt (handle, true))
 
         // `(int)l`
-        let low, counters = EvalStackValue.convToInt32 widened PointerHashCounters.empty
+        let low, counters = EvalStackValue.convToInt32 widened PointerHashState.empty
 
         // `(int)(l >> 32)`
         let shifted, counters =
@@ -1163,7 +1162,7 @@ module TestEvalStack =
         PointerHashTestHelpers.assignedCount counters |> shouldEqual 1
 
         let expectedBits, _ =
-            PointerHashSynthesis.materialiseHashBits "oracle" handle PointerHashCounters.empty
+            PointerHashSynthesis.materialiseHashBits "oracle" handle PointerHashState.empty
 
         low
         |> shouldEqual (EvalStackValue.Int32 (Int32Source.Verbatim (int32 (uint32 (uint64 expectedBits)))))

--- a/WoofWare.PawPrint.Test/TestEvalStack.fs
+++ b/WoofWare.PawPrint.Test/TestEvalStack.fs
@@ -936,8 +936,11 @@ module TestEvalStack =
                 failwith
                     $"%s{conv.Name} of widened %O{src} gave %i{viaWidened}, but of its materialised bits gave %i{viaHashBits}"
 
-            countersAfter.Assigned |> shouldEqual expectedCounters.Assigned
-            countersAfter.NextCounter |> shouldEqual expectedCounters.NextCounter
+            PointerHashTestHelpers.assigned countersAfter
+            |> shouldEqual (PointerHashTestHelpers.assigned expectedCounters)
+
+            PointerHashTestHelpers.nextCounter countersAfter
+            |> shouldEqual (PointerHashTestHelpers.nextCounter expectedCounters)
 
         Check.One (narrowingPropertyConfig, Prop.forAll (Arb.fromGen genConversionAndSource) property)
 
@@ -955,7 +958,8 @@ module TestEvalStack =
             if direct <> widened then
                 failwith $"%s{conv.Name} of %O{src} gave %i{direct} in the native-int slot but %i{widened} once widened"
 
-            directCounters.Assigned |> shouldEqual widenedCounters.Assigned
+            PointerHashTestHelpers.assigned directCounters
+            |> shouldEqual (PointerHashTestHelpers.assigned widenedCounters)
 
             // Signedness of the widening is a property of the int64 slot, not of the
             // pointer, so it cannot change the bits.
@@ -975,8 +979,12 @@ module TestEvalStack =
             let second, counters' = conv.Apply (EvalStackValue.NativeInt src) counters
 
             second |> shouldEqual first
-            counters'.NextCounter |> shouldEqual counters.NextCounter
-            counters'.Assigned |> shouldEqual counters.Assigned
+
+            PointerHashTestHelpers.nextCounter counters'
+            |> shouldEqual (PointerHashTestHelpers.nextCounter counters)
+
+            PointerHashTestHelpers.assigned counters'
+            |> shouldEqual (PointerHashTestHelpers.assigned counters)
 
         Check.One (narrowingPropertyConfig, Prop.forAll (Arb.fromGen genConversionAndSource) property)
 
@@ -1152,7 +1160,7 @@ module TestEvalStack =
             EvalStackValue.convToInt32 (EvalStackValue.Int64 shifted) counters
 
         // One identity registered across all three steps.
-        counters.Assigned.Count |> shouldEqual 1
+        PointerHashTestHelpers.assignedCount counters |> shouldEqual 1
 
         let expectedBits, _ =
             PointerHashSynthesis.materialiseHashBits "oracle" handle PointerHashCounters.empty

--- a/WoofWare.PawPrint.Test/TestIntrinsicValueArguments.fs
+++ b/WoofWare.PawPrint.Test/TestIntrinsicValueArguments.fs
@@ -18,7 +18,7 @@ open WoofWare.PawPrint
 ///
 /// What must be refused is narrowing a *pointer* to int32. `conv.i4` would synthesise
 /// bits for one, which fabricates the answer and, worse, assigns the pointer a
-/// `PointerHashCounters` identity — perturbing every synthesised pointer value later in
+/// `PointerHashState` identity — perturbing every synthesised pointer value later in
 /// the run. An int32 parameter cannot legally receive a pointer, so this is pure downside.
 [<TestFixture>]
 [<Parallelizable(ParallelScope.All)>]
@@ -104,13 +104,13 @@ module TestIntrinsicValueArguments =
         let property ((value, bits) : EvalStackValue * int64) : unit =
             let actual = Intrinsics.int32ValueArgument "Interlocked.Add" value
 
-            let viaConv, counters = EvalStackValue.convToInt32 value PointerHashCounters.empty
+            let viaConv, counters = EvalStackValue.convToInt32 value PointerHashState.empty
 
             viaConv |> shouldEqual (EvalStackValue.Int32 (Int32Source.Verbatim actual))
             actual |> shouldEqual (int32 bits)
 
             // And no identity was registered by either route, since nothing was synthesised.
-            counters |> shouldEqual PointerHashCounters.empty
+            counters |> shouldEqual PointerHashState.empty
 
         Check.One (propertyConfig, Prop.forAll (Arb.fromGen genExactIntegerValue) property)
 
@@ -129,14 +129,14 @@ module TestIntrinsicValueArguments =
 
             // Confirm the delta is real: `conv.i4` does answer, and registers an identity
             // while doing so. That side effect is what the refusal exists to prevent.
-            let _, counters = EvalStackValue.convToInt32 value PointerHashCounters.empty
+            let _, counters = EvalStackValue.convToInt32 value PointerHashState.empty
 
             match value with
             | EvalStackValue.NativeInt (NativeIntSource.ManagedPointer _)
             | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (NativeIntSource.ManagedPointer _, _)) ->
                 // A byref narrows to `NarrowedManagedPointer` instead: no synthesis, but
                 // also no number, which is why the helper still refuses it.
-                counters |> shouldEqual PointerHashCounters.empty
+                counters |> shouldEqual PointerHashState.empty
             | _ -> PointerHashTestHelpers.assignedCount counters |> shouldEqual 1
 
         Check.One (propertyConfig, Prop.forAll (Arb.fromGen genPointerShapedValue) property)
@@ -169,7 +169,7 @@ module TestIntrinsicValueArguments =
 
         let convRefuses =
             Assert.Throws<System.Exception> (fun () ->
-                EvalStackValue.convToInt32 EvalStackValue.NullObjectRef PointerHashCounters.empty
+                EvalStackValue.convToInt32 EvalStackValue.NullObjectRef PointerHashState.empty
                 |> ignore
             )
 

--- a/WoofWare.PawPrint.Test/TestIntrinsicValueArguments.fs
+++ b/WoofWare.PawPrint.Test/TestIntrinsicValueArguments.fs
@@ -137,7 +137,7 @@ module TestIntrinsicValueArguments =
                 // A byref narrows to `NarrowedManagedPointer` instead: no synthesis, but
                 // also no number, which is why the helper still refuses it.
                 counters |> shouldEqual PointerHashCounters.empty
-            | _ -> counters.Assigned.Count |> shouldEqual 1
+            | _ -> PointerHashTestHelpers.assignedCount counters |> shouldEqual 1
 
         Check.One (propertyConfig, Prop.forAll (Arb.fromGen genPointerShapedValue) property)
 

--- a/WoofWare.PawPrint.Test/TestNativeIntSource.fs
+++ b/WoofWare.PawPrint.Test/TestNativeIntSource.fs
@@ -223,7 +223,7 @@ module TestNativeIntSource =
     [<Test>]
     let ``Int64Source.negate on a cross-storage offset returns the negated synthetic`` () : unit =
         let property (s : SyntheticCrossArrayOffset) : unit =
-            match Int64Source.negate "test" (Int64Source.SyntheticCrossArrayOffset s) PointerHashCounters.empty with
+            match Int64Source.negate "test" (Int64Source.SyntheticCrossArrayOffset s) PointerHashState.empty with
             | Some (Int64Source.SyntheticCrossArrayOffset negated, _) ->
                 negated |> shouldEqual (SyntheticCrossArrayOffset.negate s)
             | other -> failwith $"expected negate to return Some (synthetic), got %O{other}"
@@ -235,7 +235,7 @@ module TestNativeIntSource =
         let property (s : SyntheticCrossArrayOffset) : unit =
             let original = Int64Source.SyntheticCrossArrayOffset s
 
-            match Int64Source.negate "test" original PointerHashCounters.empty with
+            match Int64Source.negate "test" original PointerHashState.empty with
             | None -> failwith "negate of synthetic returned None"
             | Some (onceNegated, counters) ->
                 match Int64Source.negate "test" onceNegated counters with

--- a/WoofWare.PawPrint.Test/TestNullaryIlOp.fs
+++ b/WoofWare.PawPrint.Test/TestNullaryIlOp.fs
@@ -1315,7 +1315,7 @@ module TestNullaryIlOp =
     /// The six unchecked narrowing conversions, paired with the destination width
     /// their diagnostics name. `TestEvalStack` pins what each *computes* from a
     /// pointer-shaped source; these cases pin that the op arm writes the resulting
-    /// `PointerHashCounters` back into the machine state.
+    /// `PointerHashState` back into the machine state.
     ///
     /// Without that write-back each conversion would restart counter assignment from
     /// zero, so two distinct handles could be handed identical bits — which
@@ -1342,7 +1342,7 @@ module TestNullaryIlOp =
         let state, thread =
             stateWithNullary loggerFactory op (EvalStackValue.NativeInt handle)
 
-        state.PointerHashCounters |> shouldEqual PointerHashCounters.empty
+        state.PointerHashState |> shouldEqual PointerHashState.empty
 
         match NullaryIlOp.execute loggerFactory baseClassTypes state thread op with
         | ExecutionResult.Stepped (state, whatWeDid, _) ->
@@ -1350,8 +1350,8 @@ module TestNullaryIlOp =
 
             // One identity assigned, and retained: a discarded counter map would leave
             // this at zero while still producing a plausible-looking number.
-            PointerHashTestHelpers.nextCounter state.PointerHashCounters |> shouldEqual 1UL
-            PointerHashTestHelpers.assignedCount state.PointerHashCounters |> shouldEqual 1
+            PointerHashTestHelpers.nextCounter state.PointerHashState |> shouldEqual 1UL
+            PointerHashTestHelpers.assignedCount state.PointerHashState |> shouldEqual 1
         | other -> failwith $"Expected %O{op} to step, got %O{other}"
 
     [<Test>]
@@ -1363,22 +1363,22 @@ module TestNullaryIlOp =
         let _, loggerFactory = LoggerFactory.makeTest ()
         use _loggerFactoryResource = loggerFactory
 
-        let narrow (counters : PointerHashCounters) (handle : NativeIntSource) : EvalStackValue * PointerHashCounters =
+        let narrow (counters : PointerHashState) (handle : NativeIntSource) : EvalStackValue * PointerHashState =
             let state, thread =
                 stateWithNullary loggerFactory NullaryIlOp.Conv_I4 (EvalStackValue.NativeInt handle)
 
             let state =
                 { state with
-                    PointerHashCounters = counters
+                    PointerHashState = counters
                 }
 
             match NullaryIlOp.execute loggerFactory baseClassTypes state thread NullaryIlOp.Conv_I4 with
             | ExecutionResult.Stepped (state, _, _) ->
-                IlMachineState.popEvalStack thread state |> fst, state.PointerHashCounters
+                IlMachineState.popEvalStack thread state |> fst, state.PointerHashState
             | other -> failwith $"Expected Conv_I4 to step, got %O{other}"
 
         let first, counters =
-            narrow PointerHashCounters.empty (NativeIntSource.MethodHandlePtr 17L)
+            narrow PointerHashState.empty (NativeIntSource.MethodHandlePtr 17L)
 
         let second, counters = narrow counters (NativeIntSource.MethodHandlePtr 18L)
 

--- a/WoofWare.PawPrint.Test/TestNullaryIlOp.fs
+++ b/WoofWare.PawPrint.Test/TestNullaryIlOp.fs
@@ -1350,8 +1350,8 @@ module TestNullaryIlOp =
 
             // One identity assigned, and retained: a discarded counter map would leave
             // this at zero while still producing a plausible-looking number.
-            state.PointerHashCounters.NextCounter |> shouldEqual 1UL
-            state.PointerHashCounters.Assigned.Count |> shouldEqual 1
+            PointerHashTestHelpers.nextCounter state.PointerHashCounters |> shouldEqual 1UL
+            PointerHashTestHelpers.assignedCount state.PointerHashCounters |> shouldEqual 1
         | other -> failwith $"Expected %O{op} to step, got %O{other}"
 
     [<Test>]
@@ -1385,7 +1385,7 @@ module TestNullaryIlOp =
         if first = second then
             failwith $"Conv_I4 gave both method handles the same int32 %O{first}"
 
-        counters.Assigned.Count |> shouldEqual 2
+        PointerHashTestHelpers.assignedCount counters |> shouldEqual 2
 
         // And the first handle still narrows to what it did before: assignment is
         // memoised, not re-derived.

--- a/WoofWare.PawPrint.Test/TestPointerHashSynthesis.fs
+++ b/WoofWare.PawPrint.Test/TestPointerHashSynthesis.fs
@@ -17,14 +17,15 @@ module TestPointerHashSynthesis =
         PointerHashSynthesis.materialiseHashBits "test" src counters
 
     [<Test>]
-    let ``a fresh fixture assigns bits by first-touch order`` () : unit =
-        // Pins which rule `empty` selects. Vacuous while `PointerHashAssignment` has
-        // one case; it earns its keep the moment a second lands, because the choice of
-        // default is part of the replay contract — switching it silently would change
-        // every synthesised pointer value the guest observes. The rule this names is
-        // what the `registration order assigns counters in order` test below spells out.
-        PointerHashCounters.empty.Assignment
-        |> shouldEqual PointerHashAssignment.SequentialFirstTouch
+    let ``a fresh fixture assigns bits by first-touch order, with nothing assigned yet`` () : unit =
+        // Pins which rule `empty` selects, and that it starts from a clean slate.
+        // The rule choice is vacuous while `PointerHashCounters` has one case; it
+        // earns its keep the moment a second lands, because the default is part of
+        // the replay contract — switching it silently would change every synthesised
+        // pointer value the guest observes. The rule named here is what the
+        // `registration order assigns counters in order` test below spells out.
+        PointerHashCounters.empty
+        |> shouldEqual (PointerHashCounters.SequentialFirstTouch (0UL, Map.empty))
 
     [<Test>]
     let ``same source materialised twice returns same bits and bumps counter only once`` () : unit =
@@ -32,13 +33,15 @@ module TestPointerHashSynthesis =
             NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete 42))
 
         let bits1, counters1 = materialise src PointerHashCounters.empty
-        counters1.NextCounter |> shouldEqual 1UL
-        counters1.Assigned.Count |> shouldEqual 1
+        PointerHashTestHelpers.nextCounter counters1 |> shouldEqual 1UL
+        PointerHashTestHelpers.assignedCount counters1 |> shouldEqual 1
 
         let bits2, counters2 = materialise src counters1
         bits2 |> shouldEqual bits1
-        counters2.NextCounter |> shouldEqual 1UL
-        counters2.Assigned |> shouldEqual counters1.Assigned
+        PointerHashTestHelpers.nextCounter counters2 |> shouldEqual 1UL
+
+        PointerHashTestHelpers.assigned counters2
+        |> shouldEqual (PointerHashTestHelpers.assigned counters1)
 
     [<Test>]
     let ``distinct sources get distinct bits`` () : unit =
@@ -52,8 +55,8 @@ module TestPointerHashSynthesis =
         let bitsB, counters = materialise b counters
 
         bitsA |> shouldNotEqual bitsB
-        counters.NextCounter |> shouldEqual 2UL
-        counters.Assigned.Count |> shouldEqual 2
+        PointerHashTestHelpers.nextCounter counters |> shouldEqual 2UL
+        PointerHashTestHelpers.assignedCount counters |> shouldEqual 2
 
     [<Test>]
     let ``order-stable assignment - same sequence on two fresh fixtures produces same bits`` () : unit =
@@ -125,8 +128,8 @@ module TestPointerHashSynthesis =
         bitsMt |> shouldEqual bitsTh
         // The two encodings share a canonical key, so the second materialisation
         // must reuse the first counter — no new assignment.
-        counters.NextCounter |> shouldEqual 1UL
-        counters.Assigned.Count |> shouldEqual 1
+        PointerHashTestHelpers.nextCounter counters |> shouldEqual 1UL
+        PointerHashTestHelpers.assignedCount counters |> shouldEqual 1
 
     [<Test>]
     let ``MethodTablePtr and TypeHandlePtr(Closed _) alias for OneDimArrayZero shape`` () : unit =
@@ -141,7 +144,7 @@ module TestPointerHashSynthesis =
             materialise (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed handle)) counters
 
         bitsMt |> shouldEqual bitsTh
-        counters.NextCounter |> shouldEqual 1UL
+        PointerHashTestHelpers.nextCounter counters |> shouldEqual 1UL
 
     [<Test>]
     let ``MethodTablePtr and TypeHandlePtr(Closed _) alias for Array shape`` () : unit =
@@ -156,7 +159,7 @@ module TestPointerHashSynthesis =
             materialise (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed handle)) counters
 
         bitsMt |> shouldEqual bitsTh
-        counters.NextCounter |> shouldEqual 1UL
+        PointerHashTestHelpers.nextCounter counters |> shouldEqual 1UL
 
     [<Test>]
     let ``TypeHandlePtr(Closed Pointer _) does NOT alias to MethodTablePtr - distinct canonical keys`` () : unit =
@@ -174,7 +177,7 @@ module TestPointerHashSynthesis =
             materialise (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed pointerHandle)) counters
 
         bitsMt |> shouldNotEqual bitsTh
-        counters.NextCounter |> shouldEqual 2UL
+        PointerHashTestHelpers.nextCounter counters |> shouldEqual 2UL
 
     [<Test>]
     let ``low bits are clear for MethodTablePtr`` () : unit =
@@ -260,7 +263,7 @@ module TestPointerHashSynthesis =
         tagged3 |> shouldEqual (untagged ||| 3L)
 
         // One identity, so only one counter was ever spent.
-        counters.NextCounter |> shouldEqual 1UL
+        PointerHashTestHelpers.nextCounter counters |> shouldEqual 1UL
 
     [<Test>]
     let ``a TypeDesc pointer differs from its type handle by exactly the tag bit`` () : unit =
@@ -281,7 +284,7 @@ module TestPointerHashSynthesis =
         typeDescBits |> shouldEqual (handleBits &&& ~~~2L)
 
         // One identity between them, so only one counter was spent.
-        counters.NextCounter |> shouldEqual 1UL
+        PointerHashTestHelpers.nextCounter counters |> shouldEqual 1UL
 
     [<Test>]
     let ``a MethodTable-shaped type handle has no tag to strip`` () : unit =
@@ -297,7 +300,7 @@ module TestPointerHashSynthesis =
 
         handleBits &&& 3L |> shouldEqual 0L
         methodTableBits |> shouldEqual handleBits
-        counters.NextCounter |> shouldEqual 1UL
+        PointerHashTestHelpers.nextCounter counters |> shouldEqual 1UL
 
     [<Test>]
     let ``low bits are clear for AssemblyHandle / ModuleHandle / MetadataImportHandle`` () : unit =
@@ -435,8 +438,8 @@ module TestPointerHashSynthesis =
         let _, counters = materialise mt counters
         let _, counters = materialise th counters
 
-        counters.NextCounter |> shouldEqual 1UL
-        counters.Assigned.Count |> shouldEqual 1
+        PointerHashTestHelpers.nextCounter counters |> shouldEqual 1UL
+        PointerHashTestHelpers.assignedCount counters |> shouldEqual 1
 
     [<Test>]
     let ``MethodTableAuxiliaryDataPtr is canonicalised distinctly from MethodTablePtr`` () : unit =
@@ -450,7 +453,7 @@ module TestPointerHashSynthesis =
         let bitsAux, counters = materialise aux counters
 
         bitsMt |> shouldNotEqual bitsAux
-        counters.NextCounter |> shouldEqual 2UL
+        PointerHashTestHelpers.nextCounter counters |> shouldEqual 2UL
 
     [<Test>]
     let ``EventPipeProviderPtr and EventPipeEventPtr with the same id are distinct canonical keys`` () : unit =
@@ -460,7 +463,7 @@ module TestPointerHashSynthesis =
         let bitsEvt, counters = materialise (NativeIntSource.EventPipeEventPtr 5L) counters
 
         bitsProv |> shouldNotEqual bitsEvt
-        counters.NextCounter |> shouldEqual 2UL
+        PointerHashTestHelpers.nextCounter counters |> shouldEqual 2UL
 
     [<Test>]
     let ``AssemblyHandle ModuleHandle MetadataImportHandle with same name are distinct canonical keys`` () : unit =
@@ -477,4 +480,4 @@ module TestPointerHashSynthesis =
         bitsAssy |> shouldNotEqual bitsMod
         bitsAssy |> shouldNotEqual bitsMid
         bitsMod |> shouldNotEqual bitsMid
-        counters.NextCounter |> shouldEqual 3UL
+        PointerHashTestHelpers.nextCounter counters |> shouldEqual 3UL

--- a/WoofWare.PawPrint.Test/TestPointerHashSynthesis.fs
+++ b/WoofWare.PawPrint.Test/TestPointerHashSynthesis.fs
@@ -17,6 +17,16 @@ module TestPointerHashSynthesis =
         PointerHashSynthesis.materialiseHashBits "test" src counters
 
     [<Test>]
+    let ``a fresh fixture assigns bits by first-touch order`` () : unit =
+        // Pins which rule `empty` selects. Vacuous while `PointerHashAssignment` has
+        // one case; it earns its keep the moment a second lands, because the choice of
+        // default is part of the replay contract — switching it silently would change
+        // every synthesised pointer value the guest observes. The rule this names is
+        // what the `registration order assigns counters in order` test below spells out.
+        PointerHashCounters.empty.Assignment
+        |> shouldEqual PointerHashAssignment.SequentialFirstTouch
+
+    [<Test>]
     let ``same source materialised twice returns same bits and bumps counter only once`` () : unit =
         let src =
             NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete 42))

--- a/WoofWare.PawPrint.Test/TestPointerHashSynthesis.fs
+++ b/WoofWare.PawPrint.Test/TestPointerHashSynthesis.fs
@@ -13,26 +13,26 @@ open WoofWare.PawPrint
 [<Parallelizable(ParallelScope.All)>]
 module TestPointerHashSynthesis =
 
-    let private materialise (src : NativeIntSource) (counters : PointerHashCounters) : int64 * PointerHashCounters =
+    let private materialise (src : NativeIntSource) (counters : PointerHashState) : int64 * PointerHashState =
         PointerHashSynthesis.materialiseHashBits "test" src counters
 
     [<Test>]
     let ``a fresh fixture assigns bits by first-touch order, with nothing assigned yet`` () : unit =
         // Pins which rule `empty` selects, and that it starts from a clean slate.
-        // The rule choice is vacuous while `PointerHashCounters` has one case; it
+        // The rule choice is vacuous while `PointerHashState` has one case; it
         // earns its keep the moment a second lands, because the default is part of
         // the replay contract — switching it silently would change every synthesised
         // pointer value the guest observes. The rule named here is what the
         // `registration order assigns counters in order` test below spells out.
-        PointerHashCounters.empty
-        |> shouldEqual (PointerHashCounters.SequentialFirstTouch (0UL, Map.empty))
+        PointerHashState.empty
+        |> shouldEqual (PointerHashState.SequentialFirstTouch (0UL, Map.empty))
 
     [<Test>]
     let ``same source materialised twice returns same bits and bumps counter only once`` () : unit =
         let src =
             NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete 42))
 
-        let bits1, counters1 = materialise src PointerHashCounters.empty
+        let bits1, counters1 = materialise src PointerHashState.empty
         PointerHashTestHelpers.nextCounter counters1 |> shouldEqual 1UL
         PointerHashTestHelpers.assignedCount counters1 |> shouldEqual 1
 
@@ -51,7 +51,7 @@ module TestPointerHashSynthesis =
         let b =
             NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete 2))
 
-        let bitsA, counters = materialise a PointerHashCounters.empty
+        let bitsA, counters = materialise a PointerHashState.empty
         let bitsB, counters = materialise b counters
 
         bitsA |> shouldNotEqual bitsB
@@ -71,7 +71,7 @@ module TestPointerHashSynthesis =
                 NativeIntSource.FieldHandlePtr 200L
             ]
 
-        let materialiseAll (counters : PointerHashCounters) =
+        let materialiseAll (counters : PointerHashState) =
             ((counters, []), sources)
             ||> List.fold (fun (counters, bitsSoFar) src ->
                 let bits, counters = materialise src counters
@@ -80,8 +80,8 @@ module TestPointerHashSynthesis =
             |> snd
             |> List.rev
 
-        let bitsRunA = materialiseAll PointerHashCounters.empty
-        let bitsRunB = materialiseAll PointerHashCounters.empty
+        let bitsRunA = materialiseAll PointerHashState.empty
+        let bitsRunB = materialiseAll PointerHashState.empty
         bitsRunA |> shouldEqual bitsRunB
 
     [<Test>]
@@ -93,13 +93,13 @@ module TestPointerHashSynthesis =
             NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete 12))
 
         // First registration in any sequence gets counter 0 → bits = ((0+1) <<< 2) | 0 = 4.
-        let bitsAAlone, _ = materialise a PointerHashCounters.empty
-        let bitsBAlone, _ = materialise b PointerHashCounters.empty
+        let bitsAAlone, _ = materialise a PointerHashState.empty
+        let bitsBAlone, _ = materialise b PointerHashState.empty
         bitsAAlone |> shouldEqual 4L
         bitsBAlone |> shouldEqual 4L
 
         // Register a then b: a gets counter 0, b gets counter 1.
-        let bitsA_AB, ab = materialise a PointerHashCounters.empty
+        let bitsA_AB, ab = materialise a PointerHashState.empty
         let bitsB_AB, _ = materialise b ab
         bitsA_AB |> shouldEqual 4L
         bitsB_AB |> shouldEqual 8L
@@ -107,7 +107,7 @@ module TestPointerHashSynthesis =
         // Register b then a: b gets counter 0, a gets counter 1. The bits depend only on
         // registration order, not on the source identity — that is the load-bearing
         // determinism contract.
-        let bitsB_BA, ba = materialise b PointerHashCounters.empty
+        let bitsB_BA, ba = materialise b PointerHashState.empty
         let bitsA_BA, _ = materialise a ba
         bitsB_BA |> shouldEqual 4L
         bitsA_BA |> shouldEqual 8L
@@ -122,7 +122,7 @@ module TestPointerHashSynthesis =
         let mtSrc = NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed handle)
         let thSrc = NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed handle)
 
-        let bitsMt, counters = materialise mtSrc PointerHashCounters.empty
+        let bitsMt, counters = materialise mtSrc PointerHashState.empty
         let bitsTh, counters = materialise thSrc counters
 
         bitsMt |> shouldEqual bitsTh
@@ -136,9 +136,7 @@ module TestPointerHashSynthesis =
         let handle = ConcreteTypeHandle.OneDimArrayZero (ConcreteTypeHandle.Concrete 5)
 
         let bitsMt, counters =
-            materialise
-                (NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed handle))
-                PointerHashCounters.empty
+            materialise (NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed handle)) PointerHashState.empty
 
         let bitsTh, counters =
             materialise (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed handle)) counters
@@ -151,9 +149,7 @@ module TestPointerHashSynthesis =
         let handle = ConcreteTypeHandle.Array (ConcreteTypeHandle.Concrete 3, 2)
 
         let bitsMt, counters =
-            materialise
-                (NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed handle))
-                PointerHashCounters.empty
+            materialise (NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed handle)) PointerHashState.empty
 
         let bitsTh, counters =
             materialise (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed handle)) counters
@@ -169,9 +165,7 @@ module TestPointerHashSynthesis =
         let pointerHandle = ConcreteTypeHandle.Pointer element
 
         let bitsMt, counters =
-            materialise
-                (NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed element))
-                PointerHashCounters.empty
+            materialise (NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed element)) PointerHashState.empty
 
         let bitsTh, counters =
             materialise (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed pointerHandle)) counters
@@ -184,7 +178,7 @@ module TestPointerHashSynthesis =
         let bits, _ =
             materialise
                 (NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete 7)))
-                PointerHashCounters.empty
+                PointerHashState.empty
 
         bits &&& 3L |> shouldEqual 0L
 
@@ -193,9 +187,7 @@ module TestPointerHashSynthesis =
         let handle = ConcreteTypeHandle.OneDimArrayZero (ConcreteTypeHandle.Concrete 7)
 
         let bits, _ =
-            materialise
-                (NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed handle))
-                PointerHashCounters.empty
+            materialise (NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed handle)) PointerHashState.empty
 
         bits &&& 3L |> shouldEqual 0L
 
@@ -204,9 +196,7 @@ module TestPointerHashSynthesis =
         let handle = ConcreteTypeHandle.Pointer (ConcreteTypeHandle.Concrete 7)
 
         let bits, _ =
-            materialise
-                (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed handle))
-                PointerHashCounters.empty
+            materialise (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed handle)) PointerHashState.empty
 
         bits &&& 2L |> shouldEqual 2L
 
@@ -215,30 +205,28 @@ module TestPointerHashSynthesis =
         let handle = ConcreteTypeHandle.Byref (ConcreteTypeHandle.Concrete 7)
 
         let bits, _ =
-            materialise
-                (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed handle))
-                PointerHashCounters.empty
+            materialise (NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed handle)) PointerHashState.empty
 
         bits &&& 2L |> shouldEqual 2L
 
     [<Test>]
     let ``low bits are clear for MethodHandlePtr`` () : unit =
         let bits, _ =
-            materialise (NativeIntSource.MethodHandlePtr 0xCAFEL) PointerHashCounters.empty
+            materialise (NativeIntSource.MethodHandlePtr 0xCAFEL) PointerHashState.empty
 
         bits &&& 3L |> shouldEqual 0L
 
     [<Test>]
     let ``low bits are clear for FieldHandlePtr`` () : unit =
         let bits, _ =
-            materialise (NativeIntSource.FieldHandlePtr 0xBEEFL) PointerHashCounters.empty
+            materialise (NativeIntSource.FieldHandlePtr 0xBEEFL) PointerHashState.empty
 
         bits &&& 3L |> shouldEqual 0L
 
     [<Test>]
     let ``low bits are clear for GcHandlePtr`` () : unit =
         let bits, _ =
-            materialise (NativeIntSource.GcHandlePtr (GcHandleAddress.GcHandleAddress 17, 0L)) PointerHashCounters.empty
+            materialise (NativeIntSource.GcHandlePtr (GcHandleAddress.GcHandleAddress 17, 0L)) PointerHashState.empty
 
         bits &&& 3L |> shouldEqual 0L
 
@@ -251,7 +239,7 @@ module TestPointerHashSynthesis =
         let handle = GcHandleAddress.GcHandleAddress 17
 
         let untagged, counters =
-            materialise (NativeIntSource.GcHandlePtr (handle, 0L)) PointerHashCounters.empty
+            materialise (NativeIntSource.GcHandlePtr (handle, 0L)) PointerHashState.empty
 
         let tagged1, counters =
             materialise (NativeIntSource.GcHandlePtr (handle, 1L)) counters
@@ -275,7 +263,7 @@ module TestPointerHashSynthesis =
             RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Pointer (ConcreteTypeHandle.Concrete 1))
 
         let handleBits, counters =
-            materialise (NativeIntSource.TypeHandlePtr target) PointerHashCounters.empty
+            materialise (NativeIntSource.TypeHandlePtr target) PointerHashState.empty
 
         let typeDescBits, counters =
             materialise (NativeIntSource.TypeDescPtr target) counters
@@ -293,7 +281,7 @@ module TestPointerHashSynthesis =
         let target = RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete 1)
 
         let handleBits, counters =
-            materialise (NativeIntSource.TypeHandlePtr target) PointerHashCounters.empty
+            materialise (NativeIntSource.TypeHandlePtr target) PointerHashState.empty
 
         let methodTableBits, counters =
             materialise (NativeIntSource.MethodTablePtr target) counters
@@ -305,7 +293,7 @@ module TestPointerHashSynthesis =
     [<Test>]
     let ``low bits are clear for AssemblyHandle / ModuleHandle / MetadataImportHandle`` () : unit =
         let assyBits, counters =
-            materialise (NativeIntSource.AssemblyHandle "Foo") PointerHashCounters.empty
+            materialise (NativeIntSource.AssemblyHandle "Foo") PointerHashState.empty
 
         let modBits, counters = materialise (NativeIntSource.ModuleHandle "Bar") counters
         let midBits, _ = materialise (NativeIntSource.MetadataImportHandle "Baz") counters
@@ -317,26 +305,26 @@ module TestPointerHashSynthesis =
     [<Test>]
     let ``Verbatim is returned unchanged and does not touch counters`` () : unit =
         let bits, counters =
-            materialise (NativeIntSource.Verbatim 12345L) PointerHashCounters.empty
+            materialise (NativeIntSource.Verbatim 12345L) PointerHashState.empty
 
         bits |> shouldEqual 12345L
-        counters |> shouldEqual PointerHashCounters.empty
+        counters |> shouldEqual PointerHashState.empty
 
     [<Test>]
     let ``Verbatim works for negative values without sign mangling`` () : unit =
         let bits, counters =
-            materialise (NativeIntSource.Verbatim -7L) PointerHashCounters.empty
+            materialise (NativeIntSource.Verbatim -7L) PointerHashState.empty
 
         bits |> shouldEqual -7L
-        counters |> shouldEqual PointerHashCounters.empty
+        counters |> shouldEqual PointerHashState.empty
 
     [<Test>]
     let ``null managed pointer is materialised to 0L and does not touch counters`` () : unit =
         let bits, counters =
-            materialise (NativeIntSource.ManagedPointer ManagedPointerSource.Null) PointerHashCounters.empty
+            materialise (NativeIntSource.ManagedPointer ManagedPointerSource.Null) PointerHashState.empty
 
         bits |> shouldEqual 0L
-        counters |> shouldEqual PointerHashCounters.empty
+        counters |> shouldEqual PointerHashState.empty
 
     [<Test>]
     let ``non-null managed pointer is refused with reason embedded in message`` () : unit =
@@ -347,7 +335,7 @@ module TestPointerHashSynthesis =
 
         let ex =
             Assert.Throws<System.Exception> (fun () ->
-                PointerHashSynthesis.materialiseHashBits "my-call-site" src PointerHashCounters.empty
+                PointerHashSynthesis.materialiseHashBits "my-call-site" src PointerHashState.empty
                 |> ignore
             )
 
@@ -367,7 +355,7 @@ module TestPointerHashSynthesis =
 
         let ex =
             Assert.Throws<System.Exception> (fun () ->
-                PointerHashSynthesis.materialiseHashBits "cross-array-callsite" src PointerHashCounters.empty
+                PointerHashSynthesis.materialiseHashBits "cross-array-callsite" src PointerHashState.empty
                 |> ignore
             )
 
@@ -412,7 +400,7 @@ module TestPointerHashSynthesis =
         sources.Length |> shouldEqual 100
 
         let _, allBits =
-            ((PointerHashCounters.empty, []), sources)
+            ((PointerHashState.empty, []), sources)
             ||> List.fold (fun (counters, acc) src ->
                 let bits, counters = materialise src counters
                 counters, bits :: acc
@@ -433,7 +421,7 @@ module TestPointerHashSynthesis =
         let th = NativeIntSource.TypeHandlePtr (RuntimeTypeHandleTarget.Closed handle)
 
         // Register the alias under one encoding, then via the other; total assigned should remain 1.
-        let _, counters = materialise mt PointerHashCounters.empty
+        let _, counters = materialise mt PointerHashState.empty
         let _, counters = materialise th counters
         let _, counters = materialise mt counters
         let _, counters = materialise th counters
@@ -449,7 +437,7 @@ module TestPointerHashSynthesis =
         let aux =
             NativeIntSource.MethodTableAuxiliaryDataPtr (RuntimeTypeHandleTarget.Closed handle)
 
-        let bitsMt, counters = materialise mt PointerHashCounters.empty
+        let bitsMt, counters = materialise mt PointerHashState.empty
         let bitsAux, counters = materialise aux counters
 
         bitsMt |> shouldNotEqual bitsAux
@@ -458,7 +446,7 @@ module TestPointerHashSynthesis =
     [<Test>]
     let ``EventPipeProviderPtr and EventPipeEventPtr with the same id are distinct canonical keys`` () : unit =
         let bitsProv, counters =
-            materialise (NativeIntSource.EventPipeProviderPtr 5L) PointerHashCounters.empty
+            materialise (NativeIntSource.EventPipeProviderPtr 5L) PointerHashState.empty
 
         let bitsEvt, counters = materialise (NativeIntSource.EventPipeEventPtr 5L) counters
 
@@ -470,7 +458,7 @@ module TestPointerHashSynthesis =
         let name = "X"
 
         let bitsAssy, counters =
-            materialise (NativeIntSource.AssemblyHandle name) PointerHashCounters.empty
+            materialise (NativeIntSource.AssemblyHandle name) PointerHashState.empty
 
         let bitsMod, counters = materialise (NativeIntSource.ModuleHandle name) counters
 

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -25,6 +25,7 @@
     <Compile Include="CrossAssemblyHarness.fs" />
     <Compile Include="TestCrossAssemblyOracle.fs" />
     <Compile Include="TypeIdentityTestHelpers.fs" />
+    <Compile Include="PointerHashTestHelpers.fs" />
     <Compile Include="AssemblyShape.fs" />
     <Compile Include="AssemblyGraphShape.fs" />
     <Compile Include="TestTypeResolution.fs" />

--- a/WoofWare.PawPrint/BinaryArithmetic.fs
+++ b/WoofWare.PawPrint/BinaryArithmetic.fs
@@ -981,7 +981,7 @@ module BinaryArithmetic =
     /// Apply a binary arithmetic operation. Returns the result together with
     /// the (possibly updated) machine state — the WidenedNativeInt arms that
     /// materialise synthesised pointer-hash bits register new
-    /// `PointerHashCounters` entries on `state`; every other arm returns
+    /// `PointerHashState` assignments on `state`; every other arm returns
     /// `state` unchanged. Callers MUST use the returned state, not the input
     /// state, when pushing the result.
     let execute
@@ -1031,7 +1031,7 @@ module BinaryArithmetic =
                 EvalStackValue.Int64 (Int64Source.widenedNativeInt (NativeIntSource.ManagedPointer ptr) signed)
             | Choice2Of2 i -> EvalStackValue.Int64 (Int64Source.Verbatim i)
 
-        let materialise (src : NativeIntSource) (counters : PointerHashCounters) : int64 * PointerHashCounters =
+        let materialise (src : NativeIntSource) (counters : PointerHashState) : int64 * PointerHashState =
             PointerHashSynthesis.materialiseHashBits $"BinaryArithmetic.%s{op.Name}" src counters
 
         let withState (esv : EvalStackValue) : EvalStackValue * IlMachineState = esv, state
@@ -1125,40 +1125,40 @@ module BinaryArithmetic =
         // handles, etc.). Result is tagged OpaqueHashBits so it can't
         // round-trip back to a pointer via `conv.u` / `conv.i`.
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)), EvalStackValue.Int64 (Int64Source.Verbatim val2) ->
-            let val1, counters = materialise src state.PointerHashCounters
+            let val1, counters = materialise src state.PointerHashState
 
             let state =
                 { state with
-                    PointerHashCounters = counters
+                    PointerHashState = counters
                 }
 
             op.Int64Int64 val1 val2 |> Int64Source.OpaqueHashBits |> EvalStackValue.Int64, state
         | EvalStackValue.Int64 (Int64Source.Verbatim val1), EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
-            let val2, counters = materialise src state.PointerHashCounters
+            let val2, counters = materialise src state.PointerHashState
 
             let state =
                 { state with
-                    PointerHashCounters = counters
+                    PointerHashState = counters
                 }
 
             op.Int64Int64 val1 val2 |> Int64Source.OpaqueHashBits |> EvalStackValue.Int64, state
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)),
           EvalStackValue.Int64 (Int64Source.OpaqueHashBits val2) ->
-            let val1, counters = materialise src state.PointerHashCounters
+            let val1, counters = materialise src state.PointerHashState
 
             let state =
                 { state with
-                    PointerHashCounters = counters
+                    PointerHashState = counters
                 }
 
             op.Int64Int64 val1 val2 |> Int64Source.OpaqueHashBits |> EvalStackValue.Int64, state
         | EvalStackValue.Int64 (Int64Source.OpaqueHashBits val1),
           EvalStackValue.Int64 (Int64Source.WidenedNativeInt (src, _)) ->
-            let val2, counters = materialise src state.PointerHashCounters
+            let val2, counters = materialise src state.PointerHashState
 
             let state =
                 { state with
-                    PointerHashCounters = counters
+                    PointerHashState = counters
                 }
 
             op.Int64Int64 val1 val2 |> Int64Source.OpaqueHashBits |> EvalStackValue.Int64, state
@@ -1175,12 +1175,12 @@ module BinaryArithmetic =
                 failwith
                     $"TODO: BinaryArithmetic %s{op.Name} on (WidenedNativeInt %O{src1}) and (WidenedNativeInt %O{src2}): one side is a managed pointer, the other isn't"
             | _ ->
-                let val1, counters = materialise src1 state.PointerHashCounters
+                let val1, counters = materialise src1 state.PointerHashState
                 let val2, counters = materialise src2 counters
 
                 let state =
                     { state with
-                        PointerHashCounters = counters
+                        PointerHashState = counters
                     }
 
                 op.Int64Int64 val1 val2 |> Int64Source.OpaqueHashBits |> EvalStackValue.Int64, state

--- a/WoofWare.PawPrint/CliNumericType.fs
+++ b/WoofWare.PawPrint/CliNumericType.fs
@@ -86,13 +86,13 @@ module Int64Source =
     /// genuine `Int64.MinValue` whose negation overflows; for synthesised
     /// pointer-hash bits the wraparound at `Int64.MinValue` is acceptable
     /// because the hash domain isn't a genuine signed-int value. Threads
-    /// `PointerHashCounters` because materialising a `WidenedNativeInt`
+    /// `PointerHashState` because materialising a `WidenedNativeInt`
     /// may register a new pointer.
     let negate
         (reason : string)
         (i : Int64Source)
-        (counters : PointerHashCounters)
-        : (Int64Source * PointerHashCounters) option
+        (counters : PointerHashState)
+        : (Int64Source * PointerHashState) option
         =
         match i with
         | Int64Source.Verbatim i ->
@@ -115,8 +115,8 @@ module Int64Source =
         (reason : string)
         (i : Int64Source)
         (shift : int)
-        (counters : PointerHashCounters)
-        : Int64Source * PointerHashCounters
+        (counters : PointerHashState)
+        : Int64Source * PointerHashState
         =
         match i with
         | Int64Source.Verbatim i -> i >>> shift |> Int64Source.Verbatim, counters
@@ -130,8 +130,8 @@ module Int64Source =
         (reason : string)
         (i : Int64Source)
         (shift : int)
-        (counters : PointerHashCounters)
-        : Int64Source * PointerHashCounters
+        (counters : PointerHashState)
+        : Int64Source * PointerHashState
         =
         // `open Checked` shadows `uint64` / `int64` with their overflow-checking
         // versions; an unsigned right shift needs the unchecked tag-flip, since a
@@ -151,8 +151,8 @@ module Int64Source =
         (reason : string)
         (i : Int64Source)
         (shift : int)
-        (counters : PointerHashCounters)
-        : Int64Source * PointerHashCounters
+        (counters : PointerHashState)
+        : Int64Source * PointerHashState
         =
         match i with
         | Int64Source.Verbatim i -> i <<< shift |> Int64Source.Verbatim, counters
@@ -162,12 +162,7 @@ module Int64Source =
             bits <<< shift |> Int64Source.OpaqueHashBits, counters
         | Int64Source.OpaqueHashBits bits -> bits <<< shift |> Int64Source.OpaqueHashBits, counters
 
-    let bitNot
-        (reason : string)
-        (i : Int64Source)
-        (counters : PointerHashCounters)
-        : Int64Source * PointerHashCounters
-        =
+    let bitNot (reason : string) (i : Int64Source) (counters : PointerHashState) : Int64Source * PointerHashState =
         match i with
         | Int64Source.Verbatim i -> Int64Source.Verbatim ~~~i, counters
         | Int64Source.WidenedNativeInt (src, _) ->
@@ -180,8 +175,8 @@ module Int64Source =
         (reason : string)
         (i1 : Int64Source)
         (i2 : Int64Source)
-        (counters : PointerHashCounters)
-        : Int64Source * PointerHashCounters
+        (counters : PointerHashState)
+        : Int64Source * PointerHashState
         =
         match i1, i2 with
         | Int64Source.Verbatim a, Int64Source.Verbatim b -> a &&& b |> Int64Source.Verbatim, counters
@@ -206,8 +201,8 @@ module Int64Source =
         (reason : string)
         (i1 : Int64Source)
         (i2 : Int64Source)
-        (counters : PointerHashCounters)
-        : Int64Source * PointerHashCounters
+        (counters : PointerHashState)
+        : Int64Source * PointerHashState
         =
         match i1, i2 with
         | Int64Source.Verbatim a, Int64Source.Verbatim b -> a ||| b |> Int64Source.Verbatim, counters
@@ -232,8 +227,8 @@ module Int64Source =
         (reason : string)
         (i1 : Int64Source)
         (i2 : Int64Source)
-        (counters : PointerHashCounters)
-        : Int64Source * PointerHashCounters
+        (counters : PointerHashState)
+        : Int64Source * PointerHashState
         =
         match i1, i2 with
         | Int64Source.Verbatim a, Int64Source.Verbatim b -> a ^^^ b |> Int64Source.Verbatim, counters

--- a/WoofWare.PawPrint/EvalStack.fs
+++ b/WoofWare.PawPrint/EvalStack.fs
@@ -340,7 +340,7 @@ module EvalStackValue =
     /// `conv.i1`.
     ///
     /// The narrowing integer conversions (`conv.i1` / `conv.i2` / `conv.i4` and
-    /// their unsigned counterparts) take `PointerHashCounters` because a
+    /// their unsigned counterparts) take `PointerHashState` because a
     /// pointer-shaped source must be materialised into bits before it can be
     /// truncated. The destination is narrower than a pointer, so the result cannot
     /// be a pointer and the honest answer is the source's bits;
@@ -354,7 +354,7 @@ module EvalStackValue =
     /// `(sbyte)(long)ptr` agree by construction rather than by coincidence.
     /// CoreLib chooses between those spellings with `#if TARGET_64BIT` inside
     /// `IntPtr.GetHashCode` (IntPtr.cs:90-97), so they have to.
-    let convToInt8 (value : EvalStackValue) (counters : PointerHashCounters) : int32 * PointerHashCounters =
+    let convToInt8 (value : EvalStackValue) (counters : PointerHashState) : int32 * PointerHashState =
         match value with
         | EvalStackValue.Int32 int32Source ->
             let i = Int32Source.value "Conv_I1" int32Source
@@ -372,8 +372,8 @@ module EvalStackValue =
         | EvalStackValue.ObjectRef _
         | EvalStackValue.UserDefinedValueType _ -> failReferenceConversion "Conv_I1" value
 
-    /// `conv.i2`. See `convToInt8` for why this takes `PointerHashCounters`.
-    let convToInt16 (value : EvalStackValue) (counters : PointerHashCounters) : int32 * PointerHashCounters =
+    /// `conv.i2`. See `convToInt8` for why this takes `PointerHashState`.
+    let convToInt16 (value : EvalStackValue) (counters : PointerHashState) : int32 * PointerHashState =
         match value with
         | EvalStackValue.Int32 int32Source ->
             let i = Int32Source.value "Conv_I2" int32Source
@@ -396,8 +396,8 @@ module EvalStackValue =
     let private narrowByrefTo32 (truncate : int64 -> int32) (ptr : ManagedPointerSource) : EvalStackValue =
         Int32Source.narrowManagedPointer truncate ptr |> EvalStackValue.Int32
 
-    /// `conv.i4`. See `convToInt8` for why this takes `PointerHashCounters`.
-    let convToInt32 (value : EvalStackValue) (counters : PointerHashCounters) : EvalStackValue * PointerHashCounters =
+    /// `conv.i4`. See `convToInt8` for why this takes `PointerHashState`.
+    let convToInt32 (value : EvalStackValue) (counters : PointerHashState) : EvalStackValue * PointerHashState =
         match value with
         // Identity, narrowed byrefs included: re-truncating a value that is
         // already 32 bits wide changes nothing.
@@ -467,8 +467,8 @@ module EvalStackValue =
         | EvalStackValue.UserDefinedValueType _ -> failReferenceConversion "Conv_U8" value
 
     /// `conv.u1`, then truncates to int32. See `convToInt8` for why this takes
-    /// `PointerHashCounters`.
-    let convToUInt8 (value : EvalStackValue) (counters : PointerHashCounters) : int32 * PointerHashCounters =
+    /// `PointerHashState`.
+    let convToUInt8 (value : EvalStackValue) (counters : PointerHashState) : int32 * PointerHashState =
         match value with
         | EvalStackValue.Int32 int32Source ->
             let i = Int32Source.value "Conv_U1" int32Source
@@ -487,8 +487,8 @@ module EvalStackValue =
         | EvalStackValue.UserDefinedValueType _ -> failReferenceConversion "Conv_U1" value
 
     /// `conv.u2`, then truncates to int32. See `convToInt8` for why this takes
-    /// `PointerHashCounters`.
-    let convToUInt16 (value : EvalStackValue) (counters : PointerHashCounters) : int32 * PointerHashCounters =
+    /// `PointerHashState`.
+    let convToUInt16 (value : EvalStackValue) (counters : PointerHashState) : int32 * PointerHashState =
         match value with
         | EvalStackValue.Int32 int32Source ->
             let i = Int32Source.value "Conv_U2" int32Source
@@ -507,8 +507,8 @@ module EvalStackValue =
         | EvalStackValue.UserDefinedValueType _ -> failReferenceConversion "Conv_U2" value
 
     /// `conv.u4`, then truncates to int32. See `convToInt8` for why this takes
-    /// `PointerHashCounters`.
-    let convToUInt32 (value : EvalStackValue) (counters : PointerHashCounters) : EvalStackValue * PointerHashCounters =
+    /// `PointerHashState`.
+    let convToUInt32 (value : EvalStackValue) (counters : PointerHashState) : EvalStackValue * PointerHashState =
         match value with
         // A narrowed byref is already 32 bits wide, and `conv.u4` only reinterprets
         // those bits; it neither discards any nor makes the value knowable.
@@ -607,7 +607,7 @@ module EvalStackValue =
     /// two exactly-known pointer bit patterns (`Null`, and the `NativeIntPlaceholder`
     /// produced by `Unsafe.AsRef<T>((void*)bits)`), and already-synthesised hash bits all
     /// have bits to report. A real pointer or handle does not: reporting one means
-    /// assigning it a `PointerHashCounters` identity, which is a side effect a caller may
+    /// assigning it a `PointerHashState` identity, which is a side effect a caller may
     /// have no business causing — so those, and cross-array offsets, return `ValueNone`
     /// and leave the caller to refuse with its own diagnostic.
     let rec tryExactIntegerBits (value : EvalStackValue) : int64 voption =

--- a/WoofWare.PawPrint/EvalStackValueComparisons.fs
+++ b/WoofWare.PawPrint/EvalStackValueComparisons.fs
@@ -407,14 +407,14 @@ module EvalStackValueComparisons =
         // the WidenedNativeInt would synthesise to — so the answer here is
         // "equal iff WidenedNativeInt's materialised bits equal the
         // OpaqueHashBits value". Producing the right answer requires reading
-        // the `PointerHashCounters` map, which `ceq` does not thread today.
+        // the assignments held in `PointerHashState`, which `ceq` does not thread today.
         // Fail loudly rather than silently returning false (which would have
         // been wrong under identity ops) or true (which would be wrong when
         // bits genuinely differ).
         | EvalStackValue.Int64 (Int64Source.WidenedNativeInt _), EvalStackValue.Int64 (Int64Source.OpaqueHashBits _)
         | EvalStackValue.Int64 (Int64Source.OpaqueHashBits _), EvalStackValue.Int64 (Int64Source.WidenedNativeInt _) ->
             failwith
-                $"TODO: ceq of WidenedNativeInt vs OpaqueHashBits requires looking up the pointer's materialised hash bits via PointerHashCounters; thread state through ceq to resolve. Got %O{var1} vs %O{var2}"
+                $"TODO: ceq of WidenedNativeInt vs OpaqueHashBits requires looking up the pointer's materialised hash bits via PointerHashState; thread state through ceq to resolve. Got %O{var1} vs %O{var2}"
         // Verbatim and OpaqueHashBits both carry unambiguous int64 bit patterns,
         // so equality is bit-pattern equality regardless of how the bits were
         // produced. Structural DU equality would incorrectly treat

--- a/WoofWare.PawPrint/IlMachineStateModel.fs
+++ b/WoofWare.PawPrint/IlMachineStateModel.fs
@@ -97,7 +97,7 @@ type IlMachineState =
         /// hash bits. Each canonical pointer key gets a stable bit pattern
         /// derived from its registration order; distinct keys produce
         /// distinct bits with no collisions. See `PointerHashSynthesis`.
-        PointerHashCounters : PointerHashCounters
+        PointerHashState : PointerHashState
         /// Host-kernel / syscall-emulation state: last-error registers, native
         /// heap pool, file-descriptor table, `LowLevelMonitor` registry, and
         /// monotonic ID counters for opaque kernel handles. Bundled into a

--- a/WoofWare.PawPrint/IlMachineThreadState.fs
+++ b/WoofWare.PawPrint/IlMachineThreadState.fs
@@ -301,7 +301,7 @@ module IlMachineThreadState =
                 RuntimeModuleObjects = ImmutableDictionary.Empty
                 ManagedThreadObjects = Map.empty
                 NextManagedThreadId = 2
-                PointerHashCounters = PointerHashCounters.empty
+                PointerHashState = PointerHashState.empty
                 Kernel = EmulatedKernel.initial
                 Scheduling = SchedulerState.RoundRobin
             }

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -31,7 +31,7 @@ module Intrinsics =
     ///
     /// What it does *not* do, and what `conv.i4` would, is synthesise bits for a pointer:
     /// an int32 parameter cannot legally receive one, and narrowing it would assign the
-    /// pointer a `PointerHashCounters` identity, perturbing every synthesised value later in
+    /// pointer a `PointerHashState` identity, perturbing every synthesised value later in
     /// the run. `Int32Source.value` likewise still refuses a byref that `conv.i4` already
     /// truncated, whose numeric value depends on an address PawPrint does not model.
     let internal int32ValueArgument (operation : string) (value : EvalStackValue) : int32 =
@@ -691,11 +691,11 @@ module Intrinsics =
                     // bits rather than failing.
                     let combine = if isOr then Int64Source.bitOr else Int64Source.bitAnd
 
-                    let updated, counters = combine operation current value state.PointerHashCounters
+                    let updated, counters = combine operation current value state.PointerHashState
 
                     let state =
                         { state with
-                            PointerHashCounters = counters
+                            PointerHashState = counters
                         }
 
                     let state =

--- a/WoofWare.PawPrint/NativeIntSource.fs
+++ b/WoofWare.PawPrint/NativeIntSource.fs
@@ -590,7 +590,7 @@ module NativeIntSource =
         // round-trips the handle's materialised bits into an
         // OpaqueHashBits carrier, so the answer depends on whether those
         // bits equal the handle's synthesised address. Resolving correctly
-        // requires reading the `PointerHashCounters` map, which `ceq` does
+        // requires reading the assignments held in `PointerHashState`, which `ceq` does
         // not thread today. Fail loudly rather than fall through to the
         // handle-kind catch-all (which would return a fixed `false` even
         // for the same handle). Mirrors the Int64
@@ -630,7 +630,7 @@ module NativeIntSource =
         | NativeIntSource.OpaqueHashBits _, NativeIntSource.WaitHandlePtr _
         | NativeIntSource.WaitHandlePtr _, NativeIntSource.OpaqueHashBits _ ->
             failwith
-                $"TODO (CEQ): synthesised hash bits vs handle pointer requires materialising the handle's bits through PointerHashCounters; got {a} vs {b}"
+                $"TODO (CEQ): synthesised hash bits vs handle pointer requires materialising the handle's bits through PointerHashState; got {a} vs {b}"
         // CoreCLR's TypeHandle wraps either a MethodTable* (when !IsTypeDesc) or a tagged
         // TypeDesc*; for non-TypeDesc handles the inner pointer IS the MethodTable address.
         // Patterns like `RuntimeHelpers.GetMethodTable(obj) == TypeHandleOf<T>().AsMethodTable()`

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -240,8 +240,8 @@ module NullaryIlOp =
     let private xorNativeIntSources
         (i1 : NativeIntSource)
         (i2 : NativeIntSource)
-        (counters : PointerHashCounters)
-        : NativeIntSource * PointerHashCounters
+        (counters : PointerHashState)
+        : NativeIntSource * PointerHashState
         =
         match i1, i2 with
         | NativeIntSource.Verbatim a, NativeIntSource.Verbatim b -> NativeIntSource.Verbatim (a ^^^ b), counters
@@ -278,15 +278,15 @@ module NullaryIlOp =
     /// Note that a handle-shaped source does not survive a double complement as
     /// itself: `~~handle` comes back as `OpaqueHashBits`, so comparing that against
     /// the original handle hits `equalsForCli`'s "synthesised hash bits vs handle
-    /// pointer" refusal (CEQ has no `PointerHashCounters` with which to materialise
+    /// pointer" refusal (CEQ has no `PointerHashState` with which to materialise
     /// the handle). That is a property of the hash-synthesis design rather than of
     /// `not`: `xorNativeIntSources` loses handle provenance the same way, so
     /// `(handle ^ 0) ^ 0 == handle` already fails identically. The failure is loud,
     /// and the complemented bits themselves are correct and deterministic.
     let private notNativeIntSource
         (source : NativeIntSource)
-        (counters : PointerHashCounters)
-        : NativeIntSource * PointerHashCounters
+        (counters : PointerHashState)
+        : NativeIntSource * PointerHashState
         =
         match source with
         | NativeIntSource.Verbatim i -> NativeIntSource.Verbatim ~~~i, counters
@@ -439,11 +439,7 @@ module NullaryIlOp =
     let private negInt64Unchecked (value : int64) : int64 =
         0UL - uint64<int64> value |> int64<uint64>
 
-    let private negValue
-        (value : EvalStackValue)
-        (counters : PointerHashCounters)
-        : EvalStackValue * PointerHashCounters
-        =
+    let private negValue (value : EvalStackValue) (counters : PointerHashState) : EvalStackValue * PointerHashState =
         match value with
         | EvalStackValue.Int32 int32Source ->
             let value = Int32Source.value "Neg" int32Source
@@ -1812,11 +1808,11 @@ module NullaryIlOp =
                     let i = Int32Source.value "Shr" int32Source
                     i >>> shift |> Int32Source.Verbatim |> EvalStackValue.Int32, state
                 | EvalStackValue.Int64 i ->
-                    let r, counters = Int64Source.shr "Shr" i shift state.PointerHashCounters
+                    let r, counters = Int64Source.shr "Shr" i shift state.PointerHashState
 
                     EvalStackValue.Int64 r,
                     { state with
-                        PointerHashCounters = counters
+                        PointerHashState = counters
                     }
                 | EvalStackValue.NativeInt (NativeIntSource.Verbatim i) ->
                     (i >>> shift) |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt, state
@@ -1852,11 +1848,11 @@ module NullaryIlOp =
                     |> EvalStackValue.Int32,
                     state
                 | EvalStackValue.Int64 i ->
-                    let r, counters = Int64Source.shrUn "Shr_un" i shift state.PointerHashCounters
+                    let r, counters = Int64Source.shrUn "Shr_un" i shift state.PointerHashState
 
                     EvalStackValue.Int64 r,
                     { state with
-                        PointerHashCounters = counters
+                        PointerHashState = counters
                     }
                 | EvalStackValue.NativeInt (NativeIntSource.Verbatim i) ->
                     (uint64<int64> i >>> shift |> int64<uint64>)
@@ -1890,11 +1886,11 @@ module NullaryIlOp =
                     let i = Int32Source.value "Shl" int32Source
                     i <<< shift |> Int32Source.Verbatim |> EvalStackValue.Int32, state
                 | EvalStackValue.Int64 i ->
-                    let r, counters = Int64Source.shl "Shl" i shift state.PointerHashCounters
+                    let r, counters = Int64Source.shl "Shl" i shift state.PointerHashState
 
                     EvalStackValue.Int64 r,
                     { state with
-                        PointerHashCounters = counters
+                        PointerHashState = counters
                     }
                 | EvalStackValue.NativeInt (NativeIntSource.Verbatim i) ->
                     (i <<< shift) |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt, state
@@ -1939,11 +1935,11 @@ module NullaryIlOp =
                 | EvalStackValue.Int32 (Int32Source.Verbatim mask), EvalStackValue.ManagedPointer ptr ->
                     int64<int32> mask |> andManagedPointerAddressBits state ptr, state
                 | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 ->
-                    let r, counters = Int64Source.bitAnd "And" v1 v2 state.PointerHashCounters
+                    let r, counters = Int64Source.bitAnd "And" v1 v2 state.PointerHashState
 
                     EvalStackValue.Int64 r,
                     { state with
-                        PointerHashCounters = counters
+                        PointerHashState = counters
                     }
                 | EvalStackValue.Int64 mask, EvalStackValue.ManagedPointer ptr -> failwith "TODO"
                 // andManagedPointerAddressBits state ptr mask
@@ -2019,11 +2015,11 @@ module NullaryIlOp =
                 | EvalStackValue.Int32 _, EvalStackValue.NativeInt _ ->
                     failwith $"can't do binary operation on non-verbatim native int {v2}"
                 | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 ->
-                    let r, counters = Int64Source.bitOr "Or" v1 v2 state.PointerHashCounters
+                    let r, counters = Int64Source.bitOr "Or" v1 v2 state.PointerHashState
 
                     EvalStackValue.Int64 r,
                     { state with
-                        PointerHashCounters = counters
+                        PointerHashState = counters
                     }
                 | EvalStackValue.NativeInt (NativeIntSource.Verbatim v1), EvalStackValue.Int32 (Int32Source.Verbatim v2) ->
                     v1 ||| int64<int32> v2 |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt, state
@@ -2057,22 +2053,22 @@ module NullaryIlOp =
                 | EvalStackValue.Int32 _, EvalStackValue.NativeInt _ ->
                     failwith $"can't do binary operation on non-verbatim native int {v2}"
                 | EvalStackValue.Int64 v1, EvalStackValue.Int64 v2 ->
-                    let r, counters = Int64Source.bitXor "Xor" v1 v2 state.PointerHashCounters
+                    let r, counters = Int64Source.bitXor "Xor" v1 v2 state.PointerHashState
 
                     EvalStackValue.Int64 r,
                     { state with
-                        PointerHashCounters = counters
+                        PointerHashState = counters
                     }
                 | EvalStackValue.NativeInt (NativeIntSource.Verbatim v1), EvalStackValue.Int32 (Int32Source.Verbatim v2) ->
                     v1 ^^^ int64<int32> v2 |> NativeIntSource.Verbatim |> EvalStackValue.NativeInt, state
                 | EvalStackValue.NativeInt _, EvalStackValue.Int32 _ ->
                     failwith $"can't do binary operation on non-verbatim native int {v1}"
                 | EvalStackValue.NativeInt src1, EvalStackValue.NativeInt src2 ->
-                    let r, counters = xorNativeIntSources src1 src2 state.PointerHashCounters
+                    let r, counters = xorNativeIntSources src1 src2 state.PointerHashState
 
                     EvalStackValue.NativeInt r,
                     { state with
-                        PointerHashCounters = counters
+                        PointerHashState = counters
                     }
                 | _, _ -> failwith $"refusing to do binary operation on {v1} and {v2}"
 
@@ -2107,11 +2103,11 @@ module NullaryIlOp =
             (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Conv_I1 ->
             let popped, state = IlMachineState.popEvalStack currentThread state
-            let conv, counters = EvalStackValue.convToInt8 popped state.PointerHashCounters
+            let conv, counters = EvalStackValue.convToInt8 popped state.PointerHashState
 
             let state =
                 { state with
-                    PointerHashCounters = counters
+                    PointerHashState = counters
                 }
                 |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 (Int32Source.Verbatim conv)) currentThread
 
@@ -2120,11 +2116,11 @@ module NullaryIlOp =
             (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Conv_I2 ->
             let popped, state = IlMachineState.popEvalStack currentThread state
-            let conv, counters = EvalStackValue.convToInt16 popped state.PointerHashCounters
+            let conv, counters = EvalStackValue.convToInt16 popped state.PointerHashState
 
             let state =
                 { state with
-                    PointerHashCounters = counters
+                    PointerHashState = counters
                 }
                 |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 (Int32Source.Verbatim conv)) currentThread
 
@@ -2134,12 +2130,11 @@ module NullaryIlOp =
         | Conv_I4 ->
             let popped, state = IlMachineState.popEvalStack currentThread state
 
-            let converted, counters =
-                EvalStackValue.convToInt32 popped state.PointerHashCounters
+            let converted, counters = EvalStackValue.convToInt32 popped state.PointerHashState
 
             let state =
                 { state with
-                    PointerHashCounters = counters
+                    PointerHashState = counters
                 }
                 |> IlMachineState.pushToEvalStack' converted currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
@@ -2212,11 +2207,11 @@ module NullaryIlOp =
             (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Conv_U1 ->
             let popped, state = IlMachineState.popEvalStack currentThread state
-            let conv, counters = EvalStackValue.convToUInt8 popped state.PointerHashCounters
+            let conv, counters = EvalStackValue.convToUInt8 popped state.PointerHashState
 
             let state =
                 { state with
-                    PointerHashCounters = counters
+                    PointerHashState = counters
                 }
                 |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 (Int32Source.Verbatim conv)) currentThread
 
@@ -2225,11 +2220,11 @@ module NullaryIlOp =
             (state, WhatWeDid.Executed) |> ExecutionResult.stepped
         | Conv_U2 ->
             let popped, state = IlMachineState.popEvalStack currentThread state
-            let conv, counters = EvalStackValue.convToUInt16 popped state.PointerHashCounters
+            let conv, counters = EvalStackValue.convToUInt16 popped state.PointerHashState
 
             let state =
                 { state with
-                    PointerHashCounters = counters
+                    PointerHashState = counters
                 }
                 |> IlMachineState.pushToEvalStack' (EvalStackValue.Int32 (Int32Source.Verbatim conv)) currentThread
 
@@ -2239,12 +2234,11 @@ module NullaryIlOp =
         | Conv_U4 ->
             let popped, state = IlMachineState.popEvalStack currentThread state
 
-            let converted, counters =
-                EvalStackValue.convToUInt32 popped state.PointerHashCounters
+            let converted, counters = EvalStackValue.convToUInt32 popped state.PointerHashState
 
             let state =
                 { state with
-                    PointerHashCounters = counters
+                    PointerHashState = counters
                 }
                 |> IlMachineState.pushToEvalStack' converted currentThread
                 |> IlMachineState.advanceProgramCounter currentThread
@@ -2741,11 +2735,11 @@ module NullaryIlOp =
                 |> ExecutionResult.stepped
         | Neg ->
             let val1, state = IlMachineState.popEvalStack currentThread state
-            let result, counters = negValue val1 state.PointerHashCounters
+            let result, counters = negValue val1 state.PointerHashState
 
             let state =
                 { state with
-                    PointerHashCounters = counters
+                    PointerHashState = counters
                 }
 
             state
@@ -2762,21 +2756,21 @@ module NullaryIlOp =
                     let i = Int32Source.value "Not" int32Source
                     ~~~i |> Int32Source.Verbatim |> EvalStackValue.Int32, state
                 | EvalStackValue.Int64 i ->
-                    let r, counters = Int64Source.bitNot "Not" i state.PointerHashCounters
+                    let r, counters = Int64Source.bitNot "Not" i state.PointerHashState
 
                     EvalStackValue.Int64 r,
                     { state with
-                        PointerHashCounters = counters
+                        PointerHashState = counters
                     }
                 | EvalStackValue.NativeInt src ->
                     // ECMA-335 III.3.35: `not` is defined on native ints. The BCL reaches
                     // this through the unrolled loops that round a count down to a multiple
                     // of a power of two, e.g. `numElements & ~(nuint)7` in SpanHelpers.Fill.
-                    let r, counters = notNativeIntSource src state.PointerHashCounters
+                    let r, counters = notNativeIntSource src state.PointerHashState
 
                     EvalStackValue.NativeInt r,
                     { state with
-                        PointerHashCounters = counters
+                        PointerHashState = counters
                     }
                 | EvalStackValue.ManagedPointer _
                 | EvalStackValue.NullObjectRef

--- a/WoofWare.PawPrint/PointerHashSynthesis.fs
+++ b/WoofWare.PawPrint/PointerHashSynthesis.fs
@@ -41,66 +41,58 @@ type CanonicalPointerKey =
     | ModuleHandle of string
     | MetadataImportHandle of string
 
-/// How a canonical pointer key that has not been seen before acquires its
-/// synthesised address bits.
+/// The rule by which a canonical pointer key acquires synthesised address bits,
+/// together with whatever state that rule needs. Each case owns its own state, so
+/// a run cannot be carrying bookkeeping that belongs to a rule it is not using.
 ///
-/// This is a *choice* PawPrint has made, not a fact about CoreCLR, and it is
-/// recorded as a DU so that the choice is visible at the point it is made and so
-/// that adding a second case cannot compile until every site that has to decide
-/// between them has been updated. There is exactly one case today.
+/// Which rule to use is a *choice* PawPrint has made, not a fact about CoreCLR. It
+/// is a DU so that the choice is visible where it is made, and so that adding a
+/// second case cannot compile until every site that has to decide between them has
+/// been updated. There is exactly one case today.
 ///
 /// The known alternative is a keyed scheme — derive the bits by hashing the
-/// `CanonicalPointerKey` itself, with no counter and no assignment order at all.
-/// Its advantage is that it is immune to first-touch-order desync: under
-/// `SequentialFirstTouch`, a change that materialises one extra key early in a run
-/// shifts the bits of every key materialised after it, so two nearly-identical
-/// runs diverge in every synthesised pointer value rather than in the one that
-/// actually changed. That is a real cost when diffing runs (mutation testing,
-/// delta debugging). It is not the default because the correlation between
-/// assignment order and address order is load-bearing: CoreCLR's cast-cache
-/// pipeline hashes real pointer bits whose ordering is an artefact of allocation
-/// order, and `SequentialFirstTouch` reproduces that shape where a hash of the
-/// identity would not. A keyed scheme would also have to establish
+/// `CanonicalPointerKey` itself, with no counter, no assignment order and no
+/// memo table at all. Its advantage is that it is immune to first-touch-order
+/// desync: under `SequentialFirstTouch`, a change that materialises one extra key
+/// early in a run shifts the bits of every key materialised after it, so two
+/// nearly-identical runs diverge in every synthesised pointer value rather than in
+/// the one that actually changed. That is a real cost when diffing runs (mutation
+/// testing, delta debugging). It is not the default because the correlation
+/// between assignment order and address order is load-bearing: CoreCLR's
+/// cast-cache pipeline hashes real pointer bits whose ordering is an artefact of
+/// allocation order, and `SequentialFirstTouch` reproduces that shape where a hash
+/// of the identity would not. A keyed scheme would also have to establish
 /// collision-freedom explicitly, which the counter gets by construction.
+///
+/// Whichever rule is in force is part of a run's replay contract: changing it
+/// changes every synthesised pointer value the guest observes.
 [<RequireQualifiedAccess>]
-type PointerHashAssignment =
+type PointerHashCounters =
     /// The nth distinct key to be materialised is assigned counter `n` and stores
     /// address bits `(n + 1) <<< 2`, so bits follow first-touch order and distinct
-    /// keys cannot collide. `PointerHashCounters.NextCounter` holds the live `n`.
-    | SequentialFirstTouch
-
-/// Assignment of synthesised bits to canonical pointer keys, under the rule named
-/// by `Assignment`. Under the only rule that exists today, the first time a key is
-/// materialised it is assigned counter `n` and stores address bits `(n + 1) <<< 2`.
-/// Subsequent materialisations of the same key return those same stored bits. Tag
-/// bits are NOT stored: they are a view over the identity, so `materialiseHashBits`
-/// OR-s them on per source, which is what lets two differently-tagged views of one
-/// identity (a `TypeHandlePtr` and the `TypeDescPtr` masked out of it; an untagged
-/// and a tagged GC handle) share address bits and differ only in the low region.
-///
-/// Distinct keys get distinct bit patterns by construction (no collisions),
-/// and the assignment order is deterministic given a fixed program and
-/// scheduler. This is the load-bearing property that makes synthesised hash
-/// bits a faithful guest-observable surrogate for real pointer bits in the
-/// CoreCLR cast-cache pipeline.
-type PointerHashCounters =
-    {
-        /// Rule used to mint bits for a key not already in `Assigned`. Fixed for
-        /// the lifetime of a run, and part of that run's replay contract: changing
-        /// it changes every synthesised pointer value the guest observes.
-        Assignment : PointerHashAssignment
-        NextCounter : uint64
-        Assigned : Map<CanonicalPointerKey, uint64>
-    }
+    /// keys cannot collide. Subsequent materialisations of the same key return the
+    /// same stored bits, which is what `assigned` memoises — the bits are a
+    /// function of assignment order, so they cannot be recomputed from the key.
+    ///
+    /// Tag bits are NOT stored: they are a view over the identity, so
+    /// `materialiseHashBits` OR-s them on per source, which is what lets two
+    /// differently-tagged views of one identity (a `TypeHandlePtr` and the
+    /// `TypeDescPtr` masked out of it; an untagged and a tagged GC handle) share
+    /// address bits and differ only in the low region. The counter scheme leaves
+    /// the low 2 bits clear for exactly this, so no-collision is preserved.
+    ///
+    /// Distinct keys get distinct bit patterns by construction, and the assignment
+    /// order is deterministic given a fixed program and scheduler. This is the
+    /// load-bearing property that makes synthesised hash bits a faithful
+    /// guest-observable surrogate for real pointer bits in the CoreCLR cast-cache
+    /// pipeline.
+    | SequentialFirstTouch of nextCounter : uint64 * assigned : Map<CanonicalPointerKey, uint64>
 
 [<RequireQualifiedAccess>]
 module PointerHashCounters =
+    /// A fresh fixture, assigning bits by first-touch order.
     let empty : PointerHashCounters =
-        {
-            Assignment = PointerHashAssignment.SequentialFirstTouch
-            NextCounter = 0UL
-            Assigned = Map.empty
-        }
+        PointerHashCounters.SequentialFirstTouch (0UL, Map.empty)
 
 [<RequireQualifiedAccess>]
 module PointerHashSynthesis =
@@ -214,7 +206,7 @@ module PointerHashSynthesis =
     /// helper — those should have been handled by the caller before they
     /// got here.
     ///
-    /// Determinism: under `PointerHashAssignment.SequentialFirstTouch`, bits
+    /// Determinism: under `PointerHashCounters.SequentialFirstTouch`, bits
     /// depend only on the canonical key and the order in which keys are first
     /// registered. The result is stable for a given execution trace and
     /// reproducible across runs with the same scheduler.
@@ -253,24 +245,20 @@ module PointerHashSynthesis =
         | _ ->
             let key = canonicalKey src
 
-            // Low bits are a view over an identity, not part of it, so the map
+            // Low bits are a view over an identity, not part of it, so the memo
             // stores address bits alone and the tag is OR-ed on at the end. The
             // counter scheme leaves the low 2 bits clear for exactly this, so the
             // no-collision property is preserved.
             let tagBits = lowBitsForSource src
 
-            match Map.tryFind key counters.Assigned with
-            | Some bits -> Operators.int64 (bits ||| tagBits), counters
-            | None ->
-                match counters.Assignment with
-                | PointerHashAssignment.SequentialFirstTouch ->
-                    let n = counters.NextCounter
-                    let bits = (n + 1UL) <<< 2
+            match counters with
+            | PointerHashCounters.SequentialFirstTouch (nextCounter, assigned) ->
+                match Map.tryFind key assigned with
+                | Some bits -> Operators.int64 (bits ||| tagBits), counters
+                | None ->
+                    let bits = (nextCounter + 1UL) <<< 2
 
                     let counters' =
-                        { counters with
-                            NextCounter = n + 1UL
-                            Assigned = Map.add key bits counters.Assigned
-                        }
+                        PointerHashCounters.SequentialFirstTouch (nextCounter + 1UL, Map.add key bits assigned)
 
                     Operators.int64 (bits ||| tagBits), counters'

--- a/WoofWare.PawPrint/PointerHashSynthesis.fs
+++ b/WoofWare.PawPrint/PointerHashSynthesis.fs
@@ -41,14 +41,42 @@ type CanonicalPointerKey =
     | ModuleHandle of string
     | MetadataImportHandle of string
 
-/// Counter-based assignment of synthesised bits to canonical pointer keys.
-/// The first time a key is materialised, it is assigned counter `n` and stores
-/// address bits `(n + 1) <<< 2`. Subsequent materialisations of the same key
-/// return those same stored bits. Tag bits are NOT stored: they are a view over
-/// the identity, so `materialiseHashBits` OR-s them on per source, which is what
-/// lets two differently-tagged views of one identity (a `TypeHandlePtr` and the
-/// `TypeDescPtr` masked out of it; an untagged and a tagged GC handle) share
-/// address bits and differ only in the low region.
+/// How a canonical pointer key that has not been seen before acquires its
+/// synthesised address bits.
+///
+/// This is a *choice* PawPrint has made, not a fact about CoreCLR, and it is
+/// recorded as a DU so that the choice is visible at the point it is made and so
+/// that adding a second case cannot compile until every site that has to decide
+/// between them has been updated. There is exactly one case today.
+///
+/// The known alternative is a keyed scheme — derive the bits by hashing the
+/// `CanonicalPointerKey` itself, with no counter and no assignment order at all.
+/// Its advantage is that it is immune to first-touch-order desync: under
+/// `SequentialFirstTouch`, a change that materialises one extra key early in a run
+/// shifts the bits of every key materialised after it, so two nearly-identical
+/// runs diverge in every synthesised pointer value rather than in the one that
+/// actually changed. That is a real cost when diffing runs (mutation testing,
+/// delta debugging). It is not the default because the correlation between
+/// assignment order and address order is load-bearing: CoreCLR's cast-cache
+/// pipeline hashes real pointer bits whose ordering is an artefact of allocation
+/// order, and `SequentialFirstTouch` reproduces that shape where a hash of the
+/// identity would not. A keyed scheme would also have to establish
+/// collision-freedom explicitly, which the counter gets by construction.
+[<RequireQualifiedAccess>]
+type PointerHashAssignment =
+    /// The nth distinct key to be materialised is assigned counter `n` and stores
+    /// address bits `(n + 1) <<< 2`, so bits follow first-touch order and distinct
+    /// keys cannot collide. `PointerHashCounters.NextCounter` holds the live `n`.
+    | SequentialFirstTouch
+
+/// Assignment of synthesised bits to canonical pointer keys, under the rule named
+/// by `Assignment`. Under the only rule that exists today, the first time a key is
+/// materialised it is assigned counter `n` and stores address bits `(n + 1) <<< 2`.
+/// Subsequent materialisations of the same key return those same stored bits. Tag
+/// bits are NOT stored: they are a view over the identity, so `materialiseHashBits`
+/// OR-s them on per source, which is what lets two differently-tagged views of one
+/// identity (a `TypeHandlePtr` and the `TypeDescPtr` masked out of it; an untagged
+/// and a tagged GC handle) share address bits and differ only in the low region.
 ///
 /// Distinct keys get distinct bit patterns by construction (no collisions),
 /// and the assignment order is deterministic given a fixed program and
@@ -57,6 +85,10 @@ type CanonicalPointerKey =
 /// CoreCLR cast-cache pipeline.
 type PointerHashCounters =
     {
+        /// Rule used to mint bits for a key not already in `Assigned`. Fixed for
+        /// the lifetime of a run, and part of that run's replay contract: changing
+        /// it changes every synthesised pointer value the guest observes.
+        Assignment : PointerHashAssignment
         NextCounter : uint64
         Assigned : Map<CanonicalPointerKey, uint64>
     }
@@ -65,6 +97,7 @@ type PointerHashCounters =
 module PointerHashCounters =
     let empty : PointerHashCounters =
         {
+            Assignment = PointerHashAssignment.SequentialFirstTouch
             NextCounter = 0UL
             Assigned = Map.empty
         }
@@ -181,10 +214,10 @@ module PointerHashSynthesis =
     /// helper — those should have been handled by the caller before they
     /// got here.
     ///
-    /// Determinism: bits depend only on the canonical key and the order
-    /// in which keys are first registered. The result is stable for a
-    /// given execution trace and reproducible across runs with the same
-    /// scheduler.
+    /// Determinism: under `PointerHashAssignment.SequentialFirstTouch`, bits
+    /// depend only on the canonical key and the order in which keys are first
+    /// registered. The result is stable for a given execution trace and
+    /// reproducible across runs with the same scheduler.
     ///
     /// Returned as `int64` to match `Int64Source.OpaqueHashBits` storage;
     /// the conversion from the uint64 bit pattern is an unchecked
@@ -229,13 +262,15 @@ module PointerHashSynthesis =
             match Map.tryFind key counters.Assigned with
             | Some bits -> Operators.int64 (bits ||| tagBits), counters
             | None ->
-                let n = counters.NextCounter
-                let bits = (n + 1UL) <<< 2
+                match counters.Assignment with
+                | PointerHashAssignment.SequentialFirstTouch ->
+                    let n = counters.NextCounter
+                    let bits = (n + 1UL) <<< 2
 
-                let counters' =
-                    {
-                        NextCounter = n + 1UL
-                        Assigned = Map.add key bits counters.Assigned
-                    }
+                    let counters' =
+                        { counters with
+                            NextCounter = n + 1UL
+                            Assigned = Map.add key bits counters.Assigned
+                        }
 
-                Operators.int64 (bits ||| tagBits), counters'
+                    Operators.int64 (bits ||| tagBits), counters'

--- a/WoofWare.PawPrint/PointerHashSynthesis.fs
+++ b/WoofWare.PawPrint/PointerHashSynthesis.fs
@@ -67,7 +67,7 @@ type CanonicalPointerKey =
 /// Whichever rule is in force is part of a run's replay contract: changing it
 /// changes every synthesised pointer value the guest observes.
 [<RequireQualifiedAccess>]
-type PointerHashCounters =
+type PointerHashState =
     /// The nth distinct key to be materialised is assigned counter `n` and stores
     /// address bits `(n + 1) <<< 2`, so bits follow first-touch order and distinct
     /// keys cannot collide. Subsequent materialisations of the same key return the
@@ -89,10 +89,10 @@ type PointerHashCounters =
     | SequentialFirstTouch of nextCounter : uint64 * assigned : Map<CanonicalPointerKey, uint64>
 
 [<RequireQualifiedAccess>]
-module PointerHashCounters =
+module PointerHashState =
     /// A fresh fixture, assigning bits by first-touch order.
-    let empty : PointerHashCounters =
-        PointerHashCounters.SequentialFirstTouch (0UL, Map.empty)
+    let empty : PointerHashState =
+        PointerHashState.SequentialFirstTouch (0UL, Map.empty)
 
 [<RequireQualifiedAccess>]
 module PointerHashSynthesis =
@@ -206,7 +206,7 @@ module PointerHashSynthesis =
     /// helper — those should have been handled by the caller before they
     /// got here.
     ///
-    /// Determinism: under `PointerHashCounters.SequentialFirstTouch`, bits
+    /// Determinism: under `PointerHashState.SequentialFirstTouch`, bits
     /// depend only on the canonical key and the order in which keys are first
     /// registered. The result is stable for a given execution trace and
     /// reproducible across runs with the same scheduler.
@@ -217,8 +217,8 @@ module PointerHashSynthesis =
     let materialiseHashBits
         (reason : string)
         (src : NativeIntSource)
-        (counters : PointerHashCounters)
-        : int64 * PointerHashCounters
+        (counters : PointerHashState)
+        : int64 * PointerHashState
         =
         match src with
         | NativeIntSource.Verbatim n -> n, counters
@@ -252,13 +252,13 @@ module PointerHashSynthesis =
             let tagBits = lowBitsForSource src
 
             match counters with
-            | PointerHashCounters.SequentialFirstTouch (nextCounter, assigned) ->
+            | PointerHashState.SequentialFirstTouch (nextCounter, assigned) ->
                 match Map.tryFind key assigned with
                 | Some bits -> Operators.int64 (bits ||| tagBits), counters
                 | None ->
                     let bits = (nextCounter + 1UL) <<< 2
 
                     let counters' =
-                        PointerHashCounters.SequentialFirstTouch (nextCounter + 1UL, Map.add key bits assigned)
+                        PointerHashState.SequentialFirstTouch (nextCounter + 1UL, Map.add key bits assigned)
 
                     Operators.int64 (bits ||| tagBits), counters'


### PR DESCRIPTION
`PointerHashSynthesis` mints synthesised address bits for a canonical pointer key
by handing out counters in first-touch order. That is a design decision with a
real trade-off, not a fact about CoreCLR — but nothing in the code said so: the
counter was simply what the assignment site did.

This makes the choice explicit, so that the alternative stays visible and a
second rule cannot be added without the compiler pointing at every site that has
to decide between them. **No behaviour change.**

## The trade-off being recorded

First-touch assignment is *order-dependent*: materialising one extra key early in
a run shifts the bits of every key materialised after it. Two nearly-identical
runs therefore diverge in every synthesised pointer value rather than in the one
that actually changed, which is a real cost when diffing runs (mutation testing,
delta debugging).

The alternative is a keyed rule — bits as a pure hash of the
`CanonicalPointerKey`, with no counter, no assignment order and no memo table.
It is immune to that desync, but it discards the correlation between assignment
order and address order, and that correlation is load-bearing: CoreCLR's
cast-cache pipeline hashes real pointer bits whose ordering is an artefact of
allocation order. It would also have to establish collision-freedom explicitly,
which the counter gets by construction.

So the counter stays the rule. It is now *named* as one.

## Commits

1. **`Record pointer-hash bit assignment as an explicit choice`** — introduces
   the DU with a single case, alongside the existing fields.
2. **`Move the counter state inside the assignment rule that owns it`** —
   collapses the record into the DU: `SequentialFirstTouch of nextCounter *
   assigned`. `NextCounter` and `Assigned` exist *only* because bits are minted
   from a counter in first-touch order; a keyed rule needs neither, so leaving
   them as siblings of a rule tag would be a representable illegal state. The
   memo lookup moves inside the case, which is where it belongs — it is not
   shared infrastructure, it is what makes an order-dependent assignment
   reproducible.
3. **`Rename PointerHashCounters to PointerHashState`** — the type is now a DU
   over rules, so naming it after the state one rule happens to carry asserts
   exactly what the first two commits set out to stop asserting. Pure identifier
   substitution plus fantomas reflow; three comments that called it "the
   `PointerHashCounters` map" now say "the assignments held in
   `PointerHashState`", since it is neither a record nor a map any more.

Reviewing commit-by-commit is easier than the squashed diff — commit 3 is 199
mechanical occurrences.

## Notes for review

- Test accessors live in a new `WoofWare.PawPrint.Test/PointerHashTestHelpers.fs`
  rather than beside the type, deliberately: they have nothing to return under a
  keyed rule. Their `match` failing to compile when a second case lands is the
  correct outcome, because the assertions they serve — counter ordering — would
  not describe the new case either.
- `TestPointerHashSynthesis.``a fresh fixture assigns bits by first-touch order,
  with nothing assigned yet``` is vacuous today and its comment says so; it
  becomes load-bearing when a second case exists, because the default rule is
  part of a run's replay contract.
- The two dated `docs/plans/` files mentioning the old name are left untouched:
  they record what the design looked like when they were written.

## Verification

Full suite green (2412 passed, 0 failed) before and after the rename.
`codex review --base origin/main` run twice — after commit 2 and again on the
final branch — no findings either time.

## Follow-up

This is the first of three pieces from a conversation about splitting PawPrint's
entropy so that a change in one area stops desyncing everything downstream. The
one that actually matters is next: the PCT scheduler draws all three of its
decisions (priority sampling, demotion Bernoulli, yield-honour Bernoulli) from a
single stream whose position *is* the global step count, so any change to any
thread's instruction count reshuffles every other thread's schedule. Keying those
on `(seed, tag, threadId, perThreadCounter)` fixes it, and needs a per-thread step
counter on `ThreadState` — only the global `EmulatedKernel.StepCounter` exists
today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)