### PR TITLE
Read one Property row for MetadataImport.GetPropertyProps

### DIFF
--- a/WoofWare.PawPrint.Domain/ComparablePropertyDefinitionHandle.fs
+++ b/WoofWare.PawPrint.Domain/ComparablePropertyDefinitionHandle.fs
@@ -1,0 +1,48 @@
+namespace WoofWare.PawPrint
+
+open System
+open System.Reflection.Metadata
+open System.Reflection.Metadata.Ecma335
+
+[<CustomEquality>]
+[<CustomComparison>]
+type ComparablePropertyDefinitionHandle =
+    private
+        {
+            _Inner : PropertyDefinitionHandle
+        }
+
+    override this.Equals other =
+        match other with
+        | :? ComparablePropertyDefinitionHandle as other -> this._Inner.GetHashCode () = other._Inner.GetHashCode ()
+        | _ -> false
+
+    override this.GetHashCode () : int = this._Inner.GetHashCode ()
+
+    interface IComparable<ComparablePropertyDefinitionHandle> with
+        member this.CompareTo (other : ComparablePropertyDefinitionHandle) : int =
+            this._Inner.GetHashCode().CompareTo (other._Inner.GetHashCode ())
+
+    interface IComparable with
+        member this.CompareTo (other : obj) : int =
+            match other with
+            | :? ComparablePropertyDefinitionHandle as other ->
+                (this :> IComparable<ComparablePropertyDefinitionHandle>).CompareTo other
+            | _ -> failwith "invalid comparison"
+
+    /// `PropertyDefinitionHandle` inherits `ToString` from `obj`, so rendering one yields the literal
+    /// text "System.Reflection.Metadata.PropertyDefinitionHandle" -- which makes every diagnostic
+    /// that names a property identity useless for telling two properties apart. Render the metadata
+    /// token instead, in the `0x17######` form ildasm and the ECMA-335 tables use.
+    override this.ToString () : string =
+        let token =
+            MetadataTokens.GetToken (PropertyDefinitionHandle.op_Implicit this._Inner : EntityHandle)
+
+        $"Property(0x%08x{token})"
+
+    static member Make (h : PropertyDefinitionHandle) =
+        {
+            _Inner = h
+        }
+
+    member this.Get = this._Inner

--- a/WoofWare.PawPrint.Domain/WoofWare.PawPrint.Domain.fsproj
+++ b/WoofWare.PawPrint.Domain/WoofWare.PawPrint.Domain.fsproj
@@ -30,6 +30,7 @@
         <Compile Include="ComparableTypeDefinitionHandle.fs" />
         <Compile Include="ComparableFieldDefinitionHandle.fs" />
         <Compile Include="ComparableMethodDefinitionHandle.fs" />
+        <Compile Include="ComparablePropertyDefinitionHandle.fs" />
         <Compile Include="ComparableSignatureHeader.fs" />
         <Compile Include="ComparableGenericParameterHandle.fs" />
         <Compile Include="TypeIdentity.fs" />

--- a/WoofWare.PawPrint.Test/TestFSharpPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestFSharpPureCases.fs
@@ -127,24 +127,27 @@ module TestFSharpPureCases =
     /// before recording that a case is blocked on a named primitive, un-park it and observe the
     /// failure: parking it is what stops the claim being checked.
     ///
-    /// `UnionReflection` is parked on <c>MetadataImport::GetPropertyProps</c>. Having enumerated the
-    /// union type's properties (the compiler-generated `Tag` and per-case field accessors),
-    /// `RuntimeType.PopulateProperties` turns each token into a `RuntimePropertyInfo`, whose
-    /// constructor asks for the property's name, flags and signature blob through that InternalCall.
+    /// `UnionReflection` is parked on the *associates* branch of the `MetadataImport.Enum` QCall.
+    /// Having read one of the union type's properties out of metadata, `RuntimePropertyInfo`'s
+    /// constructor calls `Associates.AssignAssociates`, which enumerates `mdtMethodDef` with a
+    /// *Property* parent. CoreCLR answers that not from the generic `EnumInit`/`EnumNext` path but
+    /// from `EnumAssociateInit`/`GetAllAssociates` (managedmdimport.cpp:527-590), which returns
+    /// `ASSOCIATE_RECORD` method/semantics *pairs* rather than plain tokens — a different result
+    /// shape, which is why it is a separate feature rather than one more token type.
+    ///
     /// Observed by un-parking it and running: the real runtime exits 0, PawPrint reports
-    /// "Unimplemented native method (InternalCall): ... MetadataImport::GetPropertyProps".
+    /// "TODO: MetadataImport.Enum does not yet support token type 0x06000000 with parent
+    /// 0x17000013".
     ///
-    /// That is not the last one on this path. A throwaway spike showed at least three more behind
-    /// it: the *associates* branch of the `MetadataImport.Enum` QCall (`mdtMethodDef` with a
-    /// Property or Event parent, which returns method/semantics pairs rather than plain tokens),
-    /// then `RuntimeMethodHandle::GetSlot`, then whatever `Associates.AssignAssociates` needs after
-    /// that.
+    /// That is not the last one on this path. A throwaway spike showed `RuntimeMethodHandle::GetSlot`
+    /// behind it, and then whatever the rest of `AssignAssociates` needs.
     ///
-    /// Seven earlier blockers are already gone: decoding each case's
+    /// Eight earlier blockers are already gone: decoding each case's
     /// `CompilationMappingAttribute(SourceConstructFlags, ...)`, whose argument is an enum;
     /// enumerating the union's nested case types; `MetadataImport::GetSigOfFieldDef`; the raw-blob
-    /// path of `Signature_Init`; `MetadataImport::GetDefaultValue`; `MetadataImport::GetName`; and
-    /// property enumeration, which the commit this comment sits in implements.
+    /// path of `Signature_Init`; `MetadataImport::GetDefaultValue`; `MetadataImport::GetName`;
+    /// property enumeration; and `MetadataImport::GetPropertyProps`, which the commit this comment
+    /// sits in implements.
     let unimplemented : Set<string> = Set.ofList [ "UnionReflection" ]
 
     // F# test cases that legitimately throw under both runtimes. Without this set, a test

--- a/WoofWare.PawPrint.Test/TestNativeMetadataImport.fs
+++ b/WoofWare.PawPrint.Test/TestNativeMetadataImport.fs
@@ -170,6 +170,24 @@ public class PropertyShapes : PropertyBase
     public static int Stat { get; set; }
     public int this[int i] { get { return i; } }
     public int Größe { get; set; }
+
+    // Every property C# normally emits has `Property.Flags = 0`, so without this one a flags
+    // assertion over this type would be vacuous and a handler that always answered 0 would pass.
+    // `[SpecialName]` on a property does set the row's `SpecialName` bit (0x0200) — checked against
+    // both the raw Property row and the host CLR's `PropertyInfo.Attributes`. It goes last so that
+    // it takes the highest token and the declaration-order expectations above only grow at the tail.
+    [System.Runtime.CompilerServices.SpecialName]
+    public int Special { get; set; }
+}
+
+// A PROPERTY signature whose Type is ELEMENT_TYPE_VAR (`28 00 13 00`), which is the shape a handler
+// that reconstructed the blob from PawPrint's parsed type model — rather than handing back the
+// metadata bytes — would get wrong. Its own type rather than a property on `GenericMetadataFields`,
+// because a property brings a `k__BackingField` with it and would churn that type's FieldDef
+// enumeration expectations for no benefit.
+public class GenericPropertyHolder<T>
+{
+    public T GenericProperty { get; set; }
 }
 
 public class TypesWithMembers
@@ -205,6 +223,7 @@ public class TypesWithMembers
             ConstantShapesType : TypeInfo<GenericParamFromMetadata, TypeDefn>
             FieldNamesType : TypeInfo<GenericParamFromMetadata, TypeDefn>
             PropertyShapesType : TypeInfo<GenericParamFromMetadata, TypeDefn>
+            GenericPropertyType : TypeInfo<GenericParamFromMetadata, TypeDefn>
             MembersType : TypeInfo<GenericParamFromMetadata, TypeDefn>
             InstanceField : FieldInfo<GenericParamFromMetadata, TypeDefn>
             StaticField : FieldInfo<GenericParamFromMetadata, TypeDefn>
@@ -298,6 +317,8 @@ public class TypesWithMembers
 
         let propertyShapesType = requiredTopLevelType assembly "" "PropertyShapes"
 
+        let genericPropertyType = requiredTopLevelType assembly "" "GenericPropertyHolder`1"
+
         let membersType = requiredTopLevelType assembly "" "TypesWithMembers"
 
         let constArrayType = requiredTopLevelType corelib "System.Reflection" "ConstArray"
@@ -353,6 +374,7 @@ public class TypesWithMembers
             ConstantShapesType = constantShapesType
             FieldNamesType = fieldNamesType
             PropertyShapesType = propertyShapesType
+            GenericPropertyType = genericPropertyType
             MembersType = membersType
             InstanceField = fieldByName "InstanceField"
             StaticField = fieldByName "StaticField"
@@ -697,9 +719,7 @@ public class TypesWithMembers
     /// base chain and can drop inherited privates and vtable-slot duplicates, and none of that
     /// filtering is the QCall's job. Restricted to one type's own rows, the managed result is the
     /// PropertyMap run itself.
-    let private hostPropertyTokens (image : byte array) (typeName : string) : int32 list =
-        let hostType = (System.Reflection.Assembly.Load image).GetType (typeName, true)
-
+    let private hostDeclaredProperties (hostType : System.Type) : System.Reflection.PropertyInfo array =
         hostType.GetProperties (
             System.Reflection.BindingFlags.DeclaredOnly
             ||| System.Reflection.BindingFlags.Public
@@ -707,8 +727,32 @@ public class TypesWithMembers
             ||| System.Reflection.BindingFlags.Instance
             ||| System.Reflection.BindingFlags.Static
         )
+
+    let private hostPropertyTokens (image : byte array) (typeName : string) : int32 list =
+        (System.Reflection.Assembly.Load image).GetType (typeName, true)
+        |> hostDeclaredProperties
         |> Array.map (fun property -> property.MetadataToken)
         |> List.ofArray
+
+    /// Every property row in the image, as the host CLR sees it. Used where the assertion should
+    /// range over the whole image rather than over the handful of shapes anyone thought to write
+    /// down, so a property added to the fixture is covered without anyone remembering to extend a
+    /// list.
+    let private hostPropertiesOfImage (image : byte array) : System.Reflection.PropertyInfo array =
+        (System.Reflection.Assembly.Load image).GetTypes ()
+        |> Array.collect hostDeclaredProperties
+
+    /// The host CLR's `PropertyInfo` for one named property. Used as the source of the *token* to
+    /// poke PawPrint with, so that a handler bug cannot pick its own input.
+    let private hostPropertyNamed
+        (image : byte array)
+        (typeName : string)
+        (propertyName : string)
+        : System.Reflection.PropertyInfo
+        =
+        (System.Reflection.Assembly.Load image).GetType (typeName, true)
+        |> hostDeclaredProperties
+        |> Array.find (fun property -> property.Name = propertyName)
 
     let private invokeGetFieldDefProps
         (fixture : MetadataImportFixture)
@@ -1027,10 +1071,10 @@ public class TypesWithMembers
         let length, tokens, storage, _ =
             invokeEnumProperties fixture fixture.PropertyShapesType fixture.State
 
-        // Six declared properties; nothing is filtered by visibility, staticness, or being an
-        // indexer, and order is guest-observable because `PopulateProperties` appends in the order
-        // it receives.
-        length |> shouldEqual 6
+        // Seven declared properties; nothing is filtered by visibility, staticness, being an
+        // indexer, or carrying `SpecialName`, and order is guest-observable because
+        // `PopulateProperties` appends in the order it receives.
+        length |> shouldEqual 7
         storage |> shouldEqual EnumResultStorage.ShortResult
         tokens |> shouldEqual (hostPropertyTokens fixture.Image "PropertyShapes")
 
@@ -2270,7 +2314,7 @@ public class TypesWithMembers
         hostProperties
         |> Array.map (fun property -> property.Name)
         |> List.ofArray
-        |> shouldEqual [ "Alpha" ; "Beta" ; "Hidden" ; "Stat" ; "Item" ; "Größe" ]
+        |> shouldEqual [ "Alpha" ; "Beta" ; "Hidden" ; "Stat" ; "Item" ; "Größe" ; "Special" ]
 
         let mutable state = fixture.State
 
@@ -2320,3 +2364,260 @@ public class TypesWithMembers
             Assert.Throws (fun () -> invokeGetName fixture 0x17FFFFFF fixture.State |> ignore)
 
         ex.Message |> shouldContainText "was not present in"
+
+    /// `GetPropertyProps` is the one `MetadataImport` call with three out parameters, so the helper
+    /// hands back all three: the null-terminated name bytes, the raw `Property.Flags` column, and
+    /// the `ConstArray` triple (length, bytes, and the `m_constArray` pointer itself).
+    let private invokeGetPropertyProps
+        (fixture : MetadataImportFixture)
+        (propertyToken : int32)
+        (state : IlMachineState)
+        : EvalStackValue * byte array * int32 * (int32 * byte array * ManagedPointerSource) * IlMachineState
+        =
+        let state, metadataImportType, getPropertyPropsMethod =
+            metadataImportMethod fixture state "GetPropertyProps" 5
+
+        let nameOut, state =
+            allocateSlotOut
+                fixture
+                fixture.BaseClassTypes.IntPtr
+                (CliType.RuntimePointer (CliRuntimePointer.Managed ManagedPointerSource.Null))
+                state
+
+        let attributesOut, state = allocateInt32Out fixture 0 state
+        let signatureOut, state = allocateConstArrayOut fixture state
+
+        let state =
+            invokeMetadataImportNative
+                fixture
+                metadataImportType
+                getPropertyPropsMethod
+                [
+                    metadataImportHandle fixture
+                    CliType.Numeric (CliNumericType.Int32 propertyToken)
+                    CliType.RuntimePointer (CliRuntimePointer.Managed nameOut)
+                    CliType.RuntimePointer (CliRuntimePointer.Managed attributesOut)
+                    CliType.RuntimePointer (CliRuntimePointer.Managed signatureOut)
+                ]
+                state
+
+        let returnValue, state = IlMachineState.popEvalStack (ThreadId 0) state
+
+        let namePtr =
+            match
+                IlMachineState.readManagedByref fixture.BaseClassTypes state nameOut
+                |> CliType.unwrapPrimitiveLikeDeep
+            with
+            | CliType.RuntimePointer (CliRuntimePointer.Managed ptr) -> ptr
+            | other -> failwith $"expected a managed pointer written to the name out param, got %O{other}"
+
+        returnValue,
+        readNameBufferIncludingTerminator state namePtr,
+        readInt32Out fixture.BaseClassTypes state attributesOut,
+        readConstArrayOut fixture state signatureOut,
+        state
+
+    /// The number of rows in the image's Property table, so a test can name the first row that is
+    /// genuinely absent. This computes an *input*, not an expectation, so reading it from the same
+    /// metadata library the handler uses is not circular.
+    let private propertyTableRowCount (fixture : MetadataImportFixture) : int =
+        System.Reflection.Metadata.Ecma335.MetadataReaderExtensions.GetTableRowCount (
+            fixture.Assembly.PeReader.GetMetadataReader (),
+            System.Reflection.Metadata.Ecma335.TableIndex.Property
+        )
+
+    [<Test>]
+    let ``MetadataImport GetPropertyProps returns the name, flags and signature of each property shape`` () : unit =
+        let fixture = makeFixture ()
+
+        // ECMA-335 II.23.2.5: a PropertySig is `PROPERTY (0x08) [| HASTHIS (0x20)]`, then a
+        // compressed ParamCount, then the Type, then one Type per index parameter. These
+        // expectations come from the standard rather than being read back out of the image, so they
+        // pin the blob's width as well as its content: ELEMENT_TYPE_I4 = 0x08, _STRING = 0x0e,
+        // _VAR = 0x13 followed by the compressed generic-parameter index.
+        let cases =
+            [
+                // Instance, no index parameters: HASTHIS set, ParamCount 0.
+                "PropertyShapes", "Alpha", 0x0000, [| 0x28uy ; 0x00uy ; 0x08uy |]
+                "PropertyShapes", "Beta", 0x0000, [| 0x28uy ; 0x00uy ; 0x0Euy |]
+                "PropertyShapes", "Hidden", 0x0000, [| 0x28uy ; 0x00uy ; 0x08uy |]
+                // Static: HASTHIS *clear*. This is the byte a handler that hardcoded 0x28 gets wrong.
+                "PropertyShapes", "Stat", 0x0000, [| 0x08uy ; 0x00uy ; 0x08uy |]
+                // The indexer: ParamCount 1, so the blob carries the index type after the property
+                // type. Its metadata name is `Item`, not its C# spelling.
+                "PropertyShapes", "Item", 0x0000, [| 0x28uy ; 0x01uy ; 0x08uy ; 0x08uy |]
+                "PropertyShapes", "Größe", 0x0000, [| 0x28uy ; 0x00uy ; 0x08uy |]
+                // The only property in the image whose Property.Flags column is not zero.
+                "PropertyShapes", "Special", 0x0200, [| 0x28uy ; 0x00uy ; 0x08uy |]
+                // ELEMENT_TYPE_VAR, generic parameter 0.
+                "GenericPropertyHolder`1", "GenericProperty", 0x0000, [| 0x28uy ; 0x00uy ; 0x13uy ; 0x00uy |]
+            ]
+
+        let mutable state = fixture.State
+
+        for typeName, propertyName, expectedFlags, expectedSignature in cases do
+            let hostProperty = hostPropertyNamed fixture.Image typeName propertyName
+
+            let returnValue, nameBytes, flags, (length, signatureBytes, _), nextState =
+                invokeGetPropertyProps fixture hostProperty.MetadataToken state
+
+            state <- nextState
+
+            returnValue |> shouldEqual (EvalStackValue.Int32 (Int32Source.Verbatim 0))
+
+            nameBytes
+            |> shouldEqual (Array.append (System.Text.Encoding.UTF8.GetBytes propertyName) [| 0uy |])
+
+            flags |> shouldEqual expectedFlags
+            signatureBytes |> shouldEqual expectedSignature
+            length |> shouldEqual expectedSignature.Length
+
+    [<Test>]
+    let ``MetadataImport GetPropertyProps agrees with the host runtime for every property`` () : unit =
+        let fixture = makeFixture ()
+
+        // Outside oracle: the same image handed to the host CLR, whose answers come from CoreCLR's
+        // own C++ metadata engine rather than from PawPrint's parse. This is what covers `Special`
+        // without writing 0x0200 down a second time, and it ranges over every property row in the
+        // image rather than the shapes listed above.
+        //
+        // The raw signature blob has no such oracle: `Module.ResolveSignature` refuses a property
+        // token outright (`ArgumentException: Token 0x17...... is not valid in the scope of module`),
+        // because the managed screen in `RuntimeModule.ResolveSignature` admits only
+        // MemberRef/MethodDef/TypeSpec/StandAloneSig/FieldDef. See the next test for the parts of
+        // the signature the host *can* answer.
+        let hostProperties = hostPropertiesOfImage fixture.Image
+
+        hostProperties.Length |> shouldEqual (propertyTableRowCount fixture)
+
+        let mutable state = fixture.State
+
+        for hostProperty in hostProperties do
+            let returnValue, nameBytes, flags, _, nextState =
+                invokeGetPropertyProps fixture hostProperty.MetadataToken state
+
+            state <- nextState
+
+            returnValue |> shouldEqual (EvalStackValue.Int32 (Int32Source.Verbatim 0))
+
+            nameBytes
+            |> shouldEqual (Array.append (System.Text.Encoding.UTF8.GetBytes hostProperty.Name) [| 0uy |])
+
+            flags |> shouldEqual (int32 hostProperty.Attributes)
+
+    [<Test>]
+    let ``MetadataImport GetPropertyProps signature agrees with the host runtime where it can`` () : unit =
+        let fixture = makeFixture ()
+
+        // The host cannot hand back the blob, but it can independently answer the two fields the
+        // blob leads with, from the MethodSemantics rows rather than from the Property row's Type
+        // blob. That covers every property in the image, including any added later that nobody
+        // wrote a byte-for-byte expectation for.
+        let hostProperties = hostPropertiesOfImage fixture.Image
+
+        let mutable state = fixture.State
+
+        for hostProperty in hostProperties do
+            let _, _, _, (length, signatureBytes, _), nextState =
+                invokeGetPropertyProps fixture hostProperty.MetadataToken state
+
+            state <- nextState
+
+            // `PropertyInfo` has no `IsStatic` of its own; staticness is the accessors'. A property
+            // always has at least one accessor.
+            let accessor =
+                match hostProperty.GetMethod, hostProperty.SetMethod with
+                | null, null -> failwith $"property %s{hostProperty.Name} has no accessor"
+                | null, setter -> setter
+                | getter, _ -> getter
+
+            length |> shouldEqual signatureBytes.Length
+            // ECMA-335 II.23.2.5: the low nibble is the PROPERTY calling convention (0x08) and
+            // 0x20 is HASTHIS.
+            signatureBytes.[0] &&& 0x0Fuy |> shouldEqual 0x08uy
+            signatureBytes.[0] &&& 0x20uy <> 0uy |> shouldEqual (not accessor.IsStatic)
+
+            // ParamCount is a *compressed* unsigned integer, so it occupies one byte only below
+            // 0x80. Nothing in this fixture comes close, and an indexer with 128 parameters is not
+            // a shape C# can express.
+            hostProperty.GetIndexParameters().Length < 0x80 |> shouldEqual true
+
+            signatureBytes.[1]
+            |> shouldEqual (byte (hostProperty.GetIndexParameters().Length))
+
+    [<Test>]
+    let ``MetadataImport GetPropertyProps points at the property's own signature blob`` () : unit =
+        let fixture = makeFixture ()
+        let hostProperty = hostPropertyNamed fixture.Image "PropertyShapes" "Alpha"
+
+        let _, _, _, (length, _, pointer), state =
+            invokeGetPropertyProps fixture hostProperty.MetadataToken fixture.State
+
+        // The pointer's shape is part of the contract, not merely a route to the bytes, and this is
+        // the assertion that separates the two ways of building a `ConstArray`. CoreCLR hands back a
+        // PCCOR_SIGNATURE straight into the mapped metadata; PawPrint models that with a PeByteRange
+        // root naming *this* PropertyDef. Copying the blob into a managed `byte[]` instead — as the
+        // `GetMemberRefProps` sibling does — would satisfy every content assertion above and still
+        // be wrong: `NativeSignature.corSigPeByteRange` accepts only null or a PeByteRange, so the
+        // blob would be unresolvable by the one thing that ever consumes it
+        // (`RuntimePropertyInfo.Signature`, via the handle-less `Signature` constructor).
+        //
+        // The `ReinterpretAs byte` projection is equally load-bearing: `BinaryArithmetic` refuses
+        // arithmetic on a bare PeByteRange root, so without it a guest's `ConstArray[i]` — which is
+        // `((byte*)m_constArray)[index]` — would fail while every content assertion still passed.
+        let byteType =
+            AllConcreteTypes.lookup fixture.ByteHandle state.ConcreteTypes
+            |> Option.defaultWith (fun () -> failwith "System.Byte was not concretized")
+
+        let propertyHandle =
+            System.Reflection.Metadata.Ecma335.MetadataTokens.PropertyDefinitionHandle hostProperty.MetadataToken
+
+        let expected =
+            ManagedPointerSource.Byref (
+                ByrefRoot.PeByteRange
+                    {
+                        AssemblyFullName = fixture.Assembly.Name.FullName
+                        Source =
+                            PeByteRangePointerSource.PropertySignatureBlob (
+                                ComparablePropertyDefinitionHandle.Make propertyHandle
+                            )
+                        RelativeVirtualAddress = 0
+                        // `int Alpha { get; set; }` is `28 00 08`. Spelled out rather than taken
+                        // from `length`, so that a handler which derived both the struct's length
+                        // and the range's size from the same wrong place would still fail here.
+                        Size = 3
+                    },
+                [ ByrefProjection.ReinterpretAs byteType ]
+            )
+
+        length |> shouldEqual 3
+        pointer |> shouldEqual expected
+
+    [<Test>]
+    let ``MetadataImport GetPropertyProps rejects a non-PropertyDef token`` () : unit =
+        let fixture = makeFixture ()
+
+        let ex =
+            Assert.Throws (fun () ->
+                invokeGetPropertyProps fixture (typeDefToken fixture.PropertyShapesType.TypeDefHandle) fixture.State
+                |> ignore
+            )
+
+        ex.Message |> shouldContainText "expected PropertyDef token"
+
+    [<Test>]
+    let ``MetadataImport GetPropertyProps rejects a PropertyDef absent from the assembly`` () : unit =
+        let fixture = makeFixture ()
+
+        // Two absent rows, because they catch different mistakes. Row 0xFFFFFF is far outside the
+        // table and dies under almost any guard at all; the first row *past the end* is the one an
+        // off-by-one guard (`> rowCount + 1`) would wave through, and it would then surface as
+        // `BadImageFormatException: Read out of bounds` from inside the metadata reader — a PawPrint
+        // gap wearing a corrupt image's clothes, which is exactly what the guard exists to prevent.
+        let firstAbsentRow = propertyTableRowCount fixture + 1
+
+        for token in [ 0x17FFFFFF ; 0x17000000 ||| firstAbsentRow ] do
+            let ex =
+                Assert.Throws (fun () -> invokeGetPropertyProps fixture token fixture.State |> ignore)
+
+            ex.Message |> shouldContainText "was not present in"

--- a/WoofWare.PawPrint.Test/TestNullaryIlOp.fs
+++ b/WoofWare.PawPrint.Test/TestNullaryIlOp.fs
@@ -1489,6 +1489,32 @@ module TestNullaryIlOp =
         exn.Message |> shouldContainText "claims no alignment"
 
     [<Test>]
+    let ``a property signature blob makes no alignment claim`` () : unit =
+        // Same reasoning as the method and field variants: an ECMA II.23.2.5 PropertySig lives in
+        // the metadata `#Blob` heap at an offset PawPrint does not track, so its
+        // RelativeVirtualAddress is a placeholder 0 and its low bits belong to no address.
+        let property =
+            ComparablePropertyDefinitionHandle.Make (
+                System.Reflection.Metadata.Ecma335.MetadataTokens.PropertyDefinitionHandle 1
+            )
+
+        let blob =
+            peByteRangeByref (PeByteRangePointerSource.PropertySignatureBlob property) 0
+
+        ManagedPointerSource.tryContainerAlignmentBits blob |> shouldEqual None
+
+        let exn =
+            Assert.Throws (fun () ->
+                runBinary
+                    NullaryIlOp.And
+                    (EvalStackValue.Int32 (Int32Source.NarrowedManagedPointer blob))
+                    (EvalStackValue.Int32 (Int32Source.Verbatim 1))
+                |> ignore<EvalStackValue>
+            )
+
+        exn.Message |> shouldContainText "claims no alignment"
+
+    [<Test>]
     let ``a field signature blob makes no alignment claim`` () : unit =
         // `FieldRva` and `ManagedResource` name real section offsets, and the image
         // base is page-aligned, so their low bits are the mapped address's low bits.

--- a/WoofWare.PawPrint.Test/sourcesPure/PropertyEnumeration.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/PropertyEnumeration.cs
@@ -4,11 +4,16 @@ using System.Reflection;
 // `RuntimeType.PopulateProperties` gets a type's property tokens from the `MetadataImport.Enum`
 // QCall with token type `mdtProperty`, then turns each into a `RuntimePropertyInfo`.
 //
-// PawPrint cannot yet construct one of those (that needs `MetadataImport.GetPropertyProps`, the
-// associates branch of `Enum`, and `RuntimeMethodHandle.GetSlot`), so what a guest can observe here
-// is exactly the two shapes below: an enumeration that comes back empty, and one that comes back
-// non-empty but whose members are all rejected by a name filter before any of them is constructed.
-// Both threw before the enumeration existed.
+// PawPrint cannot yet construct one of those (that needs the associates branch of `Enum` and
+// `RuntimeMethodHandle.GetSlot`), so what a guest can observe here is exactly the two shapes below:
+// an enumeration that comes back empty, and one that comes back non-empty but whose members are all
+// rejected by a name filter before any of them is constructed. Both threw before the enumeration
+// existed.
+//
+// In particular, asking for a property that *does* exist is still not observable, even now that
+// `MetadataImport.GetPropertyProps` is implemented: checked by writing that case and running it, and
+// it dies one call later in `Associates.AssignAssociates`. So `GetPropertyProps` has no end-to-end
+// coverage; its contract is pinned by TestNativeMetadataImport alone.
 // The field is load-bearing, not decoration: it is what makes case 1 below able to catch an
 // implementation that enumerated the FieldDef table instead of the PropertyMap run. Such an
 // implementation reports one "property" here, and the guest then dies trying to construct a

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -790,6 +790,12 @@ module IlMachineManagedByref =
                 let mutable blobReader = mdReader.GetBlobReader methodDef.Signature
                 blobReader.Offset <- byteOffset
                 blobReader.ReadBytes targetSize
+            | PeByteRangePointerSource.PropertySignatureBlob property ->
+                let mdReader = assembly.PeReader.GetMetadataReader ()
+                let propertyDef = mdReader.GetPropertyDefinition property.Get
+                let mutable blobReader = mdReader.GetBlobReader propertyDef.Signature
+                blobReader.Offset <- byteOffset
+                blobReader.ReadBytes targetSize
             | PeByteRangePointerSource.ConstantBlob field ->
                 let mdReader = assembly.PeReader.GetMetadataReader ()
                 let fieldDef = mdReader.GetFieldDefinition field.Get

--- a/WoofWare.PawPrint/IlMachineState.fs
+++ b/WoofWare.PawPrint/IlMachineState.fs
@@ -58,6 +58,9 @@ module IlMachineState =
     let peByteRangeForMethodSignatureBlob =
         IlMachineTypeResolution.peByteRangeForMethodSignatureBlob
 
+    let peByteRangeForPropertySignatureBlob =
+        IlMachineTypeResolution.peByteRangeForPropertySignatureBlob
+
     let peByteRangeForConstantBlob = IlMachineTypeResolution.peByteRangeForConstantBlob
 
     let peByteRangePointer = IlMachineTypeResolution.peByteRangePointer

--- a/WoofWare.PawPrint/IlMachineTypeResolution.fs
+++ b/WoofWare.PawPrint/IlMachineTypeResolution.fs
@@ -753,6 +753,26 @@ module IlMachineTypeResolution =
             Size = blobReader.Length
         }
 
+    /// PE byte range pointer over the COR signature blob bytes for a property
+    /// definition (ECMA II.23.2.5). Same storage story as
+    /// `peByteRangeForFieldSignatureBlob`.
+    let peByteRangeForPropertySignatureBlob
+        (assembly : DumpedAssembly)
+        (propertyHandle : PropertyDefinitionHandle)
+        : PeByteRangePointer
+        =
+        let mdReader = assembly.PeReader.GetMetadataReader ()
+        let propertyDef = mdReader.GetPropertyDefinition propertyHandle
+        let blobReader = mdReader.GetBlobReader propertyDef.Signature
+
+        {
+            AssemblyFullName = assembly.Name.FullName
+            Source =
+                PeByteRangePointerSource.PropertySignatureBlob (ComparablePropertyDefinitionHandle.Make propertyHandle)
+            RelativeVirtualAddress = 0
+            Size = blobReader.Length
+        }
+
     let peByteRangePointer
         (loggerFactory : ILoggerFactory)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)

--- a/WoofWare.PawPrint/ManagedPointerSource.fs
+++ b/WoofWare.PawPrint/ManagedPointerSource.fs
@@ -22,6 +22,11 @@ type PeByteRangePointerSource =
     /// The COR signature blob for a method definition (ECMA II.23.2.1). Same
     /// storage story as `FieldSignatureBlob`.
     | MethodSignatureBlob of method : ComparableMethodDefinitionHandle
+    /// The COR signature blob for a property definition (ECMA II.23.2.5): the
+    /// PROPERTY calling convention, the index-parameter count, the property's
+    /// type, then one type per index parameter. Same storage story as
+    /// `FieldSignatureBlob`.
+    | PropertySignatureBlob of property : ComparablePropertyDefinitionHandle
     /// The Constant table's value blob for a field definition (ECMA II.22.9): the
     /// field's compile-time constant, in the encoding its `ConstantTypeCode`
     /// names. For a string constant those bytes are UTF-16LE characters, which is
@@ -45,6 +50,7 @@ type PeByteRangePointer =
             | PeByteRangePointerSource.ManagedResource resourceName -> $"managed resource %s{resourceName}"
             | PeByteRangePointerSource.FieldSignatureBlob field -> $"field signature blob for %O{field.Get}"
             | PeByteRangePointerSource.MethodSignatureBlob method -> $"method signature blob for %O{method.Get}"
+            | PeByteRangePointerSource.PropertySignatureBlob property -> $"property signature blob for %O{property.Get}"
             | PeByteRangePointerSource.ConstantBlob field -> $"constant blob for %O{field.Get}"
 
         $"<PE data %s{this.AssemblyFullName} %s{source} at %d{this.RelativeVirtualAddress} size %d{this.Size}>"
@@ -707,6 +713,7 @@ module ManagedPointerSource =
             | PeByteRangePointerSource.ManagedResource _ -> Some 3
             | PeByteRangePointerSource.FieldSignatureBlob _
             | PeByteRangePointerSource.MethodSignatureBlob _
+            | PeByteRangePointerSource.PropertySignatureBlob _
             | PeByteRangePointerSource.ConstantBlob _ -> None
         // Object fields, static fields, stack slots and the synthetic roots have no
         // stable in-container offset either (see `tryStableAddressBits` and

--- a/WoofWare.PawPrint/Native/NativeMetadataImport.fs
+++ b/WoofWare.PawPrint/Native/NativeMetadataImport.fs
@@ -250,16 +250,18 @@ module NativeMetadataImport =
             failwith
                 $"%s{operation}: expected TypeDef parent token for property enumeration, got %O{token} from 0x%08x{parent}"
 
-    /// The <c>#Strings</c> entry naming a property definition.
+    /// One Property row, bounds-checked.
     ///
     /// The presence check is the same guard as <c>propertyDefinitionsForTypeDefinition</c>'s and
     /// exists for the same reason; <c>MetadataReader</c> has no total lookup, so the row number is
-    /// compared against the table's length directly.
-    let private propertyDefinitionName
+    /// compared against the table's length directly. An out-of-range handle otherwise reaches the
+    /// reader as <c>BadImageFormatException: Read out of bounds</c>, which reads as a corrupt image
+    /// when the truth is that PawPrint was handed a token it should never have seen.
+    let private propertyDefinition
         (operation : string)
         (assembly : DumpedAssembly)
         (propertyHandle : System.Reflection.Metadata.PropertyDefinitionHandle)
-        : string
+        : System.Reflection.Metadata.PropertyDefinition
         =
         let metadataReader = metadataReaderOf assembly
 
@@ -278,7 +280,16 @@ module NativeMetadataImport =
             failwith
                 $"%s{operation}: PropertyDef token 0x%08x{metadataTokenOfPropertyDefinitionHandle propertyHandle} was not present in %s{assembly.Name.FullName}"
 
-        metadataReader.GetString (metadataReader.GetPropertyDefinition propertyHandle).Name
+        metadataReader.GetPropertyDefinition propertyHandle
+
+    /// The <c>#Strings</c> entry naming a property definition.
+    let private propertyDefinitionName
+        (operation : string)
+        (assembly : DumpedAssembly)
+        (propertyHandle : System.Reflection.Metadata.PropertyDefinitionHandle)
+        : string
+        =
+        (metadataReaderOf assembly).GetString ((propertyDefinition operation assembly propertyHandle).Name)
 
     /// The types immediately nested inside the TypeDef named by <paramref name="parent"/>, as raw
     /// metadata tokens, in the order the real runtime returns them.
@@ -942,9 +953,11 @@ module NativeMetadataImport =
             // row reports ELEMENT_TYPE_VOID, which `MdConstant` turns into DBNull.Value.
             //
             // Only FieldDef parents are covered. The Constant table's Parent is a HasConstant coded
-            // index spanning ParamDef and PropertyDef too, but neither is reachable: PawPrint has no
-            // `GetPropertyProps` handler, and the `Enum` QCall mints no ParamDef tokens, so those
-            // arms could never be executed.
+            // index spanning ParamDef and PropertyDef too, but neither is reachable, for different
+            // reasons. A ParamDef token would have to come from the `Enum` QCall, which mints none.
+            // A PropertyDef Constant row is read by `RuntimePropertyInfo.GetRawConstantValue`, which
+            // needs a fully constructed `RuntimePropertyInfo` — so it is `Associates.AssignAssociates`
+            // that blocks it, not the absence of `GetPropertyProps`, which this file now implements.
             let operation = "MetadataImport.GetDefaultValue"
             let assemblyFullName = metadataImportHandleOfArg operation instruction.Arguments.[0]
             let assembly = metadataImportAssembly operation state assemblyFullName
@@ -1239,6 +1252,96 @@ module NativeMetadataImport =
                 IlMachineState.pushToEvalStack' (EvalStackValue.Int32 (Int32Source.Verbatim 0)) ctx.Thread state
 
             NativeHandlerResult.completed state |> Some
+        | "System.Private.CoreLib",
+          "System.Reflection",
+          "MetadataImport",
+          "GetPropertyProps",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.IntPtr
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32
+            ConcreteByref (ConcretePointer (ConcreteVoid state.ConcreteTypes))
+            ConcreteByref (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32)
+            ConcreteByref (ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                                             "System.Reflection",
+                                                             "ConstArray",
+                                                             constArrayGenerics)) ],
+          MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) when
+            constArrayGenerics.IsEmpty
+            ->
+            // CoreCLR's FCall (managedmdimport.cpp:330) forwards straight to
+            // `IMDInternalImport::GetPropertyProps`, which reads one Property row and reports three
+            // things: the `#Strings` name, the raw `Property.Flags` column, and a
+            // `PCCOR_SIGNATURE`/length pair over the row's Type blob (mdinternalro.cpp:2329). No
+            // filtering, no base-chain walk, no associates — `RuntimePropertyInfo`'s constructor
+            // does that separately through `Associates.AssignAssociates`.
+            let operation = "MetadataImport.GetPropertyProps"
+            let assemblyFullName = metadataImportHandleOfArg operation instruction.Arguments.[0]
+            let assembly = metadataImportAssembly operation state assemblyFullName
+
+            let mdToken =
+                match CliType.unwrapPrimitiveLikeDeep instruction.Arguments.[1] with
+                | CliType.Numeric (CliNumericType.Int32 mdToken) -> mdToken
+                | other -> failwith $"%s{operation}: expected Int32 mdToken argument, got %O{other}"
+
+            let nameOut =
+                NativeCall.managedPointerOfPointerArgument operation "name out pointer" instruction.Arguments.[2]
+
+            let attributesOut =
+                NativeCall.managedPointerOfPointerArgument
+                    operation
+                    "propertyAttributes out pointer"
+                    instruction.Arguments.[3]
+
+            let signatureOut =
+                NativeCall.managedPointerOfPointerArgument operation "signature out pointer" instruction.Arguments.[4]
+
+            let propertyHandle =
+                match MetadataToken.ofInt mdToken with
+                | MetadataToken.PropertyDefinition propertyHandle -> propertyHandle
+                | token -> failwith $"%s{operation}: expected PropertyDef token, got %O{token} from 0x%08x{mdToken}"
+
+            // Rejects a PropertyDef absent from this assembly, so everything below reads a row that
+            // exists.
+            let property = propertyDefinition operation assembly propertyHandle
+
+            let peByteRange =
+                IlMachineState.peByteRangeForPropertySignatureBlob assembly propertyHandle
+
+            // ECMA-335 II.23.2.5: a PropertySig is the calling-convention byte, then a compressed
+            // ParamCount, then a non-empty Type — so it is never shorter than three bytes. Anything
+            // shorter means we resolved the wrong blob, and passing it on would leave the managed
+            // parser to fail somewhere far from the cause. Same reasoning as the two-byte floor in
+            // `GetSigOfFieldDef`.
+            if peByteRange.Size < 3 then
+                failwith
+                    $"%s{operation}: PropertyDef token 0x%08x{mdToken} in %s{assemblyFullName} has a %d{peByteRange.Size}-byte signature blob, but an ECMA-335 II.23.2.5 PropertySig is at least three bytes"
+
+            // A PE byte range rather than a copy, unlike the `GetMemberRefProps` sibling. The blob's
+            // only consumer is `RuntimePropertyInfo.Signature`, which passes it to the handle-less
+            // `Signature` constructor; PawPrint resolves that through
+            // `NativeSignature.corSigPeByteRange`, which accepts only null or a `PeByteRange` — and
+            // parsing the blob will need the provenance anyway, because a custom modifier in a
+            // property signature carries a coded token that only means something against the
+            // owning assembly.
+            let constArrayValue, state =
+                buildConstArrayOverPeByteRange ctx.LoggerFactory ctx.BaseClassTypes operation peByteRange state
+
+            let state =
+                IlMachineState.writeManagedByrefWithBase ctx.BaseClassTypes state signatureOut constArrayValue
+
+            // The raw Property.Flags column, as `getPropFlagsOfProperty` returns it; the managed
+            // wrapper casts it to `PropertyAttributes`.
+            let state =
+                writeInt32AtPointer ctx.BaseClassTypes state attributesOut (int32 property.Attributes)
+
+            // Writes the name, pushes S_OK and completes. The name is the `#Strings` entry itself,
+            // as `getNameOfProperty` hands back, so an indexer reports its metadata name (`Item`, or
+            // whatever `[IndexerName]` says) rather than its C# spelling.
+            //
+            // Every failure above is instead a host-level crash rather than the negative HRESULT
+            // CoreCLR would return, as in the sibling handlers: the only guest caller passes tokens
+            // the runtime itself minted, so a rejected token is a PawPrint bug rather than a
+            // malformed image.
+            completeWithUtf8String ctx nameOut ((metadataReaderOf assembly).GetString property.Name) state
         | "System.Private.CoreLib",
           "System.Reflection",
           "MetadataImport",

--- a/WoofWare.PawPrint/Native/NativeSignature.fs
+++ b/WoofWare.PawPrint/Native/NativeSignature.fs
@@ -75,6 +75,14 @@ module NativeSignature =
             let mdReader = assembly.PeReader.GetMetadataReader ()
             let methodDef = mdReader.GetMethodDefinition method.Get
             assembly, methodDef.Signature
+        | PeByteRangePointerSource.PropertySignatureBlob _ ->
+            // This one *is* a signature blob, so it does not belong with the arm below. It is
+            // mintable as of `MetadataImport.GetPropertyProps`, and reaches here only through
+            // `RuntimePropertyInfo.Signature` — which needs a fully constructed
+            // `RuntimePropertyInfo`, so `Associates.AssignAssociates` blocks it today. Parsing an
+            // ECMA II.23.2.5 PropertySig is the feature that unblocks it.
+            failwith
+                $"TODO: %s{operation} on a property signature blob is not implemented (%O{peByteRange}); PROPERTY signatures are not yet parsed"
         | PeByteRangePointerSource.FieldRva _
         | PeByteRangePointerSource.ManagedResource _
         | PeByteRangePointerSource.ConstantBlob _ ->
@@ -340,6 +348,10 @@ module NativeSignature =
             | other ->
                 // A method-signature blob cannot arrive here: every managed `Signature` constructor
                 // that has a method passes the *handle*, and CoreCLR overwrites the blob from it.
+                // A *property*-signature blob is a different story — `RuntimePropertyInfo.Signature`
+                // does use the handle-less constructor, and `MetadataImport.GetPropertyProps` now
+                // mints such blobs — but it is still unreachable, because constructing the
+                // `RuntimePropertyInfo` that owns it needs `Associates.AssignAssociates`.
                 failwith
                     $"TODO: %s{operation} on a raw %O{other} blob is not implemented; only FieldDef signature blobs reach the handle-less constructor today"
 


### PR DESCRIPTION
Implements `MetadataImport::GetPropertyProps`, the next blocker on the `UnionReflection` path.

`RuntimeType.PopulateProperties` turns each token #921 enumerates into a `RuntimePropertyInfo`,
whose constructor (`RuntimePropertyInfo.cs:45`) calls `scope.GetPropertyProps(tkProperty, out m_utf8name, out m_flags, out _)`. CoreCLR's FCall (`vm/managedmdimport.cpp:330`) forwards straight to `MDInternalRO::GetPropertyProps` (`md/runtime/mdinternalro.cpp:2329`), which reads one Property row and reports three things: the `#Strings` name, the raw `Property.Flags` column, and a `PCCOR_SIGNATURE`/length pair over the row's Type blob. No filtering, no base-chain walk, no associates.

## Name and flags

Raw `MetadataReader`, as #921 chose for enumeration, and for the same reasons: PawPrint models no properties, the QCall's contract is raw metadata, and a domain model would be built for one call site in a published package. #921's `propertyDefinitionName` generalises to a bounds-checked `propertyDefinition`; `propertyDefinitionName` becomes a wrapper, so `GetName`'s call site is untouched and each path does exactly one bounds check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
