### PR TITLE
Fan the concurrency sweeps out from a shared fork point

### DIFF
--- a/WoofWare.PawPrint.Test/TestConcurrencyBugs.fs
+++ b/WoofWare.PawPrint.Test/TestConcurrencyBugs.fs
@@ -13,6 +13,15 @@ open WoofWare.PawPrint
 /// range of PCT seeds and asserts at least one of them produces the
 /// targeted bad outcome.
 ///
+/// The sweep does not re-run the whole guest per seed. Everything up to
+/// the first tick at which two threads are Runnable is forced — no policy
+/// has a choice there, so every seed executes it identically — so it is
+/// computed once, under the randomness-free round-robin policy, and each
+/// seed resumes from that snapshot. `Program.resumeFork` makes a resumed
+/// run bit-identical to the from-scratch `PctSeed = Some s` run it
+/// replaces, which `TestScheduleFork` pins over this exact guest corpus.
+/// The prefix is 74-94% of a run's instructions on these guests.
+///
 /// Each guest must encode the invariant violation as a deterministic,
 /// host-visible event: a sentinel exit code from Main, an unhandled
 /// guest exception, a call to Environment.FailFast, or a natural
@@ -109,15 +118,16 @@ module TestConcurrencyBugs =
         | UnhandledException of typeFullName : string * message : string option
         | FailFast of message : string
         | Signal of string
-        /// A worker spawned during a static cctor terminated the
-        /// process before Main got to run. The wrapped string is the
-        /// pre-Main `RunOutcome` collapsed to its textual classifier.
-        | CompletedBeforeMain of summary : string
 
     let private assy = typeof<RunResult>.Assembly
 
     let private dotnetRuntimes : ImmutableArray<string> =
         DotnetRuntime.SelectForDll assy.Location |> ImmutableArray.CreateRange
+
+    /// Everything about the simulated process except which of its schedules
+    /// we are exploring. `Program.runToFirstFork` takes this rather than a
+    /// `HostConfig` precisely so that no seed can reach the shared prefix.
+    let private guestConfig : GuestConfig = GuestConfig.Default dotnetRuntimes
 
     /// Compile the guest once per scenario. PCT sweeps reuse the resulting
     /// image across all seeds; recompiling per seed would dominate the
@@ -176,49 +186,64 @@ module TestConcurrencyBugs =
         | RunOutcome.FailFast (_, _, message) -> RunSummary.FailFast (Option.defaultValue "<no message>" message)
         | RunOutcome.SignalTerminated (_, signal) -> RunSummary.Signal (sprintf "%O" signal)
 
-    /// Run the guest under one PCT seed, returning a host-level summary of
-    /// where it ended up. Drives `Program.stepPrepared` directly instead of
-    /// `Program.run` so that `ProgramStepOutcome.Deadlocked` surfaces as a
-    /// classifier-friendly `RunSummary.Deadlock` rather than the
-    /// `failwith "Deadlock: ..."` that `pumpPrepared` would raise.
-    let private runOne (sourceName : string) (image : byte[]) (seed : uint64) : RunSummary =
+    /// Compute the part of a run that every seed in the sweep shares: everything
+    /// up to the guest's first *contended* scheduling decision.
+    ///
+    /// Every non-forking outcome is a test failure rather than a sweep of size
+    /// one, and deliberately so. A guest with no fork point has no schedule
+    /// space at all, so "PCT exhibits the bad interleaving" would be vacuous
+    /// even if that single forced run happened to match the scenario's
+    /// `BadOutcome` — nothing chose anything, so PCT cannot have found
+    /// anything. Failing here says which of the three ways it went wrong.
+    let private forkOf
+        (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
+        (scenario : Scenario)
+        (image : byte[])
+        : Program.ForkSnapshot
+        =
+        use peImage = new MemoryStream (image)
+
+        match Program.runToFirstFork loggerFactory (Some scenario.SourceName) peImage guestConfig with
+        | Program.PrefixOutcome.ForkedAt snapshot -> snapshot
+        | Program.PrefixOutcome.NeverForked outcome ->
+            // Collapsed to a `RunSummary` rather than rendered directly: a
+            // `RunOutcome` carries an entire `IlMachineState`, so `%A` on it
+            // would render a large chunk of the guest heap into the message.
+            failwith
+                $"%s{scenario.SourceName}: the guest ran to completion (%A{classifyRunOutcome outcome}) without ever having two threads Runnable at the same tick, so no seed can explore anything and the scenario tests nothing. A concurrency-bug guest must start a thread whose lifetime overlaps another's."
+        | Program.PrefixOutcome.DeadlockedBeforeFork stuck ->
+            failwith
+                $"%s{scenario.SourceName}: every thread blocked before any scheduling choice arose (stuck: %s{stuck}), so the guest wedges under every seed rather than under a bad interleaving."
+        | Program.PrefixOutcome.ForkedDuringStartup contenders ->
+            failwith
+                $"%s{scenario.SourceName}: a static initialiser started a thread, so the first contended decision happens during startup (contenders: %A{contenders}) and `Program.runToFirstFork` refuses to snapshot it. Start the guest's threads from Main."
+
+    /// Resume the shared prefix under one PCT seed, returning a host-level
+    /// summary of where the run ended up. Drives `Program.stepPrepared`
+    /// directly instead of `Program.pumpPrepared` so that
+    /// `ProgramStepOutcome.Deadlocked` surfaces as a classifier-friendly
+    /// `RunSummary.Deadlock` rather than the `failwith "Deadlock: ..."` the
+    /// pump would raise.
+    ///
+    /// The factory here is this seed's own: `resumeFork` rebinds the machine's
+    /// logging sink to it, so each seed's trace still carries its own
+    /// `pct_seed` property even though the prefix was logged through the
+    /// sweep's factory.
+    let private runOne (sourceName : string) (snapshot : Program.ForkSnapshot) (seed : uint64) : RunSummary =
         let _messages, loggerFactory =
             LoggerFactory.makeTestWithProperties [ "source_file", sourceName ; "pct_seed", string seed ]
 
         use _loggerFactoryResource = loggerFactory
-        use peImage = new MemoryStream (image)
         let logger = loggerFactory.CreateLogger "TestConcurrencyBugs"
 
-        match
-            Program.prepare
-                loggerFactory
-                (Some sourceName)
-                peImage
-                { HostConfig.Default dotnetRuntimes with
-                    PctSeed = (Some seed)
-                }
-        with
-        | Program.ProgramStartResult.CompletedBeforeMain outcome ->
-            // A worker spawned during a static cctor terminated the process
-            // before Main got to run. For these scenarios that almost
-            // always means the guest accidentally put effectful code into
-            // a type initializer; surface it as a labelled summary rather
-            // than silently treating it as the Main run's outcome. We
-            // collapse the inner `RunOutcome` to its string classifier so
-            // `RunSummary` itself remains equality-safe (the live
-            // `IlMachineState` in `RunOutcome` carries non-equatable
-            // fields like loggers).
-            let inner = classifyRunOutcome outcome
-            RunSummary.CompletedBeforeMain (sprintf "%A" inner)
-        | Program.ProgramStartResult.Ready prepared ->
-            let rec loop (prepared : Program.PreparedProgram) : RunSummary =
-                match Program.stepPrepared loggerFactory logger prepared with
-                | Program.ProgramStepOutcome.Completed outcome -> classifyRunOutcome outcome
-                | Program.ProgramStepOutcome.Deadlocked (_, stuck) -> RunSummary.Deadlock stuck
-                | Program.ProgramStepOutcome.InstructionStepped (p, _, _, _) -> loop p
-                | Program.ProgramStepOutcome.WorkerTerminated (p, _) -> loop p
+        let rec loop (prepared : Program.PreparedProgram) : RunSummary =
+            match Program.stepPrepared loggerFactory logger prepared with
+            | Program.ProgramStepOutcome.Completed outcome -> classifyRunOutcome outcome
+            | Program.ProgramStepOutcome.Deadlocked (_, stuck) -> RunSummary.Deadlock stuck
+            | Program.ProgramStepOutcome.InstructionStepped (p, _, _, _) -> loop p
+            | Program.ProgramStepOutcome.WorkerTerminated (p, _) -> loop p
 
-            loop prepared
+        loop (Program.resumeFork loggerFactory (Some seed) snapshot)
 
     let private matches (bad : BadOutcome) (summary : RunSummary) : bool =
         match bad, summary with
@@ -351,6 +376,22 @@ module TestConcurrencyBugs =
     let private demonstrate (scenario : Scenario) : unit =
         let image = compileImage scenario.SourceName
 
+        // Scoped to the whole sweep, not to the prefix computation:
+        // `Program.resumeFork` documents that the prefix's factory must outlive
+        // every resume, because the loaded assemblies and `BaseClassTypes` were
+        // built against it. Honouring that is cheap and the alternative is
+        // silent: disposing it right after `forkOf` was measured (with
+        // `PAWPRINT_LOG_DIR` set, so the file sinks really are closed) not to
+        // fault any seed, because `resumeFork` rebinds the machine's own sink
+        // and nothing the prefix captured logs again afterwards. So this is a
+        // documented precondition being kept, not a crash being avoided.
+        let _prefixMessages, prefixLoggerFactory =
+            LoggerFactory.makeTestWithProperties [ "source_file", scenario.SourceName ; "run_phase", "shared-prefix" ]
+
+        use _prefixLoggerFactoryResource = prefixLoggerFactory
+
+        let snapshot = forkOf prefixLoggerFactory scenario image
+
         // Sweep seeds lazily and stop at the first match. The wider the
         // default sweep grows (currently 4096), the more important this
         // is: walking the whole list would dominate the test budget when
@@ -360,11 +401,15 @@ module TestConcurrencyBugs =
         // the predicate on multiple threads concurrently, so the
         // diagnostic store must be thread-safe — a `ResizeArray.Add`
         // here races and can drop or duplicate entries (or, worse, throw
-        // out of `EnsureCapacity`), corrupting the failure diagnostic.
+        // out of `EnsureCapacity`), corrupting the failure diagnostic. The
+        // one `snapshot` is read by all of those threads at once; that is
+        // sound because everything reachable from it is persistent F# data
+        // or shared-by-design `MetadataReader` assemblies, and
+        // `TestScheduleFork` machine-checks it rather than assuming it.
         let visited = ConcurrentBag<uint64 * RunSummary> ()
 
         let visit (seed : uint64) : bool =
-            let summary = runOne scenario.SourceName image seed
+            let summary = runOne scenario.SourceName snapshot seed
             visited.Add (seed, summary)
             matches scenario.Bad summary
 

--- a/WoofWare.PawPrint.Test/TestRaces.fs
+++ b/WoofWare.PawPrint.Test/TestRaces.fs
@@ -22,6 +22,11 @@ module TestRaces =
     let private dotnetRuntimes : ImmutableArray<string> =
         DotnetRuntime.SelectForDll assy.Location |> ImmutableArray.CreateRange
 
+    /// Everything about the simulated process except which of its schedules we
+    /// are exploring. Naming it separately from `HostConfig` is what lets the
+    /// seed-independent prefix of a sweep be computed without a seed in scope.
+    let private guestConfig : GuestConfig = GuestConfig.Default dotnetRuntimes
+
     /// Extract the guest's exit code from a completed run. Fails the test
     /// loudly on any non-normal exit: FailFast / signal / unhandled exception
     /// under a race test would indicate either a corrupted interpreter state
@@ -45,24 +50,6 @@ module TestRaces =
         | RunOutcome.GuestUnhandledException (_, _, exn) ->
             failwith $"%s{sourceName} (seed=%A{seed}) threw unhandled exception: %O{exn.ExceptionObject}"
 
-    /// Run `image` through PawPrint with the given scheduler seed and return
-    /// the guest's exit code.
-    let private runPawPrint (sourceName : string) (image : byte[]) (seed : uint64 option) : int =
-        let _messages, loggerFactory =
-            LoggerFactory.makeTestWithProperties [ "source_file", sourceName ]
-
-        use _loggerFactoryResource = loggerFactory
-        use peImage = new MemoryStream (image)
-
-        Program.run
-            loggerFactory
-            (Some sourceName)
-            peImage
-            { HostConfig.Default dotnetRuntimes with
-                PctSeed = seed
-            }
-        |> exitCodeOfOutcome sourceName seed
-
     /// Run `image` through the real .NET runtime once. Fails the test on
     /// unhandled exception. The host's threading and memory ordering pin
     /// the schedule, so this is not a coverage probe — it's a sanity that
@@ -79,9 +66,65 @@ module TestRaces =
     // Seed sweep used to characterise PCT coverage. The first 30 splitmix64
     // outputs already hit both interleavings of ReadWriteRace; running 64
     // gives a generous margin for future races whose rarer interleavings
-    // might land deeper in the seed stream, while still completing in
-    // about a second on the existing test machine.
+    // might land deeper in the seed stream. Widening it is cheap: the seeds
+    // share their prefix (see `sweepPctExitCodes`), so an extra seed costs
+    // only the post-fork suffix of a run.
     let private pctSeedSweep : uint64 list = [ 0UL .. 63UL ]
+
+    /// Sweep `pctSeedSweep` over one guest and return the set of exit codes
+    /// observed.
+    ///
+    /// Everything up to the guest's first *contended* scheduling decision is
+    /// forced — no policy has a choice there, so every seed executes it
+    /// identically — so it is computed once under the randomness-free
+    /// round-robin policy and each seed resumes from the snapshot.
+    /// `Program.resumeFork` makes such a run bit-identical to the from-scratch
+    /// `PctSeed = Some s` run it replaces, which `TestScheduleFork` pins
+    /// directly for both guests swept here; the exact-coverage assertions below
+    /// are a second, independent check, since they are sensitive to the whole
+    /// seed-to-schedule mapping.
+    ///
+    /// A guest that never forks fails rather than answering the sweep in one
+    /// run: these tests characterise the outcomes a *race* can produce, and a
+    /// guest with no schedule space has no race left to characterise.
+    let private sweepPctExitCodes (sourceName : string) (image : byte[]) : Set<int> =
+        // Scoped to the whole sweep: `Program.resumeFork` documents that the
+        // prefix's factory must outlive every resume, since the loaded
+        // assemblies and `BaseClassTypes` were built against it. See
+        // `TestConcurrencyBugs.demonstrate` for why that is a precondition kept
+        // rather than a crash avoided.
+        let _prefixMessages, prefixLoggerFactory =
+            LoggerFactory.makeTestWithProperties [ "source_file", sourceName ; "run_phase", "shared-prefix" ]
+
+        use _prefixLoggerFactoryResource = prefixLoggerFactory
+
+        let snapshot =
+            use peImage = new MemoryStream (image)
+
+            match Program.runToFirstFork prefixLoggerFactory (Some sourceName) peImage guestConfig with
+            | Program.PrefixOutcome.ForkedAt snapshot -> snapshot
+            | Program.PrefixOutcome.NeverForked _ ->
+                failwith
+                    $"%s{sourceName} ran to completion without ever having two threads Runnable at the same tick, so every seed produces the same execution and the sweep characterises nothing."
+            | Program.PrefixOutcome.DeadlockedBeforeFork stuck ->
+                failwith $"%s{sourceName} wedged before any scheduling choice arose; stuck threads: %s{stuck}"
+            | Program.PrefixOutcome.ForkedDuringStartup contenders ->
+                failwith
+                    $"%s{sourceName} first contends during startup (contenders: %A{contenders}), which `Program.runToFirstFork` refuses to snapshot; the race is supposed to be between two threads inside Main."
+
+        pctSeedSweep
+        |> List.map (fun seed ->
+            let _messages, loggerFactory =
+                LoggerFactory.makeTestWithProperties [ "source_file", sourceName ; "pct_seed", string seed ]
+
+            use _loggerFactoryResource = loggerFactory
+            let logger = loggerFactory.CreateLogger "TestRaces"
+
+            Program.resumeFork loggerFactory (Some seed) snapshot
+            |> Program.pumpPrepared loggerFactory logger
+            |> exitCodeOfOutcome sourceName (Some seed)
+        )
+        |> Set.ofList
 
     /// The complete set of legal exit codes for ReadWriteRace.cs:
     ///   * 0 — Main reads `x` before the worker's `x = 1` runs (the
@@ -119,11 +162,7 @@ module TestRaces =
         // rather than passing silently as "well, it covered 0 and 1, so
         // who cares about the extras."
         let image = compileImage "ReadWriteRace.cs"
-
-        let observed =
-            pctSeedSweep
-            |> List.map (fun seed -> runPawPrint "ReadWriteRace.cs" image (Some seed))
-            |> Set.ofList
+        let observed = sweepPctExitCodes "ReadWriteRace.cs" image
 
         if observed <> readWriteRaceLegalOutcomes then
             let missing = Set.difference readWriteRaceLegalOutcomes observed
@@ -197,11 +236,7 @@ module TestRaces =
         // has to re-execute its `newobj` correctly, under every interleaving
         // PCT reaches, not merely under the default round-robin.
         let image = compileImage "NewobjCctorRace.cs"
-
-        let observed =
-            pctSeedSweep
-            |> List.map (fun seed -> runPawPrint "NewobjCctorRace.cs" image (Some seed))
-            |> Set.ofList
+        let observed = sweepPctExitCodes "NewobjCctorRace.cs" image
 
         if observed <> newobjCctorRaceLegalOutcomes then
             let missing = Set.difference newobjCctorRaceLegalOutcomes observed

--- a/WoofWare.PawPrint.Test/TestScheduleFork.fs
+++ b/WoofWare.PawPrint.Test/TestScheduleFork.fs
@@ -181,7 +181,12 @@ module TestScheduleFork =
         | Program.PrefixOutcome.ForkedAt snapshot -> snapshot
         | other -> failwith $"%s{sourceName} was expected to reach a fork point, but: %A{other}"
 
-    /// Guests that reach a fork point, each chosen for a distinct shape of prefix.
+    /// Guests that reach a fork point, each chosen for a distinct shape of prefix — plus the
+    /// whole `sourcesConcurrencyBugs` corpus, because `TestConcurrencyBugs` and `TestRaces` now
+    /// fan their seed sweeps out from a fork snapshot rather than re-running the guest per seed.
+    /// Those sweeps cannot check the fanout themselves: they assert only that *some* seed finds
+    /// the bug, which a resume exploring a subtly different schedule space would still satisfy.
+    /// So the commuting square has to be pinned here, over exactly the guests they sweep.
     let private forkingGuests : string list =
         [
             // Two threads racing on a shared int: the plainest fork there is.
@@ -194,16 +199,36 @@ module TestScheduleFork =
             // Sleeps while single-threaded, so the prefix contains a jump-to-deadline inside a
             // tick preamble — the phase a fork detector probing the inter-tick state would miss.
             "ForkAfterSoloSleep.cs"
+
+            // The `TestConcurrencyBugs` corpus. These bring the only endings other than "exit n"
+            // that this fixture sees: `SimultaneousCounter` throws under some of the seeds below
+            // and `InvertedMonitorDeadlock` wedges under seed 17, so between them they pin that a
+            // resumed run reproduces an *ending*, not merely a matching exit code. Which seed
+            // produces which ending was measured, not assumed — see the comment on `seeds`.
+            "LostUpdate.cs"
+            "JustABoolNotAMutex.cs"
+            "TwoCountersSeparated.cs"
+            "SimultaneousCounter.cs"
+            "InvertedMonitorDeadlock.cs"
+            "QueueIsNotThreadSafe.cs"
         ]
 
     /// Fixed rather than randomly generated, so a failure is reproducible without a shrink
     /// report, but drawn from across the whole `uint64` range rather than from 0..n: the RNG is
     /// splitmix64 over a 64-bit state, and small seeds exercise only one corner of it.
+    ///
+    /// 17 is the exception, and is here for a measured reason rather than for spread. Without it
+    /// every guest in the corpus ends every one of these runs in `exit n` or a thrown exception,
+    /// so `traceFrom`'s deadlock arm — and with it the claim that a resumed run reproduces a
+    /// *wedge* identically, which `TestConcurrencyBugs`' `BadOutcome.Deadlock` scenario rests on —
+    /// would never execute. 17 is the lowest seed under which `InvertedMonitorDeadlock.cs`
+    /// actually deadlocks (found by scanning 0..200; 131 and 137 also do).
     let private seeds : uint64 list =
         [
             0UL
             1UL
             7UL
+            17UL
             0xC0FFEEUL
             0xDEADBEEFCAFEBABEUL
             0xFFFFFFFFFFFFFFFFUL

--- a/docs/plans/2026-08-10-fork-point-snapshots.md
+++ b/docs/plans/2026-08-10-fork-point-snapshots.md
@@ -1,8 +1,7 @@
 # Plan: share the machine state up to the first fork point
 
-Status: **all three PRs implemented.** §3.7 and §5.7 record where implementation contradicted the
-plan. The remaining work is stage 4 — rewiring `TestConcurrencyBugs` / `TestRaces` to fan out from
-a shared fork point — which this plan describes but does not yet cover in detail.
+Status: **complete.** All four stages are implemented; §3.7, §5.7 and §7.1 record where
+implementation contradicted the plan.
 
 Goal: when sweeping many PCT seeds over one guest, compute the single-threaded prefix *once* and
 fan every seed out from it.
@@ -399,7 +398,8 @@ should keep taking the runtime dirs and returning a whole `HostConfig`, so the c
   (`Program.fs:961`) stay the prefix's; document that the prefix factory must outlive every
   resume. The sweeps' per-seed `use _loggerFactoryResource` (`TestConcurrencyBugs.fs:188`) means
   the prefix factory must be scoped to the whole sweep; disposal-after-share fails with
-  `ObjectDisposedException`, which is loud enough.
+  `ObjectDisposedException`, which is loud enough. **That last clause is false**: stage 4 mutated
+  it and nothing failed. See §7.1.
 * **Sharing across parallel resumes is not a new exposure class.** The sweeps use
   `Array.Parallel` (`TestConcurrencyBugs.fs:359`), and everything reachable from the snapshot is
   persistent F# data or `ImmutableDictionary`; `DumpedAssembly` values are *already* shared across
@@ -557,11 +557,80 @@ Fable proposed two PRs, I proposed four; the difference was mostly the now-dropp
    logic.
 3. **`ForkSnapshot` + the fork runner — done.** §5.2, §5.7 and properties P1, P4, P5, P6, plus the
    constructed preamble-contention test of §6.1.
-4. **Rewire the sweeps.** `TestConcurrencyBugs` and `TestRaces` fan out from a shared fork point;
-   report the measured speedup against §1. Still to do, and the only stage with a user-visible
-   payoff — everything before it is the machinery that makes the payoff correct.
+4. **Rewire the sweeps — done.** `TestConcurrencyBugs` and `TestRaces` fan out from a shared fork
+   point. The only stage with a user-visible payoff — everything before it is the machinery that
+   makes the payoff correct. See §7.1.
 
 PR 1 is the one to review hardest.
+
+### 7.1 What stage 4 shipped, and what it measured
+
+**The payoff (P7).** `dotnet test --filter "FullyQualifiedName~TestConcurrencyBugs|FullyQualifiedName~TestRaces"`,
+same machine, same command, before and after:
+
+| test case | before | after |
+|---|---|---|
+| `QueueIsNotThreadSafe.cs` | 52 s | 7 s |
+| `TwoCountersSeparated.cs` | 49 s | 4 s |
+| `LostUpdate.cs` | 38 s | 2 s |
+| `InvertedMonitorDeadlock.cs` | 15 s | 0.8 s |
+| `JustABoolNotAMutex.cs` | 10 s | 6 s |
+| `SimultaneousCounter.cs` | 1 s | 0.7 s |
+| `ReadWriteRace under PCT covers every legal outcome` | 4 s | 0.15 s |
+| `NewobjCctorRace under PCT covers every legal outcome` | 5 s | 1.0 s |
+| **whole filter, wall clock** | **68 s** | **12 s** |
+
+Read the per-case column as indicative only: NUnit runs these cases concurrently, so each one's
+wall time depends on what else was in flight, and the sweeps short-circuit on the first matching
+seed — which is not the same seed, nor the same *number* of seeds, from run to run, because
+`Array.Parallel.tryFind` does not visit in index order. The whole-filter figure is the honest one.
+5.7× against §1's predicted ceiling of 4–16× (74–94% of instructions shared) is where it should be.
+
+**Where the correctness lives.** The sweeps cannot check their own fanout: they assert that *some*
+seed finds the bug, which a resume exploring a subtly different schedule space would still satisfy.
+So `TestScheduleFork`'s `forkingGuests` corpus was widened from 4 guests to all 10 — the four
+prefix-shape guests plus the whole `TestConcurrencyBugs` corpus — which puts P1's commuting square
+(full post-fork decision trace, per seed) over exactly the guests the sweeps now fan out over.
+`TestRaces`' exact-outcome-coverage assertions are a second, independent check, being sensitive to
+the whole seed-to-schedule mapping; they did not move.
+
+Widening the corpus also exposed a hole in the fixture that predates this stage. The comment first
+written for the new guests claimed they brought endings other than `exit n`; dumping the actual
+endings across the seed set showed that was half true. `SimultaneousCounter` does throw, but
+*nothing* in the fixture deadlocked under any seed — so `traceFrom`'s deadlock arm never ran, and
+the claim that a resumed run reproduces a *wedge* identically (which `BadOutcome.Deadlock` in
+`TestConcurrencyBugs` rests on entirely) was untested. Scanning 0..200 found seed 17 as the lowest
+under which `InvertedMonitorDeadlock.cs` actually deadlocks; it was added to `seeds` for that
+measured reason rather than for spread, and the comment there says so. Worth recording as a general
+lesson: "this corpus covers ending X" is a claim about the seeds too, and the seeds were chosen
+before these guests existed.
+
+**Non-forking outcomes are failures, not sweeps of size one.** §5.3 framed `NeverForked` as "a
+4096-seed sweep answered by one run", and for a general harness it is. Both of these fixtures
+refuse it instead, along with `DeadlockedBeforeFork` and `ForkedDuringStartup`, because their claim
+is about *schedules*: a guest with no fork point has no schedule space, so "PCT exhibits the bad
+interleaving" is vacuous even when that single forced run happens to match the scenario's
+`BadOutcome`. Each arm names what went wrong and what to do about it. This also retires
+`RunSummary.CompletedBeforeMain`, whose job — flagging a guest that put effectful code in a type
+initialiser — is now done more precisely by `ForkedDuringStartup` and by `NeverForked`.
+
+**Mutants, and the one that survived:**
+
+| mutant | killed by |
+|---|---|
+| `runOne` resumes with `None` rather than `Some seed` | 5 of the 6 `TestConcurrencyBugs` scenarios (`SimultaneousCounter` survives, since round-robin alone reaches its bad outcome) |
+| point a scenario at a single-threaded guest | the `NeverForked` arm of `forkOf`, with the exact diagnostic |
+| point `sweepPctExitCodes` at a single-threaded guest | the `NeverForked` arm there |
+| **dispose the prefix's `ILoggerFactory` immediately after `runToFirstFork`** | **nothing** |
+
+That last one falsifies §5.5. The plan asserted that disposing the shared factory before the
+resumes "fails with `ObjectDisposedException`, which is loud enough". It does not: measured with
+`PAWPRINT_LOG_DIR` set, so the JSONL sinks really are closed, all six scenarios still pass.
+`resumeFork` rebinds the machine's own sink per seed, and nothing the prefix captured logs again
+afterwards. The factory is still scoped to the whole sweep — `resumeFork`'s docstring makes that a
+precondition and it costs nothing to keep — but it is a documented precondition being honoured, not
+a crash being avoided, and the comment at the call site says so. Had this gone unmeasured, a future
+reader would have trusted a safety net that is not there.
 
 ## 8. Open questions
 


### PR DESCRIPTION
Stage 4 of `docs/plans/2026-08-10-fork-point-snapshots.md`, and the only stage with a user-visible payoff — everything before it was the machinery that makes the payoff correct. The plan is marked complete.

## The payoff

`TestConcurrencyBugs` and `TestRaces` now compute each guest's forced prefix **once**, via `Program.runToFirstFork` under the randomness-free round-robin policy, and resume every seed from that snapshot instead of re-running the whole guest.

Same `dotnet test --filter` command, before and after:

| test case | before | after |
|---|---|---|
| `QueueIsNotThreadSafe.cs` | 52 s | 7 s |
| `TwoCountersSeparated.cs` | 49 s | 4 s |
| `LostUpdate.cs` | 38 s | 2 s |
| `InvertedMonitorDeadlock.cs` | 15 s | 0.8 s |
| `JustABoolNotAMutex.cs` | 10 s | 6 s |
| `SimultaneousCounter.cs` | 1 s | 0.7 s |
| `ReadWriteRace under PCT covers every legal outcome` | 4 s | 0.15 s |
| `NewobjCctorRace under PCT covers every legal outcome` | 5 s | 1.0 s |
| **whole filter, wall clock** | **68 s** | **12 s** |

Read the per-case column as indicative only: NUnit runs these concurrently, so each one's wall time depends on what else was in flight, and the sweeps short-circuit on the first matching seed — which is not the same seed, nor the same *number* of seeds, run to run, since `Array.Parallel.tryFind` does not visit in index order. The whole-filter figure is the honest one. 5.7× against §1's predicted 4–16× ceiling (74–94% of instructions shared) is where it should be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
