### PR TITLE
Locate a wedged guest in its own source

### DIFF
--- a/WoofWare.PawPrint.Test/Roslyn.fs
+++ b/WoofWare.PawPrint.Test/Roslyn.fs
@@ -37,12 +37,26 @@ module Roslyn =
         | Sidecar
         | None
 
+    /// Whether the compilation is optimized.
+    ///
+    /// Off by default, matching what the harness has always produced. It matters to more than
+    /// speed: unoptimized C# emits a `nop` after every call statement, and that `nop` carries
+    /// the *call's* sequence point. So in a debug build a program counter parked just past a
+    /// call still resolves to the call's own line, and a diagnostic that confuses the two looks
+    /// correct. Optimized, the `nop` is gone and the next instruction belongs to the next
+    /// statement, which is what makes the difference observable at all.
+    [<RequireQualifiedAccess>]
+    type Optimization =
+        | Release
+        | Debug
+
     let private compileCore
         (assemblyName : string)
         (outputKind : OutputKind)
         (extraReferences : MetadataReference list)
         (resources : ResourceDescription list)
         (symbols : DebugSymbols)
+        (optimization : Optimization)
         (sources : string list)
         : byte[] * byte[] option
         =
@@ -62,7 +76,13 @@ module Roslyn =
             )
             |> List.toArray
 
-        let compilationOptions = CSharpCompilationOptions(outputKind).WithAllowUnsafe true
+        let optimizationLevel =
+            match optimization with
+            | Optimization.Release -> OptimizationLevel.Release
+            | Optimization.Debug -> OptimizationLevel.Debug
+
+        let compilationOptions =
+            CSharpCompilationOptions(outputKind).WithAllowUnsafe(true).WithOptimizationLevel optimizationLevel
 
         let compilation =
             CSharpCompilation.Create (
@@ -115,7 +135,7 @@ module Roslyn =
         (sources : string list)
         : byte[]
         =
-        compileCore assemblyName outputKind extraReferences resources DebugSymbols.None sources
+        compileCore assemblyName outputKind extraReferences resources DebugSymbols.None Optimization.Debug sources
         |> fst
 
     let compileAssembly
@@ -135,7 +155,27 @@ module Roslyn =
     /// As `compile`, but the image carries an embedded portable PDB. See `DebugSymbols` for why
     /// this is a separate entry point rather than the default.
     let compileWithSymbols (sources : string list) : byte[] =
-        compileCore "PawPrintTestAssembly" OutputKind.ConsoleApplication [] [] DebugSymbols.Embedded sources
+        compileCore
+            "PawPrintTestAssembly"
+            OutputKind.ConsoleApplication
+            []
+            []
+            DebugSymbols.Embedded
+            Optimization.Debug
+            sources
+        |> fst
+
+    /// As `compileWithSymbols`, but optimized. See `Optimization` for why that changes what a
+    /// source location resolves to, and hence why a diagnostic test may need it.
+    let compileOptimizedWithSymbols (sources : string list) : byte[] =
+        compileCore
+            "PawPrintTestAssembly"
+            OutputKind.ConsoleApplication
+            []
+            []
+            DebugSymbols.Embedded
+            Optimization.Release
+            sources
         |> fst
 
     /// As `compileWithSymbols`, but the debug information is emitted as a separate portable PDB
@@ -143,7 +183,14 @@ module Roslyn =
     /// rather than embedded in the image. Returns the image and the PDB that belongs beside it.
     let compileWithSidecarSymbols (sources : string list) : byte[] * byte[] =
         let image, pdb =
-            compileCore "PawPrintTestAssembly" OutputKind.ConsoleApplication [] [] DebugSymbols.Sidecar sources
+            compileCore
+                "PawPrintTestAssembly"
+                OutputKind.ConsoleApplication
+                []
+                []
+                DebugSymbols.Sidecar
+                Optimization.Debug
+                sources
 
         match pdb with
         | Some pdb -> image, pdb

--- a/WoofWare.PawPrint.Test/TestGuestLocation.fs
+++ b/WoofWare.PawPrint.Test/TestGuestLocation.fs
@@ -1,0 +1,282 @@
+namespace WoofWare.PawPrint.Test
+
+open System
+open System.Collections.Immutable
+open System.IO
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.DotnetRuntimeLocator
+open WoofWare.PawPrint
+
+/// `GuestLocation` is what turns "the guest is stuck" into "the guest is stuck *here*". The
+/// mechanism has two halves and they fail in different ways, so they are tested apart:
+///
+/// * the renderer is pure over `GuestThreadPosition`, so every case of that DU is pinned
+///   directly, without an interpreter;
+/// * the classifier needs a real machine, and its interesting behaviour is which *frame* it
+///   reports — so those tests wedge a guest and assert on the line number, with the expected
+///   line derived from the source text rather than written out by hand.
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestGuestLocation =
+
+    let private assy = typeof<RunResult>.Assembly
+
+    // ---------------------------------------------------------------------------------------
+    // The pure renderer.
+    // ---------------------------------------------------------------------------------------
+
+    let private loc (line : int) : SourceLocation =
+        {
+            DocumentPath = "/build/Guest.cs"
+            StartLine = line
+            StartColumn = 9
+            EndLine = line
+            EndColumn = 24
+        }
+
+    let private frame (name : string) (offset : int) : GuestFrame =
+        {
+            Method = name
+            IlOffset = offset
+        }
+
+    let private render (status : ThreadStatus) (position : GuestThreadPosition) : string =
+        GuestLocation.renderThread
+            {
+                Thread = ThreadId 3
+                Status = status
+                Position = position
+            }
+
+    [<Test>]
+    let ``a thread with no live frame renders its status alone`` () : unit =
+        render ThreadStatus.NotStarted GuestThreadPosition.NoFrame
+        |> shouldEqual "thread 3 (NotStarted)"
+
+    [<Test>]
+    let ``an attributed frame names the source span`` () : unit =
+        render ThreadStatus.Runnable (GuestThreadPosition.AtSource (frame "Guest.Spin" 22, loc 17))
+        |> shouldEqual "thread 3 (Runnable) in Guest.Spin at IL offset 22 (/build/Guest.cs:17)"
+
+    /// The case the whole design exists for: the innermost frame is framework code, which ships
+    /// without a PDB, so naming only that frame would say nothing about the guest.
+    [<Test>]
+    let ``an unattributed frame names the nearest enclosing frame that has a source span`` () : unit =
+        render
+            ThreadStatus.Runnable
+            (GuestThreadPosition.CalledFrom (frame "SpinWait.SpinOnceCore" 43, 1, frame "Guest.Spin" 22, loc 17))
+        |> shouldEqual
+            "thread 3 (Runnable) in SpinWait.SpinOnceCore at IL offset 43, called from Guest.Spin at IL offset 22 (/build/Guest.cs:17)"
+
+    /// "called from" alone would read as the immediate caller. A frame buried deep in framework
+    /// code is a materially different situation from one the guest called straight into, and the
+    /// reader can only tell the two apart if the distance is stated.
+    [<Test>]
+    let ``a distant ancestor is reported with the distance walked`` () : unit =
+        render
+            ThreadStatus.Runnable
+            (GuestThreadPosition.CalledFrom (frame "Monitor.Wait" 0, 4, frame "Guest.Take" 91, loc 42))
+        |> shouldEqual
+            "thread 3 (Runnable) in Monitor.Wait at IL offset 0, called 4 frames out from Guest.Take at IL offset 91 (/build/Guest.cs:42)"
+
+    /// No symbols anywhere on the stack — the ordinary case for a guest built without a PDB, and
+    /// for any stack that bottoms out in the shared framework. The renderer must degrade to
+    /// what it could say before, not omit the frame or fabricate a location.
+    [<Test>]
+    let ``a stack with no source information at all still names the active frame`` () : unit =
+        render ThreadStatus.Runnable (GuestThreadPosition.Unattributed (frame "SpinWait.SpinOnceCore" 43))
+        |> shouldEqual "thread 3 (Runnable) in SpinWait.SpinOnceCore at IL offset 43"
+
+    [<Test>]
+    let ``a blocked thread renders the status payload`` () : unit =
+        render (ThreadStatus.BlockedOnJoin (ThreadId 1, None)) (GuestThreadPosition.Unattributed (frame "Guest.Main" 3))
+        |> shouldContainText "thread 3 (BlockedOnJoin"
+
+    // ---------------------------------------------------------------------------------------
+    // The classifier, end to end.
+    // ---------------------------------------------------------------------------------------
+
+    /// The line of the single source line containing `marker`, 1-based as a PDB counts lines.
+    ///
+    /// Derived from the source rather than written down, so that editing the guest cannot leave
+    /// a test asserting a stale number — and, more to the point, so that the assertion is a
+    /// claim about the compiler's own attribution rather than a restatement of it.
+    let private lineContaining (marker : string) (source : string) : int =
+        let lines = source.Replace("\r\n", "\n").Split '\n'
+
+        match
+            lines
+            |> Array.mapi (fun i l -> i, l)
+            |> Array.filter (fun (_, l) -> l.Contains marker)
+        with
+        | [| (i, _) |] -> i + 1
+        | [||] -> failwith $"guest source contains no line matching %s{marker}; the test's oracle is broken"
+        | many ->
+            failwith $"guest source has %d{many.Length} lines matching %s{marker}, so the expected line is ambiguous"
+
+    /// Run a guest that never terminates, and return the diagnostic the harness gave up with.
+    ///
+    /// `name` identifies the run in the message; it is *not* the document name a resolved source
+    /// location carries. `Roslyn.compileCore` parses each source as `File{index}.cs`, so that is
+    /// what the compiler records in the PDB and what the assertions below look for.
+    let private runWedged (withSymbols : bool) (maxSteps : int64) (name : string) (source : string) : string =
+        let image =
+            if withSymbols then
+                Roslyn.compileWithSymbols [ source ]
+            else
+                Roslyn.compile [ source ]
+
+        let _messages, loggerFactory =
+            LoggerFactory.makeTestWithProperties [ "source_file", name ]
+
+        use _loggerFactoryResource = loggerFactory
+
+        let dotnetRuntimes =
+            DotnetRuntime.SelectForDll assy.Location |> ImmutableArray.CreateRange
+
+        use peImage = new MemoryStream (image)
+
+        let exn =
+            Assert.Throws (fun () ->
+                BoundedRun.runWith loggerFactory maxSteps name (Some name) peImage (HostConfig.Default dotnetRuntimes)
+                |> ignore<RunOutcome>
+            )
+
+        exn.Message
+
+    /// A guest whose innermost frame is its own code. The reported line must be the statement the
+    /// guest is wedged on, not merely some line of the enclosing method.
+    [<Test>]
+    let ``a guest wedged in its own code is located at the wedged statement`` () : unit =
+        let source =
+            """
+class SpinsInGuestCode
+{
+    static int Main(string[] args)
+    {
+        int i = 0;
+        while (true) { i = i + 1; } // WEDGE
+    }
+}
+"""
+
+        let message = runWedged true 50_000L "SpinsInGuestCode.cs" source
+        let expected = lineContaining "// WEDGE" source
+
+        message |> shouldContainText "Threads: "
+        message |> shouldContainText $"File0.cs:%d{expected}"
+
+    /// The same guest without symbols. It must still report the frame — losing the PDB costs the
+    /// line and nothing else — so that a build with no debug information is merely less
+    /// informative rather than broken.
+    [<Test>]
+    let ``a guest built without symbols still reports its frame`` () : unit =
+        let source =
+            """
+class SpinsUnattributed
+{
+    static int Main(string[] args)
+    {
+        int i = 0;
+        while (true) { i = i + 1; } // WEDGE
+    }
+}
+"""
+
+        let message = runWedged false 50_000L "SpinsUnattributed.cs" source
+
+        message |> shouldContainText "Threads: "
+        message |> shouldContainText "Main at IL offset"
+        // Nothing may claim a source span: the image carries no debug information to derive one
+        // from, and inventing one would be worse than saying nothing.
+        message |> shouldNotContainText "File0.cs:"
+
+    /// The motivating case. The guest blocks inside the BCL, so the innermost frame belongs to an
+    /// assembly with no PDB; the diagnostic is only useful if it walks out to the guest's own
+    /// frame. Without the outward walk this message names a framework method and stops.
+    [<Test>]
+    let ``a guest blocked inside the BCL is located at its own call site`` () : unit =
+        let source =
+            """
+using System.Threading;
+
+class BlocksInBcl
+{
+    static int Main(string[] args)
+    {
+        var gate = new ManualResetEventSlim(false);
+        gate.Wait(); // WEDGE
+        return 0;
+    }
+}
+"""
+
+        let message = runWedged true 20_000_000L "BlocksInBcl.cs" source
+        let expected = lineContaining "// WEDGE" source
+
+        message |> shouldContainText "Threads: "
+        // The active frame is framework code, which has no PDB — so the guest line below can
+        // only have come from walking out of it. How far out is a fact about the BCL's
+        // implementation of `Wait` and deliberately not asserted; that the walk reached the
+        // guest's own frame is the claim.
+        message |> shouldContainText "in System.Private.CoreLib."
+
+        message
+        |> shouldContainText "from PawPrintTestAssembly.BlocksInBcl.Main at IL offset"
+
+        message |> shouldContainText $"File0.cs:%d{expected}"
+
+    /// A thread that exists but has never run has no frame to describe, and reaching for one
+    /// throws. The diagnostic must survive that: a guest holding a constructed-but-unstarted
+    /// `Thread` while another thread wedges is entirely ordinary.
+    [<Test>]
+    let ``an unstarted thread is described without dereferencing a frame`` () : unit =
+        let source =
+            """
+using System.Threading;
+
+class HoldsAnUnstartedThread
+{
+    static int Main(string[] args)
+    {
+        var idle = new Thread(() => { });
+        int i = 0;
+        while (true) { i = i + 1; } // WEDGE
+    }
+}
+"""
+
+        let message = runWedged true 200_000L "HoldsAnUnstartedThread.cs" source
+        let expected = lineContaining "// WEDGE" source
+
+        // Asserted, not merely survived: without this the test passes for a `GuestLocation` that
+        // never met a frameless thread at all, and the guard it is meant to cover goes untested.
+        message |> shouldContainText "thread 1 (NotStarted)"
+        message |> shouldContainText $"File0.cs:%d{expected}"
+
+    /// The rich summary must appear once, not twice. Before unification the harness printed the
+    /// library's thread description under `Stuck:` and its own under `Threads:`, which said the
+    /// same thing in two formats.
+    [<Test>]
+    let ``the thread summary is not printed twice`` () : unit =
+        let source =
+            """
+using System.Threading;
+
+class DeadlocksImmediately
+{
+    static int Main(string[] args)
+    {
+        new ManualResetEventSlim(false).Wait();
+        return 0;
+    }
+}
+"""
+
+        let message = runWedged true 20_000_000L "DeadlocksImmediately.cs" source
+
+        let occurrences =
+            message.Split ([| "thread 0 (" |], StringSplitOptions.None) |> Array.length
+
+        occurrences |> shouldEqual 2

--- a/WoofWare.PawPrint.Test/TestGuestLocation.fs
+++ b/WoofWare.PawPrint.Test/TestGuestLocation.fs
@@ -115,17 +115,26 @@ module TestGuestLocation =
         | many ->
             failwith $"guest source has %d{many.Length} lines matching %s{marker}, so the expected line is ambiguous"
 
+    [<RequireQualifiedAccess>]
+    type private Guest =
+        | WithSymbols
+        | WithoutSymbols
+        /// Optimized, so that a program counter parked one instruction past a call resolves to
+        /// the *next* statement. Unoptimized C# hides that behind the `nop` it emits after every
+        /// call statement.
+        | OptimizedWithSymbols
+
     /// Run a guest that never terminates, and return the diagnostic the harness gave up with.
     ///
     /// `name` identifies the run in the message; it is *not* the document name a resolved source
     /// location carries. `Roslyn.compileCore` parses each source as `File{index}.cs`, so that is
     /// what the compiler records in the PDB and what the assertions below look for.
-    let private runWedged (withSymbols : bool) (maxSteps : int64) (name : string) (source : string) : string =
+    let private runWedgedAs (guest : Guest) (maxSteps : int64) (name : string) (source : string) : string =
         let image =
-            if withSymbols then
-                Roslyn.compileWithSymbols [ source ]
-            else
-                Roslyn.compile [ source ]
+            match guest with
+            | Guest.WithSymbols -> Roslyn.compileWithSymbols [ source ]
+            | Guest.WithoutSymbols -> Roslyn.compile [ source ]
+            | Guest.OptimizedWithSymbols -> Roslyn.compileOptimizedWithSymbols [ source ]
 
         let _messages, loggerFactory =
             LoggerFactory.makeTestWithProperties [ "source_file", name ]
@@ -161,7 +170,7 @@ class SpinsInGuestCode
 }
 """
 
-        let message = runWedged true 50_000L "SpinsInGuestCode.cs" source
+        let message = runWedgedAs Guest.WithSymbols 50_000L "SpinsInGuestCode.cs" source
         let expected = lineContaining "// WEDGE" source
 
         message |> shouldContainText "Threads: "
@@ -184,7 +193,7 @@ class SpinsUnattributed
 }
 """
 
-        let message = runWedged false 50_000L "SpinsUnattributed.cs" source
+        let message = runWedgedAs Guest.WithoutSymbols 50_000L "SpinsUnattributed.cs" source
 
         message |> shouldContainText "Threads: "
         message |> shouldContainText "Main at IL offset"
@@ -212,7 +221,7 @@ class BlocksInBcl
 }
 """
 
-        let message = runWedged true 20_000_000L "BlocksInBcl.cs" source
+        let message = runWedgedAs Guest.WithSymbols 20_000_000L "BlocksInBcl.cs" source
         let expected = lineContaining "// WEDGE" source
 
         message |> shouldContainText "Threads: "
@@ -247,13 +256,63 @@ class HoldsAnUnstartedThread
 }
 """
 
-        let message = runWedged true 200_000L "HoldsAnUnstartedThread.cs" source
+        let message =
+            runWedgedAs Guest.WithSymbols 200_000L "HoldsAnUnstartedThread.cs" source
+
         let expected = lineContaining "// WEDGE" source
 
         // Asserted, not merely survived: without this the test passes for a `GuestLocation` that
         // never met a frameless thread at all, and the guard it is meant to cover goes untested.
         message |> shouldContainText "thread 1 (NotStarted)"
         message |> shouldContainText $"File0.cs:%d{expected}"
+
+    /// A guest that blocks by calling a native handler *directly*, so its own frame is the active
+    /// one when the thread parks.
+    ///
+    /// Every blocking QCall advances the caller's program counter past the call site before
+    /// parking, and `dispatchNative` then pops the native frame — so the raw PC names the
+    /// statement after the one that blocked. Nothing further out can correct for it here: `Main`
+    /// is the outermost guest frame, so if the active frame is misattributed the diagnostic is
+    /// simply wrong.
+    ///
+    /// Optimized deliberately. Unoptimized C# emits a `nop` after the call which carries the
+    /// call's own sequence point, so the wrong offset resolves to the right line by accident and
+    /// this test would pass against the bug it exists to catch.
+    [<Test>]
+    let ``a guest blocked in a direct native call is located at the call, not the next statement`` () : unit =
+        let source =
+            """
+using System.Runtime.InteropServices;
+
+class BlocksInDirectNativeCall
+{
+    [DllImport("libSystem.Native", EntryPoint = "SystemNative_LowLevelMonitor_Create")]
+    private static extern nint Create();
+
+    [DllImport("libSystem.Native", EntryPoint = "SystemNative_LowLevelMonitor_Acquire")]
+    private static extern void Acquire(nint monitor);
+
+    [DllImport("libSystem.Native", EntryPoint = "SystemNative_LowLevelMonitor_Wait")]
+    private static extern void Wait(nint monitor);
+
+    static int Main()
+    {
+        nint monitor = Create();
+        Acquire(monitor);
+        Wait(monitor); // WEDGE
+        return 42; // NEXT STATEMENT
+    }
+}
+"""
+
+        let message =
+            runWedgedAs Guest.OptimizedWithSymbols 20_000_000L "BlocksInDirectNativeCall.cs" source
+
+        let wedge = lineContaining "// WEDGE" source
+        let next = lineContaining "// NEXT STATEMENT" source
+
+        message |> shouldContainText $"File0.cs:%d{wedge}"
+        message |> shouldNotContainText $"File0.cs:%d{next}"
 
     /// The rich summary must appear once, not twice. Before unification the harness printed the
     /// library's thread description under `Stuck:` and its own under `Threads:`, which said the
@@ -274,7 +333,8 @@ class DeadlocksImmediately
 }
 """
 
-        let message = runWedged true 20_000_000L "DeadlocksImmediately.cs" source
+        let message =
+            runWedgedAs Guest.WithSymbols 20_000_000L "DeadlocksImmediately.cs" source
 
         let occurrences =
             message.Split ([| "thread 0 (" |], StringSplitOptions.None) |> Array.length

--- a/WoofWare.PawPrint.Test/TestHarness.fs
+++ b/WoofWare.PawPrint.Test/TestHarness.fs
@@ -90,28 +90,14 @@ module BoundedRun =
 
     /// What each thread that has not terminated is doing, for a diagnostic.
     ///
-    /// The IL offset is included, not just the method name, because the name alone does not say
+    /// `GuestLocation.describe` is the same renderer the interpreter uses for its own deadlock
+    /// reports, so the four failures below and a deadlock reported by the App read alike. It
+    /// includes the IL offset and not just the method name, because the name alone does not say
     /// *where* a guest is stuck: a spin loop never leaves its method, so every stop inside it
     /// looks identical. The offset and the kernel's step counter are also the only parts of
     /// this message that two differently-timed runs could disagree about, which is what makes
     /// the stopping point observable to a test at all.
-    let private threadSummary (state : IlMachineState) : string =
-        state.ThreadState
-        |> Map.toSeq
-        |> Seq.filter (fun (_, ts) -> ts.Status <> ThreadStatus.Terminated)
-        |> Seq.map (fun (ThreadId i, ts) ->
-            // A non-terminated thread need not have a frame: `ThreadStatus.hasNoActiveFrame`
-            // names `NotStarted` and `Parked`, and `ts.MethodState` throws on both because it
-            // resolves the active frame and there isn't one. A guest holding a constructed but
-            // unstarted `Thread` is entirely ordinary, so reaching for the method
-            // unconditionally would replace this diagnostic with "Frame ... is not live" — a
-            // failure about the harness, precisely when the guest is what needs explaining.
-            if ThreadStatus.hasNoActiveFrame ts.Status then
-                $"thread %d{i} (%O{ts.Status})"
-            else
-                $"thread %d{i} (%O{ts.Status}) in %s{ts.MethodState.ExecutingMethod.Name} at IL offset %d{ts.MethodState.IlOpIndex}"
-        )
-        |> String.concat "; "
+    let private threadSummary : IlMachineState -> string = GuestLocation.describe
 
     let runWith
         (loggerFactory : ILoggerFactory)
@@ -133,12 +119,16 @@ module BoundedRun =
 
             match Program.stepPrepared loggerFactory logger prepared with
             | Program.ProgramStepOutcome.Completed outcome -> outcome
-            | Program.ProgramStepOutcome.Deadlocked (prepared, stuck) ->
+            | Program.ProgramStepOutcome.Deadlocked (_, stuck) ->
                 // `Program.run` would raise from inside `pumpPrepared`, discarding the state
                 // along with any diagnostic it carries. Reported here instead, with the same
                 // detail as a step-budget failure so the two read alike.
+                //
+                // `stuck` is already `threadSummary` of the state at the moment of detection —
+                // the interpreter builds it with the same renderer — so re-summarising the
+                // returned state here would print the same thing twice in two formats.
                 failwith
-                    $"%s{description} deadlocked: no runnable threads and the entry thread has not terminated. Stuck: %s{stuck}. Threads: %s{threadSummary prepared.State}"
+                    $"%s{description} deadlocked: no runnable threads and the entry thread has not terminated. Threads: %s{stuck}"
             | Program.ProgramStepOutcome.InstructionStepped (prepared, _, _, _)
             | Program.ProgramStepOutcome.WorkerTerminated (prepared, _) -> goMain (steps + 1L) prepared
 
@@ -171,12 +161,12 @@ module BoundedRun =
             // the budget it claims to have enforced.
             | Program.StartupStepOutcome.Completed (Program.ProgramStartResult.Ready prepared) ->
                 goMain (steps + 1L) prepared
-            | Program.StartupStepOutcome.Deadlocked (startup, stuck) ->
-                // `Program.prepare` raises on this itself, but with no guest identification and
-                // no thread summary. Reported here in the same shape as the other three
-                // failures so all four read alike.
+            | Program.StartupStepOutcome.Deadlocked (_, stuck) ->
+                // `Program.prepare` raises on this itself, but with no guest identification.
+                // Reported here in the same shape as the other three failures so all four read
+                // alike. As above, `stuck` is already the thread summary.
                 failwith
-                    $"%s{description} deadlocked during startup: no runnable threads and startup has not finished. Stuck: %s{stuck}. Threads: %s{threadSummary startup.State}"
+                    $"%s{description} deadlocked during startup: no runnable threads and startup has not finished. Threads: %s{stuck}"
             // Every remaining outcome yields a new `Startup`, and each costs a step. Counting
             // `PhaseAdvanced` — which retires no guest instruction — is deliberate: it makes the
             // loop bounded by `maxSteps` iterations whatever sequence of outcomes occurs, rather

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -24,6 +24,7 @@
     <Compile Include="TestRealRuntimeOracle.fs" />
     <Compile Include="TestHarness.fs"/>
     <Compile Include="TestBoundedRun.fs" />
+    <Compile Include="TestGuestLocation.fs" />
     <Compile Include="CrossAssemblyHarness.fs" />
     <Compile Include="TestCrossAssemblyOracle.fs" />
     <Compile Include="TypeIdentityTestHelpers.fs" />

--- a/WoofWare.PawPrint/GuestLocation.fs
+++ b/WoofWare.PawPrint/GuestLocation.fs
@@ -1,0 +1,237 @@
+namespace WoofWare.PawPrint
+
+/// <summary>
+/// One frame of a guest thread, described for a developer reading a PawPrint diagnostic.
+/// </summary>
+type GuestFrame =
+    {
+        /// <summary>
+        /// The executing method, as <c>MethodInfo.ToString</c> renders it: <c>Assembly.Type.Method</c>.
+        /// </summary>
+        Method : string
+
+        /// <summary>
+        /// Absolute byte offset into the method's IL, which is the unit a portable PDB's
+        /// sequence points are keyed by.
+        /// </summary>
+        IlOffset : int
+    }
+
+/// <summary>
+/// Where one guest thread is, in the terms a developer asking "why is this stuck?" needs.
+/// </summary>
+/// <remarks>
+/// The three framed cases are distinguished rather than folded into one record with an optional
+/// location because they are answers to different questions, and a caller that conflates them
+/// reports a framework method as though it were the guest's own. Only the shared framework
+/// routinely ships without a PDB, so which case a thread falls into is largely a statement about
+/// whose code the thread is currently inside.
+/// </remarks>
+[<RequireQualifiedAccess>]
+type GuestThreadPosition =
+    /// <summary>
+    /// The thread has no live frame: it is <c>NotStarted</c> or <c>Parked</c>, so no IL has run
+    /// on it and there is nothing to locate.
+    /// </summary>
+    | NoFrame
+
+    /// <summary>
+    /// The active frame, and the source span the compiler attributed to the IL offset it is at.
+    /// </summary>
+    | AtSource of frame : GuestFrame * source : SourceLocation
+
+    /// <summary>
+    /// The active frame has no source attribution — its assembly carries no debug information,
+    /// or the offset falls in IL the compiler marked hidden — but a frame enclosing it does.
+    /// </summary>
+    /// <remarks>
+    /// <paramref name="ancestor" /> is the innermost enclosing frame that has attribution, which
+    /// need not be the immediate caller: <paramref name="framesOut" /> says how far out the walk
+    /// went, and is 1 exactly when it is. The ancestor's offset is its *call site*, not the
+    /// offset it will resume at, so it names the call that led here rather than the instruction
+    /// after it.
+    /// </remarks>
+    | CalledFrom of frame : GuestFrame * framesOut : int * ancestor : GuestFrame * ancestorSource : SourceLocation
+
+    /// <summary>
+    /// Neither the active frame nor any frame enclosing it has source attribution. The ordinary
+    /// outcome for a guest built without a PDB, and for a stack lying entirely within the shared
+    /// framework.
+    /// </summary>
+    | Unattributed of frame : GuestFrame
+
+/// <summary>
+/// Where one guest thread is, together with what it is doing there.
+/// </summary>
+type GuestThreadLocation =
+    {
+        Thread : ThreadId
+        Status : ThreadStatus
+        Position : GuestThreadPosition
+    }
+
+/// <summary>
+/// Locating a guest in its own source, for PawPrint's developer-facing diagnostics.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Strictly a read over existing state, and deliberately not reachable by guest code: this is
+/// what PawPrint tells the person debugging PawPrint, and it may say things — absolute paths from
+/// the machine that built the guest, frame counts — that the real runtime would never expose. The
+/// guest-observable rendering of a stack lives in
+/// <c>IlMachineRuntimeMetadata.renderExceptionStackFrame</c> and is a separate, CoreCLR-shaped
+/// thing; the two must not be unified, because fidelity constrains one and legibility the other.
+/// </para>
+/// <para>
+/// Nothing here may affect execution. It is called from failure paths, so a bug in it would
+/// replace the diagnostic that explains a wedged guest with one about itself; hence the total
+/// lookups and the bounded walk below.
+/// </para>
+/// </remarks>
+[<RequireQualifiedAccess>]
+module GuestLocation =
+
+    let private describeFrame (method : MethodState) (ilOffset : int) : GuestFrame =
+        {
+            Method =
+                string<MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>> method.ExecutingMethod
+            IlOffset = ilOffset
+        }
+
+    /// <summary>
+    /// The source span the compiler attributed to <paramref name="ilOffset" /> in
+    /// <paramref name="method" />, if that method's assembly came with debug information.
+    /// </summary>
+    /// <remarks>
+    /// The <c>MethodDefinitionHandle</c> is a row index scoped to the assembly it came from, so it
+    /// must be resolved against the *declaring type's* assembly and no other; pairing it with any
+    /// other loaded assembly would silently name a different method's lines. A synthesised method
+    /// (a marshalling or delegate stub) has no row at all and so is legitimately unattributable.
+    /// </remarks>
+    let private trySourceOf
+        (state : IlMachineState)
+        (method : MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>)
+        (ilOffset : int)
+        : SourceLocation option
+        =
+        match method.TryMetadata with
+        | None -> None
+        | Some facts ->
+            state.LoadedAssembly method.DeclaringType.Assembly
+            |> Option.bind (fun assy -> assy.TryResolveSourceLocation facts.Handle ilOffset)
+
+    /// <summary>
+    /// Where <paramref name="thread" /> is: its active frame, and — when that frame has no source
+    /// attribution — the innermost frame enclosing it that has.
+    /// </summary>
+    let positionOfThread (state : IlMachineState) (thread : ThreadState) : GuestThreadPosition =
+        // `thread.MethodState` resolves the active frame and throws when there isn't one, which
+        // `NotStarted` and `Parked` threads genuinely have. A guest holding a constructed but
+        // unstarted `Thread` while another thread wedges is entirely ordinary, so reaching for
+        // the frame unconditionally would replace the diagnostic about the guest with one about
+        // this function.
+        if ThreadStatus.hasNoActiveFrame thread.Status then
+            GuestThreadPosition.NoFrame
+        else
+
+        let active = thread.MethodState
+        let activeFrame = describeFrame active active.IlOpIndex
+
+        match trySourceOf state active.ExecutingMethod active.IlOpIndex with
+        | Some source -> GuestThreadPosition.AtSource (activeFrame, source)
+        | None ->
+
+        // Walk outwards for the innermost frame that *does* have attribution. Without this the
+        // answer for a guest blocked in the BCL is a framework method name, which is the case
+        // this whole module exists to improve on: the shared framework ships without PDBs, so
+        // the innermost frame of a stuck guest usually has nothing to say.
+        //
+        // Bounded by the number of live frames. A valid return chain is strictly decreasing in
+        // frame id and so cannot cycle, but this runs on a failure path, where looping forever
+        // would destroy the diagnostic that brought us here rather than merely degrade it.
+        let rec walk (framesOut : int) (frame : MethodState) : GuestThreadPosition =
+            if framesOut > thread.MethodStates.Count then
+                GuestThreadPosition.Unattributed activeFrame
+            else
+
+            match frame.ReturnState with
+            | None -> GuestThreadPosition.Unattributed activeFrame
+            | Some returnState ->
+
+            match ThreadState.tryGetFrame returnState.JumpTo thread with
+            | None -> GuestThreadPosition.Unattributed activeFrame
+            | Some caller ->
+
+            // `CallSiteIlOpIndex`, not the caller's own `IlOpIndex`. The caller's PC really has
+            // advanced past the call while the callee is live (measured: a blocked guest's
+            // `Monitor.Wait` frame sat at 36 with its callee's call site at 31), so the resume PC
+            // is the instruction *after* the call and attributing to it would report the next
+            // statement. `ExceptionDispatching` picks the call site for the same reason.
+            //
+            // No test distinguishes the two, and cannot with the guests we have: the harness
+            // compiles unoptimized, where Roslyn emits a `nop` immediately after each call
+            // statement, so the resume PC stays inside the call's own sequence point and both
+            // offsets resolve to the same line. Substituting `caller.IlOpIndex` here is therefore
+            // a surviving mutant. Pinning it needs an optimized guest or hand-written IL.
+            let callSite = returnState.CallSiteIlOpIndex
+
+            match trySourceOf state caller.ExecutingMethod callSite with
+            | Some source ->
+                GuestThreadPosition.CalledFrom (activeFrame, framesOut, describeFrame caller callSite, source)
+            | None -> walk (framesOut + 1) caller
+
+        walk 1 active
+
+    /// <summary>
+    /// Where every thread that has not terminated is. Terminated threads are omitted: they are
+    /// not why the guest is stuck, and a long-running guest accumulates many of them.
+    /// </summary>
+    let ofState (state : IlMachineState) : GuestThreadLocation list =
+        state.ThreadState
+        |> Map.toList
+        |> List.filter (fun (_, ts) -> ts.Status <> ThreadStatus.Terminated)
+        |> List.map (fun (threadId, ts) ->
+            {
+                Thread = threadId
+                Status = ts.Status
+                Position = positionOfThread state ts
+            }
+        )
+
+    let private renderSource (source : SourceLocation) : string =
+        // The document path exactly as the PDB records it, unshortened: it names the machine
+        // that built the guest, which is information, and two `Program.cs` in different
+        // directories are otherwise indistinguishable. Only the start line is rendered — the
+        // span's end is rarely what a reader wants and doubles the length of every frame.
+        $"%s{source.DocumentPath}:%d{source.StartLine}"
+
+    let private renderFrame (frame : GuestFrame) : string =
+        $"%s{frame.Method} at IL offset %d{frame.IlOffset}"
+
+    let renderThread (location : GuestThreadLocation) : string =
+        let (ThreadId i) = location.Thread
+        let prefix = $"thread %d{i} (%O{location.Status})"
+
+        match location.Position with
+        | GuestThreadPosition.NoFrame -> prefix
+        | GuestThreadPosition.Unattributed frame -> $"%s{prefix} in %s{renderFrame frame}"
+        | GuestThreadPosition.AtSource (frame, source) ->
+            $"%s{prefix} in %s{renderFrame frame} (%s{renderSource source})"
+        | GuestThreadPosition.CalledFrom (frame, framesOut, ancestor, ancestorSource) ->
+            let from =
+                if framesOut = 1 then
+                    "called from"
+                else
+                    // Say how far out, rather than letting "called from" imply the immediate
+                    // caller: the distance is the difference between "the guest called straight
+                    // into this" and "this is buried deep in framework code".
+                    $"called %d{framesOut} frames out from"
+
+            $"%s{prefix} in %s{renderFrame frame}, %s{from} %s{renderFrame ancestor} (%s{renderSource ancestorSource})"
+
+    /// <summary>
+    /// One line per non-terminated thread, joined by <c>"; "</c>: the summary PawPrint prints
+    /// when it gives up on a guest.
+    /// </summary>
+    let describe (state : IlMachineState) : string =
+        ofState state |> List.map renderThread |> String.concat "; "

--- a/WoofWare.PawPrint/GuestLocation.fs
+++ b/WoofWare.PawPrint/GuestLocation.fs
@@ -121,6 +121,50 @@ module GuestLocation =
             |> Option.bind (fun assy -> assy.TryResolveSourceLocation facts.Handle ilOffset)
 
     /// <summary>
+    /// The offset of the instruction immediately before <paramref name="ilOffset" /> in
+    /// <paramref name="method" />, when that instruction is a call. <c>None</c> otherwise.
+    /// </summary>
+    /// <remarks>
+    /// The cross-check that keeps <c>ThreadStatus.parksPastTheBlockingCall</c> honest. That
+    /// classifier knows how a status is reached but not what the frame actually contains, so
+    /// stepping back on its word alone would move the report onto whatever happened to precede
+    /// the PC. Requiring a call there means a misclassified status costs the step-back — which
+    /// is where we started — instead of naming an unrelated instruction.
+    /// </remarks>
+    let private precedingCallOffset
+        (method : MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>)
+        (ilOffset : int)
+        : int option
+        =
+        match MethodInfo.tryIlBody method with
+        | None -> None
+        | Some instructions ->
+
+        let candidate =
+            instructions.Locations
+            |> Map.toSeq
+            |> Seq.filter (fun (offset, _) -> offset < ilOffset)
+            |> Seq.tryLast
+
+        match candidate with
+        | Some (offset, IlOp.UnaryMetadataToken (UnaryMetadataTokenIlOp.Call, _))
+        | Some (offset, IlOp.UnaryMetadataToken (UnaryMetadataTokenIlOp.Calli, _))
+        | Some (offset, IlOp.UnaryMetadataToken (UnaryMetadataTokenIlOp.Callvirt, _)) -> Some offset
+        | Some _
+        | None -> None
+
+    /// <summary>
+    /// The offset in <paramref name="frame" /> that a diagnostic should name: normally the
+    /// program counter, but the blocking call site for a thread parked past one.
+    /// </summary>
+    let private reportableOffset (status : ThreadStatus) (frame : MethodState) : int =
+        if ThreadStatus.parksPastTheBlockingCall status then
+            precedingCallOffset frame.ExecutingMethod frame.IlOpIndex
+            |> Option.defaultValue frame.IlOpIndex
+        else
+            frame.IlOpIndex
+
+    /// <summary>
     /// Where <paramref name="thread" /> is: its active frame, and — when that frame has no source
     /// attribution — the innermost frame enclosing it that has.
     /// </summary>
@@ -135,9 +179,16 @@ module GuestLocation =
         else
 
         let active = thread.MethodState
-        let activeFrame = describeFrame active active.IlOpIndex
 
-        match trySourceOf state active.ExecutingMethod active.IlOpIndex with
+        // Not `active.IlOpIndex`: a thread parked inside a blocking QCall has already advanced
+        // past the call that blocked it, so the raw PC names the statement *after* the one the
+        // guest is stuck on. A frame further out is attributed at its `CallSiteIlOpIndex` for
+        // exactly the same reason; this is that rule applied to the frame whose callee has
+        // already been popped.
+        let activeOffset = reportableOffset thread.Status active
+        let activeFrame = describeFrame active activeOffset
+
+        match trySourceOf state active.ExecutingMethod activeOffset with
         | Some source -> GuestThreadPosition.AtSource (activeFrame, source)
         | None ->
 

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -138,12 +138,11 @@ module Program =
         | Completed of ProgramStartResult
         | Deadlocked of Startup * stuckThreads : string
 
-    let private deadlockDescription (state : IlMachineState) : string =
-        state.ThreadState
-        |> Map.toSeq
-        |> Seq.filter (fun (_, ts) -> ts.Status <> ThreadStatus.Terminated)
-        |> Seq.map (fun (ThreadId i, ts) -> $"thread {i} in state {ts.Status}")
-        |> String.concat "; "
+    /// Where each live thread is, for the deadlock reports below and for every host that
+    /// consumes a `Deadlocked` outcome. The status alone does not locate a guest — every thread
+    /// blocked on a monitor looks alike — so this names the frame each thread is in and, where
+    /// the guest was built with debug information, the source line it is on.
+    let private deadlockDescription (state : IlMachineState) : string = GuestLocation.describe state
 
     /// Discriminator for a fired wait deadline: which subsystem owns the
     /// parked thread, and therefore which `fireTimeout` implementation

--- a/WoofWare.PawPrint/ThreadState.fs
+++ b/WoofWare.PawPrint/ThreadState.fs
@@ -262,6 +262,45 @@ module ThreadStatus =
         | ThreadStatus.BlockedOnWaitHandles _ -> false
         | ThreadStatus.BlockedOnSleep _ -> false
 
+    /// True iff a thread in this status parked with its program counter already advanced
+    /// *past* the call that blocked it, so the active frame's `IlOpIndex` names the
+    /// instruction after the blocking call rather than the call itself.
+    ///
+    /// Every blocking QCall handler advances the caller's PC before parking, so that the
+    /// wake resumes after the call — `Scheduler.blockOnSleep` states that contract and
+    /// notes it is shared by "every other QCall handler that blocks" — and
+    /// `dispatchNative` then pops the native frame on `Completed`. So for these statuses
+    /// the blocking call site is one instruction back, and reporting the raw PC names the
+    /// *next* statement.
+    ///
+    /// `BlockedOnClassInit` is the exception, and for the opposite reason: the dispatcher
+    /// deliberately leaves the native frame on the stack so the handler can be re-entered
+    /// when the `.cctor` lock is released (see `NativeHandlerResult.BlockedOnClassInit`).
+    /// Nothing has been popped and no PC has advanced.
+    ///
+    /// Only diagnostics consume this; nothing about execution may depend on it. Callers
+    /// must still confirm that the preceding instruction really is a call before stepping
+    /// back onto it, because this classifier is a statement about how a status is *reached*
+    /// and cannot see the frame it is asked about.
+    ///
+    /// Fully enumerated, like `hasNoActiveFrame` above, so a new `ThreadStatus` forces an
+    /// answer here rather than silently inheriting one.
+    let parksPastTheBlockingCall (status : ThreadStatus) : bool =
+        match status with
+        | ThreadStatus.NotStarted -> false
+        | ThreadStatus.Parked -> false
+        | ThreadStatus.Runnable -> false
+        | ThreadStatus.Terminated -> false
+        | ThreadStatus.BlockedOnClassInit _ -> false
+        | ThreadStatus.BlockedOnJoin _ -> true
+        | ThreadStatus.BlockedOnMonitorAcquire _ -> true
+        | ThreadStatus.BlockedOnMonitorWait _ -> true
+        | ThreadStatus.BlockedOnSyncBlockAcquire _ -> true
+        | ThreadStatus.BlockedOnSyncBlockWait _ -> true
+        | ThreadStatus.BlockedOnWaitHandle _ -> true
+        | ThreadStatus.BlockedOnWaitHandles _ -> true
+        | ThreadStatus.BlockedOnSleep _ -> true
+
 type ThreadState =
     {
         // TODO: thread-local storage, synchronisation state, exception handling context

--- a/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
+++ b/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
@@ -58,6 +58,7 @@
     <Compile Include="RuntimeConfig.fs" />
     <Compile Include="HostConfig.fs" />
     <Compile Include="IlMachineStateModel.fs" />
+    <Compile Include="GuestLocation.fs" />
     <Compile Include="IlMachineTypeResolution.fs" />
     <Compile Include="SzArrayAllocation.fs" />
     <Compile Include="IlMachineThreadState.fs" />


### PR DESCRIPTION
PR #854 read portable PDB sequence points alongside every assembly and exposed
`DumpedAssembly.TryResolveSourceLocation`, but nothing ever called it — the mechanism was
built, tested, and left unwired, with zero production callers. This feeds it into the
host-side diagnostics, so a guest that wedges or deadlocks is reported at the source line
it is stuck on rather than only by method name and IL offset.

Before:

```
Threads: thread 0 (BlockedOnSyncBlockWait (ManagedHeapAddress 39, None)) in Wait at IL offset 12
```

After:

```
Threads: thread 0 (BlockedOnSyncBlockWait (ManagedHeapAddress 39, None)) in System.Private.CoreLib.Monitor.Wait
  at IL offset 7, called 4 frames out from PawPrintTestAssembly.BlocksInBcl.Main at IL offset 9 (File0.cs:9)
```

## The outward walk

`GuestLocation` classifies each live thread into a `GuestThreadPosition` — `NoFrame` /
`AtSource` / `CalledFrom` / `Unattributed` — and renders it. The cases are distinguished
rather than folded into one record with an optional location because they are answers to
different questions, and a caller that conflates them reports a framework method as though
it were the guest's own.

`CalledFrom` is what the design exists for. The shared framework ships without PDBs, so the
innermost frame of a stuck guest usually has nothing to say; naming only that frame is
useless. The walk goes outwards via `ReturnState.JumpTo` to the innermost frame that *does*
have attribution, and reports how far out it went — "called from" alone would read as the
immediate caller, and a frame buried deep in framework code is a materially different
situation from one the guest called straight into. The walk is bounded by the live frame
count: a valid return chain cannot cycle, but this runs on a failure path, where looping
forever would destroy the diagnostic that brought us there rather than merely degrade it.

## Unifying two renderers

`Program.deadlockDescription` reported thread status alone; `BoundedRun.threadSummary`
reported status plus method plus offset; and the harness printed **both**, the same fact in
two formats. Both now route through `GuestLocation.describe`, so the App's deadlock report
gains source locations too and all four bounded-run failures read alike.

## Not in scope

`renderExceptionStackFrame` is untouched. It is guest-observable via `Exception.StackTrace`
and deliberately CoreCLR-shaped; real .NET *does* append `in File.cs:line N` when symbols are
present, so adding it there is a fidelity question rather than a diagnostics one and belongs
in its own change with its own differential test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)