### PR TITLE
Read a field's constant for MetadataImport.GetDefaultValue

### DIFF
--- a/WoofWare.PawPrint.Test/TestFSharpPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestFSharpPureCases.fs
@@ -127,17 +127,18 @@ module TestFSharpPureCases =
     /// before recording that a case is blocked on a named primitive, un-park it and observe the
     /// failure: parking it is what stops the claim being checked.
     ///
-    /// `UnionReflection` is parked on `MetadataImport::GetDefaultValue`: having learned a literal
-    /// field's *type*, `MdFieldInfo.GetValue` goes on to read its constant out of the Constant
-    /// table through `MdConstant.GetValue`, and that reaches an InternalCall with no handler
-    /// ("Unimplemented native method (InternalCall): ... MetadataImport::GetDefaultValue").
-    /// Observed by un-parking it and running: the real runtime exits 0, PawPrint throws out of
-    /// `NativeDispatch.failUnimplemented`.
+    /// `UnionReflection` is parked on `MetadataImport::GetName`: having read a literal field's
+    /// value, `FSharpType.GetUnionCases` goes on to ask for members *by name*, and both
+    /// `MdFieldInfo.Name` and `RuntimeType`'s name-filtered member lookups reach an InternalCall
+    /// with no handler ("Unimplemented native method (InternalCall): ...
+    /// MetadataImport::GetName"). Observed by un-parking it and running: the real runtime exits 0,
+    /// PawPrint throws out of `NativeDispatch.failUnimplemented`.
     ///
-    /// Four earlier blockers are already gone: decoding each case's
+    /// Five earlier blockers are already gone: decoding each case's
     /// `CompilationMappingAttribute(SourceConstructFlags, ...)`, whose argument is an enum;
-    /// enumerating the union's nested case types; `MetadataImport::GetSigOfFieldDef`; and the
-    /// raw-blob path of `Signature_Init`, which the commit this comment sits in implements.
+    /// enumerating the union's nested case types; `MetadataImport::GetSigOfFieldDef`; the raw-blob
+    /// path of `Signature_Init`; and `MetadataImport::GetDefaultValue`, which the commit this
+    /// comment sits in implements.
     let unimplemented : Set<string> = Set.ofList [ "UnionReflection" ]
 
     // F# test cases that legitimately throw under both runtimes. Without this set, a test

--- a/WoofWare.PawPrint.Test/TestNativeMetadataImport.fs
+++ b/WoofWare.PawPrint.Test/TestNativeMetadataImport.fs
@@ -103,6 +103,30 @@ public class FieldSignatureShapes
     public volatile int VolatileField;
 }
 
+// One literal per Constant-table type code the C# compiler can emit, plus the two encodings that
+// are easy to confuse: `NullString` is ELEMENT_TYPE_CLASS (four zero bytes), and `EmptyString` has
+// a zero-length blob that the runtime reports as a null pointer. `NotAConstant` has no Constant row
+// at all, which is a third thing again (ELEMENT_TYPE_VOID).
+public class ConstantShapes
+{
+    public const bool BoolConst = true;
+    public const char CharConst = 'q';
+    public const sbyte SByteConst = -1;
+    public const byte ByteConst = 200;
+    public const short Int16Const = -300;
+    public const ushort UInt16Const = 40000;
+    public const int Int32Const = 42;
+    public const uint UInt32Const = 3000000000;
+    public const long Int64Const = -1234567890123L;
+    public const ulong UInt64Const = 18446744073709551615UL;
+    public const float SingleConst = 0.25f;
+    public const double DoubleConst = 0.5;
+    public const string StringConst = "hello";
+    public const string EmptyStringConst = "";
+    public const string NullStringConst = null;
+    public static int NotAConstant = 7;
+}
+
 public class ReferencesOtherAssemblyMembers
 {
     // `string.Empty` is a static field on a corelib type, so the reference is a MemberRef row
@@ -143,6 +167,7 @@ public class TypesWithMembers
             InnerType : TypeInfo<GenericParamFromMetadata, TypeDefn>
             SeveralNestedType : TypeInfo<GenericParamFromMetadata, TypeDefn>
             SignatureShapesType : TypeInfo<GenericParamFromMetadata, TypeDefn>
+            ConstantShapesType : TypeInfo<GenericParamFromMetadata, TypeDefn>
             MembersType : TypeInfo<GenericParamFromMetadata, TypeDefn>
             InstanceField : FieldInfo<GenericParamFromMetadata, TypeDefn>
             StaticField : FieldInfo<GenericParamFromMetadata, TypeDefn>
@@ -230,6 +255,8 @@ public class TypesWithMembers
 
         let signatureShapesType = requiredTopLevelType assembly "" "FieldSignatureShapes"
 
+        let constantShapesType = requiredTopLevelType assembly "" "ConstantShapes"
+
         let membersType = requiredTopLevelType assembly "" "TypesWithMembers"
 
         let constArrayType = requiredTopLevelType corelib "System.Reflection" "ConstArray"
@@ -250,6 +277,7 @@ public class TypesWithMembers
                  baseClassTypes.Int32
                  baseClassTypes.IntPtr
                  baseClassTypes.Byte
+                 baseClassTypes.Int64
              ])
             ||> List.fold (concretizeCorelibType loggerFactory baseClassTypes)
 
@@ -281,6 +309,7 @@ public class TypesWithMembers
             InnerType = innerType
             SeveralNestedType = severalNestedType
             SignatureShapesType = signatureShapesType
+            ConstantShapesType = constantShapesType
             MembersType = membersType
             InstanceField = fieldByName "InstanceField"
             StaticField = fieldByName "StaticField"
@@ -1603,3 +1632,321 @@ public class TypesWithMembers
             Assert.Throws (fun () -> invokeGetSigOfFieldDef fixture 0x04FFFFFF fixture.State |> ignore)
 
         ex.Message |> shouldContainText "was not present in"
+
+    let private allocateSlotOut
+        (fixture : MetadataImportFixture)
+        (elementType : TypeInfo<GenericParamFromMetadata, TypeDefn>)
+        (zero : CliType)
+        (state : IlMachineState)
+        : ManagedPointerSource * IlMachineState
+        =
+        let handle =
+            AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes elementType
+
+        let arrayAddr, state =
+            IlMachineState.allocateArray (ConcreteTypeHandle.OneDimArrayZero handle) (fun () -> zero) 1 state
+
+        ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arrayAddr, 0), []), state
+
+    /// The four out-params of `GetDefaultValue`, read back: the 64-bit buffer, the `char*`, the
+    /// length, and the ELEMENT_TYPE code.
+    type private DefaultValueOut =
+        {
+            Value : int64
+            StringPointer : ManagedPointerSource
+            Length : int32
+            CorElementType : int32
+        }
+
+    let private invokeGetDefaultValue
+        (fixture : MetadataImportFixture)
+        (fieldToken : int32)
+        (state : IlMachineState)
+        : EvalStackValue * DefaultValueOut * IlMachineState
+        =
+        let state, metadataImportType, getDefaultValueMethod =
+            metadataImportMethod fixture state "GetDefaultValue" 6
+
+        let valueOut, state =
+            allocateSlotOut
+                fixture
+                fixture.BaseClassTypes.Int64
+                (CliType.Numeric (CliNumericType.Int64 (Int64Source.Verbatim 0L)))
+                state
+
+        let stringValueOut, state =
+            allocateSlotOut
+                fixture
+                fixture.BaseClassTypes.IntPtr
+                (CliType.RuntimePointer (CliRuntimePointer.Managed ManagedPointerSource.Null))
+                state
+
+        let lengthOut, state = allocateInt32Out fixture 0 state
+        let corElementTypeOut, state = allocateInt32Out fixture 0 state
+
+        let state =
+            invokeMetadataImportNative
+                fixture
+                metadataImportType
+                getDefaultValueMethod
+                [
+                    metadataImportHandle fixture
+                    CliType.Numeric (CliNumericType.Int32 fieldToken)
+                    CliType.RuntimePointer (CliRuntimePointer.Managed valueOut)
+                    CliType.RuntimePointer (CliRuntimePointer.Managed stringValueOut)
+                    CliType.RuntimePointer (CliRuntimePointer.Managed lengthOut)
+                    CliType.RuntimePointer (CliRuntimePointer.Managed corElementTypeOut)
+                ]
+                state
+
+        let returnValue, state = IlMachineState.popEvalStack (ThreadId 0) state
+
+        let value =
+            match
+                IlMachineState.readManagedByref fixture.BaseClassTypes state valueOut
+                |> CliType.unwrapPrimitiveLikeDeep
+            with
+            | CliType.Numeric (CliNumericType.Int64 (Int64Source.Verbatim v)) -> v
+            | other -> failwith $"expected Int64 value out, got %O{other}"
+
+        let stringPointer =
+            match
+                IlMachineState.readManagedByref fixture.BaseClassTypes state stringValueOut
+                |> CliType.unwrapPrimitiveLikeDeep
+            with
+            | CliType.RuntimePointer (CliRuntimePointer.Managed ptr) -> ptr
+            | other -> failwith $"expected managed pointer string out, got %O{other}"
+
+        let out =
+            {
+                Value = value
+                StringPointer = stringPointer
+                Length = readInt32Out fixture.BaseClassTypes state lengthOut
+                CorElementType = readInt32Out fixture.BaseClassTypes state corElementTypeOut
+            }
+
+        returnValue, out, state
+
+    let private constantField
+        (fixture : MetadataImportFixture)
+        (name : string)
+        : FieldInfo<GenericParamFromMetadata, TypeDefn>
+        =
+        fixture.ConstantShapesType.Fields
+        |> List.tryFind (fun field -> field.Name = name)
+        |> Option.defaultWith (fun () -> failwith $"constant field %s{name} not found")
+
+    [<Test>]
+    let ``MetadataImport GetDefaultValue packs each constant into the low bytes of the buffer`` () : unit =
+        let fixture = makeFixture ()
+
+        // ECMA-335 II.23.1.16 element types, and the value as CoreCLR's `m_ullValue` carries it:
+        // the blob's bytes little-endian in the low bytes, with the high bytes zero. `MdConstant`
+        // reinterprets only the low member-width bytes (`*(sbyte*)&buffer` and friends), so the
+        // *upper* bytes are unobservable to a guest and zero is PawPrint's determinism choice
+        // rather than a fidelity claim — CoreCLR leaves them as stack garbage.
+        let cases =
+            [
+                "BoolConst", 0x02, 1L, 1
+                "CharConst", 0x03, int64 'q', 2
+                // -1 as I1 is the single byte 0xFF: zero-extended here, and the managed side
+                // recovers the sign by reinterpreting the low byte.
+                "SByteConst", 0x04, 0xFFL, 1
+                "ByteConst", 0x05, 200L, 1
+                "Int16Const", 0x06, 0xFED4L, 2
+                "UInt16Const", 0x07, 40000L, 2
+                "Int32Const", 0x08, 42L, 4
+                "UInt32Const", 0x09, 3000000000L, 4
+                "Int64Const", 0x0A, -1234567890123L, 8
+                // All eight bytes set: the one case where zero-extension has nothing left to do.
+                "UInt64Const", 0x0B, -1L, 8
+                // Floating point is a bit pattern, not a conversion.
+                "SingleConst", 0x0C, int64 (System.BitConverter.SingleToInt32Bits 0.25f), 4
+                "DoubleConst", 0x0D, System.BitConverter.DoubleToInt64Bits 0.5, 8
+            ]
+
+        let mutable state = fixture.State
+
+        for name, expectedElementType, expectedValue, expectedLength in cases do
+            let field = constantField fixture name
+
+            let returnValue, out, nextState =
+                invokeGetDefaultValue fixture (fieldDefToken field.Handle) state
+
+            state <- nextState
+
+            returnValue |> shouldEqual (EvalStackValue.Int32 (Int32Source.Verbatim 0))
+            out.CorElementType |> shouldEqual expectedElementType
+            out.Value |> shouldEqual expectedValue
+            out.Length |> shouldEqual expectedLength
+            out.StringPointer |> shouldEqual ManagedPointerSource.Null
+
+    [<Test>]
+    let ``MetadataImport GetDefaultValue points at the constant blob for a string`` () : unit =
+        let fixture = makeFixture ()
+        let field = constantField fixture "StringConst"
+
+        let _, out, state =
+            invokeGetDefaultValue fixture (fieldDefToken field.Handle) fixture.State
+
+        out.CorElementType |> shouldEqual 0x0E
+        // Length is in *characters* here and in bytes for every other code: the FCall divides by
+        // sizeof(WCHAR) only on this branch. "hello" is 5 chars in a 10-byte blob.
+        out.Length |> shouldEqual 5
+        out.Value |> shouldEqual 0L
+
+        // The pointer must carry a `ReinterpretAs` projection, not just name the range:
+        // `String.Ctor(char*, int, int)` offsets it before reading, and pointer arithmetic on a
+        // bare PE-byte-range root is refused outright — the guest case fails without one. The
+        // projection's *type* is not what makes the guest work (the offset is zero and the copy is
+        // byte-wise, so `byte` would also do); `char` is pinned here because it is the type the API
+        // declares, and pinning it is what stops it drifting silently.
+        match out.StringPointer with
+        | ManagedPointerSource.Byref (ByrefRoot.PeByteRange range, [ ByrefProjection.ReinterpretAs charType ]) ->
+            range.AssemblyFullName |> shouldEqual fixture.Assembly.Name.FullName
+            range.Size |> shouldEqual 10
+
+            range.Source
+            |> shouldEqual (PeByteRangePointerSource.ConstantBlob (ComparableFieldDefinitionHandle.Make field.Handle))
+
+            // Look up Char in the *post*-invocation state: the handler is what concretizes it.
+            let expectedCharType =
+                AllConcreteTypes.lookup
+                    (AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes fixture.BaseClassTypes.Char)
+                    state.ConcreteTypes
+                |> Option.defaultWith (fun () -> failwith "System.Char was not concretized")
+
+            charType |> shouldEqual expectedCharType
+        | other -> failwith $"expected a char pointer over the constant blob, got %O{other}"
+
+    [<Test>]
+    let ``MetadataImport GetDefaultValue reports an empty string as a null pointer`` () : unit =
+        // `_FillMDDefaultValue` nulls the pointer when the blob is zero-length
+        // (mdinternalro.cpp:3214); the managed wrapper's `stringVal ?? string.Empty` is what turns
+        // that back into "". Handing back a zero-length range instead would make the wrapper build
+        // a string from a pointer addressing nothing.
+        let fixture = makeFixture ()
+        let field = constantField fixture "EmptyStringConst"
+
+        let _, out, _ =
+            invokeGetDefaultValue fixture (fieldDefToken field.Handle) fixture.State
+
+        out.CorElementType |> shouldEqual 0x0E
+        out.Length |> shouldEqual 0
+        out.StringPointer |> shouldEqual ManagedPointerSource.Null
+
+    [<Test>]
+    let ``MetadataImport GetDefaultValue reports a null constant as ELEMENT_TYPE_CLASS`` () : unit =
+        // A null reference constant is its own element type, distinct from "no Constant row at
+        // all", and ECMA-335 II.22.9 fixes its blob at four zero bytes.
+        let fixture = makeFixture ()
+        let field = constantField fixture "NullStringConst"
+
+        let _, out, _ =
+            invokeGetDefaultValue fixture (fieldDefToken field.Handle) fixture.State
+
+        out.CorElementType |> shouldEqual 0x12
+        out.Length |> shouldEqual 4
+        out.Value |> shouldEqual 0L
+        out.StringPointer |> shouldEqual ManagedPointerSource.Null
+
+    [<Test>]
+    let ``MetadataImport GetDefaultValue reports ELEMENT_TYPE_VOID for a field with no constant`` () : unit =
+        // `MdConstant` turns VOID into DBNull.Value. CoreCLR leaves the buffer and length as stack
+        // garbage on this path; PawPrint writes zeros, because a replay must not depend on the
+        // host's stack.
+        let fixture = makeFixture ()
+        let field = constantField fixture "NotAConstant"
+
+        let returnValue, out, _ =
+            invokeGetDefaultValue fixture (fieldDefToken field.Handle) fixture.State
+
+        returnValue |> shouldEqual (EvalStackValue.Int32 (Int32Source.Verbatim 0))
+        out.CorElementType |> shouldEqual 0x01
+        out.Value |> shouldEqual 0L
+        out.Length |> shouldEqual 0
+        out.StringPointer |> shouldEqual ManagedPointerSource.Null
+
+    [<Test>]
+    let ``MetadataImport GetDefaultValue agrees with the host runtime for every literal`` () : unit =
+        // Outside oracle: the same image in the host CLR, asked the same question through its own
+        // metadata engine. This compares the *decoded* value rather than the raw out-params, so it
+        // checks the packing and the element type together, in the way a guest would see them.
+        let fixture = makeFixture ()
+
+        let hostType =
+            (System.Reflection.Assembly.Load fixture.Image).GetType "ConstantShapes"
+
+        let literals =
+            fixture.ConstantShapesType.Fields
+            |> List.filter (fun field -> field.Attributes.HasFlag System.Reflection.FieldAttributes.Literal)
+
+        literals.Length |> shouldEqual 15
+
+        let mutable state = fixture.State
+
+        for field in literals do
+            let _, out, nextState =
+                invokeGetDefaultValue fixture (fieldDefToken field.Handle) state
+
+            state <- nextState
+
+            let expected = hostType.GetField(field.Name).GetRawConstantValue ()
+
+            // Recover the same value the managed `MdConstant` would build from our out-params.
+            let actual : obj =
+                match out.CorElementType with
+                | 0x02 -> box (out.Value <> 0L)
+                | 0x03 -> box (char (uint16 out.Value))
+                | 0x04 -> box (sbyte (byte out.Value))
+                | 0x05 -> box (byte out.Value)
+                | 0x06 -> box (int16 (uint16 out.Value))
+                | 0x07 -> box (uint16 out.Value)
+                | 0x08 -> box (int32 (uint32 out.Value))
+                | 0x09 -> box (uint32 out.Value)
+                | 0x0A -> box out.Value
+                | 0x0B -> box (uint64 out.Value)
+                | 0x0C -> box (System.BitConverter.Int32BitsToSingle (int32 (uint32 out.Value)))
+                | 0x0D -> box (System.BitConverter.Int64BitsToDouble out.Value)
+                | 0x0E ->
+                    match out.StringPointer with
+                    | ManagedPointerSource.Null -> box ""
+                    | ManagedPointerSource.Byref (ByrefRoot.PeByteRange range, _) ->
+                        let charTemplate, _ =
+                            IlMachineState.cliTypeZeroOfHandle
+                                state
+                                fixture.BaseClassTypes
+                                (AllConcreteTypes.getRequiredNonGenericHandle
+                                    state.ConcreteTypes
+                                    fixture.BaseClassTypes.Char)
+
+                        System.String (
+                            Array.init
+                                out.Length
+                                (fun i ->
+                                    match
+                                        IlMachineState.readPeByteRangeBytesAs state range (i * 2) charTemplate
+                                        |> CliType.unwrapPrimitiveLikeDeep
+                                    with
+                                    | CliType.Char (hi, lo) -> char ((int hi <<< 8) ||| int lo)
+                                    | other -> failwith $"expected Char in constant blob, got %O{other}"
+                                )
+                        )
+                        |> box
+                    | other -> failwith $"unexpected string pointer %O{other}"
+                | 0x12 -> null
+                | other -> failwith $"unexpected element type 0x%x{other} for %s{field.Name}"
+
+            actual |> shouldEqual expected
+
+    [<Test>]
+    let ``MetadataImport GetDefaultValue rejects a non-FieldDef token`` () : unit =
+        let fixture = makeFixture ()
+
+        let ex =
+            Assert.Throws (fun () ->
+                invokeGetDefaultValue fixture (typeDefToken fixture.TargetType.TypeDefHandle) fixture.State
+                |> ignore
+            )
+
+        ex.Message |> shouldContainText "expected FieldDef token"

--- a/WoofWare.PawPrint.Test/sourcesPure/LiteralFieldValue.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/LiteralFieldValue.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Reflection;
+
+// `FieldInfo.GetRawConstantValue` on a literal reaches `MdConstant.GetValue`, which calls the
+// `MetadataImport.GetDefaultValue` InternalCall to read the field's Constant-table row.
+//
+// Two constraints, both load-bearing, and both the same as in the sibling LiteralFieldType.cs.
+// Every subject must be `const`: a literal has no FieldDesc, so it is reflected over by
+// `MdFieldInfo`, and only that class reaches `MdConstant`. And fields are reached through
+// `GetFields()` rather than `GetField(name)`, because a name filter makes `PopulateLiteralFields`
+// call `MetadataImport.GetName`, which PawPrint does not implement — that blocker would mask this
+// one. Hence one holder type per literal.
+public class IntConst { public const int Value = 42; }
+public class NegativeSByteConst { public const sbyte Value = -1; }
+public class NegativeLongConst { public const long Value = -1234567890123L; }
+public class ULongConst { public const ulong Value = 18446744073709551615UL; }
+public class BoolConst { public const bool Value = true; }
+public class CharConst { public const char Value = 'q'; }
+public class DoubleConst { public const double Value = 0.5; }
+public class FloatConst { public const float Value = 0.25f; }
+public class StringConst { public const string Value = "hello"; }
+public class EmptyStringConst { public const string Value = ""; }
+public class NullStringConst { public const string Value = null; }
+
+public class LiteralFieldValue
+{
+    private static FieldInfo TheOnlyField(Type t)
+    {
+        FieldInfo[] fields = t.GetFields();
+        if (fields.Length != 1)
+        {
+            return null;
+        }
+
+        return fields[0];
+    }
+
+    private static bool Check(Type t, object expected)
+    {
+        FieldInfo f = TheOnlyField(t);
+        if (f == null || !f.IsLiteral)
+        {
+            return false;
+        }
+
+        object actual = f.GetRawConstantValue();
+        if (expected == null)
+        {
+            return actual == null;
+        }
+
+        return expected.Equals(actual);
+    }
+
+    public static int Main(string[] argv)
+    {
+        if (!Check(typeof(IntConst), 42)) return 1;
+        // -1 as an I1 is the byte 0xFF; the managed side recovers the sign by reinterpreting the
+        // low byte, so a handler that widened it wrongly shows up here.
+        if (!Check(typeof(NegativeSByteConst), (sbyte)(-1))) return 2;
+        if (!Check(typeof(NegativeLongConst), -1234567890123L)) return 3;
+        // All eight bytes set: distinguishes a buffer packed as unsigned from one that lost a bit.
+        if (!Check(typeof(ULongConst), 18446744073709551615UL)) return 4;
+        if (!Check(typeof(BoolConst), true)) return 5;
+        if (!Check(typeof(CharConst), 'q')) return 6;
+        // Floating point is reinterpreted from the buffer's bits, not converted.
+        if (!Check(typeof(DoubleConst), 0.5)) return 7;
+        if (!Check(typeof(FloatConst), 0.25f)) return 8;
+        // The string cases are the ones that exercise the `char*` out-parameter.
+        if (!Check(typeof(StringConst), "hello")) return 9;
+        // An empty string constant has a zero-length blob, which the runtime reports as a *null*
+        // pointer with length 0; `string.Empty` is recovered by the managed wrapper, not by us.
+        if (!Check(typeof(EmptyStringConst), "")) return 10;
+        // A null string constant is ELEMENT_TYPE_CLASS, which is a different code from "no Constant
+        // row at all" and must not be confused with it.
+        if (!Check(typeof(NullStringConst), null)) return 11;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -790,6 +790,21 @@ module IlMachineManagedByref =
                 let mutable blobReader = mdReader.GetBlobReader methodDef.Signature
                 blobReader.Offset <- byteOffset
                 blobReader.ReadBytes targetSize
+            | PeByteRangePointerSource.ConstantBlob field ->
+                let mdReader = assembly.PeReader.GetMetadataReader ()
+                let fieldDef = mdReader.GetFieldDefinition field.Get
+                let constantHandle = fieldDef.GetDefaultValue ()
+
+                if constantHandle.IsNil then
+                    // The pointer could only have been minted from a Constant row, so its
+                    // disappearance would mean the metadata reader disagrees with itself.
+                    failwith $"PE byte-view read: field %O{field.Get} no longer has a Constant row"
+
+                let mutable blobReader =
+                    mdReader.GetBlobReader (mdReader.GetConstant constantHandle).Value
+
+                blobReader.Offset <- byteOffset
+                blobReader.ReadBytes targetSize
 
         CliType.ofBytesLike targetTemplate bytes
 

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -58,7 +58,11 @@ module IlMachineState =
     let peByteRangeForMethodSignatureBlob =
         IlMachineTypeResolution.peByteRangeForMethodSignatureBlob
 
+    let peByteRangeForConstantBlob = IlMachineTypeResolution.peByteRangeForConstantBlob
+
     let peByteRangePointer = IlMachineTypeResolution.peByteRangePointer
+
+    let peByteRangeCharPointer = IlMachineTypeResolution.peByteRangeCharPointer
 
     let getFrame = IlMachineThreadState.getFrame
 

--- a/WoofWare.PawPrint/IlMachineTypeResolution.fs
+++ b/WoofWare.PawPrint/IlMachineTypeResolution.fs
@@ -791,17 +791,6 @@ module IlMachineTypeResolution =
         |> Some
 
     /// A `char*` over a PE byte range, as opposed to `peByteRangePointer`'s `byte*`.
-    ///
-    /// Having *a* `ReinterpretAs` projection is load-bearing: `ArithmeticTarget.decompose` refuses
-    /// pointer arithmetic on a bare PE-byte-range root, and that refusal is reached even by
-    /// `ptr + 0`, since the zero-offset shortcut sits after the decomposition. A guest doing
-    /// `new string(ptr, 0, length)` offsets the pointer before reading it, so a projection-less
-    /// pointer faults there rather than here — confirmed by mutation.
-    ///
-    /// Which primitive the projection names is *not* load-bearing for that guest path: the offset is
-    /// zero and the copy that follows is byte-wise, so a `byte` projection reaches the same answer.
-    /// `char` is chosen because it is the type the API declares (`out char*`), which keeps the
-    /// pointer self-describing to anything that later inspects it.
     let peByteRangeCharPointer
         (loggerFactory : ILoggerFactory)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
@@ -809,6 +798,16 @@ module IlMachineTypeResolution =
         (state : IlMachineState)
         : IlMachineState * ManagedPointerSource
         =
+        /// Having *a* `ReinterpretAs` projection is necessary: `ArithmeticTarget.decompose` refuses
+        /// pointer arithmetic on a bare PE-byte-range root, and that refusal is reached even by
+        /// `ptr + 0`, since the zero-offset shortcut sits after the decomposition. A guest doing
+        /// `new string(ptr, 0, length)` offsets the pointer before reading it, so a projection-less
+        /// pointer faults there rather than here.
+        ///
+        /// *Which* primitive the projection names doesn't matter: the offset is
+        /// zero and the copy that follows is byte-wise, so a `byte` projection reaches the same answer.
+        /// `char` is chosen because it is the type the API declares (`out char*`), which keeps the
+        /// pointer self-describing to anything that later inspects it.
         let state, charType = ensureCharConcreteType loggerFactory baseClassTypes state
 
         state,

--- a/WoofWare.PawPrint/IlMachineTypeResolution.fs
+++ b/WoofWare.PawPrint/IlMachineTypeResolution.fs
@@ -798,16 +798,16 @@ module IlMachineTypeResolution =
         (state : IlMachineState)
         : IlMachineState * ManagedPointerSource
         =
-        /// Having *a* `ReinterpretAs` projection is necessary: `ArithmeticTarget.decompose` refuses
-        /// pointer arithmetic on a bare PE-byte-range root, and that refusal is reached even by
-        /// `ptr + 0`, since the zero-offset shortcut sits after the decomposition. A guest doing
-        /// `new string(ptr, 0, length)` offsets the pointer before reading it, so a projection-less
-        /// pointer faults there rather than here.
-        ///
-        /// *Which* primitive the projection names doesn't matter: the offset is
-        /// zero and the copy that follows is byte-wise, so a `byte` projection reaches the same answer.
-        /// `char` is chosen because it is the type the API declares (`out char*`), which keeps the
-        /// pointer self-describing to anything that later inspects it.
+        // Having *a* `ReinterpretAs` projection is necessary: `ArithmeticTarget.decompose` refuses
+        // pointer arithmetic on a bare PE-byte-range root, and that refusal is reached even by
+        // `ptr + 0`, since the zero-offset shortcut sits after the decomposition. A guest doing
+        // `new string(ptr, 0, length)` offsets the pointer before reading it, so a projection-less
+        // pointer faults there rather than here.
+        //
+        // *Which* primitive the projection names doesn't matter: the offset is
+        // zero and the copy that follows is byte-wise, so a `byte` projection reaches the same answer.
+        // `char` is chosen because it is the type the API declares (`out char*`), which keeps the
+        // pointer self-describing to anything that later inspects it.
         let state, charType = ensureCharConcreteType loggerFactory baseClassTypes state
 
         state,

--- a/WoofWare.PawPrint/IlMachineTypeResolution.fs
+++ b/WoofWare.PawPrint/IlMachineTypeResolution.fs
@@ -631,6 +631,31 @@ module IlMachineTypeResolution =
 
         state, byteType
 
+    let ensureCharConcreteType
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        : IlMachineState * ConcreteType<ConcreteTypeHandle>
+        =
+        let charTypeDefn =
+            DumpedAssembly.typeInfoToTypeDefn' baseClassTypes state._LoadedAssemblies baseClassTypes.Char
+
+        let state, charHandle =
+            concretizeType
+                loggerFactory
+                baseClassTypes
+                state
+                baseClassTypes.Corelib.Name
+                ImmutableArray.Empty
+                ImmutableArray.Empty
+                charTypeDefn
+
+        let charType =
+            AllConcreteTypes.lookup charHandle state.ConcreteTypes
+            |> Option.defaultWith (fun () -> failwith "System.Char was not present after concretization")
+
+        state, charType
+
     let peByteRangeForFieldRva
         (loggerFactory : ILoggerFactory)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
@@ -739,3 +764,52 @@ module IlMachineTypeResolution =
 
         state,
         ManagedPointerSource.Byref (ByrefRoot.PeByteRange peByteRange, [ ByrefProjection.ReinterpretAs byteType ])
+
+    /// PE byte range pointer over the Constant table's value blob for a field
+    /// definition (ECMA II.22.9).
+    let peByteRangeForConstantBlob
+        (assembly : DumpedAssembly)
+        (fieldHandle : FieldDefinitionHandle)
+        : PeByteRangePointer option
+        =
+        let mdReader = assembly.PeReader.GetMetadataReader ()
+        let fieldDef = mdReader.GetFieldDefinition fieldHandle
+        let constantHandle = fieldDef.GetDefaultValue ()
+
+        if constantHandle.IsNil then
+            None
+        else
+
+        let blobReader = mdReader.GetBlobReader (mdReader.GetConstant constantHandle).Value
+
+        {
+            AssemblyFullName = assembly.Name.FullName
+            Source = PeByteRangePointerSource.ConstantBlob (ComparableFieldDefinitionHandle.Make fieldHandle)
+            RelativeVirtualAddress = 0
+            Size = blobReader.Length
+        }
+        |> Some
+
+    /// A `char*` over a PE byte range, as opposed to `peByteRangePointer`'s `byte*`.
+    ///
+    /// Having *a* `ReinterpretAs` projection is load-bearing: `ArithmeticTarget.decompose` refuses
+    /// pointer arithmetic on a bare PE-byte-range root, and that refusal is reached even by
+    /// `ptr + 0`, since the zero-offset shortcut sits after the decomposition. A guest doing
+    /// `new string(ptr, 0, length)` offsets the pointer before reading it, so a projection-less
+    /// pointer faults there rather than here — confirmed by mutation.
+    ///
+    /// Which primitive the projection names is *not* load-bearing for that guest path: the offset is
+    /// zero and the copy that follows is byte-wise, so a `byte` projection reaches the same answer.
+    /// `char` is chosen because it is the type the API declares (`out char*`), which keeps the
+    /// pointer self-describing to anything that later inspects it.
+    let peByteRangeCharPointer
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (peByteRange : PeByteRangePointer)
+        (state : IlMachineState)
+        : IlMachineState * ManagedPointerSource
+        =
+        let state, charType = ensureCharConcreteType loggerFactory baseClassTypes state
+
+        state,
+        ManagedPointerSource.Byref (ByrefRoot.PeByteRange peByteRange, [ ByrefProjection.ReinterpretAs charType ])

--- a/WoofWare.PawPrint/ManagedPointerSource.fs
+++ b/WoofWare.PawPrint/ManagedPointerSource.fs
@@ -22,6 +22,13 @@ type PeByteRangePointerSource =
     /// The COR signature blob for a method definition (ECMA II.23.2.1). Same
     /// storage story as `FieldSignatureBlob`.
     | MethodSignatureBlob of method : ComparableMethodDefinitionHandle
+    /// The Constant table's value blob for a field definition (ECMA II.22.9): the
+    /// field's compile-time constant, in the encoding its `ConstantTypeCode`
+    /// names. For a string constant those bytes are UTF-16LE characters, which is
+    /// what `MetadataImport.GetDefaultValue` hands back as a `char*`. Same storage
+    /// story as `FieldSignatureBlob` — it lives in the `#Blob` heap, so the RVA has
+    /// no PE-section meaning and is fixed at 0.
+    | ConstantBlob of field : ComparableFieldDefinitionHandle
 
 type PeByteRangePointer =
     {
@@ -38,6 +45,7 @@ type PeByteRangePointer =
             | PeByteRangePointerSource.ManagedResource resourceName -> $"managed resource %s{resourceName}"
             | PeByteRangePointerSource.FieldSignatureBlob field -> $"field signature blob for %O{field.Get}"
             | PeByteRangePointerSource.MethodSignatureBlob method -> $"method signature blob for %O{method.Get}"
+            | PeByteRangePointerSource.ConstantBlob field -> $"constant blob for %O{field.Get}"
 
         $"<PE data %s{this.AssemblyFullName} %s{source} at %d{this.RelativeVirtualAddress} size %d{this.Size}>"
 
@@ -595,7 +603,8 @@ module ManagedPointerSource =
             | PeByteRangePointerSource.FieldRva _
             | PeByteRangePointerSource.ManagedResource _ -> Some 3
             | PeByteRangePointerSource.FieldSignatureBlob _
-            | PeByteRangePointerSource.MethodSignatureBlob _ -> None
+            | PeByteRangePointerSource.MethodSignatureBlob _
+            | PeByteRangePointerSource.ConstantBlob _ -> None
         // Object fields, static fields, stack slots and the synthetic roots have no
         // stable in-container offset either (see `tryStableAddressBits` and
         // `NullaryIlOp.tryManagedPointerAddressBits`), so there is nothing to pair

--- a/WoofWare.PawPrint/Native/NativeEnum.fs
+++ b/WoofWare.PawPrint/Native/NativeEnum.fs
@@ -135,16 +135,19 @@ module NativeEnum =
         (field : FieldInfo<GenericParamFromMetadata, TypeDefn>)
         : CliType
         =
-        let fieldDefinition = metadataReader.GetFieldDefinition field.Handle
-        let constantHandle = fieldDefinition.GetDefaultValue ()
+        // The raw Constant row; this projection is the *enum* view of it, which insists the row's
+        // type code agrees with the declared underlying type. `MetadataImport.GetDefaultValue` takes
+        // the same row and must not insist on anything, so the two share the lookup and not the
+        // interpretation.
+        let typeCode, blobReader =
+            NativeMetadataImport.constantRowOfField metadataReader field.Handle
+            |> Option.defaultWith (fun () ->
+                failwith $"%s{operation}: static literal enum field %s{field.Name} had no metadata constant"
+            )
 
-        if constantHandle.IsNil then
-            failwith $"%s{operation}: static literal enum field %s{field.Name} had no metadata constant"
+        let mutable reader = blobReader
 
-        let constant = metadataReader.GetConstant constantHandle
-        let mutable reader = metadataReader.GetBlobReader constant.Value
-
-        match underlying, constant.TypeCode with
+        match underlying, typeCode with
         | PrimitiveType.SByte, ConstantTypeCode.SByte ->
             CliType.Numeric (CliNumericType.UInt8 (byte (reader.ReadSByte ())))
         | PrimitiveType.Byte, ConstantTypeCode.Byte -> CliType.Numeric (CliNumericType.UInt8 (reader.ReadByte ()))

--- a/WoofWare.PawPrint/Native/NativeMetadataImport.fs
+++ b/WoofWare.PawPrint/Native/NativeMetadataImport.fs
@@ -255,6 +255,94 @@ module NativeMetadataImport =
                 failwith $"%s{operation}: FieldDef token 0x%08x{mdToken} was not present in %s{assembly.Name.FullName}"
         | token -> failwith $"%s{operation}: expected FieldDef token, got %O{token} from 0x%08x{mdToken}"
 
+    /// The Constant table row (ECMA-335 II.22.9) attached to a field definition: its declared type
+    /// code and a reader over its value blob. <c>None</c> when the field has no Constant row.
+    ///
+    /// Deliberately raw, because the two callers disagree about what the answer means.
+    /// <c>NativeEnum</c> requires the type code to match the enum's declared underlying type and
+    /// fails otherwise, and treats a missing row as a corrupt image;
+    /// <c>MetadataImport.GetDefaultValue</c> must do neither, because <c>MdConstant</c> is the thing
+    /// that decides what the bytes mean, and a missing row is its ordinary "no default value"
+    /// answer.
+    let constantRowOfField
+        (metadataReader : System.Reflection.Metadata.MetadataReader)
+        (fieldHandle : System.Reflection.Metadata.FieldDefinitionHandle)
+        : (System.Reflection.Metadata.ConstantTypeCode * System.Reflection.Metadata.BlobReader) option
+        =
+        let constantHandle =
+            (metadataReader.GetFieldDefinition fieldHandle).GetDefaultValue ()
+
+        if constantHandle.IsNil then
+            None
+        else
+
+        let constant = metadataReader.GetConstant constantHandle
+        Some (constant.TypeCode, metadataReader.GetBlobReader constant.Value)
+
+    /// ECMA-335 II.23.1.16 <c>ELEMENT_TYPE_*</c> code for a Constant row's type, paired with the
+    /// number of bytes its value blob must contain — CoreCLR's <c>_FillMDDefaultValue</c> checks
+    /// exactly this width per code and reports <c>CLDB_E_FILE_CORRUPT</c> when the blob is shorter.
+    /// A *longer* blob is tolerated there and only its first <c>width</c> bytes are read, so the
+    /// width is a minimum for validation and an exact count for decoding.
+    ///
+    /// <c>ELEMENT_TYPE_STRING</c> has no fixed width; its blob is however many UTF-16 code units
+    /// the string has, so it carries width 0 and is handled separately by the caller.
+    ///
+    /// <c>System.Reflection.Metadata</c>'s <c>ConstantTypeCode</c> values happen to be the same
+    /// numbers as the element types, but this maps them explicitly rather than casting: they are
+    /// two separate contracts, and a cast would silently follow either one if it moved.
+    let private elementTypeOfConstantTypeCode
+        (operation : string)
+        (code : System.Reflection.Metadata.ConstantTypeCode)
+        : int32 * int
+        =
+        match code with
+        | System.Reflection.Metadata.ConstantTypeCode.Boolean -> 0x02, 1
+        | System.Reflection.Metadata.ConstantTypeCode.Char -> 0x03, 2
+        | System.Reflection.Metadata.ConstantTypeCode.SByte -> 0x04, 1
+        | System.Reflection.Metadata.ConstantTypeCode.Byte -> 0x05, 1
+        | System.Reflection.Metadata.ConstantTypeCode.Int16 -> 0x06, 2
+        | System.Reflection.Metadata.ConstantTypeCode.UInt16 -> 0x07, 2
+        | System.Reflection.Metadata.ConstantTypeCode.Int32 -> 0x08, 4
+        | System.Reflection.Metadata.ConstantTypeCode.UInt32 -> 0x09, 4
+        | System.Reflection.Metadata.ConstantTypeCode.Int64 -> 0x0A, 8
+        | System.Reflection.Metadata.ConstantTypeCode.UInt64 -> 0x0B, 8
+        | System.Reflection.Metadata.ConstantTypeCode.Single -> 0x0C, 4
+        | System.Reflection.Metadata.ConstantTypeCode.Double -> 0x0D, 8
+        | System.Reflection.Metadata.ConstantTypeCode.String -> 0x0E, 0
+        | System.Reflection.Metadata.ConstantTypeCode.NullReference -> 0x12, 4
+        | code -> failwith $"%s{operation}: Constant row has unrepresentable type code %O{code}"
+
+    /// <c>ELEMENT_TYPE_VOID</c>, which is how CoreCLR reports "this token has no Constant row".
+    let private elementTypeVoid : int32 = 0x01
+
+    /// <c>ELEMENT_TYPE_STRING</c>, the one code whose blob is handed back as a pointer rather than
+    /// packed into the 64-bit buffer.
+    let private elementTypeString : int32 = 0x0E
+
+    /// <c>ELEMENT_TYPE_CLASS</c>, which ECMA-335 II.22.9 permits only as a null reference: exactly
+    /// four bytes, all zero.
+    let private elementTypeClass : int32 = 0x12
+
+    /// Pack a Constant blob into the low bytes of a 64-bit buffer, little-endian, as
+    /// <c>MetaDataImport::GetDefaultValue</c>'s <c>*pDefaultValue = value.m_ullValue</c> does.
+    ///
+    /// The high bytes are zero *by PawPrint's choice*, not by CoreCLR's: there,
+    /// <c>MDDefaultValue</c> is an uninitialised stack union and <c>_FillMDDefaultValue</c> writes
+    /// only the member-width low bytes, so the rest is whatever was on the stack. That is
+    /// unobservable upstream — <c>MdConstant</c> reinterprets only the low member-width bytes for
+    /// every type code, so sign- versus zero-extension cannot be told apart by a guest — but a
+    /// replay must not depend on the host's stack, so we pick zeros and say so.
+    /// Reads exactly <paramref name="width"/> bytes, which is what CoreCLR does: a blob longer than
+    /// its type requires has its tail ignored rather than folded in.
+    let private packConstantBuffer (width : int) (bytes : byte array) : int64 =
+        let mutable buffer = 0UL
+
+        for i in 0 .. width - 1 do
+            buffer <- buffer ||| (uint64 bytes.[i] <<< (8 * i))
+
+        int64 buffer
+
     /// Walk the assembly's methods to find which one owns <paramref name="paramHandle"/>.
     /// CLI metadata exposes the param->method relation only via per-method ranges, so
     /// answering "who owns this Param row?" requires iterating method definitions.
@@ -671,6 +759,149 @@ module NativeMetadataImport =
             let state =
                 writeInt32AtPointer ctx.BaseClassTypes state attributesOut (int32 field.Attributes)
 
+            let state =
+                IlMachineState.pushToEvalStack' (EvalStackValue.Int32 (Int32Source.Verbatim 0)) ctx.Thread state
+
+            NativeHandlerResult.completed state |> Some
+        | "System.Private.CoreLib",
+          "System.Reflection",
+          "MetadataImport",
+          "GetDefaultValue",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32
+            ConcreteByref (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int64)
+            ConcreteByref (ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.Char))
+            ConcreteByref (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32)
+            ConcreteByref (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
+            // CoreCLR's FCall (managedmdimport.cpp:80) unpacks one `MDDefaultValue`: a string
+            // constant reports its blob as a `char*` with a length in *characters*, everything else
+            // packs into the 64-bit buffer with a length in *bytes*, and a token with no Constant
+            // row reports ELEMENT_TYPE_VOID, which `MdConstant` turns into DBNull.Value.
+            //
+            // Only FieldDef parents are covered. The Constant table's Parent is a HasConstant coded
+            // index spanning ParamDef and PropertyDef too, but neither is reachable: PawPrint has no
+            // `GetPropertyProps` handler, and the `Enum` QCall mints no ParamDef tokens, so those
+            // arms could never be executed.
+            let operation = "MetadataImport.GetDefaultValue"
+            let assemblyFullName = metadataImportHandleOfArg operation instruction.Arguments.[0]
+            let assembly = metadataImportAssembly operation state assemblyFullName
+
+            let mdToken =
+                match CliType.unwrapPrimitiveLikeDeep instruction.Arguments.[1] with
+                | CliType.Numeric (CliNumericType.Int32 mdToken) -> mdToken
+                | other -> failwith $"%s{operation}: expected Int32 mdToken argument, got %O{other}"
+
+            let valueOut =
+                NativeCall.managedPointerOfPointerArgument operation "value out pointer" instruction.Arguments.[2]
+
+            let stringValueOut =
+                NativeCall.managedPointerOfPointerArgument
+                    operation
+                    "stringMetadataEncoding out pointer"
+                    instruction.Arguments.[3]
+
+            let lengthOut =
+                NativeCall.managedPointerOfPointerArgument operation "length out pointer" instruction.Arguments.[4]
+
+            let corElementTypeOut =
+                NativeCall.managedPointerOfPointerArgument
+                    operation
+                    "corElementType out pointer"
+                    instruction.Arguments.[5]
+
+            // Rejects a non-FieldDef token, and a FieldDef absent from this assembly.
+            let field = fieldDefinition operation assembly mdToken
+            let mr = metadataReaderOf assembly
+
+            let writeInt64 (state : IlMachineState) (value : int64) : IlMachineState =
+                IlMachineState.writeManagedByrefWithBase
+                    ctx.BaseClassTypes
+                    state
+                    valueOut
+                    (CliType.Numeric (CliNumericType.Int64 (Int64Source.Verbatim value)))
+
+            let writeStringPointer (state : IlMachineState) (pointer : ManagedPointerSource) : IlMachineState =
+                IlMachineState.writeManagedByrefWithBase
+                    ctx.BaseClassTypes
+                    state
+                    stringValueOut
+                    (CliType.RuntimePointer (CliRuntimePointer.Managed pointer))
+
+            let state, value, stringPointer, length, corElementType =
+                match constantRowOfField mr field.Handle with
+                | None ->
+                    // CoreCLR returns here having set only `m_bType`, so its buffer and length are
+                    // whatever was on the stack. `MdConstant` looks at nothing but the element type
+                    // in this case, but a replay must not depend on the host's stack, so pick zeros.
+                    // (Its `*pStringValue = NULL` *is* written, unconditionally, by the FCall.)
+                    state, 0L, ManagedPointerSource.Null, 0, elementTypeVoid
+                | Some (typeCode, blobReader) ->
+
+                let elementType, requiredWidth = elementTypeOfConstantTypeCode operation typeCode
+                let mutable reader = blobReader
+                let bytes = reader.ReadBytes reader.Length
+
+                // `_FillMDDefaultValue` bounds-checks every fixed-width code and reports
+                // CLDB_E_FILE_CORRUPT on a short blob, so zero-padding one would fabricate a value
+                // the real runtime refuses to produce. STRING is exempt: its width is whatever the
+                // string is.
+                if bytes.Length < requiredWidth then
+                    failwith
+                        $"%s{operation}: Constant blob for %O{field.Handle} has %d{bytes.Length} bytes but element type 0x%02x{elementType} requires %d{requiredWidth}; CoreCLR reports CLDB_E_FILE_CORRUPT for this"
+
+                if elementType = elementTypeString then
+                    // An odd-length blob is *not* rejected. `_FillMDDefaultValue` applies no length
+                    // check to STRING, and the FCall's `m_cbSize / sizeof(WCHAR)` is integer
+                    // division, so CoreCLR silently drops a trailing half code unit. Refusing here
+                    // would make PawPrint decline metadata the real runtime reads without
+                    // complaint — a divergence, and one a differential test would catch.
+                    if bytes.Length = 0 then
+                        // `_FillMDDefaultValue` nulls the pointer for an empty string blob
+                        // (mdinternalro.cpp:3214), and the managed wrapper's `stringVal ?? string.Empty`
+                        // is what recovers `""`. Pointing at a zero-length range instead would make
+                        // the wrapper build a string from a pointer that addresses nothing.
+                        state, 0L, ManagedPointerSource.Null, 0, elementType
+                    else
+
+                    let peByteRange =
+                        IlMachineState.peByteRangeForConstantBlob assembly field.Handle
+                        |> Option.defaultWith (fun () ->
+                            failwith $"%s{operation}: Constant row for %O{field.Handle} vanished between reads"
+                        )
+
+                    let state, pointer =
+                        IlMachineState.peByteRangeCharPointer ctx.LoggerFactory ctx.BaseClassTypes peByteRange state
+
+                    // Length is in characters here and in bytes everywhere else — the FCall divides
+                    // by sizeof(WCHAR) only on this branch.
+                    state, 0L, pointer, bytes.Length / 2, elementType
+                else if
+
+                    elementType = elementTypeClass
+                then
+                    // ECMA-335 II.22.9: a CLASS constant is a null reference, and CoreCLR asserts
+                    // the four bytes it reads are zero before reporting CLDB_E_FILE_CORRUPT for a
+                    // non-null one. The width check above has already rejected a short blob.
+                    if packConstantBuffer 4 bytes <> 0L then
+                        failwith
+                            $"%s{operation}: ELEMENT_TYPE_CLASS Constant blob for %O{field.Handle} must be a null reference, got %A{bytes}"
+
+                    state, 0L, ManagedPointerSource.Null, bytes.Length, elementType
+                else
+
+                state, packConstantBuffer requiredWidth bytes, ManagedPointerSource.Null, bytes.Length, elementType
+
+            let state = writeInt64 state value
+            let state = writeStringPointer state stringPointer
+            let state = writeInt32AtPointer ctx.BaseClassTypes state lengthOut length
+
+            let state =
+                writeInt32AtPointer ctx.BaseClassTypes state corElementTypeOut corElementType
+
+            // The managed wrapper turns a negative HRESULT into BadImageFormatException, but as in
+            // every sibling handler the failures above are host-level crashes: the only guest caller
+            // passes a token the runtime itself minted.
             let state =
                 IlMachineState.pushToEvalStack' (EvalStackValue.Int32 (Int32Source.Verbatim 0)) ctx.Thread state
 

--- a/WoofWare.PawPrint/Native/NativeSignature.fs
+++ b/WoofWare.PawPrint/Native/NativeSignature.fs
@@ -76,7 +76,8 @@ module NativeSignature =
             let methodDef = mdReader.GetMethodDefinition method.Get
             assembly, methodDef.Signature
         | PeByteRangePointerSource.FieldRva _
-        | PeByteRangePointerSource.ManagedResource _ ->
+        | PeByteRangePointerSource.ManagedResource _
+        | PeByteRangePointerSource.ConstantBlob _ ->
             failwith $"%s{operation}: signature `_sig` byref points at non-signature PE byte range %O{peByteRange}"
 
     /// Resolve a Signature `_sig` argument to the COR signature blob bytes it


### PR DESCRIPTION
Implements `MetadataImport::GetDefaultValue`, the next blocker on the `UnionReflection` path. With it, `FieldInfo.GetRawConstantValue` works on literal fields; F#'s `FSharpType.GetUnionCases` needs it for a union's `Tags` constants.

## Three out-param shapes in one call

`MdConstant.GetValue` reads a literal's Constant-table row through this FCall, and the row is reported three different ways:

- a **string** constant hands back its blob as a `char*` with a length in *characters*;
- everything else packs into a **64-bit buffer** with a length in *bytes*;
- a token with **no Constant row** reports `ELEMENT_TYPE_VOID`, which `MdConstant` turns into `DBNull.Value`.

Two encodings are easy to confuse with that last one, and are handled separately: a null reference constant is `ELEMENT_TYPE_CLASS` with four mandatory zero bytes, and an *empty* string has a zero-length blob that CoreCLR reports as a **null pointer** — `string.Empty` is recovered by the managed wrapper's `stringVal ?? string.Empty`, not here.

## The string pointer

A PE byte range over the Constant blob (new `PeByteRangePointerSource.ConstantBlob`), not a copy — the same choice as the two changes before this, and for the same reason: CoreCLR hands back a pointer into the mapped metadata.

It survives `new string(char*, int, int)` because `SpanHelpers.Memmove` is intercepted rather than interpreted, so the copy bottoms out in `CellAwareMemOps`, which already models PE byte ranges. Having a `ReinterpretAs` projection on the pointer **is** load-bearing — pointer arithmetic on a bare PE-byte-range root is refused outright, and `String.Ctor` offsets before reading. Which primitive the projection names is **not**: `byte` works identically, and `char` is chosen only because it is the type the API declares. The comments and the test say exactly that rather than implying more.

## Scope and sharing

`ConstantTypeCode` is mapped to `ELEMENT_TYPE` explicitly rather than cast. The two enums do coincide numerically, which is precisely why a cast would be a silent hazard if either moved.

Only FieldDef parents are covered. The Constant table's Parent spans ParamDef and PropertyDef too, but neither is reachable — no `GetPropertyProps` handler exists and no ParamDef tokens are minted — so those arms would be code that could never run.

`NativeEnum` already read the Constant table as an enum-shaped *view*. It now shares the row lookup while keeping its own interpretation: it must reject a type-code that disagrees with the declared underlying type, and this handler must not, because `MdConstant` is what decides what the bytes mean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
