### PR TITLE
Represent open constructed types, so F-bounded constraints resolve

### DIFF
--- a/WoofWare.PawPrint.Test/TestTypeResolution.fs
+++ b/WoofWare.PawPrint.Test/TestTypeResolution.fs
@@ -1090,6 +1090,9 @@ public class OpenBox<T> { }
             failwith "TypeSpec-like token was incorrectly classified as a generic parameter"
         | RuntimeTypeHandleTarget.MethodGenericParameter _ ->
             failwith "TypeSpec-like token was incorrectly classified as a method generic parameter"
+        | RuntimeTypeHandleTarget.OpenConstructed _ ->
+            failwith
+                "TypeSpec-like token was incorrectly classified as an open constructed type; its argument is closed, so it must be a Closed handle"
         | RuntimeTypeHandleTarget.Closed handle ->
             let constructed =
                 AllConcreteTypes.lookup handle state.ConcreteTypes

--- a/WoofWare.PawPrint.Test/sourcesPure/TypeGetGenericParameterConstraintsSelfReferential.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/TypeGetGenericParameterConstraintsSelfReferential.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Generic;
+
+namespace TypeGetGenericParameterConstraintsSelfReferential
+{
+    // `where T : IComparable<T>` is the canonical self-referential (F-bounded) constraint, and
+    // the shape most ordinary generic code reaches for. The constraint's own signature mentions
+    // the parameter it constrains, so it cannot be resolved to a closed type: it is a generic
+    // instantiation one of whose arguments is a type variable.
+    class SelfBox<T> where T : struct, IComparable<T> { }
+
+    // The embedded parameter need not be the constrained one.
+    class Pair<A, B> where B : IComparable<A> { }
+
+    // ... and it can be nested arbitrarily deep inside the constraint's shape.
+    class NestedBox<T> where T : IComparable<List<T>> { }
+
+    // The CRTP shape: the constraint is the declaring type applied to exactly its own
+    // parameters, in order. This is what `IParsable<TSelf>` and the whole generic-math
+    // hierarchy look like, and the runtime treats it specially — see the checks below.
+    interface ISelf<T> where T : ISelf<T> { }
+
+    // A *class* constraint that embeds a parameter, so the parameter's base type is itself an
+    // open constructed type rather than Object or ValueType.
+    class CBox<T> where T : Comparer<T> { }
+
+    interface IWrap<T> { }
+
+    // The CRTP collapse happening *inside* another instantiation: the inner `INested<T>` is the
+    // typical instantiation and so collapses to the bare definition, which then appears as a
+    // generic argument of `IWrap<>`. Legal metadata cannot spell a bare definition as an
+    // argument, but canonicalisation can produce one, so it has to be accepted there.
+    interface INested<T> where T : IWrap<INested<T>> { }
+
+    // Two arguments, to pin the separator used when rendering an instantiation.
+    class DictBox<A, B> where B : IDictionary<A, B> { }
+
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            Type t = typeof(SelfBox<>).GetGenericArguments()[0];
+
+            // Roslyn writes the explicit row first and the synthetic System.ValueType row last,
+            // as for `where T : struct, IDisposable` in the sibling file.
+            Type[] cs = t.GetGenericParameterConstraints();
+            if (cs.Length != 2) return 1;
+            if (cs[1] != typeof(ValueType)) return 2;
+
+            // The interesting one: an open constructed type. It is a generic type, its
+            // definition is IComparable<>, and its single argument is the very parameter being
+            // constrained — not a copy of it, the same Type object.
+            if (!cs[0].IsGenericType) return 3;
+            if (cs[0].GetGenericTypeDefinition() != typeof(IComparable<>)) return 4;
+            if (cs[0].GetGenericArguments().Length != 1) return 5;
+            if (cs[0].GetGenericArguments()[0] != t) return 6;
+
+            // `IsInterface` is what CoreLib's `RuntimeType.GetBaseType()` asks of each
+            // constraint before deciding a type variable's base type, so it has to be right on
+            // an open constructed constraint specifically.
+            if (!cs[0].IsInterface) return 7;
+            if (!cs[0].ContainsGenericParameters) return 8;
+
+            // An open constructed type is NOT a generic type *definition*: it has been applied
+            // to arguments, even though those arguments are not closed.
+            if (cs[0].IsGenericTypeDefinition) return 9;
+
+            // Naming. A type containing generic parameters has no FullName.
+            if (cs[0].Name != "IComparable`1") return 10;
+            if (cs[0].Namespace != "System") return 11;
+            if (cs[0].FullName != null) return 12;
+
+            // Identity is canonical: asking twice yields the same object, in fresh arrays.
+            Type[] csAgain = t.GetGenericParameterConstraints();
+            if (ReferenceEquals(cs, csAgain)) return 13;
+            if (!ReferenceEquals(cs[0], csAgain[0])) return 14;
+
+            // The consequence that motivates all of this: the base-type walk can run, so a
+            // parameter carrying both the `struct` flag and a self-referential constraint
+            // answers correctly. `BaseType` is the property `IsValueType` is defined in terms
+            // of for a type variable, and unlike `IsValueType` it is not short-circuited.
+            if (t.BaseType != typeof(ValueType)) return 15;
+            if (!t.IsValueType) return 16;
+
+            // A constraint embedding a *different* parameter of the same type.
+            Type a = typeof(Pair<,>).GetGenericArguments()[0];
+            Type b = typeof(Pair<,>).GetGenericArguments()[1];
+            Type[] bcs = b.GetGenericParameterConstraints();
+            if (bcs.Length != 1) return 17;
+            if (bcs[0].GetGenericTypeDefinition() != typeof(IComparable<>)) return 18;
+            if (bcs[0].GetGenericArguments()[0] != a) return 19;
+            // Interface-only constraints leave the base type as Object.
+            if (b.BaseType != typeof(object)) return 20;
+
+            // A constraint whose embedded parameter is nested inside a further instantiation.
+            Type n = typeof(NestedBox<>).GetGenericArguments()[0];
+            Type[] ncs = n.GetGenericParameterConstraints();
+            if (ncs.Length != 1) return 21;
+            if (ncs[0].GetGenericTypeDefinition() != typeof(IComparable<>)) return 22;
+            Type inner = ncs[0].GetGenericArguments()[0];
+            if (inner.GetGenericTypeDefinition() != typeof(List<>)) return 23;
+            if (inner.GetGenericArguments()[0] != n) return 24;
+
+            // The CRTP collapse. `ISelf<T>` applied to exactly its own parameter in order is
+            // the *typical instantiation*, which the runtime represents as the generic type
+            // definition itself — so the constraint here is reference-equal to
+            // `typeof(ISelf<>)`, and reports IsGenericTypeDefinition. Any representation that
+            // mints a distinct "ISelf applied to its own T" object fails these two checks.
+            Type s = typeof(ISelf<>).GetGenericArguments()[0];
+            Type[] scs = s.GetGenericParameterConstraints();
+            if (scs.Length != 1) return 25;
+            if (scs[0] != typeof(ISelf<>)) return 26;
+            if (!scs[0].IsGenericTypeDefinition) return 27;
+
+            // A non-interface constraint that embeds a parameter becomes the parameter's base
+            // type, so `BaseType` itself hands back an open constructed type — the same object
+            // the constraint array holds.
+            Type c = typeof(CBox<>).GetGenericArguments()[0];
+            Type[] ccs = c.GetGenericParameterConstraints();
+            if (ccs.Length != 1) return 28;
+            if (ccs[0].IsInterface) return 29;
+            if (!ReferenceEquals(c.BaseType, ccs[0])) return 30;
+            // Ordinary reflection over the returned constraint object itself, not just over the
+            // parameter it constrains. `Comparer<T>`'s own base is Object, and everything is
+            // assignable to Object.
+            if (ccs[0].BaseType != typeof(object)) return 37;
+            if (!typeof(object).IsAssignableFrom(ccs[0])) return 38;
+            // An instantiation is not an array, pointer or byref, so it has no element type.
+            if (cs[0].GetElementType() != null) return 42;
+
+            // The collapse composed with nesting: the constraint is `IWrap<INested<T>>`, and its
+            // argument — being the typical instantiation of INested — is `typeof(INested<>)`
+            // itself. So a canonical *definition* legitimately appears as a generic argument,
+            // even though no signature can spell one there.
+            Type nested = typeof(INested<>).GetGenericArguments()[0];
+            Type[] nestedCs = nested.GetGenericParameterConstraints();
+            if (nestedCs.Length != 1) return 31;
+            if (nestedCs[0].GetGenericTypeDefinition() != typeof(IWrap<>)) return 32;
+            if (nestedCs[0].GetGenericArguments()[0] != typeof(INested<>)) return 33;
+            // A collapsed definition appearing as an argument still renders its own formal
+            // parameter list.
+            if (nestedCs[0].ToString()
+                != "TypeGetGenericParameterConstraintsSelfReferential.IWrap`1[TypeGetGenericParameterConstraintsSelfReferential.INested`1[T]]")
+                return 36;
+
+            // Multiple arguments: pins the separator between them.
+            Type db = typeof(DictBox<,>).GetGenericArguments()[1];
+            Type[] dbCs = db.GetGenericParameterConstraints();
+            if (dbCs.Length != 1) return 34;
+            if (dbCs[0].ToString() != "System.Collections.Generic.IDictionary`2[A,B]") return 35;
+
+            // Rendering a bare generic definition differs by format: `ToString()` includes the
+            // formal parameter list, `FullName` and `AssemblyQualifiedName` do not.
+            if (typeof(List<>).ToString() != "System.Collections.Generic.List`1[T]") return 39;
+            if (typeof(List<>).FullName != "System.Collections.Generic.List`1") return 40;
+            if (!typeof(List<>).AssemblyQualifiedName.StartsWith("System.Collections.Generic.List`1, "))
+                return 41;
+
+            return 0;
+        }
+    }
+}

--- a/WoofWare.PawPrint/FieldHandleRegistry.fs
+++ b/WoofWare.PawPrint/FieldHandleRegistry.fs
@@ -86,6 +86,9 @@ module FieldHandleRegistry =
         : CliType * FieldHandleRegistry * 'allocState
         =
         match declaringType with
+        | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+            failwith
+                $"TODO: open constructed types are not handled at FieldHandleRegistry.fs:%s{__LINE__}; got %O{openConstructed}"
         | RuntimeTypeHandleTarget.Closed _
         | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ -> ()
         | RuntimeTypeHandleTarget.GenericParameter _

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -399,7 +399,13 @@ module IlMachineRuntimeMetadata =
                 resolveBaseConcreteType loggerFactory baseClassTypes state handle
 
             state, parent |> Option.map RuntimeTypeHandleTarget.Closed
-        | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
+        // An instantiation's parent is its definition's base type with the instantiation
+        // substituted in. The substitution is only needed when the base actually mentions a
+        // parameter, and the existing guard below refuses exactly that case — so the common
+        // shapes (`Comparer<T>`, whose base is `System.Object`, and any non-generic base) are
+        // answered correctly and the rest stays loud.
+        | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity
+        | RuntimeTypeHandleTarget.OpenConstructed (identity, _) ->
             let assy =
                 match state.LoadedAssembly identity.Assembly with
                 | Some assembly -> assembly
@@ -2344,6 +2350,24 @@ module IlMachineRuntimeMetadata =
         : IlMachineState * bool
         =
         match source, target with
+        // Every type is assignable to System.Object — a reference type by inheritance, a value
+        // type by boxing — regardless of what its generic arguments are. That makes this one
+        // answer decidable without the substitution the general case needs, and it is the query
+        // reflection over a returned constraint object actually makes
+        // (`typeof(object).IsAssignableFrom(constraint)`).
+        | RuntimeTypeHandleTarget.OpenConstructed _, RuntimeTypeHandleTarget.Closed t when
+            (match AllConcreteTypes.lookup t state.ConcreteTypes with
+             | Some ct -> ct.Identity = baseClassTypes.Object.Identity
+             | None -> false)
+            ->
+            state, true
+        // Anything else needs variance and argument substitution over the instantiation, which
+        // the cast oracle does not model. Reachable — a constraint object can be handed to any
+        // reflection assignability API — so it fails loudly rather than guessing.
+        | (RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed), _
+        | _, (RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed) ->
+            failwith
+                $"TODO: isRuntimeTypeHandleTargetAssignableTo does not model open constructed types except assignability to System.Object; got %O{openConstructed} (source %O{source}, target %O{target})"
         | RuntimeTypeHandleTarget.Closed s, RuntimeTypeHandleTarget.Closed t ->
             isConcreteTypeAssignableTo loggerFactory baseClassTypes state s t
         | RuntimeTypeHandleTarget.Closed _, RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->

--- a/WoofWare.PawPrint/ManagedPointerSource.fs
+++ b/WoofWare.PawPrint/ManagedPointerSource.fs
@@ -60,6 +60,17 @@ type RuntimeTypeHandleTarget =
         declaringType : ResolvedTypeIdentity *
         declaringMethod : ComparableMethodDefinitionHandle *
         position : int
+    /// A generic type definition applied to arguments at least one of which is not closed —
+    /// ECMA-335's "open constructed type", e.g. `IComparable&lt;T&gt;` as it appears in
+    /// `class Box&lt;T&gt; where T : IComparable&lt;T&gt;`. Unlike a bare generic parameter this has a
+    /// real MethodTable in CoreCLR (`TypeVarTypeDesc::LoadConstraints` loads each constraint
+    /// under the declaring type's formal `SigTypeContext`, typedesc.cpp:826-830), which is why
+    /// `RuntimeType.IsActualInterface` can answer for one.
+    ///
+    /// Construct via <c>RuntimeTypeHandleTarget.openConstructed</c>, never directly: the
+    /// well-formedness rules there are what keep guest `Type` identity canonical, and
+    /// `TypeHandleRegistry` keys on this value.
+    | OpenConstructed of definition : ResolvedTypeIdentity * arguments : RuntimeTypeHandleTarget list
 
     override this.ToString () : string =
         match this with
@@ -70,6 +81,98 @@ type RuntimeTypeHandleTarget =
             $"generic parameter #%i{position} of %s{declaringType.Assembly.Name}/%O{declaringType.TypeDefinition.Get}"
         | RuntimeTypeHandleTarget.MethodGenericParameter (declaringType, declaringMethod, position) ->
             $"method generic parameter #%i{position} of method %O{declaringMethod.Get} on %s{declaringType.Assembly.Name}/%O{declaringType.TypeDefinition.Get}"
+        | RuntimeTypeHandleTarget.OpenConstructed (definition, arguments) ->
+            let args = arguments |> List.map string |> String.concat ", "
+
+            $"open constructed %s{definition.Assembly.Name}/%O{definition.TypeDefinition.Get}[%s{args}]"
+
+[<RequireQualifiedAccess>]
+module RuntimeTypeHandleTarget =
+    /// Is this target the definition <paramref name="definition"/> applied to exactly its own
+    /// formal parameters, in declaration order? CoreCLR calls that the *typical instantiation*,
+    /// and represents it as the generic type definition itself rather than as a distinct
+    /// instantiation: `ClassLoader::LoadGenericInstantiationThrowing` (clsload.cpp:1426) routes
+    /// such a request to `LoadTypeDefThrowing`, and `IsTypicalInstantiation` (clsload.cpp:242-270)
+    /// is this same check — each argument a type variable of the same owner, at its own index.
+    ///
+    /// This matters constantly rather than exotically: `interface ISelf&lt;T&gt; where T : ISelf&lt;T&gt;`
+    /// is the CRTP shape of `IParsable&lt;TSelf&gt;` and the whole generic-math hierarchy, and real
+    /// .NET hands its constraint back as `typeof(ISelf&lt;&gt;)` — reference-equal, and reporting
+    /// `IsGenericTypeDefinition`. `TypeGetGenericParameterConstraintsSelfReferential.cs` pins it.
+    let private isTypicalInstantiation
+        (definition : ResolvedTypeIdentity)
+        (arguments : RuntimeTypeHandleTarget list)
+        : bool
+        =
+        arguments
+        |> List.indexed
+        |> List.forall (fun (i, arg) ->
+            match arg with
+            | RuntimeTypeHandleTarget.GenericParameter (owner, position) -> position = i && owner = definition
+            | _ -> false
+        )
+
+    /// The target for <paramref name="definition"/> applied to <paramref name="arguments"/>,
+    /// canonicalised. Use this rather than the `OpenConstructed` case directly: `TypeHandleRegistry`
+    /// keys guest `Type` object identity on the target, so two spellings of one type would mint two
+    /// `Type` objects and break the reference identity .NET guarantees.
+    ///
+    /// Three collapses, each mirroring what CoreCLR's class loader does:
+    ///   * no arguments at all is the bare definition;
+    ///   * the definition applied to its own formals is the definition (see above);
+    ///   * every argument closed means the whole thing is closed, and belongs in
+    ///     `AllConcreteTypes` as a `Closed` handle — which this function cannot mint, so it
+    ///     refuses rather than inventing a second representation. The caller holds the
+    ///     concretization context and must take that path itself.
+    let openConstructed
+        (definition : ResolvedTypeIdentity)
+        (arguments : RuntimeTypeHandleTarget list)
+        : RuntimeTypeHandleTarget
+        =
+        if List.isEmpty arguments then
+            RuntimeTypeHandleTarget.OpenGenericTypeDefinition definition
+        elif isTypicalInstantiation definition arguments then
+            RuntimeTypeHandleTarget.OpenGenericTypeDefinition definition
+        else
+
+        // No check that an argument is not itself a bare definition. No *signature* can spell
+        // one there, but canonicalisation can produce one: in
+        // `interface INested<T> where T : IWrap<INested<T>>` the inner `INested<T>` is the
+        // typical instantiation, collapses to the definition by the rule above, and then appears
+        // as an argument of `IWrap<>`. Real .NET agrees — that constraint's argument is
+        // `typeof(INested<>)` — and `TypeGetGenericParameterConstraintsSelfReferential.cs`
+        // pins it.
+        let isClosed (arg : RuntimeTypeHandleTarget) : bool =
+            match arg with
+            | RuntimeTypeHandleTarget.Closed _ -> true
+            | _ -> false
+
+        if arguments |> List.forall isClosed then
+            failwith
+                $"RuntimeTypeHandleTarget.openConstructed: every argument to %O{definition.TypeDefinition.Get} is closed, so this is a closed type and must be concretized into a `Closed` handle rather than represented as `OpenConstructed`"
+
+        RuntimeTypeHandleTarget.OpenConstructed (definition, arguments)
+
+    /// Recursively check the canonicalisation rules `openConstructed` establishes. Called at
+    /// `TypeHandleRegistry.getOrAllocate`, the one choke point through which a target becomes a
+    /// guest-visible `Type`, so that anything constructing the DU case directly is caught before
+    /// it can hand the guest a duplicate identity.
+    let rec assertWellFormed (target : RuntimeTypeHandleTarget) : unit =
+        match target with
+        | RuntimeTypeHandleTarget.OpenConstructed (definition, arguments) ->
+            // Re-running the constructor must be a no-op: anything it would have collapsed or
+            // rejected is by definition not canonical.
+            match openConstructed definition arguments with
+            | RuntimeTypeHandleTarget.OpenConstructed _ -> ()
+            | collapsed ->
+                failwith
+                    $"RuntimeTypeHandleTarget: %O{target} is not canonical; it should have been built as %O{collapsed}"
+
+            arguments |> List.iter assertWellFormed
+        | RuntimeTypeHandleTarget.Closed _
+        | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _
+        | RuntimeTypeHandleTarget.GenericParameter _
+        | RuntimeTypeHandleTarget.MethodGenericParameter _ -> ()
 
 /// The root storage location that a managed pointer points into.
 [<NoComparison>]

--- a/WoofWare.PawPrint/MethodTableProjection.fs
+++ b/WoofWare.PawPrint/MethodTableProjection.fs
@@ -296,7 +296,12 @@ module internal MethodTableProjection =
         =
         match methodTableFor with
         | RuntimeTypeHandleTarget.Closed handle -> categoryFlags baseClassTypes state handle
-        | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
+        // An open constructed type's category is its definition's: instantiating
+        // `IComparable`1` over a type variable does not stop it being an interface. This is
+        // the read behind `RuntimeType.IsActualInterface`, and hence behind every base-type
+        // walk over a generic parameter's constraints.
+        | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity
+        | RuntimeTypeHandleTarget.OpenConstructed (identity, _) ->
             openGenericTypeInfoOrFail state identity
             |> categoryFlagsForTypeInfo baseClassTypes state
         | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
@@ -749,7 +754,20 @@ module internal MethodTableProjection =
         =
         match methodTableFor with
         | RuntimeTypeHandleTarget.Closed handle -> containsGcPointers loggerFactory baseClassTypes state handle
-        | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
+        // Answered from the definition's fields, without substituting the instantiation's
+        // arguments. That is exact for a bare definition, but an approximation for a partial
+        // construction: for `class C<A, B> { A field; }`, `C<int, T>` is reported as containing
+        // GC pointers because `A` is walked unbound, where an exact layout would clear the flag.
+        //
+        // Deliberately not fixed here, and deliberately not made to throw. The bit is inert for
+        // these targets — an open constructed type can never be allocated, and this flag only
+        // informs allocation and GC scanning — and answering conservatively extends the
+        // approximation `OpenGenericTypeDefinition` already makes rather than inventing a second
+        // one. An exact answer needs field-type substitution under a mixed
+        // closed/type-variable context, which is the same machinery the array/pointer TODO in
+        // `RuntimeTypeHandle_GetConstraints` is waiting on.
+        | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity
+        | RuntimeTypeHandleTarget.OpenConstructed (identity, _) ->
             openGenericContainsGcPointers loggerFactory baseClassTypes state identity
         | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
             failwith
@@ -761,6 +779,11 @@ module internal MethodTableProjection =
     let private genericsFlags (state : IlMachineState) (methodTableFor : RuntimeTypeHandleTarget) : int32 =
         match methodTableFor with
         | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ -> genericsMaskTypicalInst
+        // Not `TypicalInst`: the typical instantiation is the definition applied to its own
+        // formals, which `RuntimeTypeHandleTarget.openConstructed` collapses to
+        // `OpenGenericTypeDefinition`. Anything still spelled `OpenConstructed` is a shared
+        // (canonical) instantiation over some *other* arguments.
+        | RuntimeTypeHandleTarget.OpenConstructed _ -> genericsMaskGenericInst
         | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
             failwith $"TODO: genericsFlags for generic parameter #%i{position} of %O{declaringType.TypeDefinition.Get}"
         | RuntimeTypeHandleTarget.MethodGenericParameter (declaringType, declaringMethod, position) ->
@@ -794,6 +817,10 @@ module internal MethodTableProjection =
             else
                 true
         | RuntimeTypeHandleTarget.Closed _ -> false
+        // Openness is the defining property of the case: `openConstructed` refuses an
+        // all-closed argument list, so reaching here means at least one argument transitively
+        // contains a variable.
+        | RuntimeTypeHandleTarget.OpenConstructed _ -> true
         | RuntimeTypeHandleTarget.GenericParameter _
         | RuntimeTypeHandleTarget.MethodGenericParameter _ ->
             // A generic parameter T is itself an unbound variable, so its MethodTable contains
@@ -822,7 +849,9 @@ module internal MethodTableProjection =
             | RuntimeTypeHandleTarget.Closed handle ->
                 Option.isSome (tryArrayElement handle)
                 || isStringType baseClassTypes state handle
-            | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ -> false
+            | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _
+            // Neither a string nor an array: only `Closed` can name those shapes.
+            | RuntimeTypeHandleTarget.OpenConstructed _ -> false
             | RuntimeTypeHandleTarget.GenericParameter _
             | RuntimeTypeHandleTarget.MethodGenericParameter _ -> false
 
@@ -847,7 +876,10 @@ module internal MethodTableProjection =
                 | RuntimeTypeHandleTarget.Closed handle ->
                     AllConcreteTypes.lookup handle state.ConcreteTypes
                     |> Option.map (fun concreteType -> concreteType.Identity)
-                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity -> Some identity
+                // A `ref struct R<T>` keeps the flag when instantiated, just as the bare
+                // definition does; the attribute lives on the definition either way.
+                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity
+                | RuntimeTypeHandleTarget.OpenConstructed (identity, _) -> Some identity
                 | RuntimeTypeHandleTarget.GenericParameter _
                 | RuntimeTypeHandleTarget.MethodGenericParameter _ -> None
 
@@ -869,7 +901,8 @@ module internal MethodTableProjection =
                 let componentSize, state = componentSize baseClassTypes state handle
                 int32<uint16> componentSize, state
             | RuntimeTypeHandleTarget.Closed _
-            | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ -> 0, state
+            | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _
+            | RuntimeTypeHandleTarget.OpenConstructed _ -> 0, state
             | RuntimeTypeHandleTarget.GenericParameter _
             | RuntimeTypeHandleTarget.MethodGenericParameter _ -> 0, state
 
@@ -938,7 +971,8 @@ module internal MethodTableProjection =
             | "BaseSize" ->
                 match methodTableFor with
                 | RuntimeTypeHandleTarget.Closed handle -> Some (uint32Field (uint32 (baseSize handle)), state)
-                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
+                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _
+                | RuntimeTypeHandleTarget.OpenConstructed _ ->
                     failwith $"TODO: MethodTable::BaseSize projection for %O{methodTableFor}"
                 | RuntimeTypeHandleTarget.GenericParameter _
                 | RuntimeTypeHandleTarget.MethodGenericParameter _ ->
@@ -948,7 +982,8 @@ module internal MethodTableProjection =
                 | RuntimeTypeHandleTarget.Closed handle ->
                     let componentSize, state = componentSize baseClassTypes state handle
                     Some (CliType.Numeric (CliNumericType.UInt16 componentSize), state)
-                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
+                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _
+                | RuntimeTypeHandleTarget.OpenConstructed _ ->
                     failwith $"TODO: MethodTable::ComponentSize projection for %O{methodTableFor}"
                 | RuntimeTypeHandleTarget.GenericParameter _
                 | RuntimeTypeHandleTarget.MethodGenericParameter _ ->
@@ -965,7 +1000,8 @@ module internal MethodTableProjection =
                             state
                         )
                     | None -> failwith $"TODO: MethodTable::ElementType projection for non-array type %O{handle}"
-                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
+                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _
+                | RuntimeTypeHandleTarget.OpenConstructed _ ->
                     failwith $"TODO: MethodTable::ElementType projection for %O{methodTableFor}"
                 | RuntimeTypeHandleTarget.GenericParameter _
                 | RuntimeTypeHandleTarget.MethodGenericParameter _ ->
@@ -973,10 +1009,12 @@ module internal MethodTableProjection =
             | "AuxiliaryData" ->
                 // CoreCLR represents generic parameters (TypeVarTypeDesc) as TypeDesc handles, which
                 // have no MethodTable and therefore no AuxiliaryData. Keep the projection honest:
-                // only Closed and OpenGenericTypeDefinition targets carry a MethodTable.
+                // only the MethodTable-shaped targets carry one — which, per
+                // `TypeHandleTag.forTarget`, includes an open constructed type.
                 match methodTableFor with
                 | RuntimeTypeHandleTarget.Closed _
-                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
+                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _
+                | RuntimeTypeHandleTarget.OpenConstructed _ ->
                     Some (CliType.RuntimePointer (CliRuntimePointer.MethodTableAuxiliaryDataPtr methodTableFor), state)
                 | RuntimeTypeHandleTarget.GenericParameter _
                 | RuntimeTypeHandleTarget.MethodGenericParameter _ ->
@@ -984,8 +1022,11 @@ module internal MethodTableProjection =
                         $"MethodTable::AuxiliaryData projection refused for TypeDesc target %O{methodTableFor}: generic parameters have no MethodTable in CoreCLR"
             | "ParentMethodTable" ->
                 match methodTableFor with
+                // Reached for real: `Type.BaseType` on a returned class constraint (say
+                // `Comparer<T>` from `where T : Comparer<T>`) reads this.
                 | RuntimeTypeHandleTarget.Closed _
-                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
+                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _
+                | RuntimeTypeHandleTarget.OpenConstructed _ ->
                     let state, parent =
                         IlMachineState.resolveBaseRuntimeTypeHandleTarget
                             loggerFactory
@@ -1022,6 +1063,9 @@ module internal MethodTableProjection =
                 // explicit dictionary-index modelling before this can be
                 // broadened.
                 match methodTableFor with
+                | RuntimeTypeHandleTarget.OpenConstructed (definition, _) ->
+                    failwith
+                        $"TODO: MethodTable::PerInstInfo projection for open constructed %O{definition.TypeDefinition.Get}: the projection is deliberately gated to System.Nullable`1 (see above)"
                 | RuntimeTypeHandleTarget.Closed handle ->
                     match handle with
                     | ConcreteTypeHandle.Concrete _ ->
@@ -1114,9 +1158,10 @@ module internal MethodTableProjection =
             | "ExposedClassObjectRaw" ->
                 match methodTableFor with
                 | RuntimeTypeHandleTarget.Closed _
-                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
-                    // Both Closed instantiations and open generic type definitions
-                    // have a real MethodTable in CoreCLR, so this auxiliary cell is
+                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _
+                | RuntimeTypeHandleTarget.OpenConstructed _ ->
+                    // Closed instantiations, open generic type definitions and open constructed
+                    // types all have a real MethodTable in CoreCLR, so this auxiliary cell is
                     // well-defined. Pre-allocate the canonical RuntimeType so the
                     // read through the byref is a pure registry lookup.
                     let _addr, state =

--- a/WoofWare.PawPrint/Native/NativeArray.fs
+++ b/WoofWare.PawPrint/Native/NativeArray.fs
@@ -32,6 +32,9 @@ module NativeArray =
         : ConcreteTypeHandle * ConcreteTypeHandle
         =
         match target with
+        | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+            failwith
+                $"TODO: open constructed types are not handled at Native/NativeArray.fs:%s{__LINE__}; got %O{openConstructed}"
         | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
             failwith $"TODO: %s{operation} for open generic type definition %O{identity}"
         | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->

--- a/WoofWare.PawPrint/Native/NativeCall.fs
+++ b/WoofWare.PawPrint/Native/NativeCall.fs
@@ -105,6 +105,9 @@ module NativeCall =
         : ConcreteTypeHandle
         =
         match qCallTypeHandleToRuntimeTypeHandleTarget operation state arg with
+        | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+            failwith
+                $"TODO: open constructed types are not handled at Native/NativeCall.fs:%s{__LINE__}; got %O{openConstructed}"
         | RuntimeTypeHandleTarget.Closed cth -> cth
         | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
             failwith
@@ -606,6 +609,9 @@ module NativeCall =
         : System.Reflection.AssemblyName
         =
         match typeHandleTarget with
+        // An instantiation lives in the assembly that declares its definition, exactly as a
+        // closed one does (`typeof(List<int>).Assembly` is corelib, not the caller's).
+        | RuntimeTypeHandleTarget.OpenConstructed (identity, _)
         | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity -> identity.Assembly
         | RuntimeTypeHandleTarget.GenericParameter (declaringType, _)
         | RuntimeTypeHandleTarget.MethodGenericParameter (declaringType, _, _) ->

--- a/WoofWare.PawPrint/Native/NativeCustomAttribute.fs
+++ b/WoofWare.PawPrint/Native/NativeCustomAttribute.fs
@@ -274,6 +274,9 @@ module NativeCustomAttribute =
 
                 let instantiatedHandle =
                     match typeHandleTarget with
+                    | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+                        failwith
+                            $"TODO: open constructed types are not handled at Native/NativeCustomAttribute.fs:%s{__LINE__}; got %O{openConstructed}"
                     | RuntimeTypeHandleTarget.Closed handle -> handle
                     | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
                         failwith

--- a/WoofWare.PawPrint/Native/NativeEnum.fs
+++ b/WoofWare.PawPrint/Native/NativeEnum.fs
@@ -21,6 +21,9 @@ module NativeEnum =
 
         let concreteTypeHandle =
             match NativeCall.qCallTypeHandleToRuntimeTypeHandleTarget operation state arg with
+            | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+                failwith
+                    $"TODO: open constructed types are not handled at Native/NativeEnum.fs:%s{__LINE__}; got %O{openConstructed}"
             | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
                 failwith $"%s{operation}: expected a closed enum RuntimeTypeHandle, got open generic %O{identity}"
             | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->

--- a/WoofWare.PawPrint/Native/NativeGc.fs
+++ b/WoofWare.PawPrint/Native/NativeGc.fs
@@ -78,6 +78,9 @@ module NativeGc =
                 $"%s{operation}: expected the type handle of an SZ array, got %O{other}; both managed callers pass typeof(T[]).TypeHandle"
         | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
             failwith $"%s{operation}: expected a closed SZ array type handle, got open generic definition %O{identity}"
+        | RuntimeTypeHandleTarget.OpenConstructed (definition, _) ->
+            failwith
+                $"%s{operation}: expected a closed SZ array type handle, got open constructed type %O{definition.TypeDefinition.Get}"
         | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
             failwith
                 $"%s{operation}: expected a closed SZ array type handle, got generic parameter #%i{position} of %O{declaringType.TypeDefinition.Get}"

--- a/WoofWare.PawPrint/Native/NativeRuntimeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeHelpers.fs
@@ -32,6 +32,9 @@ module NativeRuntimeHelpers =
                 NativeCall.qCallTypeHandleToRuntimeTypeHandleTarget operation state qCallHandle
 
             match typeHandleTarget with
+            | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+                failwith
+                    $"TODO: open constructed types are not handled at Native/NativeRuntimeHelpers.fs:%s{__LINE__}; got %O{openConstructed}"
             | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ ->
                 failwith
                     $"TODO: RuntimeHelpers.RunClassConstructor for open generic type definition %O{typeHandleTarget}"

--- a/WoofWare.PawPrint/Native/NativeRuntimeMethodHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeMethodHandle.fs
@@ -348,6 +348,9 @@ module NativeRuntimeMethodHandle =
             assembly.TypeDefs.[identity.TypeDefinition.Get]
 
         match target with
+        | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+            failwith
+                $"TODO: open constructed types are not handled at Native/NativeRuntimeMethodHandle.fs:%s{__LINE__}; got %O{openConstructed}"
         | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete _ as handle) ->
             let concreteType =
                 AllConcreteTypes.lookup handle state.ConcreteTypes
@@ -478,6 +481,9 @@ module NativeRuntimeMethodHandle =
             assembly, typeInfo
 
         match target with
+        | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+            failwith
+                $"TODO: open constructed types are not handled at Native/NativeRuntimeMethodHandle.fs:%s{__LINE__}; got %O{openConstructed}"
         | RuntimeTypeHandleTarget.Closed handle ->
             match handle with
             | ConcreteTypeHandle.Concrete _ ->
@@ -884,6 +890,9 @@ module NativeRuntimeMethodHandle =
                 instantiationTargets
                 |> List.mapi (fun index target ->
                     match target with
+                    | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+                        failwith
+                            $"TODO: open constructed types are not handled at Native/NativeRuntimeMethodHandle.fs:%s{__LINE__}; got %O{openConstructed}"
                     | RuntimeTypeHandleTarget.Closed handle -> handle
                     | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _
                     | RuntimeTypeHandleTarget.GenericParameter _

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeFCall.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeFCall.fs
@@ -91,6 +91,9 @@ module NativeRuntimeTypeFCall =
 
             let state, fieldHandleIds =
                 match typeHandleTarget with
+                | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+                    failwith
+                        $"TODO: open constructed types are not handled at Native/NativeRuntimeTypeFCall.fs:%s{__LINE__}; got %O{openConstructed}"
                 | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
                     failwith
                         $"TODO: %s{operation} for open generic type definition %O{identity}; expected behavior is to enumerate the canonical type's non-literal fields"
@@ -162,6 +165,9 @@ module NativeRuntimeTypeFCall =
             // means the wrapper's guard was bypassed, so fail rather than invent a name.
             let name =
                 match typeHandleTarget with
+                | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+                    failwith
+                        $"TODO: open constructed types are not handled at Native/NativeRuntimeTypeFCall.fs:%s{__LINE__}; got %O{openConstructed}"
                 | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete _ as typeHandle) ->
                     match IlMachineState.tryGetConcreteTypeInfo state typeHandle with
                     | Some (_, typeInfo) -> typeInfo.Name
@@ -277,6 +283,10 @@ module NativeRuntimeTypeFCall =
                 match target with
                 | RuntimeTypeHandleTarget.GenericParameter _
                 | RuntimeTypeHandleTarget.MethodGenericParameter _ -> true
+                // An open constructed type *contains* generic variables but is not one: it has a
+                // MethodTable, and `RuntimeType.GetBaseType` branches on this to decide whether
+                // to walk constraints at all.
+                | RuntimeTypeHandleTarget.OpenConstructed _
                 | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _
                 | RuntimeTypeHandleTarget.Closed _ -> false
 
@@ -305,6 +315,9 @@ module NativeRuntimeTypeFCall =
 
             let index =
                 match target with
+                | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+                    failwith
+                        $"TODO: open constructed types are not handled at Native/NativeRuntimeTypeFCall.fs:%s{__LINE__}; got %O{openConstructed}"
                 | RuntimeTypeHandleTarget.GenericParameter (_, position)
                 | RuntimeTypeHandleTarget.MethodGenericParameter (_, _, position) -> position
                 | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _
@@ -338,6 +351,9 @@ module NativeRuntimeTypeFCall =
                 NativeCall.runtimeTypeHandleTargetOfRuntimeTypeRef operation state runtimeTypeRef
 
             match target with
+            | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+                failwith
+                    $"TODO: open constructed types are not handled at Native/NativeRuntimeTypeFCall.fs:%s{__LINE__}; got %O{openConstructed}"
             | RuntimeTypeHandleTarget.GenericParameter _
             | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _
             | RuntimeTypeHandleTarget.Closed _ ->
@@ -572,10 +588,13 @@ module NativeRuntimeTypeFCall =
 
             let elementTypeSource : NativeIntSource =
                 match target with
+                | RuntimeTypeHandleTarget.OpenConstructed _
                 | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _
                 | RuntimeTypeHandleTarget.GenericParameter _
                 | RuntimeTypeHandleTarget.MethodGenericParameter _ ->
-                    // GetElementType returns null for non-array/pointer/byref types.
+                    // GetElementType returns null for non-array/pointer/byref types. An open
+                    // constructed type is a generic instantiation, so it has no element type
+                    // any more than its definition does.
                     NativeIntSource.Verbatim 0L
                 | RuntimeTypeHandleTarget.Closed handle ->
                     match handle with
@@ -618,6 +637,9 @@ module NativeRuntimeTypeFCall =
 
             let sourceHandle =
                 match sourceTarget with
+                | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+                    failwith
+                        $"TODO: open constructed types are not handled at Native/NativeRuntimeTypeFCall.fs:%s{__LINE__}; got %O{openConstructed}"
                 | RuntimeTypeHandleTarget.Closed handle -> handle
                 | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
                     failwith
@@ -631,6 +653,9 @@ module NativeRuntimeTypeFCall =
 
             let targetHandle =
                 match targetTarget with
+                | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+                    failwith
+                        $"TODO: open constructed types are not handled at Native/NativeRuntimeTypeFCall.fs:%s{__LINE__}; got %O{openConstructed}"
                 | RuntimeTypeHandleTarget.Closed handle -> handle
                 | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
                     failwith
@@ -706,7 +731,10 @@ module NativeRuntimeTypeFCall =
                 match target with
                 | RuntimeTypeHandleTarget.GenericParameter _
                 | RuntimeTypeHandleTarget.MethodGenericParameter _ -> int System.Reflection.TypeAttributes.Public
-                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
+                // An instantiation's attributes are its definition's: instantiating an interface
+                // leaves it an interface, which is what `Type.IsInterface` reads here.
+                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity
+                | RuntimeTypeHandleTarget.OpenConstructed (identity, _) ->
                     let assembly =
                         state.LoadedAssembly identity.Assembly
                         |> Option.defaultWith (fun () ->
@@ -806,6 +834,9 @@ module NativeRuntimeTypeFCall =
 
             let handle =
                 match target with
+                | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+                    failwith
+                        $"TODO: open constructed types are not handled at Native/NativeRuntimeTypeFCall.fs:%s{__LINE__}; got %O{openConstructed}"
                 | RuntimeTypeHandleTarget.Closed handle -> handle
                 | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
                     failwith

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
@@ -249,7 +249,12 @@ module NativeRuntimeTypeHelpers =
         : int32
         =
         match typeHandleTarget with
-        | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
+        // An open constructed type is not a TypeDesc, so CoreCLR's
+        // `TypeHandle::GetSignatureCorElementType` (typehandle.cpp:1160) routes it to
+        // `MethodTable::GetSignatureCorElementType`, which reports the EEClass's internal
+        // element type — the same CLASS/VALUETYPE the definition reports.
+        | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity
+        | RuntimeTypeHandleTarget.OpenConstructed (identity, _) ->
             let assembly =
                 state.LoadedAssembly identity.Assembly
                 |> Option.defaultWith (fun () ->
@@ -573,7 +578,10 @@ module NativeRuntimeTypeHelpers =
         : int32
         =
         match typeHandleTarget with
-        | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity -> typeDefinitionToken identity.TypeDefinition.Get
+        // An instantiation carries no metadata row of its own; `Type.MetadataToken` reports
+        // the generic definition's TypeDef row for both the open and the closed forms.
+        | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity
+        | RuntimeTypeHandleTarget.OpenConstructed (identity, _) -> typeDefinitionToken identity.TypeDefinition.Get
         | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
             // ECMA-335 §II.22.20: GenericParam table tag 0x2A. The parameter's
             // GenericParameterHandle is owned by the declaring type's metadata
@@ -699,6 +707,9 @@ module NativeRuntimeTypeHelpers =
         : IlMachineState * int
         =
         match typeHandleTarget with
+        | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+            failwith
+                $"TODO: open constructed types are not handled at Native/NativeRuntimeTypeHelpers.fs:%s{__LINE__}; got %O{openConstructed}"
         | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
             // CoreCLR's GetNumVirtuals asserts !typeHandle.IsGenericVariable(); the BCL's
             // RuntimeType.GetMethodCandidates strips generic variables before calling.
@@ -850,6 +861,9 @@ module NativeRuntimeTypeHelpers =
         : ManagedHeapAddress option * IlMachineState
         =
         match typeHandleTarget with
+        | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+            failwith
+                $"TODO: open constructed types are not handled at Native/NativeRuntimeTypeHelpers.fs:%s{__LINE__}; got %O{openConstructed}"
         | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
             let assembly =
                 state.LoadedAssembly identity.Assembly
@@ -938,6 +952,9 @@ module NativeRuntimeTypeHelpers =
         =
         let baseHandle, state =
             match typeHandleTarget with
+            | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+                failwith
+                    $"TODO: open constructed types are not handled at Native/NativeRuntimeTypeHelpers.fs:%s{__LINE__}; got %O{openConstructed}"
             | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
                 let assembly =
                     state.LoadedAssembly identity.Assembly
@@ -1009,6 +1026,9 @@ module NativeRuntimeTypeHelpers =
         =
         let elementHandle =
             match typeHandleTarget with
+            | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+                failwith
+                    $"TODO: open constructed types are not handled at Native/NativeRuntimeTypeHelpers.fs:%s{__LINE__}; got %O{openConstructed}"
             | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ -> None
             // A generic parameter is not an array/pointer/byref, so GetElementType returns null.
             | RuntimeTypeHandleTarget.GenericParameter _
@@ -1198,6 +1218,9 @@ module NativeRuntimeTypeHelpers =
         : ConcreteTypeHandle * IlMachineState
         =
         match target with
+        | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+            failwith
+                $"TODO: open constructed types are not handled at Native/NativeRuntimeTypeHelpers.fs:%s{__LINE__}; got %O{openConstructed}"
         | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
             instantiateOpenGenericTypeDefinition loggerFactory baseClassTypes operation state identity genericArguments
         | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete _ as typeHandle) ->
@@ -1246,6 +1269,9 @@ module NativeRuntimeTypeHelpers =
             | Some assembly -> Some assembly.TypeDefs.[identity.TypeDefinition.Get]
 
         match target with
+        | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+            failwith
+                $"TODO: open constructed types are not handled at Native/NativeRuntimeTypeHelpers.fs:%s{__LINE__}; got %O{openConstructed}"
         | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity -> lookupFromIdentity identity
         | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete _ as handle) ->
             match AllConcreteTypes.lookup handle state.ConcreteTypes with
@@ -1798,60 +1824,127 @@ module NativeRuntimeTypeHelpers =
                 else
                     name
 
-        match typeHandleTarget with
-        | RuntimeTypeHandleTarget.Closed typeHandle -> concreteTypeHandleName typeHandle
-        | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
-            let assembly =
-                state.LoadedAssembly identity.Assembly
-                |> Option.defaultWith (fun () ->
+        let rec targetName (target : RuntimeTypeHandleTarget) : string =
+            match target with
+            | RuntimeTypeHandleTarget.Closed typeHandle -> concreteTypeHandleName typeHandle
+            | RuntimeTypeHandleTarget.OpenConstructed (definition, arguments) ->
+                // CoreCLR's `TypeString::AppendType` emits the definition's name followed by the
+                // instantiation in brackets, exactly as for a closed one; the arguments simply
+                // happen to include type variables, which print as their bare parameter names.
+                let assembly =
+                    state.LoadedAssembly definition.Assembly
+                    |> Option.defaultWith (fun () ->
+                        failwith
+                            $"%s{operation}: assembly for open constructed type is not loaded: %s{definition.AssemblyFullName}"
+                    )
+
+                let typeInfo = assembly.TypeDefs.[definition.TypeDefinition.Get]
+                let name = typeInfoDisplayName includeNamespace assembly typeInfo
+
+                let name =
+                    // Same gate as the closed case just above: CoreCLR's
+                    // `TypeString::AppendType` appends the instantiation only when
+                    // FormatNamespace or FormatAssembly is set. `Type.Name` asks for neither, so
+                    // it is "IComparable`1" rather than "IComparable`1[T]"; `ToString()` asks for
+                    // FormatNamespace and so gets the brackets.
+                    if includeNamespace || includeAssembly then
+                        // Comma with no space, as the closed-handle path above does and as
+                        // CoreCLR's `TypeString` emits: `IDictionary\`2[A,B]`.
+                        let args = arguments |> List.map targetName |> String.concat ","
+                        $"%s{name}[%s{args}]"
+                    else
+                        name
+
+                if includeAssembly then
+                    $"%s{name}, %s{assemblyDisplayName noVersion definition.Assembly}"
+                else
+                    name
+            | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _
+            | RuntimeTypeHandleTarget.GenericParameter _
+            | RuntimeTypeHandleTarget.MethodGenericParameter _ -> nonConstructedName target
+
+        and nonConstructedName (typeHandleTarget : RuntimeTypeHandleTarget) : string =
+            match typeHandleTarget with
+            | RuntimeTypeHandleTarget.Closed typeHandle -> concreteTypeHandleName typeHandle
+            | RuntimeTypeHandleTarget.OpenConstructed _ -> targetName typeHandleTarget
+            | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
+                let assembly =
+                    state.LoadedAssembly identity.Assembly
+                    |> Option.defaultWith (fun () ->
+                        failwith
+                            $"%s{operation}: assembly for open generic type definition is not loaded: %s{identity.AssemblyFullName}"
+                    )
+
+                let typeInfo = assembly.TypeDefs.[identity.TypeDefinition.Get]
+                let name = typeInfoDisplayName includeNamespace assembly typeInfo
+
+                let name =
+                    // A generic definition renders its own formal parameters for `ToString()`
+                    // (FormatNamespace alone): `typeof(List<>).ToString()` is
+                    // "System.Collections.Generic.List`1[T]", while `.Name` is "List`1".
+                    //
+                    // But *not* for `FullName` or `AssemblyQualifiedName`, which CoreLib asks for
+                    // with FormatFullInst set: those are "System.Collections.Generic.List`1",
+                    // because a full name has to stay parseable and `List`1[T]` is not. This is
+                    // the opposite of the closed case above, where FormatFullInst is precisely
+                    // what makes the instantiation render in full.
+                    //
+                    // The formals also matter in argument position, since the
+                    // typical-instantiation collapse puts definitions there —
+                    // `IWrap<INested<T>>` renders its argument as "INested`1[T]".
+                    let fullInst = hasFormatFlag formatFullInstFlag flags
+
+                    if includeNamespace && not fullInst && not typeInfo.Generics.IsEmpty then
+                        let formals =
+                            typeInfo.Generics |> Seq.map (fun (p, _) -> p.Name) |> String.concat ","
+
+                        $"%s{name}[%s{formals}]"
+                    else
+                        name
+
+                if includeAssembly then
+                    $"%s{name}, %s{assemblyDisplayName noVersion identity.Assembly}"
+                else
+                    name
+            | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
+                // CoreCLR's TypeString::AppendType for a generic parameter emits only the
+                // parameter name regardless of the FormatNamespace / FormatAssembly /
+                // FormatGenericParameters bits: parameters have no namespace, no owning
+                // assembly suffix, and no instantiation of their own.
+                let assembly =
+                    state.LoadedAssembly declaringType.Assembly
+                    |> Option.defaultWith (fun () ->
+                        failwith
+                            $"%s{operation}: assembly for declaring type of generic parameter is not loaded: %s{declaringType.AssemblyFullName}"
+                    )
+
+                let typeInfo = assembly.TypeDefs.[declaringType.TypeDefinition.Get]
+
+                if position < 0 || position >= typeInfo.Generics.Length then
                     failwith
-                        $"%s{operation}: assembly for open generic type definition is not loaded: %s{identity.AssemblyFullName}"
-                )
+                        $"%s{operation}: generic parameter position %d{position} is out of range for %O{declaringType.TypeDefinition.Get} (declares %d{typeInfo.Generics.Length} parameters)"
 
-            let typeInfo = assembly.TypeDefs.[identity.TypeDefinition.Get]
-            let name = typeInfoDisplayName includeNamespace assembly typeInfo
+                let parameter, _ = typeInfo.Generics.[position]
+                parameter.Name
+            | RuntimeTypeHandleTarget.MethodGenericParameter (declaringType, declaringMethod, position) ->
+                // Same as type-generic parameters: CoreCLR emits only the parameter name.
+                let assembly =
+                    state.LoadedAssembly declaringType.Assembly
+                    |> Option.defaultWith (fun () ->
+                        failwith
+                            $"%s{operation}: assembly for declaring type of method generic parameter is not loaded: %s{declaringType.AssemblyFullName}"
+                    )
 
-            if includeAssembly then
-                $"%s{name}, %s{assemblyDisplayName noVersion identity.Assembly}"
-            else
-                name
-        | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
-            // CoreCLR's TypeString::AppendType for a generic parameter emits only the
-            // parameter name regardless of the FormatNamespace / FormatAssembly /
-            // FormatGenericParameters bits: parameters have no namespace, no owning
-            // assembly suffix, and no instantiation of their own.
-            let assembly =
-                state.LoadedAssembly declaringType.Assembly
-                |> Option.defaultWith (fun () ->
+                let methodInfo = assembly.Methods.[declaringMethod.Get]
+
+                if position < 0 || position >= methodInfo.Generics.Length then
                     failwith
-                        $"%s{operation}: assembly for declaring type of generic parameter is not loaded: %s{declaringType.AssemblyFullName}"
-                )
+                        $"%s{operation}: method generic parameter position %d{position} is out of range for method %O{declaringMethod.Get} (declares %d{methodInfo.Generics.Length} method generics)"
 
-            let typeInfo = assembly.TypeDefs.[declaringType.TypeDefinition.Get]
+                let parameter, _ = methodInfo.Generics.[position]
+                parameter.Name
 
-            if position < 0 || position >= typeInfo.Generics.Length then
-                failwith
-                    $"%s{operation}: generic parameter position %d{position} is out of range for %O{declaringType.TypeDefinition.Get} (declares %d{typeInfo.Generics.Length} parameters)"
-
-            let parameter, _ = typeInfo.Generics.[position]
-            parameter.Name
-        | RuntimeTypeHandleTarget.MethodGenericParameter (declaringType, declaringMethod, position) ->
-            // Same as type-generic parameters: CoreCLR emits only the parameter name.
-            let assembly =
-                state.LoadedAssembly declaringType.Assembly
-                |> Option.defaultWith (fun () ->
-                    failwith
-                        $"%s{operation}: assembly for declaring type of method generic parameter is not loaded: %s{declaringType.AssemblyFullName}"
-                )
-
-            let methodInfo = assembly.Methods.[declaringMethod.Get]
-
-            if position < 0 || position >= methodInfo.Generics.Length then
-                failwith
-                    $"%s{operation}: method generic parameter position %d{position} is out of range for method %O{declaringMethod.Get} (declares %d{methodInfo.Generics.Length} method generics)"
-
-            let parameter, _ = methodInfo.Generics.[position]
-            parameter.Name
+        targetName typeHandleTarget
 
     /// PawPrint's rendering of CoreCLR's `CopyRuntimeTypeHandles` (runtimehandles.cpp:561), the
     /// single helper behind every QCall that hands a type list back through an
@@ -2040,6 +2133,9 @@ module ActivationInfo =
         =
         let handle =
             match target with
+            | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+                failwith
+                    $"TODO: open constructed types are not handled at Native/NativeRuntimeTypeHelpers.fs:%s{__LINE__}; got %O{openConstructed}"
             | RuntimeTypeHandleTarget.Closed handle -> handle
             | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _
             | RuntimeTypeHandleTarget.GenericParameter _

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
@@ -288,6 +288,11 @@ module NativeRuntimeTypeQCall =
 
             let genericArgumentTargets : RuntimeTypeHandleTarget list =
                 match typeHandleTarget with
+                // The arguments are already targets, and they are already canonical, so the
+                // `Type` objects handed back are the very ones the registry holds — which is
+                // what makes `typeof(Box<>).GetGenericArguments()[0]` reference-equal to the
+                // argument of its own `IComparable<T>` constraint.
+                | RuntimeTypeHandleTarget.OpenConstructed (_, arguments) -> arguments
                 | RuntimeTypeHandleTarget.Closed handle ->
                     match handle with
                     | ConcreteTypeHandle.Concrete _ ->
@@ -392,6 +397,11 @@ module NativeRuntimeTypeQCall =
             // `MethodTableProjection.targetContainsGenericVariables`.
             let definitionTarget =
                 match typeHandleTarget with
+                // `openConstructed` has already collapsed the typical instantiation to
+                // `OpenGenericTypeDefinition`, so anything still spelled `OpenConstructed` is a
+                // genuine instantiation whose definition is exactly this.
+                | RuntimeTypeHandleTarget.OpenConstructed (definition, _) ->
+                    RuntimeTypeHandleTarget.OpenGenericTypeDefinition definition
                 | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete _ as handle) ->
                     let concreteType =
                         AllConcreteTypes.lookup handle state.ConcreteTypes
@@ -456,6 +466,9 @@ module NativeRuntimeTypeQCall =
                 NativeCall.objectHandleOnStackTarget operation state "retTypes" instruction.Arguments.[1]
 
             match typeHandleTarget with
+            | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+                failwith
+                    $"TODO: open constructed types are not handled at Native/NativeRuntimeTypeQCall.fs:%s{__LINE__}; got %O{openConstructed}"
             | RuntimeTypeHandleTarget.GenericParameter (declaringType, position) ->
                 let assembly =
                     state.LoadedAssembly declaringType.Assembly
@@ -502,6 +515,77 @@ module NativeRuntimeTypeQCall =
                     | TypeDefn.FromDefinition _
                     | TypeDefn.Void -> false
 
+                // Resolve the head of a generic instantiation to the canonical identity of its
+                // definition. Identity, not spelling: the same definition reached via
+                // `FromDefinition` and via a `FromReference` in some other assembly must produce
+                // one `ResolvedTypeIdentity`, because `TypeHandleRegistry` keys guest `Type`
+                // object identity on the resulting target.
+                let resolveDefinitionIdentity
+                    (state : IlMachineState)
+                    (genericDef : TypeDefn)
+                    : IlMachineState * ResolvedTypeIdentity
+                    =
+                    match genericDef with
+                    | TypeDefn.FromDefinition (identity, _) -> state, identity
+                    | _ ->
+                        let state, _, resolved =
+                            IlMachineState.resolveTypeFromDefn
+                                ctx.LoggerFactory
+                                ctx.BaseClassTypes
+                                genericDef
+                                ImmutableArray.Empty
+                                ImmutableArray.Empty
+                                assembly
+                                state
+
+                        state, resolved.Identity
+
+                // Map one constraint signature to the target that names it. A constraint that
+                // mentions no generic parameter is an ordinary closed type; one that does is an
+                // open constructed type, whose arguments are themselves targets — recursively,
+                // since `where T : IComparable<List<T>>` is legal.
+                let rec constraintTarget
+                    (state : IlMachineState)
+                    (ty : TypeDefn)
+                    : IlMachineState * RuntimeTypeHandleTarget
+                    =
+                    match ty with
+                    | TypeDefn.GenericTypeParameter idx ->
+                        state, RuntimeTypeHandleTarget.GenericParameter (declaringType, idx)
+                    | TypeDefn.GenericMethodParameter idx ->
+                        failwith
+                            $"%s{operation}: type-generic parameter #%d{position} of %O{declaringType.TypeDefinition.Get} declares a method-generic parameter constraint !!%d{idx}; impossible without a method context"
+                    | TypeDefn.GenericInstantiation (genericDef, args) when embedsTypeParameter ty ->
+                        let state, definition = resolveDefinitionIdentity state genericDef
+
+                        let state, argumentTargets =
+                            ((state, []), args)
+                            ||> Seq.fold (fun (state, acc) arg ->
+                                let state, target = constraintTarget state arg
+                                state, target :: acc
+                            )
+
+                        // `openConstructed` is what keeps this canonical: it collapses the
+                        // typical instantiation (the CRTP `where T : ISelf<T>`) back to the bare
+                        // definition, exactly as CoreCLR's class loader does, so the guest sees
+                        // one `Type` object rather than two.
+                        state, RuntimeTypeHandleTarget.openConstructed definition (List.rev argumentTargets)
+                    | _ when embedsTypeParameter ty ->
+                        failwith
+                            $"TODO: %s{operation}: constraint %O{ty} on type-generic parameter #%d{position} of %O{declaringType.TypeDefinition.Get} embeds a generic parameter beneath an array, pointer, byref or function-pointer shape; only generic instantiations are represented today (`RuntimeTypeHandleTarget.OpenConstructed`)"
+                    | _ ->
+                        let state, handle =
+                            IlMachineState.concretizeType
+                                ctx.LoggerFactory
+                                ctx.BaseClassTypes
+                                state
+                                assembly.Name
+                                ImmutableArray.Empty
+                                ImmutableArray.Empty
+                                ty
+
+                        state, RuntimeTypeHandleTarget.Closed handle
+
                 // Closed (non-parameter) constraints are concretized against the declaring
                 // assembly with no generic context: a constraint like `where T : List<int>`
                 // resolves to the closed type. Constraints that reference another type-generic
@@ -511,15 +595,14 @@ module NativeRuntimeTypeQCall =
                     ((List.empty, state), metadata.Constraints)
                     ||> Seq.fold (fun (acc, state) ty ->
                         match ty with
-                        | TypeDefn.GenericTypeParameter idx ->
-                            let target = RuntimeTypeHandleTarget.GenericParameter (declaringType, idx)
+                        | TypeDefn.GenericTypeParameter _
+                        | TypeDefn.GenericMethodParameter _
+                        | TypeDefn.GenericInstantiation _ ->
+                            let state, target = constraintTarget state ty
                             target :: acc, state
-                        | TypeDefn.GenericMethodParameter idx ->
-                            failwith
-                                $"%s{operation}: type-generic parameter #%d{position} of %O{declaringType.TypeDefinition.Get} declares a method-generic parameter constraint !!%d{idx}; impossible without a method context"
                         | _ when embedsTypeParameter ty ->
-                            failwith
-                                $"TODO: %s{operation}: constraint %O{ty} on type-generic parameter #%d{position} of %O{declaringType.TypeDefinition.Get} embeds a generic-parameter reference; concretization needs to bind parameters to parameter targets"
+                            let state, target = constraintTarget state ty
+                            target :: acc, state
                         | _ ->
                             let state, handle =
                                 IlMachineState.concretizeType
@@ -559,6 +642,9 @@ module NativeRuntimeTypeQCall =
                             |> List.exists (fun t ->
                                 match t with
                                 | RuntimeTypeHandleTarget.Closed h -> h = valueTypeHandle
+                                // An open constructed type is never System.ValueType, which is
+                                // non-generic.
+                                | RuntimeTypeHandleTarget.OpenConstructed _
                                 | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _
                                 | RuntimeTypeHandleTarget.GenericParameter _
                                 | RuntimeTypeHandleTarget.MethodGenericParameter _ -> false
@@ -841,7 +927,10 @@ module NativeRuntimeTypeQCall =
             // through here.
             let typeInfo : TypeInfo<GenericParamFromMetadata, TypeDefn> option =
                 match target with
-                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
+                // The declaring type of an instantiation is the declaring type of its
+                // definition — `IComparable<T>` is nested exactly where `IComparable<>` is.
+                | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity
+                | RuntimeTypeHandleTarget.OpenConstructed (identity, _) ->
                     let assembly =
                         state.LoadedAssembly identity.Assembly
                         |> Option.defaultWith (fun () ->
@@ -922,6 +1011,9 @@ module NativeRuntimeTypeQCall =
             // shape rather than silently returning a wrong answer.
             let declaringTarget, state =
                 match target with
+                | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+                    failwith
+                        $"TODO: open constructed types are not handled at Native/NativeRuntimeTypeQCall.fs:%s{__LINE__}; got %O{openConstructed}"
                 | RuntimeTypeHandleTarget.GenericParameter (declaringType, _) ->
                     // The owning type of a type-generic parameter is always generic
                     // (the parameter could not exist otherwise), so the declaring
@@ -1009,6 +1101,9 @@ module NativeRuntimeTypeQCall =
                 NativeCall.objectHandleOnStackTarget operation state "result" instruction.Arguments.[1]
 
             match typeHandleTarget with
+            | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+                failwith
+                    $"TODO: open constructed types are not handled at Native/NativeRuntimeTypeQCall.fs:%s{__LINE__}; got %O{openConstructed}"
             | RuntimeTypeHandleTarget.GenericParameter _ ->
                 // Type-level generic parameter: CoreCLR's `defToken` is mdtTypeDef,
                 // so the early-exit branch leaves `result` null. Mirror that.
@@ -1454,6 +1549,9 @@ module NativeRuntimeTypeQCall =
 
             let state, fieldHandleIds =
                 match typeHandleTarget with
+                | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+                    failwith
+                        $"TODO: open constructed types are not handled at Native/NativeRuntimeTypeQCall.fs:%s{__LINE__}; got %O{openConstructed}"
                 | RuntimeTypeHandleTarget.OpenGenericTypeDefinition identity ->
                     // CoreCLR's RuntimeTypeHandle::GetFields walks the canonical
                     // (open-generic) MethodTable's FieldDescs. The resulting handles
@@ -1540,6 +1638,9 @@ module NativeRuntimeTypeQCall =
                 NativeCall.objectHandleOnStackTarget operation state "result" instruction.Arguments.[1]
 
             match typeHandleTarget with
+            | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+                failwith
+                    $"TODO: open constructed types are not handled at Native/NativeRuntimeTypeQCall.fs:%s{__LINE__}; got %O{openConstructed}"
             | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Byref _ as handle)
             | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Pointer _ as handle)
             | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.FunctionPointer _ as handle) ->
@@ -1603,6 +1704,9 @@ module NativeRuntimeTypeQCall =
                     // reached by the base-type walk below); byrefs, pointers and function
                     // pointers are TypeDescs, which have no MethodTable and so no map at
                     // all. Either way the walk continues to the parent rather than stopping.
+                    | RuntimeTypeHandleTarget.OpenConstructed _ as openConstructed ->
+                        failwith
+                            $"TODO: open constructed types are not handled at Native/NativeRuntimeTypeQCall.fs:%s{__LINE__}; got %O{openConstructed}"
                     | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.OneDimArrayZero _)
                     | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Array _)
                     | RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Byref _)

--- a/WoofWare.PawPrint/Native/NativeSignature.fs
+++ b/WoofWare.PawPrint/Native/NativeSignature.fs
@@ -208,6 +208,11 @@ module NativeSignature =
         // An open generic definition has no instantiation to substitute. Pass empty generics and let
         // `concretizeType` fault with its own diagnostic if the signature actually needs them.
         | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ -> ImmutableArray.Empty
+        | RuntimeTypeHandleTarget.OpenConstructed (definition, _) ->
+            // An open constructed type does have an instantiation, but its arguments are targets
+            // rather than `ConcreteTypeHandle`s, which is what this slice needs to substitute.
+            failwith
+                $"TODO: %s{operation}: declaring type is the open constructed type %O{definition.TypeDefinition.Get}; substituting its arguments needs them as concrete handles, which an open instantiation has not got"
         | RuntimeTypeHandleTarget.GenericParameter _
         | RuntimeTypeHandleTarget.MethodGenericParameter _ ->
             failwith

--- a/WoofWare.PawPrint/NativeIntSource.fs
+++ b/WoofWare.PawPrint/NativeIntSource.fs
@@ -416,6 +416,13 @@ module TypeHandleTag =
     let forTarget (target : RuntimeTypeHandleTarget) : int64 =
         match target with
         | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ -> 0L
+        // An open constructed type is a real MethodTable, not a TypeDesc, even though it
+        // contains type variables: `TypeVarTypeDesc::LoadConstraints` loads each constraint
+        // under the declaring type's formal `SigTypeContext` (typedesc.cpp:826-830), yielding an
+        // instantiated MethodTable over `TypeVarTypeDesc` arguments. That is exactly what lets
+        // `RuntimeType.IsActualInterface` (RuntimeType.CoreCLR.cs:3488-3498) answer for one:
+        // it short-circuits to false on a TypeDesc before ever reading `MethodTable::IsInterface`.
+        | RuntimeTypeHandleTarget.OpenConstructed _ -> 0L
         // Generic parameters in CoreCLR are TypeVarTypeDesc, a TypeDesc subclass, so the
         // tagged-pointer encoding sets the second-lowest bit. Reflection paths such as
         // `RuntimeType.get_IsInterface` rely on `TypeHandle.IsTypeDesc` to short-circuit
@@ -657,6 +664,16 @@ module NativeIntSource =
             | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _, RuntimeTypeHandleTarget.Closed _ ->
                 // The closed instantiation has its own MT distinct from the typedef's canonical MT.
                 false
+            // An open constructed type has its own MethodTable too, distinct from both the
+            // definition's canonical MT and any closed instantiation's, so it aliases only
+            // itself. Canonicalisation in `RuntimeTypeHandleTarget.openConstructed` is what
+            // makes this structural equality an identity test rather than a spelling test.
+            | RuntimeTypeHandleTarget.OpenConstructed (d1, a1), RuntimeTypeHandleTarget.OpenConstructed (d2, a2) ->
+                d1 = d2 && a1 = a2
+            | RuntimeTypeHandleTarget.OpenConstructed _,
+              (RuntimeTypeHandleTarget.Closed _ | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _)
+            | (RuntimeTypeHandleTarget.Closed _ | RuntimeTypeHandleTarget.OpenGenericTypeDefinition _),
+              RuntimeTypeHandleTarget.OpenConstructed _ -> false
             | RuntimeTypeHandleTarget.GenericParameter _, _
             | RuntimeTypeHandleTarget.MethodGenericParameter _, _
             | _, RuntimeTypeHandleTarget.GenericParameter _

--- a/WoofWare.PawPrint/PointerHashSynthesis.fs
+++ b/WoofWare.PawPrint/PointerHashSynthesis.fs
@@ -109,7 +109,13 @@ module PointerHashSynthesis =
         match src with
         | NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.Closed handle) ->
             CanonicalPointerKey.MethodTable handle
-        | NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ as target) ->
+        // Same reasoning as `OpenGenericTypeDefinition`: an open constructed type is a real
+        // MethodTable (see `TypeHandleTag.forTarget`), so its `MethodTablePtr` and
+        // `TypeHandlePtr` are one address and must share a key — the `ceq` arm in
+        // `NativeIntSource.equalsForCli` says they are equal, and the synthesised bits have
+        // to agree with that.
+        | NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.OpenGenericTypeDefinition _ as target)
+        | NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.OpenConstructed _ as target) ->
             CanonicalPointerKey.TypeHandle target
         | NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.GenericParameter _ as target)
         | NativeIntSource.MethodTablePtr (RuntimeTypeHandleTarget.MethodGenericParameter _ as target) ->

--- a/WoofWare.PawPrint/TypeHandleRegistry.fs
+++ b/WoofWare.PawPrint/TypeHandleRegistry.fs
@@ -34,6 +34,12 @@ module TypeHandleRegistry =
         (reg : TypeHandleRegistry)
         : ManagedHeapAddress * TypeHandleRegistry * 'allocState
         =
+        // This is the one place a target becomes a guest-visible `Type`, and the map lookup just
+        // below is what makes that object reference-stable. A non-canonical target would
+        // therefore hand the guest a second `Type` for a type it already has one for, so check
+        // canonicality here rather than trusting every construction site.
+        RuntimeTypeHandleTarget.assertWellFormed def
+
         match Map.tryFind def reg.TypeToHandle with
         | Some v -> v, reg, allocState
         | None ->


### PR DESCRIPTION
Fixes a regression that is **live on `main`** since #884.

## The bug

`RuntimeTypeHandle_GetConstraints` refused any constraint whose signature embeds a generic parameter, so an utterly ordinary F-bounded constraint threw:

```csharp
class Box<T> where T : struct, IComparable<T> { }
typeof(Box<>).GetGenericArguments()[0].GetGenericParameterConstraints();  // TODO failwith
```

That hole was always there, but #884 made `Type.IsValueType` answer from CoreLib's managed body, which reaches `RuntimeType.GetBaseType()` → `GetGenericParameterConstraints()`. So on current `main`, `t.IsValueType` on such a parameter now throws too, where before #884 the deleted intrinsic arm answered it from the `struct` flag. Verified both directions against `origin/main`.

## Why a new representation was needed

`ConcreteTypeHandle` and `AllConcreteTypes` are closed-only by construction — generic arguments are themselves `ConcreteTypeHandle`s — so `IComparable<T>` could not be named at all. `RuntimeTypeHandleTarget` had cases for a closed type, a bare definition, and a parameter, but nothing for a definition applied to arguments that include one.

Added: `OpenConstructed of definition : ResolvedTypeIdentity * arguments : RuntimeTypeHandleTarget list`, recursive so the shape nests (`where T : IComparable<List<T>>`).

Structured identity rather than a `TypeDefn` payload: `TypeHandleRegistry` keys guest `Type` object identity on the target, and a `TypeDefn` is a pre-resolution *spelling* (FromDefinition vs FromReference, per-assembly TypeRef scoping), so it would mint two `Type` objects for one type and break the reference identity .NET guarantees.

## Canonicalisation is the subtle part

It lives in a smart constructor, with a recursive assertion at `TypeHandleRegistry.getOrAllocate` — the one point where a target becomes guest-visible. Three collapses, each mirroring CoreCLR's class loader:

- no arguments → the bare definition;
- every argument closed → this is a closed type and belongs in `AllConcreteTypes`; refused here rather than given a second representation;
- **the definition applied to exactly its own formals → the definition itself.** CoreCLR calls this the typical instantiation and collapses it at `LoadGenericInstantiationThrowing` (clsload.cpp:1426). Without it, `interface ISelf<T> where T : ISelf<T>` — the CRTP shape of `IParsable<TSelf>` and all of generic math — hands the guest a second `Type` for one that already has one. Real .NET returns `typeof(ISelf<>)`, reference-equal and reporting `IsGenericTypeDefinition`.

Note the third rule makes a bare definition a legal *argument* (`IWrap<INested<T>>`), even though no signature can spell one there.

## Behaviour

An open constructed type is a real MethodTable, not a TypeDesc — `TypeVarTypeDesc::LoadConstraints` loads constraints under the declaring type's formal `SigTypeContext` (typedesc.cpp:826-830) — which is exactly what lets `RuntimeType.IsActualInterface` answer for one, and `IsActualInterface` is all `GetBaseType` asks of an interface constraint. So the tag is 0, its `MethodTablePtr` and `TypeHandlePtr` alias under `ceq`, and `PointerHashSynthesis` collapses them to one key; those three move together.

Flags, attributes, corElementType, token, assembly, declaring type and parent all delegate to the definition. `GetInstantiation` returns the argument targets; `GetGenericTypeDefinition` the definition; `GetElementType` null.

## Deliberately not done

Everything requiring **substitution of an instantiation's arguments into the definition's metadata** stays loud, with a message naming that gap: variance-aware assignability (beyond assignability to `System.Object`, which is unconditionally true), a parent whose base type mentions a parameter, and a parameter beneath an array/pointer/byref (`where T : IComparable<T[]>` — which failed before this change too).

One knowing approximation rather than a throw: `ContainsGCPointers` for a partial construction is answered from the definition's fields without substitution. Documented at the site. The bit is inert — an open constructed type is never allocated — and making it throw would break the `Flags` read that `IsInterface` needs.

## Tests

`TypeGetGenericParameterConstraintsSelfReferential.cs`, 42 checks: self-referential, cross-parameter, nested, CRTP, and CRTP-inside-another-instantiation shapes, plus naming, `BaseType`, assignability, `GetElementType`, and registry canonicalisation observed from the guest.

Every expectation was validated against the real runtime *before* any product code was written, by parking the file in `unimplemented` — that fixture runs real .NET only, so a green run proves the spec. Mutation-tested: dropping the typical-instantiation collapse fails exactly check 26.

Six `codex review` rounds; the last is clean. Three rounds found genuine defects, including one regression this PR had introduced to `FullName` on *every* open generic definition (a definition's formals render for `ToString()` but not under `FormatFullInst`, the reverse of the closed case) — now pinned by three checks on `typeof(List<>)`.

Full suite green: 2554.

🤖 Generated with [Claude Code](https://claude.com/claude-code)