### PR TITLE
Name a scheduler test for what it asserts, not for the diff that added it

### DIFF
--- a/WoofWare.PawPrint.Test/TestSchedulerYieldDebt.fs
+++ b/WoofWare.PawPrint.Test/TestSchedulerYieldDebt.fs
@@ -429,9 +429,11 @@ module TestSchedulerYieldDebt =
         withPeer |> shouldEqual expected
 
     [<Test>]
-    let ``a Pct run with no yields consumes the RNG exactly as before`` () : unit =
-        // Property 4 from the plan: the filter itself must draw nothing, so a guest that never
-        // yields replays bit-identically against seeds recorded before this change.
+    let ``a Pct run with no yields consumes no RNG`` () : unit =
+        // The fairness filter draws nothing of its own: only an honoured yield consults the
+        // policy's coin. So a guest that never yields consumes the seed at exactly the rate
+        // `chooseNext` alone would, and its schedule is a function of the seed and the guest,
+        // not of whether the filter exists.
         let state =
             baseState () |> withThreads (runnable 3) |> IlMachineState.withPctSeed 99UL
 


### PR DESCRIPTION
Follow-up to the comment cleanup in #850, which covered that branch's own text. This is the remaining site in the earlier #844 work.

`a Pct run with no yields consumes the RNG exactly as before` names a comparison to a state of the code that no longer exists, and its comment cited "Property 4 from the plan" — a scratch document that was never in the repository, so the reference points nowhere a reader can follow.

Renamed to `consumes no RNG`, with the invariant stated directly: only an honoured yield consults the policy's coin, so a guest that never yields consumes the seed at exactly the rate `chooseNext` alone would, and its schedule is a function of the seed and the guest rather than of whether the filter exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)