### PR TITLE
Separate the schedule seed from the rest of the host configuration

### DIFF
--- a/WoofWare.PawPrint.App/DebuggerServer.fs
+++ b/WoofWare.PawPrint.App/DebuggerServer.fs
@@ -353,11 +353,14 @@ module DebuggerServer =
                 loggerFactory
                 (Some dllPath)
                 fileStream
-                { HostConfig.Default dotnetRuntimeDirs with
-                    Kernel = kernelConfig
+                {
+                    Guest =
+                        { GuestConfig.Default dotnetRuntimeDirs with
+                            Kernel = kernelConfig
+                            Argv = argv
+                            AppContext = HostRuntimeConfig.forAssembly dllPath
+                        }
                     PctSeed = pctSeed
-                    Argv = argv
-                    AppContext = HostRuntimeConfig.forAssembly dllPath
                 }
         with
         | Program.ProgramStartResult.Ready prepared -> SessionState.Running (prepared, 0L)

--- a/WoofWare.PawPrint.App/Program.fs
+++ b/WoofWare.PawPrint.App/Program.fs
@@ -373,11 +373,14 @@ module AppProgram =
                 loggerFactory
                 (Some dllPath)
                 fileStream
-                { HostConfig.Default dotnetRuntimes with
-                    Kernel = kernelConfig
+                {
+                    Guest =
+                        { GuestConfig.Default dotnetRuntimes with
+                            Kernel = kernelConfig
+                            Argv = args
+                            AppContext = HostRuntimeConfig.forAssembly dllPath
+                        }
                     PctSeed = pctSeed
-                    Argv = args
-                    AppContext = HostRuntimeConfig.forAssembly dllPath
                 }
             |> pumpStartup
 

--- a/WoofWare.PawPrint.Test/TestBulkMoveCellAccess.fs
+++ b/WoofWare.PawPrint.Test/TestBulkMoveCellAccess.fs
@@ -358,13 +358,7 @@ public class TestBulkMoveCellAccessSweep
 
         let outcome =
             try
-                Program.run
-                    loggerFactory
-                    (Some sourceName)
-                    peImage
-                    { HostConfig.Default dotnetRuntimes with
-                        Kernel = KernelConfig.Default
-                    }
+                Program.run loggerFactory (Some sourceName) peImage (HostConfig.Default dotnetRuntimes)
             with _ ->
                 for message in messages () do
                     Console.Error.WriteLine $"{message}"

--- a/WoofWare.PawPrint.Test/TestFSharpPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestFSharpPureCases.fs
@@ -180,7 +180,10 @@ module TestFSharpPureCases =
                     (Some dllPath)
                     peImage
                     { HostConfig.Default dotnetRuntimes with
-                        Argv = [ testCaseName ]
+                        Guest =
+                            { GuestConfig.Default dotnetRuntimes with
+                                Argv = [ testCaseName ]
+                            }
                     }
 
             match realResult, pawPrintResult with

--- a/WoofWare.PawPrint.Test/TestImpureCases.fs
+++ b/WoofWare.PawPrint.Test/TestImpureCases.fs
@@ -620,8 +620,11 @@ module TestImpureCases =
                         (Some case.FileName)
                         peImage
                         { HostConfig.Default dotnetRuntimes with
-                            Kernel = case.KernelConfig
-                            AppContext = case.AppContext
+                            Guest =
+                                { GuestConfig.Default dotnetRuntimes with
+                                    Kernel = case.KernelConfig
+                                    AppContext = case.AppContext
+                                }
                         }
                 with
                 | RunOutcome.GuestUnhandledException (_, _, exn) ->

--- a/WoofWare.PawPrint.Test/TestInlineArrayLayout.fs
+++ b/WoofWare.PawPrint.Test/TestInlineArrayLayout.fs
@@ -203,13 +203,7 @@ public class TestInlineArrayLayoutSweep
 
         let outcome =
             try
-                Program.run
-                    loggerFactory
-                    (Some sourceName)
-                    peImage
-                    { HostConfig.Default dotnetRuntimes with
-                        Kernel = KernelConfig.Default
-                    }
+                Program.run loggerFactory (Some sourceName) peImage (HostConfig.Default dotnetRuntimes)
             with _ ->
                 for message in messages () do
                     Console.Error.WriteLine $"{message}"

--- a/WoofWare.PawPrint.Test/TestNativeThreadSpinWait.fs
+++ b/WoofWare.PawPrint.Test/TestNativeThreadSpinWait.fs
@@ -67,7 +67,10 @@ public static class Entry
                 (Some "ThreadSpinWaitTest.cs")
                 peImage
                 { HostConfig.Default dotnetRuntimes with
-                    Kernel = kernelConfig
+                    Guest =
+                        { GuestConfig.Default dotnetRuntimes with
+                            Kernel = kernelConfig
+                        }
                 }
         with
         | Program.ProgramStartResult.Ready prepared -> prepared

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -103,7 +103,10 @@ module TestPureCases =
                     (Some sourceName)
                     peImage
                     { HostConfig.Default dotnetRuntimes with
-                        Kernel = kernelConfig
+                        Guest =
+                            { GuestConfig.Default dotnetRuntimes with
+                                Kernel = kernelConfig
+                            }
                     }
 
             assertResult image pawPrintResult

--- a/WoofWare.PawPrint.Test/TestReinterpretCellAccess.fs
+++ b/WoofWare.PawPrint.Test/TestReinterpretCellAccess.fs
@@ -215,13 +215,7 @@ public class Probe
 
         let outcome =
             try
-                Program.run
-                    loggerFactory
-                    (Some sourceName)
-                    peImage
-                    { HostConfig.Default dotnetRuntimes with
-                        Kernel = KernelConfig.Default
-                    }
+                Program.run loggerFactory (Some sourceName) peImage (HostConfig.Default dotnetRuntimes)
             with _ ->
                 for message in messages () do
                     Console.Error.WriteLine $"{message}"

--- a/WoofWare.PawPrint/HostConfig.fs
+++ b/WoofWare.PawPrint/HostConfig.fs
@@ -2,13 +2,20 @@ namespace WoofWare.PawPrint
 
 open System.Collections.Immutable
 
-/// Everything the host supplies to configure one run of a guest program, as
-/// distinct from the program image itself (which `Program.prepare` takes
-/// separately, as a stream plus the path it came from).
+/// Everything the host supplies that describes the simulated process itself, as opposed to
+/// which of its possible thread interleavings we are exploring: where its framework comes from,
+/// what its kernel looks like, what it was invoked with.
 ///
-/// Every field here is part of a run's replay contract. Two runs with equal
-/// `HostConfig` over the same image will produce the same trace.
-type HostConfig =
+/// Split out of `HostConfig` so that the schedule seed can be handed over separately. Two runs
+/// of the same image that share a `GuestConfig` but differ in seed are the *same program*
+/// explored along different schedules — and, up to the first point at which more than one thread
+/// is Runnable, they are bit-for-bit the same execution. A harness that wants to compute that
+/// shared prefix once and fan out over seeds therefore needs to name "everything except the
+/// seed", and needs it to be impossible to pass a seed in by accident. See
+/// `docs/plans/2026-08-10-fork-point-snapshots.md`.
+///
+/// Every field here is part of a run's replay contract, as is `HostConfig.PctSeed`.
+type GuestConfig =
     {
         /// Directories on the real host machine searched, in order, for framework assemblies. Binding is
         /// by simple name and takes the first hit, so putting a runtime pack at
@@ -17,9 +24,6 @@ type HostConfig =
         /// The simulated process's kernel-visible state: environment, processor
         /// count, virtual clock, platform identity.
         Kernel : KernelConfig
-        /// Seed for the PCT scheduler. `None` runs the deterministic default
-        /// schedule; `Some` explores a randomised-but-reproducible interleaving.
-        PctSeed : uint64 option
         /// The guest's command-line arguments, as `Main` receives them — i.e.
         /// excluding the program name. Distinct from `Kernel.Environment`
         /// because the runtime hands these to `Main` directly rather than the
@@ -43,15 +47,42 @@ type HostConfig =
     }
 
     /// A host that expresses no preference beyond where to find the framework:
-    /// default kernel state, the deterministic default schedule, no guest
-    /// arguments, and no AppContext properties of its own. Such a guest is still
-    /// seeded with `AppContextProperties.runtimeBaseline`, which is PawPrint's
-    /// rather than the host's.
-    static member Default (dotnetRuntimeDirs : ImmutableArray<string>) : HostConfig =
+    /// default kernel state, no guest arguments, and no AppContext properties of
+    /// its own. Such a guest is still seeded with
+    /// `AppContextProperties.runtimeBaseline`, which is PawPrint's rather than
+    /// the host's.
+    static member Default (dotnetRuntimeDirs : ImmutableArray<string>) : GuestConfig =
         {
             DotnetRuntimeDirs = dotnetRuntimeDirs
             Kernel = KernelConfig.Default
-            PctSeed = None
             Argv = []
             AppContext = AppContextProperties.empty
+        }
+
+/// Everything the host supplies to configure one run of a guest program, as
+/// distinct from the program image itself (which `Program.prepare` takes
+/// separately, as a stream plus the path it came from).
+///
+/// Every field here is part of a run's replay contract. Two runs with equal
+/// `HostConfig` over the same image will produce the same trace.
+///
+/// The seed is deliberately the *only* thing at this level: it is the one input that selects
+/// among the schedules of an otherwise fixed program, and separating it is what lets a
+/// schedule-sweeping harness say "this program, under all of these seeds" without being able to
+/// name a seed in the part that is shared. See `GuestConfig`.
+type HostConfig =
+    {
+        /// The simulated process: framework, kernel, arguments, AppContext.
+        Guest : GuestConfig
+        /// Seed for the PCT scheduler. `None` runs the deterministic default
+        /// schedule; `Some` explores a randomised-but-reproducible interleaving.
+        PctSeed : uint64 option
+    }
+
+    /// A host that expresses no preference beyond where to find the framework:
+    /// `GuestConfig.Default`, run under the deterministic default schedule.
+    static member Default (dotnetRuntimeDirs : ImmutableArray<string>) : HostConfig =
+        {
+            Guest = GuestConfig.Default dotnetRuntimeDirs
+            PctSeed = None
         }

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -694,10 +694,10 @@ module Program =
         : Startup
         =
         let logger = loggerFactory.CreateLogger "Program"
-        let dotnetRuntimeDirs = hostConfig.DotnetRuntimeDirs
-        let kernelConfig = hostConfig.Kernel
+        let dotnetRuntimeDirs = hostConfig.Guest.DotnetRuntimeDirs
+        let kernelConfig = hostConfig.Guest.Kernel
         let pctSeed = hostConfig.PctSeed
-        let argv = hostConfig.Argv
+        let argv = hostConfig.Guest.Argv
 
         let dumped = Assembly.read loggerFactory originalPath fileStream
 
@@ -927,7 +927,7 @@ module Program =
         // that a host which builds its `HostConfig` some other way — the App, which replaces
         // `AppContext` wholesale with the guest's `runtimeconfig.json` — cannot drop it.
         let propertiesToSeed =
-            AppContextProperties.withRuntimeBaseline hostConfig.AppContext
+            AppContextProperties.withRuntimeBaseline hostConfig.Guest.AppContext
 
         let rec loadInitialState (state : IlMachineState) =
             match

--- a/docs/plans/2026-08-10-fork-point-snapshots.md
+++ b/docs/plans/2026-08-10-fork-point-snapshots.md
@@ -343,7 +343,7 @@ module ScheduleFork =
         | NeverForked of RunOutcome
         | DeadlockedBeforeFork of stuckThreads : string
 
-    val runToFork : ILoggerFactory -> string option -> Stream -> PrefixConfig -> PrefixOutcome
+    val runToFork : ILoggerFactory -> string option -> Stream -> GuestConfig -> PrefixOutcome
 
     /// Install a policy and hand back ordinary driver state; `None` resumes RoundRobin.
     /// Rebinds the state's Logger/LoggerFactory to the factory given (see §5.5).
@@ -368,10 +368,15 @@ contract, not the prefix's. `runToFork` must not be handed one.
    wrong experiment;
 2. take `HostConfig` and `failwith` unless `PctSeed = None` — loud, zero churn, but validation
    where parsing is available;
-3. **split**: `HostConfig = { Prefix : PrefixConfig ; PctSeed : uint64 option }`, `runToFork`
-   taking `PrefixConfig`.
+3. **split**: `HostConfig = { Guest : GuestConfig ; PctSeed : uint64 option }`, `runToFork`
+   taking `GuestConfig`.
 
-**Decided: 3.** `WoofWare.PawPrint` is `IsPackable=true` with `PackageId=WoofWare.PawPrint`
+**Decided: 3.** (This plan first called the inner record `PrefixConfig`. That name was wrong and
+was changed during implementation: the record does not configure the *prefix*, it configures the
+whole run, and it is only the seed that the prefix and its continuations differ in. Naming it
+after one downstream consumer would also have exported a concept — the fork prefix — into a file
+whose reader has no context for it. `GuestConfig` says what it is: everything describing the
+simulated process, as against which of its schedules we are exploring.) `WoofWare.PawPrint` is `IsPackable=true` with `PackageId=WoofWare.PawPrint`
 (`WoofWare.PawPrint.fsproj:6-7`), so `HostConfig` is a published surface and this is a breaking
 change for external consumers — but the package is prerelease and the maintainer has confirmed
 breaking it outright is fine, so the compile-time-correct factoring wins over any variant that
@@ -382,7 +387,7 @@ In-repo churn is 37 `HostConfig.Default` construction sites (9 setting `PctSeed`
 each `Argv`/`AppContext`), all mechanical — the compiler finds every one. `HostConfig.Default`
 should keep taking the runtime dirs and returning a whole `HostConfig`, so the common
 `{ HostConfig.Default dirs with PctSeed = ... }` shape survives; only sites that set a
-`PrefixConfig` field move a level down.
+`GuestConfig` field move a level down.
 
 ### 5.5 Logging and parallel fan-out
 


### PR DESCRIPTION
`HostConfig` mixed two different things: the description of the simulated process (framework directories, kernel, argv, AppContext) and the one input that selects among that process's possible thread interleavings. The fork-point work needs to name "everything except the seed", and needs it to be *impossible* to pass a seed into the part that is shared across seeds — a silently-ignored `PctSeed` would turn a caller's type error into a wrong experiment.

```fsharp
type GuestConfig =
    { DotnetRuntimeDirs : ImmutableArray<string>
      Kernel : KernelConfig
      Argv : string list
      AppContext : AppContextProperties }

type HostConfig =
    { Guest : GuestConfig
      PctSeed : uint64 option }
```

This is stage 2 of `docs/plans/2026-08-10-fork-point-snapshots.md`, pulled out as its own PR so the mechanical churn doesn't bury stage 3's `ScheduleFork` module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
