### PR TITLE
Reinterpret bytes for a narrowing ldind at byte offset zero

### DIFF
--- a/WoofWare.PawPrint.Test/TestNullaryIlOp.fs
+++ b/WoofWare.PawPrint.Test/TestNullaryIlOp.fs
@@ -5,6 +5,7 @@ open System.Collections.Generic
 open System.Collections.Immutable
 open System.IO
 open System.Reflection.Emit
+open System.Runtime.InteropServices
 open FsCheck
 open FsCheck.FSharp
 open FsUnitTyped
@@ -1706,3 +1707,184 @@ module TestNullaryIlOp =
         // memoised, not re-derived.
         let again, _ = narrow counters (NativeIntSource.MethodHandlePtr 17L)
         again |> shouldEqual first
+
+    // --- Byte views of a primitive cell at byte offset zero ---
+    //
+    // `*(byte*)&aLong` reads one byte at the address of an eight-byte cell. A *non-zero*
+    // index (`p[1]`) already worked, because C# emits the offset as pointer arithmetic and
+    // the resulting byref carries a trailing byte-view projection; index zero emits no
+    // arithmetic at all, so the byref names the whole cell and the read has to decide for
+    // itself that a narrower requested width means "reinterpret these bytes" rather than
+    // "convert this value".
+    //
+    // The oracle is `System.BitConverter`, which is not derived from PawPrint: the bytes the
+    // interpreter hands back must be the bytes the host runtime finds at that address.
+
+    /// A frame whose argument 0 holds `cell`, with `ManagedPointer` addressing that argument
+    /// on the eval stack — the shape `ldloca`/`ldarga` produces, with no projections at all.
+    let private stateWithByrefToCell
+        (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
+        (op : NullaryIlOp)
+        (cell : CliType)
+        : IlMachineState * ThreadId
+        =
+        // The placeholder is popped straight off again: the byref cannot be built until the
+        // frame exists, and the frame does not exist until `stateWithNullary` has run.
+        let state, thread =
+            stateWithNullary loggerFactory op (EvalStackValue.Int32 (Int32Source.Verbatim 0))
+
+        let frame = state.ThreadState.[thread].ActiveMethodState
+        let _, state = IlMachineState.popEvalStack thread state
+
+        let ptr = ManagedPointerSource.Byref (ByrefRoot.Argument (thread, frame, 0us), [])
+
+        let state =
+            state
+            |> IlMachineState.setArgument thread frame 0us cell
+            |> IlMachineState.pushToEvalStack' (EvalStackValue.ManagedPointer ptr) thread
+
+        state, thread
+
+    let private runLdindOverCell (op : NullaryIlOp) (cell : CliType) : EvalStackValue =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+
+        let state, thread = stateWithByrefToCell loggerFactory op cell
+
+        match NullaryIlOp.execute loggerFactory baseClassTypes state thread op with
+        | ExecutionResult.Stepped (state, whatWeDid, _) ->
+            whatWeDid |> shouldEqual WhatWeDid.Executed
+            IlMachineState.popEvalStack thread state |> fst
+        | other -> failwith $"Expected %O{op} to step, got %O{other}"
+
+    let private int32Value (reason : string) (value : EvalStackValue) : int32 =
+        match value with
+        | EvalStackValue.Int32 source -> Int32Source.value reason source
+        | other -> failwith $"Expected an int32 for %s{reason}, got %O{other}"
+
+    [<Test>]
+    let ``a narrow ldind over an int64 cell reinterprets its bytes`` () : unit =
+        let property (value : int64) : unit =
+            let cell = CliType.Numeric (CliNumericType.Int64 (Int64Source.Verbatim value))
+            let bytes = BitConverter.GetBytes value
+
+            runLdindOverCell NullaryIlOp.Ldind_u1 cell
+            |> int32Value "ldind.u1"
+            |> shouldEqual (int32 bytes.[0])
+
+            runLdindOverCell NullaryIlOp.Ldind_i1 cell
+            |> int32Value "ldind.i1"
+            |> shouldEqual (int32 (sbyte bytes.[0]))
+
+            runLdindOverCell NullaryIlOp.Ldind_u2 cell
+            |> int32Value "ldind.u2"
+            |> shouldEqual (int32 (BitConverter.ToUInt16 (bytes, 0)))
+
+            runLdindOverCell NullaryIlOp.Ldind_i2 cell
+            |> int32Value "ldind.i2"
+            |> shouldEqual (int32 (BitConverter.ToInt16 (bytes, 0)))
+
+            runLdindOverCell NullaryIlOp.Ldind_i4 cell
+            |> int32Value "ldind.i4"
+            |> shouldEqual (BitConverter.ToInt32 (bytes, 0))
+
+        // The default int64 generator is size-bounded, so drive the full range explicitly:
+        // a value whose low byte differs from its low word is what distinguishes a byte view
+        // from a truncating conversion at all.
+        let gen : Gen<int64> =
+            Gen.frequency
+                [
+                    8, ArbMap.defaults |> ArbMap.generate<int64>
+                    2, Gen.elements [ Int64.MinValue ; Int64.MaxValue ; -1L ; 0L ; 1L ; 0x0102030405060708L ]
+                ]
+
+        Check.One (config, Prop.forAll (Arb.fromGen gen) property)
+
+    [<Test>]
+    let ``a narrow ldind over a float64 cell reinterprets its bytes`` () : unit =
+        // `*(float*)&aDouble` is a reinterpretation of the low four bytes of the bit
+        // pattern, not the numeric narrowing `(float)aDouble`; 2.0 is the cleanest witness,
+        // because its low four bytes are zero while `(float)2.0` is 2.0f.
+        let cell = CliType.Numeric (CliNumericType.Float64 2.0)
+        let bytes = BitConverter.GetBytes 2.0
+
+        match runLdindOverCell NullaryIlOp.Ldind_r4 cell with
+        | EvalStackValue.Float actual -> actual |> shouldEqual (float (BitConverter.ToSingle (bytes, 0)))
+        | other -> failwith $"Expected a float from ldind.r4, got %O{other}"
+
+        runLdindOverCell NullaryIlOp.Ldind_i4 cell
+        |> int32Value "ldind.i4"
+        |> shouldEqual (BitConverter.ToInt32 (bytes, 0))
+
+    [<Test>]
+    let ``a narrow ldind over a native-int cell reinterprets its bytes`` () : unit =
+        let value = 0x1122334455667788L
+
+        let cell =
+            CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim value))
+
+        let bytes = BitConverter.GetBytes value
+
+        runLdindOverCell NullaryIlOp.Ldind_u1 cell
+        |> int32Value "ldind.u1"
+        |> shouldEqual (int32 bytes.[0])
+
+        runLdindOverCell NullaryIlOp.Ldind_i4 cell
+        |> int32Value "ldind.i4"
+        |> shouldEqual (BitConverter.ToInt32 (bytes, 0))
+
+    [<Test>]
+    let ``a narrow ldind unwraps a primitive-like wrapper before deciding`` () : unit =
+        // A guest's `IntPtr` local is stored as the single-field wrapper, not as the bare
+        // native int: `EvalStackValue.ofCliType` flattens it on the way to the eval stack,
+        // so a routing decision taken on the wrapper's own shape would answer a different
+        // question from the one the value-coercion path asks.
+        let value = 0x1122334455667788L
+
+        let intPtrHandle =
+            AllConcreteTypes.getRequiredNonGenericHandle concreteTypes baseClassTypes.IntPtr
+
+        let cell =
+            {
+                CliField.Id = FieldId.named "_value"
+                CliField.Name = "_value"
+                Contents = CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.Verbatim value))
+                Offset = None
+                Type = intPtrHandle
+                MarshallingDescriptor = None
+            }
+            |> List.singleton
+            |> CliValueType.OfFields baseClassTypes concreteTypes intPtrHandle Layout.Default CharSet.Ansi
+            |> CliType.ValueType
+
+        match cell with
+        | CliType.ValueType vt -> vt.PrimitiveLikeKind |> shouldEqual (Some PrimitiveLikeKind.FlattenToNativeInt)
+        | other -> failwith $"Expected a value type, got %O{other}"
+
+        let bytes = BitConverter.GetBytes value
+
+        runLdindOverCell NullaryIlOp.Ldind_u1 cell
+        |> int32Value "ldind.u1"
+        |> shouldEqual (int32 bytes.[0])
+
+    [<Test>]
+    let ``an equal-width ldind over a provenance-bearing cell keeps the provenance`` () : unit =
+        // The other side of the routing decision. A pointer identity has no byte image at all
+        // (`CliType.ToBytes` refuses one), so a read at the pointer's own width must return the
+        // cell rather than its bytes: widening the predicate to divert equal-width reads too
+        // would turn every such read into a byte-addressability refusal.
+        let handle = RuntimeTypeHandleTarget.Closed (ConcreteTypeHandle.Concrete 1)
+
+        let cell =
+            CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.TypeHandlePtr handle))
+
+        runLdindOverCell NullaryIlOp.Ldind_i cell
+        |> shouldEqual (EvalStackValue.NativeInt (NativeIntSource.TypeHandlePtr handle))
+
+        // Synthesised hash bits are byte-imageless for the same reason, and `ldind.i8` over a
+        // native-int cell is a widening rather than a narrowing, so it too stays typed.
+        let hashCell =
+            CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.OpaqueHashBits 0x40L))
+
+        runLdindOverCell NullaryIlOp.Ldind_i8 hashCell
+        |> shouldEqual (EvalStackValue.Int64 (Int64Source.OpaqueHashBits 0x40L))

--- a/WoofWare.PawPrint.Test/sourcesPure/ByteViewOfPrimitiveLocal.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/ByteViewOfPrimitiveLocal.cs
@@ -1,0 +1,205 @@
+using System;
+
+// Reinterpreting the storage of a primitive through a pointer of a *narrower* type, at
+// byte offset zero. A non-zero index (`p[1]`) already worked, because C# emits the offset
+// as pointer arithmetic and the byref then carries a trailing byte-view projection; index
+// zero emits no arithmetic at all, so the byref names the whole cell and the read has to
+// decide for itself that `ldind.u1` means "one byte here" rather than "convert this cell".
+//
+// Everything asserted here is a fact about both runtimes on the same host. Where the answer
+// depends on byte order the expectation is selected by `BitConverter.IsLittleEndian` rather
+// than assumed, so the file states what is true rather than what is true on x64/arm64.
+unsafe class ByteViewOfPrimitiveLocal
+{
+    struct WithLong
+    {
+        public int Before;
+        public long L;
+    }
+
+    static int TestNarrowReadsOfLong()
+    {
+        long v = 0x0102030405060708L;
+        byte* p = (byte*)&v;
+
+        // The arm under test: offset zero.
+        byte expected0 = BitConverter.IsLittleEndian ? (byte)0x08 : (byte)0x01;
+        if (p[0] != expected0)
+            return 1;
+
+        // The offsets that already worked, so a fix that only moved the problem is caught.
+        for (int i = 0; i < 8; i++)
+        {
+            int shift = BitConverter.IsLittleEndian ? 8 * i : 8 * (7 - i);
+            if (p[i] != (byte)(v >> shift))
+                return 2;
+        }
+
+        // Reassembling every byte must give the original back, whichever order they came in.
+        ulong rebuilt = 0;
+        for (int i = 0; i < 8; i++)
+        {
+            int shift = BitConverter.IsLittleEndian ? 8 * i : 8 * (7 - i);
+            rebuilt |= (ulong)p[i] << shift;
+        }
+
+        if (rebuilt != (ulong)v)
+            return 3;
+
+        // Widths between one byte and the whole cell, all at offset zero.
+        int expectedInt = BitConverter.IsLittleEndian ? unchecked((int)v) : (int)(v >> 32);
+        if (*(int*)&v != expectedInt)
+            return 4;
+
+        short expectedShort = BitConverter.IsLittleEndian ? unchecked((short)v) : (short)(v >> 48);
+        if (*(short*)&v != expectedShort)
+            return 5;
+
+        return 0;
+    }
+
+    static int TestNarrowReadOfInt()
+    {
+        int v = 0x11223344;
+        byte* p = (byte*)&v;
+
+        byte expected0 = BitConverter.IsLittleEndian ? (byte)0x44 : (byte)0x11;
+        if (p[0] != expected0)
+            return 10;
+
+        return 0;
+    }
+
+    static int TestNarrowReadOfNativeInt()
+    {
+        IntPtr v = (IntPtr)0x1122334455667788L;
+        byte* p = (byte*)&v;
+
+        byte expected0 = BitConverter.IsLittleEndian ? (byte)0x88 : (byte)0x11;
+        if (p[0] != expected0)
+            return 20;
+
+        // Reassembling gives the pointer-sized value back.
+        ulong rebuilt = 0;
+        for (int i = 0; i < IntPtr.Size; i++)
+        {
+            int shift = BitConverter.IsLittleEndian ? 8 * i : 8 * (IntPtr.Size - 1 - i);
+            rebuilt |= (ulong)p[i] << shift;
+        }
+
+        if (rebuilt != (ulong)(long)v)
+            return 21;
+
+        return 0;
+    }
+
+    // `*(float*)&aDouble` is a *reinterpretation*, not the numeric conversion `(float)aDouble`.
+    // 2.0 has bit pattern 0x4000_0000_0000_0000, so its low four bytes are all zero and its
+    // high four are 0x40000000 — meaning the reinterpreted float is +0 on a little-endian host
+    // and 2.0f on a big-endian one. Either way it is never `(float)2.0` on the host that
+    // answers zero, which is what makes this distinguish the two behaviours without needing
+    // any bit-conversion helper as an oracle.
+    static int TestReinterpretDoubleAsFloat()
+    {
+        double d = 2.0;
+        float f = *(float*)&d;
+
+        float expected = BitConverter.IsLittleEndian ? 0.0f : 2.0f;
+        if (f != expected)
+            return 30;
+
+        return 0;
+    }
+
+    // A pointer read at its own width must keep naming the pointer: this is not a narrowing
+    // read, so it must not be diverted to a byte view (a pointer has no byte image, so that
+    // would fail rather than answer).
+    static int TestPointerToPointerDereference()
+    {
+        long v = 42;
+        long* p = &v;
+        long** pp = &p;
+
+        if (**pp != 42)
+            return 40;
+
+        if (*pp != p)
+            return 41;
+
+        return 0;
+    }
+
+    static int TestStructFieldAndArrayElement()
+    {
+        WithLong s;
+        s.Before = -1;
+        s.L = 0x0102030405060708L;
+
+        byte* pf = (byte*)&s.L;
+        byte expected0 = BitConverter.IsLittleEndian ? (byte)0x08 : (byte)0x01;
+        if (pf[0] != expected0)
+            return 50;
+
+        long[] arr = { 0x0102030405060708L, 0 };
+        fixed (long* q = arr)
+        {
+            byte* pa = (byte*)q;
+            if (pa[0] != expected0)
+                return 51;
+        }
+
+        return 0;
+    }
+
+    // The write side already reinterprets at offset zero; pin that the two directions agree,
+    // so a change to one cannot silently drift from the other.
+    static int TestWriteThenReadRoundTrip()
+    {
+        long v = 0x0102030405060708L;
+        byte* p = (byte*)&v;
+
+        p[0] = 0x99;
+
+        long expected = BitConverter.IsLittleEndian ? 0x0102030405060799L : unchecked((long)0x9902030405060708UL);
+        if (v != expected)
+            return 60;
+
+        if (p[0] != 0x99)
+            return 61;
+
+        return 0;
+    }
+
+    static int Main(string[] args)
+    {
+        int result = TestNarrowReadsOfLong();
+        if (result != 0)
+            return result;
+
+        result = TestNarrowReadOfInt();
+        if (result != 0)
+            return result;
+
+        result = TestNarrowReadOfNativeInt();
+        if (result != 0)
+            return result;
+
+        result = TestReinterpretDoubleAsFloat();
+        if (result != 0)
+            return result;
+
+        result = TestPointerToPointerDereference();
+        if (result != 0)
+            return result;
+
+        result = TestStructFieldAndArrayElement();
+        if (result != 0)
+            return result;
+
+        result = TestWriteThenReadRoundTrip();
+        if (result != 0)
+            return result;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -1139,6 +1139,44 @@ module NullaryIlOp =
         | LdindR4 -> CliType.Numeric (CliNumericType.Float32 0.0f)
         | LdindR8 -> CliType.Numeric (CliNumericType.Float64 0.0)
 
+    /// Does a plain-byref `ldind` of `target` over a storage cell of `cell` have to
+    /// reinterpret the cell's bytes, rather than read the cell and coerce it?
+    ///
+    /// Reading the typed cell is right when the cell already holds a value of the requested
+    /// kind, and it is the *only* possibility for a cell whose provenance has no byte image —
+    /// a `TypeHandlePtr`, a `WidenedNativeInt`, synthesised hash bits — because
+    /// `CliType.ToBytes` deliberately refuses those. It is not right when the requested type
+    /// is strictly *narrower* than the cell: `*(byte*)&aLong` asks for the byte at that
+    /// address, and the cell is eight bytes of something else, so the answer is a
+    /// reinterpretation rather than a numeric conversion. Exactly that case routes through
+    /// `readManagedByrefBytesAs`, which is what every other byref root already does for it
+    /// (`readArrayBytesAs`, `readStackMemoryBytesAs`, `tryReadHeapValueFieldPrecise`).
+    ///
+    /// The test is on *width* alone, with no same-kind clause: `CliNumericType.SizeOf` is a
+    /// function of the kind constructor, so a same-kind pair can never be strictly narrower
+    /// and a `not (SameKind ...)` conjunct would be unfalsifiable. Same-width kind changes
+    /// (`ldind.i4` over a `Float32` cell, `ldind.i` over an `Int64` one) therefore keep the
+    /// incumbent answer, which is what preserves provenance through `ldind.i8` over a
+    /// native-int cell.
+    ///
+    /// Primitive-like single-field wrappers (`IntPtr`, `RuntimeTypeHandle`, enums) are
+    /// unwrapped first, because this predicate's contract is "classify what
+    /// `EvalStackValue.ofCliType` will hand to `toCliTypeCoerced`", and that function
+    /// flattens them through `CliValueType.PrimitiveLikeField` before the coercion sees
+    /// them. Classifying the wrapper itself would answer a different question. The recursion
+    /// is unguarded for the same reason `ofCliType`'s is: a value type cannot contain itself
+    /// in well-formed metadata, and both downstream routes walk the identical structure.
+    let rec private ldindNeedsByteView (target : CliNumericType) (cell : CliType) : bool =
+        match cell with
+        | CliType.ValueType vt when vt.PrimitiveLikeKind.IsSome ->
+            ldindNeedsByteView target (CliValueType.PrimitiveLikeField vt).Contents
+        | CliType.Numeric c -> CliNumericType.SizeOf target < CliNumericType.SizeOf c
+        | CliType.ValueType _
+        | CliType.Bool _
+        | CliType.Char _
+        | CliType.ObjectRef _
+        | CliType.RuntimePointer _ -> false
+
     // Unified Ldind implementation
     let private executeLdind
         (loggerFactory : ILoggerFactory)
@@ -1234,7 +1272,30 @@ module NullaryIlOp =
                 || isTrailingByteViewPointer src
                 ->
                 IlMachineState.readManagedByrefBytesAs corelib state src targetCliType
-            | EvalStackValue.ManagedPointer src -> IlMachineState.readManagedByref corelib state src
+            // Must stay *after* the guarded arm above, for two reasons. A byte-only root has no
+            // typed cell for `readManagedByref` to return, so reading one to ask the routing
+            // question would throw before the question could be answered. And
+            // `isTrailingByteViewPointer` already claims every chain ending in a `ReinterpretAs`,
+            // so what reaches here is a *plain* byref — `[]` or a chain ending in a `Field` — for
+            // which `readManagedByref` falls to its `readProjectedValue` branch and hands back
+            // the projected cell verbatim, rather than reinterpreting anything itself.
+            | EvalStackValue.ManagedPointer src ->
+                let target =
+                    match targetCliType with
+                    | CliType.Numeric target -> target
+                    | other ->
+                        failwith
+                            $"Ldind target type is always numeric (`getTargetLdindCliType`, and `ldind.ref` has its own handler), but %O{targetType} produced %O{other}"
+
+                // The cell has to be read before the routing question can be asked, and is
+                // discarded when the answer is "bytes". Reads are pure, so this costs a walk
+                // and nothing else; it is not an oversight to be optimised into a partial read.
+                let cell = IlMachineState.readManagedByref corelib state src
+
+                if ldindNeedsByteView target cell then
+                    IlMachineState.readManagedByrefBytesAs corelib state src targetCliType
+                else
+                    cell
             | EvalStackValue.NativeInt (NativeIntSource.ManagedPointer src) ->
                 IlMachineState.readManagedByrefBytesAs corelib state src targetCliType
             | EvalStackValue.NativeInt nativeIntSource ->


### PR DESCRIPTION
Next slice towards runtime IL emission (#849), and the one the recorded stage-2 blocker
turned out to be sitting on top of.

## What was measured

The issue records this blocker for a `DynamicMethod` whose signature mentions a user-defined
type:

> `todo: NativeInt(<type ID 83>) to uint8` in `SignatureHelper.InternalAddRuntimeType`,
> before any emit

`InternalAddRuntimeType` writes a type handle into a signature blob a byte at a time:

```csharp
IntPtr handle = type.TypeHandle.Value;
byte* phandle = (byte*)&handle;
for (int i = 0; i < sizeof(void*); i++)
    m_signature[m_currSig++] = phandle[i];
```

Re-measuring it turned up two independent gaps stacked on each other, and the first is
nothing to do with pointers or with emit. The identical failure reproduces for a plain
`long`:

```csharp
long v = 0x0102030405060708L;
byte* p = (byte*)&v;
byte b0 = p[0];      // todo: Int64(72623859790382856) to uint8
```

while `p[1]`, `p[7]` and the write `p[0] = 0x99` all succeed. **This PR is that gap.** The
provenance question the issue actually names — giving a `TypeHandlePtr` a byte image — is the
next one.

## Root cause

`ldind` dispatches in `NullaryIlOp.executeLdind`. Three pointer shapes route to
`readManagedByrefBytesAs`, which is told the requested type; a plain byref instead routes to
`readManagedByref`, which takes no target type and returns the whole typed cell, leaving the
width mismatch to `EvalStackValue.toCliTypeCoerced`. That function's `UInt8` arm accepts only
`Int32`, so an `Int32` cell coerces via `i % 256` — accidentally the right byte on a
little-endian host — while an `Int64`, `NativeInt` or `Float64` cell throws.

`p[1]` works because a non-zero index emits pointer arithmetic, so the byref carries a
trailing byte-view projection and `isTrailingByteViewPointer` claims it. Index zero emits no
arithmetic at all. The write side has no such gap because `stind` goes through
`writeIndirectPrimitiveStore`, a width- and provenance-aware dispatcher with no counterpart
on the read side; that asymmetry is the bug.

## The fix

One predicate and one dispatch arm. `readManagedByref`, `toCliTypeCoerced` and the whole
write side are untouched.

```fsharp
let rec private ldindNeedsByteView (target : CliNumericType) (cell : CliType) : bool =
    match cell with
    | CliType.ValueType vt when vt.PrimitiveLikeKind.IsSome ->
        ldindNeedsByteView target (CliValueType.PrimitiveLikeField vt).Contents
    | CliType.Numeric c -> CliNumericType.SizeOf target < CliNumericType.SizeOf c
    | _ -> false
```

Reading the typed cell is right when the cell already holds a value of the requested kind, and
it is the *only* possibility for a cell whose provenance has no byte image — `CliType.ToBytes`
deliberately refuses a `TypeHandlePtr`, a `WidenedNativeInt` or synthesised hash bits. It is
not right when the requested type is strictly narrower than the cell, because then the answer
is a reinterpretation rather than a conversion. Only that case moves.

Two details that took a couple of passes to get right:

* **The test is on width alone.** An earlier draft had `not (SameKind target c) &&` in front
  of it. That conjunct is unfalsifiable: `CliNumericType.SizeOf` matches on the kind
  constructor alone, so same-kind implies same size, so the size comparison is already false
  whenever `SameKind` is true. No test could kill it, so it is gone rather than kept.
* **Primitive-like wrappers are unwrapped first.** The predicate's contract is "classify what
  `EvalStackValue.ofCliType` will hand to `toCliTypeCoerced`", and that flattens `IntPtr`,
  `RuntimeTypeHandle` and enums through `CliValueType.PrimitiveLikeField` before the coercion
  sees them. A guest's `IntPtr` local *is* the wrapper, so classifying the wrapper itself
  would answer a different question — and this is exactly the cell on the
  `InternalAddRuntimeType` path.

## What changes, honestly

Only strictly-narrowing numeric reads move, and of those:

1. **Integer narrowing agrees.** `EvalStack.fs` does not `open Checked`, so `i % 256` is an
   unchecked truncation and is congruent to the low byte for negatives too. No observable
   change.
2. **`ldind.r4` over a `Float64` cell changes answer, and the new one is correct.** Today
   `*(float*)&aDouble` returns the numeric narrowing `(float)theDouble`; C# means "reinterpret
   the low four bytes", which is what the byte view gives. It has its own test.
3. **Cells wider than the target that threw start working**, which is the point; and where the
   cell's provenance has no byte image the failure moves from a coercion `TODO` to the
   byte-addressability refusal that names the offending source.

Deliberately unchanged: the `NativeInt (NativeIntSource.ManagedPointer …)` arm stays
unconditionally bytewise, so the two representations of one pointer still disagree — unifying
them would regress reads the byte walk serves today. Equal-width kind changes keep the
incumbent answer, which is what preserves `WidenedNativeInt` and `OpaqueHashBits` provenance
through `ldind.i8`. Non-primitive-like structs keep the incumbent projection.

## Tests

* `sourcesPure/ByteViewOfPrimitiveLocal.cs` — differential. Byte views of a `long`, an `int`,
  an `IntPtr` and a `double` at offset 0 and at every other offset, narrower-than-cell reads,
  the `*(float*)&aDouble` reinterpretation, byte views through a struct field and an array
  element, a write-then-read round trip, and `long** pp` to pin that an equal-width pointer
  read is *not* diverted. Every expectation that depends on byte order selects itself from
  `BitConverter.IsLittleEndian` rather than assuming. Validated against real .NET through the
  harness's own compile, by parking it, before it was used as an oracle.
* `TestNullaryIlOp.fs` — property tests with `BitConverter` as an outside oracle over `int64`,
  `float64` and `nativeint` cells; a primitive-like-wrapper case; and two provenance cases
  (`ldind.i` over a `TypeHandlePtr`, `ldind.i8` over `OpaqueHashBits`) that must keep returning
  the typed cell. The provenance ones can only be built in the unit fixture, because a guest
  local is the wrapper rather than the bare cell.
* Mutation-tested, four separate mutations, each killed by a named test: deleting the
  primitive-like unwrap arm; forcing the size test constantly false; widening `<` to `<=`;
  and diverting `RuntimePointer` cells bytewise (the `long** pp` case is what kills that
  one).

## Where this leaves #849

The `TypeHandle` probe now stops at

```
refusing byte view over value type containing non-byte-addressable field 3::_value:
native int with non-byte-addressable provenance <type ID 83>
```

which is the honest statement of the remaining gap — a `RuntimeTypeHandle.Value` has no byte
image — and the right place for the provenance discussion to start. That is the next PR.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
