### PR TITLE
Bound the end-to-end harness so a stuck guest fails instead of hanging

### DIFF
--- a/WoofWare.PawPrint.Test/TestBoundedRun.fs
+++ b/WoofWare.PawPrint.Test/TestBoundedRun.fs
@@ -1,0 +1,199 @@
+namespace WoofWare.PawPrint.Test
+
+open System.Collections.Immutable
+open System.IO
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.DotnetRuntimeLocator
+open WoofWare.PawPrint
+
+/// The end-to-end harness runs guests in-process, so a guest that never terminates does not
+/// fail its test — it wedges the whole suite, and CI reports a timeout with nothing in it.
+/// `BoundedRun` is the guard against that, and a guard nothing exercises is a guard you find
+/// out about the day it does not work.
+///
+/// The bound is a step count rather than a wall clock, so these tests can assert on it exactly:
+/// a livelocked guest fails at a *known* number of steps on every machine. That is the property
+/// a timeout could not have given, and it is why the bound is shaped this way.
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestBoundedRun =
+
+    let private assy = typeof<RunResult>.Assembly
+
+    let private runSource (maxSteps : int64) (name : string) (source : string) : RunOutcome =
+        let image = Roslyn.compile [ source ]
+
+        let _messages, loggerFactory =
+            LoggerFactory.makeTestWithProperties [ "source_file", name ]
+
+        use _loggerFactoryResource = loggerFactory
+
+        let dotnetRuntimes =
+            DotnetRuntime.SelectForDll assy.Location |> ImmutableArray.CreateRange
+
+        use peImage = new MemoryStream (image)
+        BoundedRun.runWith loggerFactory maxSteps name (Some name) peImage (HostConfig.Default dotnetRuntimes)
+
+    /// The guard fires, and says enough to diagnose the guest rather than merely that it gave
+    /// up: the budget it was given, and what each live thread was executing.
+    [<Test>]
+    let ``a guest that never terminates fails instead of running for ever`` () : unit =
+        let source =
+            """
+class SpinsForEver
+{
+    static int Main(string[] args)
+    {
+        // No BCL involved: this is a bare IL loop, so what the harness is bounding is
+        // unambiguously the interpreter stepping guest instructions.
+        while (true) { }
+    }
+}
+"""
+
+        // Small enough to trip in well under a second, which is the point of the bound being
+        // a parameter rather than a constant.
+        let exn =
+            Assert.Throws (fun () -> runSource 50_000L "SpinsForEver.cs" source |> ignore<RunOutcome>)
+
+        let message = exn.Message
+
+        message |> shouldContainText "SpinsForEver.cs"
+        message |> shouldContainText "50000"
+        message |> shouldContainText "did not terminate"
+        // The thread summary is what makes the failure actionable.
+        message |> shouldContainText "Main"
+
+    /// A deadlocked guest is a different shape — the scheduler detects it and no step is
+    /// possible — and must also be a test failure rather than an escaping host exception.
+    [<Test>]
+    let ``a deadlocked guest is reported, not raised out of the interpreter`` () : unit =
+        let source =
+            """
+using System.Threading;
+
+class Deadlocks
+{
+    static int Main(string[] args)
+    {
+        // Nothing will ever set this, and there is no other thread to do so.
+        new ManualResetEventSlim(false).Wait();
+        return 0;
+    }
+}
+"""
+
+        let exn =
+            Assert.Throws (fun () -> runSource BoundedRun.defaultMaxSteps "Deadlocks.cs" source |> ignore<RunOutcome>)
+
+        exn.Message |> shouldContainText "Deadlocks.cs"
+        exn.Message |> shouldContainText "deadlocked"
+
+    /// The bound must not be reachable by ordinary work: a guest that terminates does so
+    /// unaffected, and its outcome is exactly what an unbounded run would have produced.
+    [<Test>]
+    let ``a terminating guest is unaffected by the bound`` () : unit =
+        let source =
+            """
+class Terminates
+{
+    static int Main(string[] args)
+    {
+        int total = 0;
+        for (int i = 0; i < 1000; i++) { total += i; }
+        return total == 499500 ? 0 : 1;
+    }
+}
+"""
+
+        match runSource BoundedRun.defaultMaxSteps "Terminates.cs" source with
+        | RunOutcome.NormalExit (state, thread) ->
+            match state.ThreadState.[thread].MethodState.EvaluationStack.Values with
+            | EvalStackValue.Int32 (Int32Source.Verbatim exitCode) :: _ -> exitCode |> shouldEqual 0
+            | other -> failwith $"expected an int exit code, got %O{other}"
+        | other -> failwith $"expected a normal exit, got %O{other}"
+
+    let private spinsForEver =
+        """
+class SpinsForEver
+{
+    static int Main(string[] args)
+    {
+        while (true) { }
+    }
+}
+"""
+
+    let private budgetFailure (maxSteps : int64) : string =
+        let exn =
+            Assert.Throws (fun () -> runSource maxSteps "Determinism.cs" spinsForEver |> ignore<RunOutcome>)
+
+        exn.Message
+
+    /// The budget counts *steps*, not time, so the same guest gives up in the same machine
+    /// state every run. Without that, the bound would be one more source of the flakiness this
+    /// interpreter exists to remove — a busy CI machine could fail a guest that a quiet laptop
+    /// passes, and the failure would not reproduce.
+    ///
+    /// This pairs with the test below, and neither is worth much alone. Equality here says the
+    /// stopping point is reproducible; the test below says the message can actually tell
+    /// stopping points apart, without which this one would hold for a wall-clock bound too.
+    [<Test>]
+    let ``the budget is deterministic: the same guest gives up in the same state every time`` () : unit =
+        budgetFailure 50_000L |> shouldEqual (budgetFailure 50_000L)
+
+    /// The diagnostic distinguishes *where* the guest was stopped, so the equality above is a
+    /// claim about the machine state rather than about a message too coarse to disagree.
+    ///
+    /// One extra step of budget must move the stopping point, and does: the kernel's step
+    /// counter differs, and for this guest — a bare loop of more than one instruction — so does
+    /// the IL offset. A message reporting only the thread's status and method would be
+    /// identical across both, and this is what would catch that.
+    [<Test>]
+    let ``the diagnostic distinguishes different stopping points`` () : unit =
+        let atBudget = budgetFailure 50_000L
+        let oneStepLater = budgetFailure 50_001L
+
+        atBudget |> shouldNotEqual oneStepLater
+
+        // Specifically: it is the stopping point that differs, not merely the budget echoed
+        // back into the text.
+        let stateOf (message : string) : string =
+            match message.IndexOf "Threads: " with
+            | -1 -> failwith $"diagnostic carried no thread summary, so it cannot locate the guest: %s{message}"
+            | i -> message.Substring i
+
+        stateOf atBudget |> shouldNotEqual (stateOf oneStepLater)
+
+    /// The diagnostic must survive threads that have no active frame.
+    ///
+    /// `ThreadStatus.hasNoActiveFrame` names two such states, `NotStarted` and `Parked`, and
+    /// `ThreadState.MethodState` throws on both — it resolves the active frame, and there
+    /// isn't one. A summary that reached for the executing method unconditionally would
+    /// therefore crash with "Frame ... is not live" *instead of* reporting the stuck guest,
+    /// destroying the diagnostic exactly when it is needed. A guest holding a constructed but
+    /// unstarted thread is an entirely ordinary way to be in that state.
+    [<Test>]
+    let ``the diagnostic survives threads with no active frame`` () : unit =
+        let source =
+            """
+using System.Threading;
+
+class SpinsWithUnstartedThread
+{
+    static int Main(string[] args)
+    {
+        // Constructed, never started: a machine thread in `NotStarted`, with no frame.
+        Thread t = new Thread(() => { });
+        while (true) { }
+    }
+}
+"""
+
+        let exn =
+            Assert.Throws (fun () -> runSource 200_000L "SpinsWithUnstartedThread.cs" source |> ignore<RunOutcome>)
+
+        // The budget diagnostic, not a frame-resolution failure from building it.
+        exn.Message |> shouldContainText "did not terminate"
+        exn.Message |> shouldNotContainText "is not live"

--- a/WoofWare.PawPrint.Test/TestHarness.fs
+++ b/WoofWare.PawPrint.Test/TestHarness.fs
@@ -42,3 +42,111 @@ type EndToEndTestCase =
         /// against.
         AssertTerminalState : (IlMachineState -> unit) option
     }
+
+/// `Program.run`, bounded so a guest that never terminates fails its test instead of wedging
+/// the whole suite.
+///
+/// The bound is a **step count, not a wall-clock timeout**, and that is deliberate. A timeout
+/// would make the suite's verdict depend on how loaded the machine is: the same guest could
+/// pass on a quiet laptop and fail on a busy CI runner, which is precisely the flakiness this
+/// interpreter exists to eliminate. A step budget is a property of the guest, so it gives the
+/// same answer everywhere and a failure reproduces exactly.
+///
+/// This is a test-harness concern only. `Program.run` stays unbounded, because a real host
+/// running a real program has no business deciding the guest has gone on too long.
+[<RequireQualifiedAccess>]
+module BoundedRun =
+
+    open System.IO
+    open Microsoft.Extensions.Logging
+
+    /// How many interpreted IL steps a guest may retire before the harness calls it stuck.
+    ///
+    /// Chosen from measurement, not taste. Across the whole end-to-end corpus (596 guests at
+    /// the time of writing) the mean guest retires ~22k steps and the heaviest —
+    /// `RegexConstructionRepeatedNonBacktracking.cs` — retires 1,817,355. This bound is ~11x
+    /// that worst case.
+    ///
+    /// The other half of the trade is how long a genuinely stuck guest takes to be caught.
+    /// Measured on an idle machine, the interpreter retires roughly 90k steps/second, so this
+    /// bound trips after about three or four minutes; under the suite's own parallelism it
+    /// will be slower, but it is bounded, which is the entire point.
+    ///
+    /// If a legitimate case ever approaches this, raise it — the cost of a bound that is too
+    /// low is a confusing failure on real work. Do not lower it to make a stuck test fail
+    /// faster; that trades a rare, clear failure for a common, confusing one.
+    let defaultMaxSteps : int64 = 20_000_000L
+
+    /// What each thread that has not terminated is doing, for a diagnostic.
+    ///
+    /// The IL offset is included, not just the method name, because the name alone does not say
+    /// *where* a guest is stuck: a spin loop never leaves its method, so every stop inside it
+    /// looks identical. The offset and the kernel's step counter are also the only parts of
+    /// this message that two differently-timed runs could disagree about, which is what makes
+    /// the stopping point observable to a test at all.
+    let private threadSummary (state : IlMachineState) : string =
+        state.ThreadState
+        |> Map.toSeq
+        |> Seq.filter (fun (_, ts) -> ts.Status <> ThreadStatus.Terminated)
+        |> Seq.map (fun (ThreadId i, ts) ->
+            // A non-terminated thread need not have a frame: `ThreadStatus.hasNoActiveFrame`
+            // names `NotStarted` and `Parked`, and `ts.MethodState` throws on both because it
+            // resolves the active frame and there isn't one. A guest holding a constructed but
+            // unstarted `Thread` is entirely ordinary, so reaching for the method
+            // unconditionally would replace this diagnostic with "Frame ... is not live" — a
+            // failure about the harness, precisely when the guest is what needs explaining.
+            if ThreadStatus.hasNoActiveFrame ts.Status then
+                $"thread %d{i} (%O{ts.Status})"
+            else
+                $"thread %d{i} (%O{ts.Status}) in %s{ts.MethodState.ExecutingMethod.Name} at IL offset %d{ts.MethodState.IlOpIndex}"
+        )
+        |> String.concat "; "
+
+    let runWith
+        (loggerFactory : ILoggerFactory)
+        (maxSteps : int64)
+        (description : string)
+        (originalPath : string option)
+        (fileStream : Stream)
+        (hostConfig : HostConfig)
+        : RunOutcome
+        =
+        let logger = loggerFactory.CreateLogger "BoundedRun"
+
+        // Startup (`prepare`) is not bounded here: it pumps the AppContext seed and the class
+        // initialisers internally and hands back only when both are done. A guest that wedges
+        // in a static initialiser therefore still hangs. Bounding it needs the steppable
+        // startup that `Program.beginStartup`/`stepStartup` provide.
+        match Program.prepare loggerFactory originalPath fileStream hostConfig with
+        | Program.ProgramStartResult.CompletedBeforeMain outcome -> outcome
+        | Program.ProgramStartResult.Ready prepared ->
+
+        let rec go (steps : int64) (prepared : Program.PreparedProgram) : RunOutcome =
+            if steps >= maxSteps then
+                failwith
+                    $"%s{description} did not terminate within %d{maxSteps} interpreted steps, so the harness gave up (kernel step counter %d{prepared.State.Kernel.StepCounter}). This is what a livelocked guest looks like: every thread is runnable but nothing progresses. Threads: %s{threadSummary prepared.State}"
+            else
+
+            match Program.stepPrepared loggerFactory logger prepared with
+            | Program.ProgramStepOutcome.Completed outcome -> outcome
+            | Program.ProgramStepOutcome.Deadlocked (prepared, stuck) ->
+                // `Program.run` would raise from inside `pumpPrepared`, discarding the state
+                // along with any diagnostic it carries. Reported here instead, with the same
+                // detail as a step-budget failure so the two read alike.
+                failwith
+                    $"%s{description} deadlocked: no runnable threads and the entry thread has not terminated. Stuck: %s{stuck}. Threads: %s{threadSummary prepared.State}"
+            | Program.ProgramStepOutcome.InstructionStepped (prepared, _, _, _)
+            | Program.ProgramStepOutcome.WorkerTerminated (prepared, _) -> go (steps + 1L) prepared
+
+        go 0L prepared
+
+    /// `runWith` at `defaultMaxSteps`.
+    let run
+        (loggerFactory : ILoggerFactory)
+        (description : string)
+        (originalPath : string option)
+        (fileStream : Stream)
+        (hostConfig : HostConfig)
+        : RunOutcome
+        =
+        runWith loggerFactory defaultMaxSteps description originalPath fileStream hostConfig

--- a/WoofWare.PawPrint.Test/TestImpureCases.fs
+++ b/WoofWare.PawPrint.Test/TestImpureCases.fs
@@ -599,8 +599,9 @@ module TestImpureCases =
         try
             let terminalState, terminatingThread =
                 match
-                    Program.run
+                    BoundedRun.run
                         loggerFactory
+                        case.FileName
                         (Some case.FileName)
                         peImage
                         { HostConfig.Default dotnetRuntimes with

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -96,8 +96,9 @@ module TestPureCases =
 
         try
             let pawPrintResult =
-                Program.run
+                BoundedRun.run
                     loggerFactory
+                    sourceName
                     (Some sourceName)
                     peImage
                     { HostConfig.Default dotnetRuntimes with

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -23,6 +23,7 @@
     <Compile Include="RealRuntime.fs" />
     <Compile Include="TestRealRuntimeOracle.fs" />
     <Compile Include="TestHarness.fs"/>
+    <Compile Include="TestBoundedRun.fs" />
     <Compile Include="CrossAssemblyHarness.fs" />
     <Compile Include="TestCrossAssemblyOracle.fs" />
     <Compile Include="TypeIdentityTestHelpers.fs" />


### PR DESCRIPTION
The end-to-end fixtures run guests in-process with no bound, so a guest that never terminates does not fail its test — it wedges the suite, and CI reports a timeout with nothing in it. That became a live risk when `CancellationTokenRegistrationDisposeCrossThread.cs` was un-parked in #891: what it detects is a livelock, so a regression in the multi-region `leave` fix hangs rather than fails.

`BoundedRun` drives `stepPrepared` with a step budget, and both the pure and impure runners go through it.

## Why a step budget rather than a timeout

A wall-clock timeout would make the suite's verdict depend on how loaded the machine is: the same guest could pass on a quiet laptop and fail on a busy CI runner, and the failure would not reproduce. That is precisely the flakiness this interpreter exists to eliminate. A step budget is a property of the guest, so it gives the same answer everywhere.

`Program.run` stays unbounded. A real host running a real program has no business deciding the guest has gone on too long.

## The number is measured

| | |
|---|---|
| guests in the corpus | 596 |
| mean steps | ~22k |
| heaviest (`RegexConstructionRepeatedNonBacktracking.cs`) | 1,817,355 |
| budget | 20,000,000 (~11x the worst case) |
| measured interpreter rate | ~90k steps/s, so the bound trips in 3–4 minutes rather than never |

🤖 Generated with [Claude Code](https://claude.com/claude-code)