### PR TITLE
Read portable PDB sequence points alongside each assembly

### DIFF
--- a/WoofWare.PawPrint.Domain/Assembly.fs
+++ b/WoofWare.PawPrint.Domain/Assembly.fs
@@ -965,6 +965,20 @@ module Assembly =
             FullPath : string
             Length : int64
             LastWriteTimeUtc : DateTime
+
+            /// <summary>
+            /// Length and last-write time of the side-by-side <c>.pdb</c>, or <c>None</c> when
+            /// there isn't one. A cached parse carries that PDB's sequence points, so a PDB
+            /// added, removed or rebuilt without the assembly changing must miss the cache —
+            /// otherwise the first caller's symbols (or lack of them) are served forever.
+            /// </summary>
+            /// <remarks>
+            /// Sound only because <c>PortablePdb.sidecarPath</c> is the single path a read will
+            /// consider: were symbols searched for, this key could not describe what was found.
+            /// An embedded PDB needs no such treatment, being part of the image already covered
+            /// by <c>Length</c> and <c>LastWriteTimeUtc</c>.
+            /// </remarks>
+            SidecarPdb : (int64 * DateTime) option
         }
 
     /// Process-lifetime cache for explicit file-backed reads. The parsed metadata is
@@ -1194,11 +1208,17 @@ module Assembly =
 
     let private fileCacheKey (path : string) : AssemblyFileCacheKey =
         let fileInfo = FileInfo path
+        let pdbInfo = FileInfo (PortablePdb.sidecarPath fileInfo.FullName)
 
         {
             FullPath = fileInfo.FullName
             Length = fileInfo.Length
             LastWriteTimeUtc = fileInfo.LastWriteTimeUtc
+            SidecarPdb =
+                if pdbInfo.Exists then
+                    Some (pdbInfo.Length, pdbInfo.LastWriteTimeUtc)
+                else
+                    None
         }
 
     let private withLogger

--- a/WoofWare.PawPrint.Domain/Assembly.fs
+++ b/WoofWare.PawPrint.Domain/Assembly.fs
@@ -227,6 +227,20 @@ type DumpedAssembly =
         ContentHash : ImmutableArray<byte>
 
         /// <summary>
+        /// Sequence points from this assembly's portable PDB — embedded in the image, or a
+        /// side-by-side <c>.pdb</c> when the assembly was read from a path — keyed by the
+        /// method definition they describe. Empty when the image carries no debug information,
+        /// which is the normal case for the shared framework.
+        /// </summary>
+        /// <remarks>
+        /// Parsed during <c>Assembly.read</c> and held as plain data, so it outlives both the
+        /// stream the caller handed us and this record's own <c>PeReader</c>. Diagnostics are
+        /// the only consumer: nothing about the guest's behaviour may depend on whether symbols
+        /// happened to be present, because that varies with how the guest was built.
+        /// </remarks>
+        SequencePoints : ImmutableDictionary<ComparableMethodDefinitionHandle, MethodSequencePoints>
+
+        /// <summary>
         /// Dictionary of all custom attributes in this assembly, keyed by their handle.
         /// </summary>
         Attributes : ImmutableDictionary<CustomAttributeHandle, WoofWare.PawPrint.CustomAttribute>
@@ -729,6 +743,15 @@ type DumpedAssembly =
         | false, _ -> None
         | true, v -> Some v
 
+    /// <summary>
+    /// The source span the compiler attributed to <paramref name="ilOffset" /> within
+    /// <paramref name="method" />, if this assembly came with debug information covering it.
+    /// </summary>
+    member this.TryResolveSourceLocation (method : MethodDefinitionHandle) (ilOffset : int) : SourceLocation option =
+        match this.SequencePoints.TryGetValue (ComparableMethodDefinitionHandle.Make method) with
+        | false, _ -> None
+        | true, points -> MethodSequencePoints.resolve ilOffset points
+
     interface IDisposable with
         member this.Dispose () =
             if this.OwnsPeReader then
@@ -1117,6 +1140,11 @@ module Assembly =
 
         let logger = loggerFactory.CreateLogger assy.Name.Name
 
+        // Must happen here for the same reason `contentHash` does: callers own the stream they
+        // handed us. Parsing eagerly additionally decouples the result from `peReader`, which
+        // this record's `Dispose` may close while the parsed assembly lives on.
+        let sequencePoints = PortablePdb.readSequencePoints logger peReader originalPath
+
         let friends =
             let input : FriendAssembliesScanInput =
                 {
@@ -1151,6 +1179,7 @@ module Assembly =
             PeReader = peReader
             OwnsPeReader = true
             ContentHash = contentHash
+            SequencePoints = sequencePoints
             Attributes = attrs
             CustomAttributesByParentToken = customAttributesByParentToken
             ExportedTypes = exportedTypes

--- a/WoofWare.PawPrint.Domain/Assembly.fs
+++ b/WoofWare.PawPrint.Domain/Assembly.fs
@@ -1208,17 +1208,18 @@ module Assembly =
 
     let private fileCacheKey (path : string) : AssemblyFileCacheKey =
         let fileInfo = FileInfo path
-        let pdbInfo = FileInfo (PortablePdb.sidecarPath fileInfo.FullName)
+
+        let pdbInfo = PortablePdb.sidecarPath fileInfo.FullName |> Option.map FileInfo
 
         {
             FullPath = fileInfo.FullName
             Length = fileInfo.Length
             LastWriteTimeUtc = fileInfo.LastWriteTimeUtc
             SidecarPdb =
-                if pdbInfo.Exists then
-                    Some (pdbInfo.Length, pdbInfo.LastWriteTimeUtc)
-                else
-                    None
+                match pdbInfo with
+                | Some pdbInfo when pdbInfo.Exists -> Some (pdbInfo.Length, pdbInfo.LastWriteTimeUtc)
+                | Some _
+                | None -> None
         }
 
     let private withLogger

--- a/WoofWare.PawPrint.Domain/SequencePoint.fs
+++ b/WoofWare.PawPrint.Domain/SequencePoint.fs
@@ -133,19 +133,22 @@ module PortablePdb =
     /// <para>
     /// Deliberately a single fixed path rather than a search. It is also the assembly parse
     /// cache's notion of "the symbols for this assembly" (see <c>AssemblyFileCacheKey</c>), and
-    /// that cache can only stay honest about symbols changing underneath it if the set of files
-    /// that could have been read is exactly this one. Deriving the path from the image's
-    /// CodeView entry instead — which is what a debugger does — would be more faithful, but the
-    /// cache key is computed from a path alone and cannot open the image to find out.
+    /// that cache can only stay honest about symbols changing underneath it if the file a read
+    /// could have consulted is exactly this one.
     /// </para>
     /// <para>
-    /// The cost of that trade is an assembly file renamed after it was built: its CodeView entry
-    /// still names the original PDB, we look for one matching the new name, and it silently
-    /// loses its symbols. An embedded PDB travels with the image and is unaffected.
+    /// <c>None</c> when <paramref name="assemblyPath" /> cannot be interpreted as a path at all.
+    /// Callers hand us whatever they were given, which for an in-memory image may be a
+    /// descriptive label rather than a filename; that must cost the symbols and nothing more.
     /// </para>
     /// </remarks>
-    let sidecarPath (assemblyPath : string) : string =
-        Path.GetFullPath (Path.ChangeExtension (assemblyPath, ".pdb"))
+    let sidecarPath (assemblyPath : string) : string option =
+        try
+            Some (Path.GetFullPath (Path.ChangeExtension (assemblyPath, ".pdb")))
+        with
+        | :? ArgumentException
+        | :? NotSupportedException
+        | :? PathTooLongException -> None
 
     /// <summary>
     /// Open this image's portable PDB, if it has one: a PDB embedded in the PE itself, or —
@@ -165,41 +168,46 @@ module PortablePdb =
         | Some entry -> Some (peReader.ReadEmbeddedPortablePdbDebugDirectoryData entry)
         | None ->
 
-        match originalPath with
-        | None -> None
-        | Some path ->
-            let wanted = sidecarPath path
+        match originalPath, Option.bind sidecarPath originalPath with
+        | None, _ -> None
+        | Some path, None ->
+            logger.LogDebug ("Not looking for symbols: {AssemblyPath} is not usable as a filesystem path", path)
 
-            // TryOpenAssociatedPortablePdb checks that the PDB it finds actually belongs to this
-            // image (the CodeView GUID must match), so a stale .pdb left beside a rebuilt
-            // assembly is rejected rather than silently misattributing every line in it.
-            let opener =
-                Func<string, Stream> (fun candidate ->
-                    try
-                        // SRM offers several candidates, among them the *absolute path recorded
-                        // in the image's own CodeView entry* — which names the machine that built
-                        // it. Accept only the conventional sidecar: PawPrint has no business
-                        // opening files at paths chosen by a third-party binary, and the parse
-                        // cache cannot account for any path but this one.
-                        if String.Equals (Path.GetFullPath candidate, wanted, StringComparison.Ordinal) then
-                            File.OpenRead candidate :> Stream
-                        else
-                            null
-                    with
-                    | :? IOException
-                    | :? UnauthorizedAccessException
-                    | :? ArgumentException
-                    | :? NotSupportedException ->
-                        // "No readable PDB beside the assembly" is the overwhelmingly common
-                        // case, not an error: null tells SRM to carry on to the next candidate.
+            None
+        | Some path, Some wanted ->
+
+        // TryOpenAssociatedPortablePdb checks that the PDB it is given actually belongs to this
+        // image (the CodeView GUID must match), so a stale .pdb left beside a rebuilt assembly is
+        // rejected rather than silently misattributing every line in it. That check is the whole
+        // reason to route through SRM rather than opening the file ourselves.
+        //
+        // Its *search*, on the other hand, we want no part of: it offers candidate paths derived
+        // from the image's own CodeView entry, including the absolute path on the machine that
+        // built it. So the provider ignores what it is asked for and answers with the one file we
+        // are willing to read. Filtering SRM's candidates by comparing paths would instead have
+        // to decide whether this filesystem is case-sensitive — and get it right, or lose the
+        // symbols of any assembly opened under different casing from the name the compiler
+        // recorded.
+        let opener =
+            Func<string, Stream> (fun _candidate ->
+                try
+                    if File.Exists wanted then
+                        File.OpenRead wanted :> Stream
+                    else
                         null
-                )
+                with
+                | :? IOException
+                | :? UnauthorizedAccessException ->
+                    // "No readable PDB beside the assembly" is the overwhelmingly common case,
+                    // not an error: null tells SRM there is nothing here.
+                    null
+            )
 
-            match peReader.TryOpenAssociatedPortablePdb (path, opener) with
-            | true, provider, _ when not (isNull provider) -> Some provider
-            | _ ->
-                logger.LogDebug ("No portable PDB found for assembly at {AssemblyPath}", path)
-                None
+        match peReader.TryOpenAssociatedPortablePdb (path, opener) with
+        | true, provider, _ when not (isNull provider) -> Some provider
+        | _ ->
+            logger.LogDebug ("No portable PDB found for assembly at {AssemblyPath}", path)
+            None
 
     /// <summary>
     /// Sequence points for every method in this image that has any, keyed by method definition
@@ -320,6 +328,25 @@ module PortablePdb =
         | :? UnauthorizedAccessException as e ->
             logger.LogWarning (
                 "Not permitted to read debug information for assembly at {AssemblyPath}: {DebugInfoError}",
+                describe originalPath,
+                e.Message
+            )
+
+            ImmutableDictionary.Empty
+        // `sidecarPath` has already rejected paths it cannot normalise, so these are a backstop
+        // rather than a known route: SRM validates the path it is handed too, and the invariant
+        // that matters is that *nothing* about optional symbols can refuse an assembly.
+        | :? ArgumentException as e ->
+            logger.LogWarning (
+                "Could not look for debug information for assembly at {AssemblyPath}: {DebugInfoError}",
+                describe originalPath,
+                e.Message
+            )
+
+            ImmutableDictionary.Empty
+        | :? NotSupportedException as e ->
+            logger.LogWarning (
+                "Could not look for debug information for assembly at {AssemblyPath}: {DebugInfoError}",
                 describe originalPath,
                 e.Message
             )

--- a/WoofWare.PawPrint.Domain/SequencePoint.fs
+++ b/WoofWare.PawPrint.Domain/SequencePoint.fs
@@ -69,11 +69,6 @@ type MethodSequencePoints =
 [<RequireQualifiedAccess>]
 module MethodSequencePoints =
 
-    let empty : MethodSequencePoints =
-        {
-            _Points = ImmutableArray.Empty
-        }
-
     /// <summary>
     /// Index the supplied points for lookup. Sorting is stable, so where several points share an
     /// IL offset the input order decides which one <c>resolve</c> reports.
@@ -124,9 +119,37 @@ module MethodSequencePoints =
 [<RequireQualifiedAccess>]
 module PortablePdb =
 
+    let private describe (originalPath : string option) : string =
+        match originalPath with
+        | None -> "<in-memory image>"
+        | Some path -> path
+
+    /// <summary>
+    /// The one side-by-side PDB path PawPrint will consider for an assembly read from
+    /// <paramref name="assemblyPath" />: the conventional <c>.pdb</c> beside it, which is what
+    /// the SDK's default <c>DebugType=portable</c> emits.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Deliberately a single fixed path rather than a search. It is also the assembly parse
+    /// cache's notion of "the symbols for this assembly" (see <c>AssemblyFileCacheKey</c>), and
+    /// that cache can only stay honest about symbols changing underneath it if the set of files
+    /// that could have been read is exactly this one. Deriving the path from the image's
+    /// CodeView entry instead — which is what a debugger does — would be more faithful, but the
+    /// cache key is computed from a path alone and cannot open the image to find out.
+    /// </para>
+    /// <para>
+    /// The cost of that trade is an assembly file renamed after it was built: its CodeView entry
+    /// still names the original PDB, we look for one matching the new name, and it silently
+    /// loses its symbols. An embedded PDB travels with the image and is unaffected.
+    /// </para>
+    /// </remarks>
+    let sidecarPath (assemblyPath : string) : string =
+        Path.GetFullPath (Path.ChangeExtension (assemblyPath, ".pdb"))
+
     /// <summary>
     /// Open this image's portable PDB, if it has one: a PDB embedded in the PE itself, or —
-    /// when we know where the image was read from — a side-by-side <c>.pdb</c> beside it.
+    /// when we know where the image was read from — the side-by-side <c>.pdb</c> beside it.
     /// </summary>
     let private tryOpenReaderProvider
         (logger : ILogger)
@@ -145,16 +168,30 @@ module PortablePdb =
         match originalPath with
         | None -> None
         | Some path ->
+            let wanted = sidecarPath path
+
             // TryOpenAssociatedPortablePdb checks that the PDB it finds actually belongs to this
             // image (the CodeView GUID must match), so a stale .pdb left beside a rebuilt
             // assembly is rejected rather than silently misattributing every line in it.
             let opener =
                 Func<string, Stream> (fun candidate ->
                     try
-                        File.OpenRead candidate :> Stream
-                    with :? IOException ->
-                        // "No PDB beside the assembly" is the overwhelmingly common case, not an
-                        // error: returning null tells SRM to carry on looking.
+                        // SRM offers several candidates, among them the *absolute path recorded
+                        // in the image's own CodeView entry* — which names the machine that built
+                        // it. Accept only the conventional sidecar: PawPrint has no business
+                        // opening files at paths chosen by a third-party binary, and the parse
+                        // cache cannot account for any path but this one.
+                        if String.Equals (Path.GetFullPath candidate, wanted, StringComparison.Ordinal) then
+                            File.OpenRead candidate :> Stream
+                        else
+                            null
+                    with
+                    | :? IOException
+                    | :? UnauthorizedAccessException
+                    | :? ArgumentException
+                    | :? NotSupportedException ->
+                        // "No readable PDB beside the assembly" is the overwhelmingly common
+                        // case, not an error: null tells SRM to carry on to the next candidate.
                         null
                 )
 
@@ -174,29 +211,13 @@ module PortablePdb =
     /// with no lifetime relationship to <paramref name="peReader" />: it stays valid after the
     /// <c>DumpedAssembly</c> holding it — and hence its <c>PEReader</c> — has been disposed.
     /// </remarks>
-    let readSequencePoints
+    let private readCore
         (logger : ILogger)
         (peReader : PEReader)
         (originalPath : string option)
         : ImmutableDictionary<ComparableMethodDefinitionHandle, MethodSequencePoints>
         =
-        let provider =
-            try
-                tryOpenReaderProvider logger peReader originalPath
-            with :? BadImageFormatException as e ->
-                // Malformed debug information must not stop us running an assembly that the real
-                // runtime would happily run: symbols are a diagnostic aid, not a prerequisite.
-                logger.LogDebug (
-                    "Ignoring malformed debug directory for assembly at {AssemblyPath}: {DebugDirectoryError}",
-                    (match originalPath with
-                     | None -> "<in-memory image>"
-                     | Some p -> p),
-                    e.Message
-                )
-
-                None
-
-        match provider with
+        match tryOpenReaderProvider logger peReader originalPath with
         | None -> ImmutableDictionary.Empty
         | Some provider ->
 
@@ -248,3 +269,59 @@ module PortablePdb =
                     result.Add (ComparableMethodDefinitionHandle.Make (handle.ToDefinitionHandle ()), points)
 
         result.ToImmutable ()
+
+    /// <summary>
+    /// Sequence points for every method in this image that has any, keyed by method definition
+    /// handle. Empty when the image carries no debug information, which is the normal case for
+    /// the shared framework.
+    /// </summary>
+    /// <remarks>
+    /// Parses eagerly and closes the PDB before returning, so the result is plain immutable data
+    /// with no lifetime relationship to <paramref name="peReader" />: it stays valid after the
+    /// <c>DumpedAssembly</c> holding it — and hence its <c>PEReader</c> — has been disposed.
+    /// </remarks>
+    let readSequencePoints
+        (logger : ILogger)
+        (peReader : PEReader)
+        (originalPath : string option)
+        : ImmutableDictionary<ComparableMethodDefinitionHandle, MethodSequencePoints>
+        =
+        // Symbols are a diagnostic aid, never a prerequisite, and `Assembly.read` calls this
+        // unconditionally. Damaged or unreadable debug information must therefore cost us the
+        // symbols and nothing else: failing here would refuse an assembly that the real runtime
+        // runs perfectly well, which is a far worse outcome than an unattributed stack frame.
+        //
+        // The guard has to span the parse and not merely the open. A PDB whose header and
+        // CodeView GUID are intact but whose heaps are damaged opens cleanly and then throws
+        // from `GetDocumentName` part-way through enumeration.
+        // Logged at Warning, unlike the far more common "this assembly has no PDB at all", which
+        // stays at Debug: symbols that are present but unusable are rare, are never what the
+        // author intended, and are exactly what someone asking "why has this frame no line
+        // number?" needs to be told.
+        try
+            readCore logger peReader originalPath
+        with
+        | :? BadImageFormatException as e ->
+            logger.LogWarning (
+                "Ignoring malformed debug information for assembly at {AssemblyPath}: {DebugInfoError}",
+                describe originalPath,
+                e.Message
+            )
+
+            ImmutableDictionary.Empty
+        | :? IOException as e ->
+            logger.LogWarning (
+                "Could not read debug information for assembly at {AssemblyPath}: {DebugInfoError}",
+                describe originalPath,
+                e.Message
+            )
+
+            ImmutableDictionary.Empty
+        | :? UnauthorizedAccessException as e ->
+            logger.LogWarning (
+                "Not permitted to read debug information for assembly at {AssemblyPath}: {DebugInfoError}",
+                describe originalPath,
+                e.Message
+            )
+
+            ImmutableDictionary.Empty

--- a/WoofWare.PawPrint.Domain/SequencePoint.fs
+++ b/WoofWare.PawPrint.Domain/SequencePoint.fs
@@ -1,0 +1,250 @@
+namespace WoofWare.PawPrint
+
+open System
+open System.Collections.Generic
+open System.Collections.Immutable
+open System.IO
+open System.Reflection.Metadata
+open System.Reflection.PortableExecutable
+open Microsoft.Extensions.Logging
+
+/// <summary>
+/// A span in a source document, as recorded by a portable PDB sequence point.
+/// </summary>
+type SourceLocation =
+    {
+        /// <summary>
+        /// The document path exactly as the PDB records it, which is whatever the compiler was
+        /// told the file was called: an absolute path on the machine that built the assembly for
+        /// an ordinary build, or a <c>/_/</c>-rooted path when the compilation set
+        /// <c>ContinuousIntegrationBuild</c>. Deliberately not resolved against the host
+        /// filesystem — it frequently names a machine that is not this one, and PawPrint has no
+        /// business reading host files to find out.
+        /// </summary>
+        DocumentPath : string
+
+        StartLine : int
+        StartColumn : int
+        EndLine : int
+        EndColumn : int
+    }
+
+/// <summary>
+/// One portable-PDB sequence point: the start of a range of IL which the compiler has either
+/// attributed to a source span, or explicitly declared to have none.
+/// </summary>
+[<RequireQualifiedAccess>]
+type SequencePoint =
+    /// <summary>
+    /// IL from this point up to the next sequence point corresponds to this source span.
+    /// </summary>
+    | Source of SourceLocation
+
+    /// <summary>
+    /// IL from this point up to the next sequence point has deliberately been given no source
+    /// attribution: the <c>0xFEEFEE</c> hidden-line sentinel, which compilers emit over
+    /// generated code and which debuggers step through rather than halting in.
+    /// </summary>
+    /// <remarks>
+    /// Represented rather than discarded at parse time. Discarding it would leave the
+    /// *preceding* source span apparently covering the hidden range, so compiler-generated IL
+    /// would be attributed to whichever user line happened to precede it.
+    /// </remarks>
+    | Hidden
+
+/// <summary>
+/// The sequence points of a single method, indexed for lookup by IL offset.
+/// </summary>
+type MethodSequencePoints =
+    private
+        {
+            /// <summary>
+            /// Ascending by IL offset. Where the PDB records several points at one offset, the
+            /// order in which they were read is preserved, and <c>resolve</c> reports the last
+            /// of them — the one in effect from that offset onwards.
+            /// </summary>
+            _Points : ImmutableArray<int * SequencePoint>
+        }
+
+[<RequireQualifiedAccess>]
+module MethodSequencePoints =
+
+    let empty : MethodSequencePoints =
+        {
+            _Points = ImmutableArray.Empty
+        }
+
+    /// <summary>
+    /// Index the supplied points for lookup. Sorting is stable, so where several points share an
+    /// IL offset the input order decides which one <c>resolve</c> reports.
+    /// </summary>
+    let ofSeq (points : (int * SequencePoint) seq) : MethodSequencePoints =
+        {
+            _Points = points |> Seq.sortBy fst |> ImmutableArray.CreateRange
+        }
+
+    let toList (points : MethodSequencePoints) : (int * SequencePoint) list = List.ofSeq points._Points
+
+    let isEmpty (points : MethodSequencePoints) : bool = points._Points.IsEmpty
+
+    /// <summary>
+    /// The source span covering <paramref name="ilOffset" />: the last sequence point at or
+    /// before it. <c>None</c> when no sequence point precedes the offset (so the compiler
+    /// attributed nothing to it), or when the covering point is <c>Hidden</c>.
+    /// </summary>
+    let resolve (ilOffset : int) (points : MethodSequencePoints) : SourceLocation option =
+        let points = points._Points
+
+        // Last index whose offset is <= ilOffset. Binary search rather than a linear scan
+        // because a method's sequence point list is as long as its statement count, and
+        // formatting a stack trace resolves one of these per frame.
+        let mutable lo = 0
+        let mutable hi = points.Length - 1
+        let mutable found = -1
+
+        while lo <= hi do
+            let mid = lo + (hi - lo) / 2
+
+            if fst points.[mid] <= ilOffset then
+                found <- mid
+                lo <- mid + 1
+            else
+                hi <- mid - 1
+
+        if found < 0 then
+            None
+        else
+            match snd points.[found] with
+            | SequencePoint.Source loc -> Some loc
+            | SequencePoint.Hidden -> None
+
+/// <summary>
+/// Reading of portable PDB debug information accompanying a PE image.
+/// </summary>
+[<RequireQualifiedAccess>]
+module PortablePdb =
+
+    /// <summary>
+    /// Open this image's portable PDB, if it has one: a PDB embedded in the PE itself, or —
+    /// when we know where the image was read from — a side-by-side <c>.pdb</c> beside it.
+    /// </summary>
+    let private tryOpenReaderProvider
+        (logger : ILogger)
+        (peReader : PEReader)
+        (originalPath : string option)
+        : MetadataReaderProvider option
+        =
+        let embedded =
+            peReader.ReadDebugDirectory ()
+            |> Seq.tryFind (fun entry -> entry.Type = DebugDirectoryEntryType.EmbeddedPortablePdb)
+
+        match embedded with
+        | Some entry -> Some (peReader.ReadEmbeddedPortablePdbDebugDirectoryData entry)
+        | None ->
+
+        match originalPath with
+        | None -> None
+        | Some path ->
+            // TryOpenAssociatedPortablePdb checks that the PDB it finds actually belongs to this
+            // image (the CodeView GUID must match), so a stale .pdb left beside a rebuilt
+            // assembly is rejected rather than silently misattributing every line in it.
+            let opener =
+                Func<string, Stream> (fun candidate ->
+                    try
+                        File.OpenRead candidate :> Stream
+                    with :? IOException ->
+                        // "No PDB beside the assembly" is the overwhelmingly common case, not an
+                        // error: returning null tells SRM to carry on looking.
+                        null
+                )
+
+            match peReader.TryOpenAssociatedPortablePdb (path, opener) with
+            | true, provider, _ when not (isNull provider) -> Some provider
+            | _ ->
+                logger.LogDebug ("No portable PDB found for assembly at {AssemblyPath}", path)
+                None
+
+    /// <summary>
+    /// Sequence points for every method in this image that has any, keyed by method definition
+    /// handle. Empty when the image carries no debug information, which is the normal case for
+    /// the shared framework.
+    /// </summary>
+    /// <remarks>
+    /// Parses eagerly and closes the PDB before returning, so the result is plain immutable data
+    /// with no lifetime relationship to <paramref name="peReader" />: it stays valid after the
+    /// <c>DumpedAssembly</c> holding it — and hence its <c>PEReader</c> — has been disposed.
+    /// </remarks>
+    let readSequencePoints
+        (logger : ILogger)
+        (peReader : PEReader)
+        (originalPath : string option)
+        : ImmutableDictionary<ComparableMethodDefinitionHandle, MethodSequencePoints>
+        =
+        let provider =
+            try
+                tryOpenReaderProvider logger peReader originalPath
+            with :? BadImageFormatException as e ->
+                // Malformed debug information must not stop us running an assembly that the real
+                // runtime would happily run: symbols are a diagnostic aid, not a prerequisite.
+                logger.LogDebug (
+                    "Ignoring malformed debug directory for assembly at {AssemblyPath}: {DebugDirectoryError}",
+                    (match originalPath with
+                     | None -> "<in-memory image>"
+                     | Some p -> p),
+                    e.Message
+                )
+
+                None
+
+        match provider with
+        | None -> ImmutableDictionary.Empty
+        | Some provider ->
+
+        use provider = provider
+        let pdb = provider.GetMetadataReader ()
+
+        // One document typically backs every method in the assembly, and each sequence point
+        // names it, so resolving the blob-encoded name per point would dominate this parse.
+        let documentNames = Dictionary<DocumentHandle, string> ()
+
+        let documentName (handle : DocumentHandle) : string =
+            match documentNames.TryGetValue handle with
+            | true, name -> name
+            | false, _ ->
+                let name = pdb.GetString (pdb.GetDocument handle).Name
+                documentNames.[handle] <- name
+                name
+
+        let result = ImmutableDictionary.CreateBuilder ()
+
+        for handle in pdb.MethodDebugInformation do
+            let info = pdb.GetMethodDebugInformation handle
+
+            if not info.SequencePointsBlob.IsNil then
+                let points =
+                    info.GetSequencePoints ()
+                    |> Seq.map (fun point ->
+                        if point.IsHidden then
+                            point.Offset, SequencePoint.Hidden
+                        else
+                            let location =
+                                {
+                                    DocumentPath = documentName point.Document
+                                    StartLine = point.StartLine
+                                    StartColumn = point.StartColumn
+                                    EndLine = point.EndLine
+                                    EndColumn = point.EndColumn
+                                }
+
+                            point.Offset, SequencePoint.Source location
+                    )
+                    |> MethodSequencePoints.ofSeq
+
+                if not (MethodSequencePoints.isEmpty points) then
+                    // The MethodDebugInformation table is defined to be row-for-row parallel to
+                    // the PE's MethodDef table; ToDefinitionHandle is that correspondence. Doing
+                    // the row arithmetic by hand here would fail silently, by attributing one
+                    // method's lines to its neighbour.
+                    result.Add (ComparableMethodDefinitionHandle.Make (handle.ToDefinitionHandle ()), points)
+
+        result.ToImmutable ()

--- a/WoofWare.PawPrint.Domain/WoofWare.PawPrint.Domain.fsproj
+++ b/WoofWare.PawPrint.Domain/WoofWare.PawPrint.Domain.fsproj
@@ -45,6 +45,7 @@
         <Compile Include="ExportedType.fs" />
         <Compile Include="TypeSpec.fs" />
         <Compile Include="FriendAssemblies.fs" />
+        <Compile Include="SequencePoint.fs" />
         <Compile Include="Assembly.fs" />
         <Compile Include="AccessCheck.fs" />
         <Compile Include="IlFormatting.fs" />

--- a/WoofWare.PawPrint.Test/Roslyn.fs
+++ b/WoofWare.PawPrint.Test/Roslyn.fs
@@ -2,8 +2,11 @@ namespace WoofWare.PawPrint.Test
 
 open System
 open System.IO
+open System.Text
 open Microsoft.CodeAnalysis
 open Microsoft.CodeAnalysis.CSharp
+open Microsoft.CodeAnalysis.Emit
+open Microsoft.CodeAnalysis.Text
 
 [<RequireQualifiedAccess>]
 module Roslyn =
@@ -17,11 +20,25 @@ module Roslyn =
 
         Array.append runtimeReferences (extraReferences |> List.toArray)
 
-    let compileAssemblyWithResources
+    /// Whether the emitted image carries an embedded portable PDB.
+    ///
+    /// Off by default, and opt-in per case rather than globally, because debug information is
+    /// *guest-observable*: with symbols present the real runtime appends `in File0.cs:line N` to
+    /// every frame of `Exception.StackTrace`, while PawPrint does not. Every differential case
+    /// that inspects a stack trace today happens to use positive substring checks and so
+    /// survives either way, but that is luck rather than design — turning this on wholesale
+    /// would silently widen a divergence the corpus is merely tolerating.
+    [<RequireQualifiedAccess>]
+    type DebugSymbols =
+        | Embedded
+        | None
+
+    let private compileCore
         (assemblyName : string)
         (outputKind : OutputKind)
         (extraReferences : MetadataReference list)
         (resources : ResourceDescription list)
+        (symbols : DebugSymbols)
         (sources : string list)
         : byte[]
         =
@@ -32,7 +49,12 @@ module Roslyn =
             sources
             |> List.mapi (fun idx src ->
                 let fileName = $"File{idx}.cs"
-                CSharpSyntaxTree.ParseText (src, parseOptions, fileName)
+
+                // The source text must carry an encoding or emitting debug information fails
+                // with CS8055: a PDB records each document's encoding so that a consumer can
+                // re-read the file. Supplying it unconditionally costs nothing when no PDB is
+                // emitted, and keeps a single parse path.
+                CSharpSyntaxTree.ParseText (SourceText.From (src, Encoding.UTF8), parseOptions, fileName)
             )
             |> List.toArray
 
@@ -48,7 +70,15 @@ module Roslyn =
 
         use peStream = new MemoryStream ()
 
-        let emitResult = compilation.Emit (peStream, manifestResources = resources)
+        // `Embedded` puts the PDB inside the PE, so there is no `pdbStream` to supply and no
+        // second file for a caller to keep track of.
+        let emitOptions =
+            match symbols with
+            | DebugSymbols.None -> EmitOptions ()
+            | DebugSymbols.Embedded -> EmitOptions().WithDebugInformationFormat DebugInformationFormat.Embedded
+
+        let emitResult =
+            compilation.Emit (peStream, manifestResources = resources, options = emitOptions)
 
         if emitResult.Success then
             peStream.ToArray ()
@@ -60,6 +90,16 @@ module Roslyn =
                 |> String.concat Environment.NewLine
 
             failwith $"Compilation failed:\n{diagnostics}"
+
+    let compileAssemblyWithResources
+        (assemblyName : string)
+        (outputKind : OutputKind)
+        (extraReferences : MetadataReference list)
+        (resources : ResourceDescription list)
+        (sources : string list)
+        : byte[]
+        =
+        compileCore assemblyName outputKind extraReferences resources DebugSymbols.None sources
 
     let compileAssembly
         (assemblyName : string)
@@ -74,3 +114,8 @@ module Roslyn =
     /// Raises if compilation fails.
     let compile (sources : string list) : byte[] =
         compileAssembly "PawPrintTestAssembly" OutputKind.ConsoleApplication [] sources
+
+    /// As `compile`, but the image carries an embedded portable PDB. See `DebugSymbols` for why
+    /// this is a separate entry point rather than the default.
+    let compileWithSymbols (sources : string list) : byte[] =
+        compileCore "PawPrintTestAssembly" OutputKind.ConsoleApplication [] [] DebugSymbols.Embedded sources

--- a/WoofWare.PawPrint.Test/Roslyn.fs
+++ b/WoofWare.PawPrint.Test/Roslyn.fs
@@ -30,7 +30,11 @@ module Roslyn =
     /// would silently widen a divergence the corpus is merely tolerating.
     [<RequireQualifiedAccess>]
     type DebugSymbols =
+        /// The PDB lives inside the PE image.
         | Embedded
+        /// The PDB is emitted separately, to sit beside the assembly as `<name>.pdb`. This is
+        /// the shape the SDK produces by default (`DebugType=portable`).
+        | Sidecar
         | None
 
     let private compileCore
@@ -40,7 +44,7 @@ module Roslyn =
         (resources : ResourceDescription list)
         (symbols : DebugSymbols)
         (sources : string list)
-        : byte[]
+        : byte[] * byte[] option
         =
         let parseOptions =
             CSharpParseOptions.Default.WithLanguageVersion LanguageVersion.Preview
@@ -69,19 +73,31 @@ module Roslyn =
             )
 
         use peStream = new MemoryStream ()
+        use pdbStream = new MemoryStream ()
 
         // `Embedded` puts the PDB inside the PE, so there is no `pdbStream` to supply and no
-        // second file for a caller to keep track of.
+        // second file for a caller to keep track of; `Sidecar` is the opposite.
         let emitOptions =
             match symbols with
             | DebugSymbols.None -> EmitOptions ()
             | DebugSymbols.Embedded -> EmitOptions().WithDebugInformationFormat DebugInformationFormat.Embedded
+            | DebugSymbols.Sidecar -> EmitOptions().WithDebugInformationFormat DebugInformationFormat.PortablePdb
 
         let emitResult =
-            compilation.Emit (peStream, manifestResources = resources, options = emitOptions)
+            match symbols with
+            | DebugSymbols.Sidecar ->
+                compilation.Emit (peStream, pdbStream = pdbStream, manifestResources = resources, options = emitOptions)
+            | DebugSymbols.None
+            | DebugSymbols.Embedded -> compilation.Emit (peStream, manifestResources = resources, options = emitOptions)
 
         if emitResult.Success then
-            peStream.ToArray ()
+            let pdb =
+                match symbols with
+                | DebugSymbols.Sidecar -> Some (pdbStream.ToArray ())
+                | DebugSymbols.None
+                | DebugSymbols.Embedded -> None
+
+            peStream.ToArray (), pdb
         else
             let diagnostics =
                 emitResult.Diagnostics
@@ -100,6 +116,7 @@ module Roslyn =
         : byte[]
         =
         compileCore assemblyName outputKind extraReferences resources DebugSymbols.None sources
+        |> fst
 
     let compileAssembly
         (assemblyName : string)
@@ -119,3 +136,15 @@ module Roslyn =
     /// this is a separate entry point rather than the default.
     let compileWithSymbols (sources : string list) : byte[] =
         compileCore "PawPrintTestAssembly" OutputKind.ConsoleApplication [] [] DebugSymbols.Embedded sources
+        |> fst
+
+    /// As `compileWithSymbols`, but the debug information is emitted as a separate portable PDB
+    /// — the shape `DebugType=portable` produces, and hence what most real projects ship —
+    /// rather than embedded in the image. Returns the image and the PDB that belongs beside it.
+    let compileWithSidecarSymbols (sources : string list) : byte[] * byte[] =
+        let image, pdb =
+            compileCore "PawPrintTestAssembly" OutputKind.ConsoleApplication [] [] DebugSymbols.Sidecar sources
+
+        match pdb with
+        | Some pdb -> image, pdb
+        | None -> failwith "BUG: a Sidecar compilation returned no PDB"

--- a/WoofWare.PawPrint.Test/TestSequencePoints.fs
+++ b/WoofWare.PawPrint.Test/TestSequencePoints.fs
@@ -1,0 +1,234 @@
+namespace WoofWare.PawPrint.Test
+
+open System
+open System.IO
+open System.Reflection.Metadata
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+[<TestFixture>]
+module TestSequencePoints =
+
+    let private loc (line : int) : SourceLocation =
+        {
+            DocumentPath = "Doc.cs"
+            StartLine = line
+            StartColumn = 1
+            EndLine = line
+            EndColumn = 10
+        }
+
+    [<Test>]
+    let ``resolve reports the last sequence point at or before the offset`` () : unit =
+        let points =
+            MethodSequencePoints.ofSeq [ 0, SequencePoint.Source (loc 10) ; 7, SequencePoint.Source (loc 11) ]
+
+        MethodSequencePoints.resolve 0 points |> shouldEqual (Some (loc 10))
+        MethodSequencePoints.resolve 3 points |> shouldEqual (Some (loc 10))
+        MethodSequencePoints.resolve 6 points |> shouldEqual (Some (loc 10))
+        MethodSequencePoints.resolve 7 points |> shouldEqual (Some (loc 11))
+        MethodSequencePoints.resolve 99 points |> shouldEqual (Some (loc 11))
+
+    [<Test>]
+    let ``an offset before the first sequence point has no source`` () : unit =
+        let points = MethodSequencePoints.ofSeq [ 4, SequencePoint.Source (loc 10) ]
+
+        MethodSequencePoints.resolve 0 points |> shouldEqual None
+        MethodSequencePoints.resolve 3 points |> shouldEqual None
+        MethodSequencePoints.resolve 4 points |> shouldEqual (Some (loc 10))
+
+    [<Test>]
+    let ``an empty method has no source anywhere`` () : unit =
+        let points = MethodSequencePoints.ofSeq []
+
+        MethodSequencePoints.isEmpty points |> shouldEqual true
+        MethodSequencePoints.resolve 0 points |> shouldEqual None
+
+    /// This is the reason `SequencePoint` has a `Hidden` case at all. Dropping hidden points
+    /// at parse time would leave the *preceding* source span apparently covering the hidden
+    /// range, so compiler-generated IL would be attributed to whichever user line happened to
+    /// precede it.
+    [<Test>]
+    let ``a hidden sequence point masks the preceding source`` () : unit =
+        let points =
+            MethodSequencePoints.ofSeq
+                [
+                    0, SequencePoint.Source (loc 10)
+                    5, SequencePoint.Hidden
+                    9, SequencePoint.Source (loc 12)
+                ]
+
+        MethodSequencePoints.resolve 4 points |> shouldEqual (Some (loc 10))
+        MethodSequencePoints.resolve 5 points |> shouldEqual None
+        MethodSequencePoints.resolve 8 points |> shouldEqual None
+        MethodSequencePoints.resolve 9 points |> shouldEqual (Some (loc 12))
+
+    [<Test>]
+    let ``ofSeq sorts by offset, and the last point at a repeated offset wins`` () : unit =
+        let points =
+            MethodSequencePoints.ofSeq
+                [
+                    9, SequencePoint.Source (loc 12)
+                    0, SequencePoint.Source (loc 10)
+                    9, SequencePoint.Source (loc 13)
+                ]
+
+        MethodSequencePoints.resolve 1 points |> shouldEqual (Some (loc 10))
+        MethodSequencePoints.resolve 9 points |> shouldEqual (Some (loc 13))
+
+    // ---- Reading symbols out of a real image ----
+
+    /// Line numbers are load-bearing in the assertions below, so the source is assembled from
+    /// explicit lines rather than a triple-quoted literal whose leading newline and indentation
+    /// are easy to disturb. `Triple` occupies lines 3-7, with its opening brace on line 4.
+    let private source : string =
+        String.concat
+            "\n"
+            [
+                "public static class Sut" // 1
+                "{" // 2
+                "    public static int Triple(int x)" // 3
+                "    {" // 4
+                "        int y = x * 3;" // 5
+                "        return y;" // 6
+                "    }" // 7
+                "    public static int Main()" // 8
+                "    {" // 9
+                "        return Triple(0);" // 10
+                "    }" // 11
+                "}" // 12
+            ]
+
+    let private readImage (image : byte[]) : DumpedAssembly =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use stream = new MemoryStream (image, false)
+        AssemblyApi.read loggerFactory None stream
+
+    let private tripleHandle (assy : DumpedAssembly) : MethodDefinitionHandle =
+        assy.Methods
+        |> Seq.pick (fun kvp -> if kvp.Value.Name = "Triple" then Some kvp.Key else None)
+
+    [<Test>]
+    let ``an image compiled with symbols exposes its sequence points`` () : unit =
+        let assy = readImage (Roslyn.compileWithSymbols [ source ])
+        let handle = tripleHandle assy
+
+        let points =
+            match assy.SequencePoints.TryGetValue (ComparableMethodDefinitionHandle.Make handle) with
+            | false, _ -> failwith "expected sequence points for Triple"
+            | true, v -> v
+
+        let lines =
+            MethodSequencePoints.toList points
+            |> List.choose (fun (_, point) ->
+                match point with
+                | SequencePoint.Source loc -> Some loc.StartLine
+                | SequencePoint.Hidden -> None
+            )
+
+        // Every point attributed to Triple must fall inside Triple's own source span. A
+        // row-for-row misjoin between the PDB's MethodDebugInformation table and the PE's
+        // MethodDef table would show up here as lines belonging to some other member.
+        lines |> List.isEmpty |> shouldEqual false
+        lines |> List.filter (fun l -> l < 4 || l > 7) |> shouldEqual []
+        lines |> List.contains 5 |> shouldEqual true
+        lines |> List.contains 6 |> shouldEqual true
+
+        match assy.TryResolveSourceLocation handle 0 with
+        | None -> failwith "expected a source location for Triple's first instruction"
+        | Some loc ->
+            // Roslyn names the syntax tree File0.cs; see Roslyn.compileAssemblyWithResources.
+            loc.DocumentPath |> shouldEqual "File0.cs"
+            // A debug-configuration C# method opens with a `nop` attributed to its brace.
+            loc.StartLine |> shouldEqual 4
+
+    [<Test>]
+    let ``an image compiled without symbols has no sequence points`` () : unit =
+        let assy = readImage (Roslyn.compile [ source ])
+
+        assy.SequencePoints.Count |> shouldEqual 0
+        assy.TryResolveSourceLocation (tripleHandle assy) 0 |> shouldEqual None
+
+    /// `SequencePoints` must be data rather than a view onto the still-open image: the PDB is
+    /// parsed eagerly during `read`, so resolution keeps working once the assembly (and hence
+    /// its `PEReader`) has been disposed. A lazily-reading implementation fails this.
+    [<Test>]
+    let ``sequence points survive disposal of the assembly`` () : unit =
+        let assy = readImage (Roslyn.compileWithSymbols [ source ])
+        let handle = tripleHandle assy
+
+        (assy :> IDisposable).Dispose ()
+
+        // The premise, asserted rather than assumed: disposal really does invalidate reads
+        // through the PE reader. Without this the test below would pass for a lazy
+        // implementation too, and so would prove nothing.
+        let peReaderIsUnusable =
+            try
+                assy.PeReader.GetMetadataReader () |> ignore<MetadataReader>
+                false
+            with :? ObjectDisposedException ->
+                true
+
+        peReaderIsUnusable |> shouldEqual true
+
+        assy.TryResolveSourceLocation handle 0 |> Option.isSome |> shouldEqual true
+
+    let private domainAssembly () : DumpedAssembly =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        AssemblyApi.readFile loggerFactory typeof<DumpedAssembly>.Assembly.Location
+
+    /// The `Hidden` case is only load-bearing if the *parser* records it; the unit tests above
+    /// exercise `resolve` on hand-built points and would all still pass if hidden points were
+    /// dropped at read time. F# emits them over compiler-generated IL, so a real F# assembly is
+    /// the corpus that pins the parse down.
+    [<Test>]
+    let ``hidden sequence points survive parsing`` () : unit =
+        let assy = domainAssembly ()
+
+        let hidden =
+            assy.SequencePoints
+            |> Seq.sumBy (fun kvp ->
+                MethodSequencePoints.toList kvp.Value
+                |> List.sumBy (fun (_, point) ->
+                    match point with
+                    | SequencePoint.Hidden -> 1
+                    | SequencePoint.Source _ -> 0
+                )
+            )
+
+        hidden |> shouldBeGreaterThan 0
+
+    /// Exhaustive rather than sampled: the corpus is every method of a real, symbol-bearing
+    /// assembly, so there is nothing to gain from generating a subset of it.
+    ///
+    /// Sequence point offsets are required to fall on instruction boundaries, and `Locations`
+    /// is keyed by exactly those boundaries. The property therefore catches both a misjoined
+    /// PDB and a PDB that does not belong to this image at all (a stale `.pdb` beside a
+    /// rebuilt assembly), either of which would otherwise misattribute lines in silence.
+    [<Test>]
+    let ``every sequence point offset is an instruction boundary`` () : unit =
+        let assy = domainAssembly ()
+
+        // The whole test is vacuous if this assembly turns out to carry no symbols, which is
+        // exactly what would happen if DebugType stopped being `embedded` in Directory.Build.props.
+        assy.SequencePoints.Count |> shouldBeGreaterThan 100
+
+        let mutable verified = 0
+
+        for KeyValue (handle, points) in assy.SequencePoints do
+            match assy.Methods.TryGetValue handle.Get with
+            | false, _ -> failwith $"PDB names method row %O{handle.Get} which the PE does not define"
+            | true, method ->
+                match MethodInfo.tryIlBody method with
+                | None -> ()
+                | Some body ->
+                    for offset, _ in MethodSequencePoints.toList points do
+                        if not (body.Locations.ContainsKey offset) then
+                            failwith
+                                $"Sequence point at IL offset %d{offset} in %s{method.DeclaringType.Name}.%s{method.Name} is not an instruction boundary"
+
+                        verified <- verified + 1
+
+        // Likewise: a corpus that reached no IL bodies would pass the loop trivially.
+        verified |> shouldBeGreaterThan 1000

--- a/WoofWare.PawPrint.Test/TestSequencePoints.fs
+++ b/WoofWare.PawPrint.Test/TestSequencePoints.fs
@@ -3,6 +3,7 @@ namespace WoofWare.PawPrint.Test
 open System
 open System.IO
 open System.Reflection.Metadata
+open System.Text
 open FsUnitTyped
 open NUnit.Framework
 open WoofWare.PawPrint
@@ -173,6 +174,134 @@ module TestSequencePoints =
         peReaderIsUnusable |> shouldEqual true
 
         assy.TryResolveSourceLocation handle 0 |> Option.isSome |> shouldEqual true
+
+    /// Materialise an assembly, and optionally its sidecar PDB, into a directory of its own.
+    /// Fresh per call because `Assembly.readFile`'s parse cache is process-wide and keyed by
+    /// path: reusing a path would have one test observing another's cache entry.
+    let private writeTempAssembly (image : byte[]) (pdb : byte[] option) : string =
+        let unique = Guid.NewGuid().ToString "N"
+        let dir = Path.Combine (Path.GetTempPath (), $"pawprint-pdb-%s{unique}")
+
+        Directory.CreateDirectory dir |> ignore<DirectoryInfo>
+
+        // Named for the assembly it contains, as every real build names it: PawPrint looks for
+        // `<assembly file>.pdb` and ignores the file name recorded in the image's CodeView entry
+        // (see `PortablePdb.sidecarPath`), so a file renamed after compilation finds no symbols.
+        let dll = Path.Combine (dir, "PawPrintTestAssembly.dll")
+        File.WriteAllBytes (dll, image)
+
+        match pdb with
+        | Some pdb -> File.WriteAllBytes (Path.ChangeExtension (dll, ".pdb"), pdb)
+        | None -> ()
+
+        dll
+
+    let private readFile (path : string) : DumpedAssembly =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        AssemblyApi.readFile loggerFactory path
+
+    [<Test>]
+    let ``a side-by-side pdb supplies sequence points`` () : unit =
+        let image, pdb = Roslyn.compileWithSidecarSymbols [ source ]
+        let assy = readFile (writeTempAssembly image (Some pdb))
+
+        assy.SequencePoints.Count |> shouldBeGreaterThan 0
+
+        match assy.TryResolveSourceLocation (tripleHandle assy) 0 with
+        | None -> failwith "expected a source location for Triple's first instruction"
+        | Some loc -> loc.StartLine |> shouldEqual 4
+
+    /// Locate a named stream within a standalone portable PDB by walking the metadata root.
+    /// A hard-coded offset would quietly stop pointing at the heap the moment a compiler changed
+    /// its layout, and the test built on it would go vacuous rather than fail.
+    let private streamOffset (name : string) (pdb : byte[]) : int =
+        let mutable p = 12
+        let versionLength = BitConverter.ToInt32 (pdb, p)
+        p <- p + 4 + ((versionLength + 3) / 4) * 4
+        p <- p + 2 // Flags
+        let streamCount = int (BitConverter.ToUInt16 (pdb, p))
+        p <- p + 2
+
+        let mutable found = -1
+
+        for _ in 1..streamCount do
+            let offset = BitConverter.ToInt32 (pdb, p)
+            p <- p + 8
+            let nameStart = p
+
+            while pdb.[p] <> 0uy do
+                p <- p + 1
+
+            let thisName = Encoding.ASCII.GetString (pdb, nameStart, p - nameStart)
+            p <- nameStart + ((p - nameStart + 1 + 3) / 4) * 4
+
+            if thisName = name then
+                found <- offset
+
+        if found < 0 then
+            failwith $"portable PDB has no %s{name} stream"
+
+        found
+
+    let private readFileLogging (path : string) : (unit -> LogLine list) * DumpedAssembly =
+        let logs, loggerFactory = LoggerFactory.makeTest ()
+        logs, AssemblyApi.readFile loggerFactory path
+
+    /// Both damage tests assert that the *guard* fired, not merely that no symbols came back.
+    /// Without that, either would also pass against an implementation that quietly failed to
+    /// find the PDB at all — which is precisely how an earlier version of this test went vacuous.
+    let private shouldHaveReportedUnusableSymbols (logs : unit -> LogLine list) : unit =
+        logs ()
+        |> List.exists (fun line -> line.Message.Contains "malformed debug information")
+        |> shouldEqual true
+
+    /// Symbols are a diagnostic aid, so damaged ones must cost us the symbols and nothing else.
+    /// This damage spares the header, the `#Pdb` id and the `#GUID` stream, so the PDB opens and
+    /// is still accepted as belonging to this image; it fails part-way through *enumeration*,
+    /// which is a different code path from failing to open.
+    [<Test>]
+    let ``a side-by-side pdb with a damaged heap costs symbols, not the assembly`` () : unit =
+        let image, pdb = Roslyn.compileWithSidecarSymbols [ source ]
+        let damaged = Array.copy pdb
+        let blobHeap = streamOffset "#Blob" pdb
+
+        // The front of the blob heap is where the document-name and sequence-point blobs live.
+        for i in blobHeap .. min (blobHeap + 200) (damaged.Length - 1) do
+            damaged.[i] <- 0xFFuy
+
+        let logs, assy = readFileLogging (writeTempAssembly image (Some damaged))
+
+        assy.SequencePoints.Count |> shouldEqual 0
+        // The assembly itself must have parsed perfectly well.
+        assy.Methods.Count |> shouldBeGreaterThan 0
+        shouldHaveReportedUnusableSymbols logs
+
+    /// The sibling of the test above, for the other arm of the guard: this PDB fails as it is
+    /// opened rather than as it is enumerated.
+    [<Test>]
+    let ``a truncated side-by-side pdb costs symbols, not the assembly`` () : unit =
+        let image, pdb = Roslyn.compileWithSidecarSymbols [ source ]
+
+        let logs, assy =
+            readFileLogging (writeTempAssembly image (Some pdb.[0 .. pdb.Length / 2]))
+
+        assy.SequencePoints.Count |> shouldEqual 0
+        assy.Methods.Count |> shouldBeGreaterThan 0
+        shouldHaveReportedUnusableSymbols logs
+
+    /// The parse cache is keyed on the assembly file, but a cached entry carries the *symbols*
+    /// that were beside it at the time. Adding a PDB to an already-cached assembly must
+    /// therefore miss the cache, or the first caller's lack of symbols is served forever.
+    [<Test>]
+    let ``adding a side-by-side pdb invalidates the cached parse`` () : unit =
+        let image, pdb = Roslyn.compileWithSidecarSymbols [ source ]
+        let dll = writeTempAssembly image None
+
+        (readFile dll).SequencePoints.Count |> shouldEqual 0
+
+        File.WriteAllBytes (Path.ChangeExtension (dll, ".pdb"), pdb)
+
+        (readFile dll).SequencePoints.Count |> shouldBeGreaterThan 0
 
     let private domainAssembly () : DumpedAssembly =
         let _, loggerFactory = LoggerFactory.makeTest ()

--- a/WoofWare.PawPrint.Test/TestSequencePoints.fs
+++ b/WoofWare.PawPrint.Test/TestSequencePoints.fs
@@ -183,10 +183,6 @@ module TestSequencePoints =
         let dir = Path.Combine (Path.GetTempPath (), $"pawprint-pdb-%s{unique}")
 
         Directory.CreateDirectory dir |> ignore<DirectoryInfo>
-
-        // Named for the assembly it contains, as every real build names it: PawPrint looks for
-        // `<assembly file>.pdb` and ignores the file name recorded in the image's CodeView entry
-        // (see `PortablePdb.sidecarPath`), so a file renamed after compilation finds no symbols.
         let dll = Path.Combine (dir, "PawPrintTestAssembly.dll")
         File.WriteAllBytes (dll, image)
 
@@ -210,6 +206,41 @@ module TestSequencePoints =
         match assy.TryResolveSourceLocation (tripleHandle assy) 0 with
         | None -> failwith "expected a source location for Triple's first instruction"
         | Some loc -> loc.StartLine |> shouldEqual 4
+
+    /// PawPrint looks for `<assembly file>.pdb` and pays no attention to the file name recorded
+    /// in the image's CodeView entry, so an assembly renamed after it was built keeps its symbols
+    /// as long as the PDB was renamed with it. Depending on the recorded name instead would also
+    /// mean deciding whether this filesystem is case-sensitive, and losing the symbols of any
+    /// assembly opened under casing that differs from what the compiler wrote down.
+    [<Test>]
+    let ``a renamed assembly finds the sidecar named after it`` () : unit =
+        let image, pdb = Roslyn.compileWithSidecarSymbols [ source ]
+
+        let unique = Guid.NewGuid().ToString "N"
+        let dir = Path.Combine (Path.GetTempPath (), $"pawprint-pdb-%s{unique}")
+        Directory.CreateDirectory dir |> ignore<DirectoryInfo>
+
+        // Deliberately *not* the assembly name the compiler recorded, which is
+        // PawPrintTestAssembly.
+        let dll = Path.Combine (dir, "SomethingElse.dll")
+        File.WriteAllBytes (dll, image)
+        File.WriteAllBytes (Path.ChangeExtension (dll, ".pdb"), pdb)
+
+        (readFile dll).SequencePoints.Count |> shouldBeGreaterThan 0
+
+    /// `originalPath` is whatever the caller was given, and for an in-memory image that may be a
+    /// descriptive label rather than a filename. Failing to interpret it must cost the symbols
+    /// and nothing else — certainly not the assembly.
+    [<TestCase "">]
+    [<TestCase "\000not a path">]
+    [<TestCase "<in-memory>">]
+    let ``an originalPath that is not a path costs symbols, not the assembly`` (label : string) : unit =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use stream = new MemoryStream (Roslyn.compile [ source ], false)
+        let assy = AssemblyApi.read loggerFactory (Some label) stream
+
+        assy.SequencePoints.Count |> shouldEqual 0
+        assy.Methods.Count |> shouldBeGreaterThan 0
 
     /// Locate a named stream within a standalone portable PDB by walking the metadata root.
     /// A hard-coded offset would quietly stop pointing at the heap the moment a compiler changed

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -12,6 +12,7 @@
     <Compile Include="Assembly.fs" />
     <Compile Include="Roslyn.fs" />
     <Compile Include="TestAssemblyReadCache.fs" />
+    <Compile Include="TestSequencePoints.fs" />
     <Compile Include="TestCustomAttributeBlob.fs" />
     <Compile Include="TestCustomAttribValueLowering.fs" />
     <Compile Include="TestAttributeFormatting.fs" />


### PR DESCRIPTION
Reads portable PDB sequence points alongside each assembly, so that an executing method and IL offset can be turned into a file and line. **Nothing consumes it yet** — this is the data layer, deliberately landed on its own.

The motivation is diagnostics: `AbstractMachine.executeOneStep`'s trace log and every `failwith "TODO: ..."` currently identify an instruction as a method name plus an `IlOpIndex`. Reading symbols is *reading*, not compiler infrastructure — `MetadataReaderProvider` plus `MethodDebugInformation.GetSequencePoints`, no IL emission anywhere.

## Shape

`DumpedAssembly` gains a `SequencePoints` side table keyed by method definition handle, plus `TryResolveSourceLocation`.

A side table rather than a field on `MethodInstructions`: the PDB is a genuinely separate metadata source (a separate file, even), and folding it in would put an `option` on construction paths that can never carry source — `MethodInstructions.onlyRet` synthesises bodies with no document at all. Every site that would want a location already has the assembly in hand.

Parsed eagerly during `read`, with the PDB closed before returning, so the result is plain immutable data. It survives both the caller closing the stream it handed us (as `ContentHash` already must) and this record's own `Dispose` closing its `PEReader`.

Hidden sequence points (the `0xFEEFEE` sentinel) are represented rather than discarded. Dropping them would leave the preceding source span apparently covering compiler-generated IL, misattributing it to whichever user line happened to precede it.

## The invariant everything here rests on

**Symbols may never cost more than the symbols.** Debug information is optional and `Assembly.read` consults it unconditionally, so damaged, unreadable or absent symbols must lose us the line numbers and nothing else — never refuse an assembly the real runtime runs perfectly well.

Four of the five defects found in review were violations of exactly that, which is why the failure envelope gets more attention below than the parsing does.

## Design notes worth a reviewer's attention

**Sidecar discovery does not filter SRM's search; it answers it.** `TryOpenAssociatedPortablePdb` offers candidate paths derived from the image's own CodeView entry, including the absolute path on the machine that built it. Filtering those by comparing paths would mean deciding whether this filesystem is case-sensitive — no portable API answers that, and getting it wrong loses the symbols of any assembly opened under casing that differs from what the compiler recorded. So the provider ignores what it is asked for and answers with the single file we are willing to read (`<assembly>.pdb` beside the assembly), leaving SRM to do the part it is good at: checking the PDB belongs to this image. A renamed assembly therefore keeps its symbols provided the PDB was renamed with it.

**The parse cache now keys on the sidecar too.** `readFile`'s cached entry carries the sequence points of whatever PDB sat beside the assembly at parse time, so adding, removing or rebuilding a sidecar without touching the assembly must miss the cache. That is only sound because exactly one file could have been read — the two decisions are load-bearing on each other.

**`sidecarPath` is total.** `originalPath` is whatever the caller was given and need not be a filename; for an in-memory image it may be a label. `Path.GetFullPath` throws on `""` and on paths containing a null character.

**Test images opt into symbols case by case** (`Roslyn.compileWithSymbols`, `compileWithSidecarSymbols`) rather than globally, because debug information is guest-observable: with symbols present the real runtime appends `in File0.cs:line N` to every `Exception.StackTrace` frame, and PawPrint does not. The four differential cases that inspect stack traces survive either way today, but only because each happens to use a positive substring check — turning symbols on wholesale would silently widen a divergence the corpus is merely tolerating.

## Follow-ups, deliberately not in this PR

- Consume it: source locations in `AbstractMachine.fs`'s trace log and in `failwith "TODO: ..."` messages. This is where it starts paying for itself on PawPrint bugs.
- Per-case symbol opt-in for any differential test that wants line numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
