### PR TITLE
No zero-length value types, as CoreCLR enforces

### DIFF
--- a/WoofWare.PawPrint.Test/TestManifestResources.fs
+++ b/WoofWare.PawPrint.Test/TestManifestResources.fs
@@ -262,27 +262,34 @@ public static class Entry
         | CliType.Numeric (CliNumericType.UInt8 value) -> value
         | other -> failwith $"expected byte read, got %O{other}"
 
-    let private readZeroBytes
+    /// A zero-length payload has no readable byte at all, and that — not "a read of nothing
+    /// succeeds" — is the guarantee worth pinning.
+    ///
+    /// This used to read a hand-built zero-sized value type and assert it yielded `[||]`. No such
+    /// template exists any more: CoreCLR forbids zero-length value classes (`SetInstanceBytesSize`,
+    /// class.h:497, and methodtablebuilder.cpp:8568), and `CliValueType.SizeOfFieldStorage` now
+    /// models that floor, so every value type is at least one byte wide. The old template was in
+    /// any case a shape real metadata cannot produce — `TypeLayout.IsDefault` is true when size and
+    /// packing are both zero, so parsing never yields `Layout.Custom (0, 0)`; only a test could
+    /// construct it. Assert the real contract instead: the narrowest read there is gets rejected,
+    /// naming the empty range it was rejected against.
+    let private shouldRejectEveryRead
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (state : IlMachineState)
         (ptr : ManagedPointerSource)
-        : byte[]
+        : unit
         =
-        let zeroSizeDeclaredType =
-            AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes baseClassTypes.Byte
+        let exn =
+            Assert.Throws<Exception> (fun () ->
+                IlMachineState.readManagedByrefBytesAs
+                    baseClassTypes
+                    state
+                    ptr
+                    (CliType.Numeric (CliNumericType.UInt8 0uy))
+                |> ignore
+            )
 
-        let zeroSizeTemplate =
-            CliValueType.OfFields
-                baseClassTypes
-                state.ConcreteTypes
-                zeroSizeDeclaredType
-                (Layout.Custom (size = 0, packingSize = 0))
-                CharSet.Ansi
-                []
-            |> CliType.ValueType
-
-        IlMachineState.readManagedByrefBytesAs baseClassTypes state ptr zeroSizeTemplate
-        |> CliType.ToBytes
+        exn.Message |> shouldContainText "outside byte range size 0"
 
     let private invokeAssemblyNativeGetResourceWithArguments
         (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
@@ -808,7 +815,7 @@ public static class Entry
         let state, emptyPtr =
             IlMachineState.peByteRangePointer loggerFactory baseClassTypes emptyPeByteRange state
 
-        readZeroBytes baseClassTypes state emptyPtr |> shouldEqual [||]
+        shouldRejectEveryRead baseClassTypes state emptyPtr
 
     [<Test>]
     let ``AssemblyNative_GetResource returns embedded resource byte range`` () : unit =
@@ -863,7 +870,7 @@ public static class Entry
             ManagedPointerSource.tryStableAddressBits ptr
             |> shouldEqual (Some (int64 emptyResource.PayloadRelativeVirtualAddress))
 
-            readZeroBytes prepared.BaseClassTypes state ptr |> shouldEqual [||]
+            shouldRejectEveryRead prepared.BaseClassTypes state ptr
         | other -> failwith $"expected managed resource pointer for empty manifest resource, got %O{other}"
 
         let state, length, ret =

--- a/WoofWare.PawPrint.Test/sourcesPure/EmptyStructMinimumSize.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/EmptyStructMinimumSize.cs
@@ -1,0 +1,65 @@
+// CoreCLR enforces that no value class has length 0: "Like C++ we enforce that there can be
+// no 0 length structures. Thus for a value class with no fields, we 'pad' the length to be 1"
+// (methodtablebuilder.cpp:8568, the auto-layout path). Sequential and explicit layout reach the
+// same rule through `EEClassLayoutInfo::SetInstanceBytesSize` (class.h:497), which is literally
+// `return size == 0 ? 1 : size;`. So the padding is universal across layout kinds, and it
+// applies to a declared `Size = 0` just as it does to a struct that simply has no fields.
+//
+// The padding is observable: it is the managed size, so it drives `Unsafe.SizeOf<T>`, the array
+// element stride, and the size an enclosing struct reserves for a field of the type.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+public class Program
+{
+    struct Empty { }
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct EmptySequential { }
+
+    [StructLayout(LayoutKind.Explicit)]
+    struct EmptyExplicit { }
+
+    [StructLayout(LayoutKind.Explicit, Size = 0)]
+    struct EmptyExplicitSizeZero { }
+
+    // A declared `Pack` with no `Size` is a distinct route to the same place: a ClassLayout row
+    // exists, so the metadata layout is *not* the default one, but it carries no size to act as a
+    // floor. (`TypeLayout.IsDefault` requires both size and packing to be zero.)
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    struct EmptyPacked { }
+
+    struct ContainsEmpty { public Empty A; }
+
+    struct ContainsTwoEmpties { public Empty A; public Empty B; }
+
+    struct EmptyThenByte { public Empty A; public byte B; }
+
+    public static int Main(string[] args)
+    {
+        if (Unsafe.SizeOf<Empty>() != 1) return 1;
+        if (Unsafe.SizeOf<EmptySequential>() != 1) return 2;
+        if (Unsafe.SizeOf<EmptyExplicit>() != 1) return 3;
+        if (Unsafe.SizeOf<EmptyExplicitSizeZero>() != 1) return 4;
+        if (Unsafe.SizeOf<EmptyPacked>() != 1) return 10;
+
+        // The padding is recursive: an empty field occupies a real byte in its container.
+        if (Unsafe.SizeOf<ContainsEmpty>() != 1) return 5;
+        if (Unsafe.SizeOf<ContainsTwoEmpties>() != 2) return 6;
+        if (Unsafe.SizeOf<EmptyThenByte>() != 2) return 7;
+
+        // Array element stride follows the managed size, so distinct elements are distinct
+        // addresses. If the stride were 0 every element would alias element 0.
+        Empty[] arr = new Empty[3];
+        ref Empty first = ref arr[0];
+        ref Empty second = ref arr[1];
+        if (Unsafe.AreSame(ref first, ref second)) return 8;
+
+        long stride = Unsafe.ByteOffset(ref first, ref second).ToInt64();
+        if (stride != 1) return 9;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/CellAwareMemOps.fs
+++ b/WoofWare.PawPrint/CellAwareMemOps.fs
@@ -430,11 +430,11 @@ module internal CellAwareMemOps =
     ///   strictly beyond the cursor — untouched. The backward loop is the mirror image. The
     ///   argument never mentions the width, so letting it vary changes nothing.
     /// - **A step always advances.** Widths are positive and at most `cap`, so the caller cannot
-    ///   spin. PawPrint gives fieldless default-layout structs `sizeOf = 0`, and a zero-sized cell
-    ///   would otherwise return a zero-width "success" and loop forever; that shape is rejected
-    ///   here rather than being left to the byte step, which would itself fail loudly — the
-    ///   intended outcome, since a positive byte copy anchored on a zero-sized cell is an
-    ///   interpreter-bug shape.
+    ///   spin. A zero-sized cell would return a zero-width "success" and loop forever, so it is
+    ///   rejected here rather than being left to the byte step. No value type should now be able
+    ///   to present that shape — `CliValueType.SizeOfFieldStorage` models CoreCLR's floor of one
+    ///   byte per value class — so this is a guard on the termination invariant rather than a
+    ///   live case, and it stays cheap enough to be worth keeping as one.
     ///
     /// Cells must additionally have compatible CLI shape (`cellsHaveCompatibleShape`), so that the
     /// wholesale typed write does not silently rewrite what the destination cell claims to hold.
@@ -588,7 +588,9 @@ module internal CellAwareMemOps =
 
             // `cellSize <= 0` is rejected for the same reason as on the copy
             // path: a zero-sized cell would advance the caller's cursor by
-            // zero and spin forever.
+            // zero and spin forever. As there, no value type should be able to
+            // present that shape now that `SizeOfFieldStorage` models CoreCLR's
+            // one-byte floor; the guard remains for the termination invariant.
             if cellSize <= 0 || cellSize > bytesRemaining then
                 None
             else

--- a/WoofWare.PawPrint/CliType.fs
+++ b/WoofWare.PawPrint/CliType.fs
@@ -1066,7 +1066,20 @@ and CliValueType =
         // An empty field list cannot contain references, so this is decided before the GC cases.
         if fields.IsEmpty then
             {
-                Size = minimumSize
+                // CoreCLR: "Like C++ we enforce that there can be no 0 length structures. Thus for
+                // a value class with no fields, we 'pad' the length to be 1"
+                // (methodtablebuilder.cpp:8568, the auto-layout path). Sequential and explicit
+                // layout reach the same floor via `EEClassLayoutInfo::SetInstanceBytesSize`
+                // (class.h:497), which is `return size == 0 ? 1 : size;` — so the floor is
+                // universal across layout kinds, and applies whether the 0 came from having no
+                // fields or from a declared `Size = 0`.
+                //
+                // This is not merely a hand-written-IL concern. Roslyn hides it for a plain
+                // `struct Empty {}` by emitting a `ClassLayout` row of `Size = 1` itself, but an
+                // explicit `[StructLayout(LayoutKind.Sequential)]` or `[StructLayout(
+                // LayoutKind.Explicit)]` on a fieldless struct emits *no* `ClassLayout` row, so
+                // the type arrives here as `Layout.Default` and the floor has to be applied.
+                Size = max 1 minimumSize
                 Alignment = 1
             }
         else


### PR DESCRIPTION
CoreCLR forbids zero-length value classes. PawPrint reported 0 for a fieldless struct, which is observable as `Unsafe.SizeOf<T>`, as the array element stride, and as the space an enclosing struct reserves for such a field.

## The rule

The floor is universal across all three layout paths:

- **Auto layout** — `methodtablebuilder.cpp:8568`: *"Like C++ we enforce that there can be no 0 length structures. Thus for a value class with no fields, we 'pad' the length to be 1"*.
- **Sequential and explicit layout** — both end in `EEClassLayoutInfo::SetInstanceBytesSize` (`class.h:497`), literally `return size == 0 ? 1 : size;`.

So it applies whatever the layout kind, and to a declared `Size = 0` as much as to a struct with no fields.

## Why this was not just a hand-written-IL curiosity

Roslyn hides it for the common case, which is why it stayed buried. Metadata actually emitted:

| Declaration | ClassLayout row | PawPrint (before) | CoreCLR |
|---|---|---|---|
| `struct Empty {}` | `Size=1` | 1 | 1 |
| `[StructLayout(LayoutKind.Sequential)] struct E {}` | *none* | **0** | 1 |
| `[StructLayout(LayoutKind.Explicit)] struct E {}` | *none* | **0** | 1 |
| `[StructLayout(LayoutKind.Explicit, Size = 0)] struct E {}` | *none* | **0** | 1 |
| `[StructLayout(LayoutKind.Sequential, Pack = 4)] struct E {}` | `Pack=4, Size=0` | **0** | 1 |

Roslyn emits `ClassLayout Size = 1` itself for a plain struct, but writing the attribute explicitly makes it emit no `ClassLayout` row at all, leaving the runtime to apply its own floor. The `Pack`-only case is a third route: a row exists, so the layout is not the default one, but it carries no size to act as a floor (`TypeLayout.IsDefault` requires size *and* packing to be zero).

Offsets were affected too: `struct { Empty a; byte b; }` was one byte with `b` at offset 0, rather than two with `b` at 1.

## The change

A one-byte floor in `CliValueType.SizeOfFieldStorage`. `PreservedBytes` derives from the same function, so the byte image follows automatically.

Two consequences, both handled rather than papered over:

- `CellAwareMemOps` documented `sizeOf = 0` as a live case justifying its zero-width rejection. The rejection still guards the loop-termination invariant and is cheap, so it stays — but the rationale now says it is a guard rather than a live case, since leaving a comment asserting something untrue is its own defect.
- `TestManifestResources` synthesised a zero-sized value type as a device to read zero bytes from an empty embedded resource. No such template exists any more — and that shape was never reachable from real metadata anyway, since parsing never yields `Layout.Custom (0, 0)`. Both tests already asserted the real contract (the range's size is 0; the pointer is at the payload RVA); the supplementary "reading nothing yields `[||]`" is replaced by the stronger guarantee that a zero-length payload rejects even a one-byte read.

## Testing

New differential case `EmptyStructMinimumSize.cs` covers all five empty shapes above plus nesting (`ContainsEmpty`, `ContainsTwoEmpties`, `EmptyThenByte`) and the array element stride. The `Pack = 4` case was checked against the emitted metadata to confirm it really takes the `Layout.Custom` route rather than duplicating the `Layout.Default` ones.

Full suite green (2441/2441).

🤖 Generated with [Claude Code](https://claude.com/claude-code)