### PR TITLE
Annotate interpreter failures with where the guest was

### DIFF
--- a/WoofWare.PawPrint.Test/TestGuestFailure.fs
+++ b/WoofWare.PawPrint.Test/TestGuestFailure.fs
@@ -10,12 +10,12 @@ open WoofWare.PawPrint
 
 /// PawPrint has ~2,400 `failwith` sites and almost none of them can say where the guest was:
 /// the most context-free of all live in pure helpers (`convOvfI4Un`, `divUnValues`) that have no
-/// `IlMachineState` to consult. Rather than thread state into all of them, `executeOneStep`
-/// annotates whatever escapes it — so every one of those sites gains a guest location at once.
+/// `IlMachineState` to consult. Rather than thread state into all of them, `Program.stepDecided`
+/// annotates whatever escapes a tick — so every one of those sites gains a guest location at once.
 ///
-/// These tests pin the three properties that make the annotation safe to apply that broadly: it
-/// must add information without destroying any, it must not fire twice, and it must never
-/// replace the failure it is describing.
+/// These tests pin the properties that make the annotation safe to apply that broadly: it must
+/// add information without destroying any, it must not fire twice, it must cover the whole tick
+/// rather than only the instruction, and it must never replace the failure it is describing.
 [<TestFixture>]
 [<Parallelizable(ParallelScope.All)>]
 module TestGuestFailure =
@@ -116,8 +116,8 @@ class CallsMissingNative
             failure.InnerException.StackTrace |> shouldContainText "WoofWare.PawPrint"
         | other -> failwith $"expected a GuestFailureException, got %s{other.GetType().FullName}"
 
-    /// `executeOneStep` must not annotate an already-annotated failure. Without the guard, a
-    /// re-entrant step would nest wrappers and repeat the thread summary once per level.
+    /// A tick must not annotate an already-annotated failure. Without the guard, a nested tick
+    /// would nest wrappers and repeat the thread summary once per level.
     [<Test>]
     let ``the annotation is applied exactly once`` () : unit =
         let exn = runToFailure "CallsMissingNative.cs" callsMissingNative
@@ -130,6 +130,42 @@ class CallsMissingNative
                 exn.Message.Split ([| "Guest was:" |], StringSplitOptions.None) |> Array.length
 
             occurrences |> shouldEqual 2
+        | other -> failwith $"expected a GuestFailureException, got %s{other.GetType().FullName}"
+
+    /// Not every guest-provoked failure comes from executing an instruction. Scheduler
+    /// bookkeeping runs on either side of one — `chooseNext` before, `dischargeYieldDebts`,
+    /// `onStepOutcome` and `onThreadTerminated` after — and `onThreadTerminated` refusing a
+    /// worker that exited still holding a SyncBlock is as much a statement about the guest as
+    /// any opcode failure. Annotating only `executeOneStep` would miss all of these, which is
+    /// why the boundary is the whole tick.
+    [<Test>]
+    let ``a failure in post-step scheduler bookkeeping is annotated too`` () : unit =
+        let source =
+            """
+using System.Threading;
+
+class AbandonsALock
+{
+    static readonly object Gate = new object();
+
+    static int Main()
+    {
+        var t = new Thread(() => { Monitor.Enter(Gate); }); // ABANDONS
+        t.Start();
+        t.Join();
+        return 0;
+    }
+}
+"""
+
+        let exn = runToFailure "AbandonsALock.cs" source
+
+        // The failure is raised by `Scheduler.onThreadTerminated`, after `executeOneStep` has
+        // returned the worker's final `Ret` perfectly happily.
+        exn.Message |> shouldContainText "terminated while still holding"
+
+        match exn with
+        | :? GuestFailureException as failure -> failure.Guest |> shouldNotEqual []
         | other -> failwith $"expected a GuestFailureException, got %s{other.GetType().FullName}"
 
     /// The structured location is the reason this is an exception type rather than a string

--- a/WoofWare.PawPrint.Test/TestGuestFailure.fs
+++ b/WoofWare.PawPrint.Test/TestGuestFailure.fs
@@ -1,0 +1,155 @@
+namespace WoofWare.PawPrint.Test
+
+open System
+open System.Collections.Immutable
+open System.IO
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.DotnetRuntimeLocator
+open WoofWare.PawPrint
+
+/// PawPrint has ~2,400 `failwith` sites and almost none of them can say where the guest was:
+/// the most context-free of all live in pure helpers (`convOvfI4Un`, `divUnValues`) that have no
+/// `IlMachineState` to consult. Rather than thread state into all of them, `executeOneStep`
+/// annotates whatever escapes it — so every one of those sites gains a guest location at once.
+///
+/// These tests pin the three properties that make the annotation safe to apply that broadly: it
+/// must add information without destroying any, it must not fire twice, and it must never
+/// replace the failure it is describing.
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestGuestFailure =
+
+    let private assy = typeof<RunResult>.Assembly
+
+    /// A guest that reaches a native entry point PawPrint does not implement. `failUnimplemented`
+    /// is the single most common way PawPrint fails in practice, and its message names the
+    /// missing native but nothing about the guest that wanted it.
+    let private callsMissingNative =
+        """
+using System.Runtime.InteropServices;
+
+class CallsMissingNative
+{
+    [DllImport("libSystem.Native", EntryPoint = "SystemNative_PawPrintDoesNotImplementThis")]
+    private static extern int Missing();
+
+    static int Main()
+    {
+        return Missing(); // CALL SITE
+    }
+}
+"""
+
+    let private lineContaining (marker : string) (source : string) : int =
+        let lines = source.Replace("\r\n", "\n").Split '\n'
+
+        match
+            lines
+            |> Array.mapi (fun i l -> i, l)
+            |> Array.filter (fun (_, l) -> l.Contains marker)
+        with
+        | [| (i, _) |] -> i + 1
+        | [||] -> failwith $"guest source contains no line matching %s{marker}; the test's oracle is broken"
+        | many ->
+            failwith $"guest source has %d{many.Length} lines matching %s{marker}, so the expected line is ambiguous"
+
+    let private runToFailure (name : string) (source : string) : exn =
+        let image = Roslyn.compileWithSymbols [ source ]
+
+        let _messages, loggerFactory =
+            LoggerFactory.makeTestWithProperties [ "source_file", name ]
+
+        use _loggerFactoryResource = loggerFactory
+
+        let dotnetRuntimes =
+            DotnetRuntime.SelectForDll assy.Location |> ImmutableArray.CreateRange
+
+        use peImage = new MemoryStream (image)
+
+        // `Assert.Catch`, not `Assert.Throws`: the latter is an *exact* type constraint, so it
+        // rejects the `GuestFailureException` subclass these tests exist to inspect. Each test
+        // below asserts the type it wants for itself.
+        Assert.Catch (fun () ->
+            BoundedRun.runWith
+                loggerFactory
+                BoundedRun.defaultMaxSteps
+                name
+                (Some name)
+                peImage
+                (HostConfig.Default dotnetRuntimes)
+            |> ignore<RunOutcome>
+        )
+
+    [<Test>]
+    let ``a failure inside a step names the guest code that provoked it`` () : unit =
+        let exn = runToFailure "CallsMissingNative.cs" callsMissingNative
+        let callSite = lineContaining "// CALL SITE" callsMissingNative
+
+        // The point of the whole exercise: "which native is missing" plus "who asked for it".
+        exn.Message |> shouldContainText "SystemNative_PawPrintDoesNotImplementThis"
+        exn.Message |> shouldContainText "PawPrintTestAssembly.CallsMissingNative.Main"
+        exn.Message |> shouldContainText $"File0.cs:%d{callSite}"
+
+    /// Annotation must be purely additive. A wrapper that swallowed the original text would
+    /// trade a message that says what went wrong for one that says only where.
+    [<Test>]
+    let ``the original failure message survives verbatim`` () : unit =
+        let exn = runToFailure "CallsMissingNative.cs" callsMissingNative
+
+        match exn with
+        | :? GuestFailureException as failure ->
+            failure.InnerException |> shouldNotEqual null
+            exn.Message |> shouldContainText failure.InnerException.Message
+        | other -> failwith $"expected a GuestFailureException, got %s{other.GetType().FullName}"
+
+    /// The inner exception is the only thing carrying the *host* stack trace — where in PawPrint's
+    /// own source the `failwith` was. Losing it would trade a PawPrint-side diagnostic for a
+    /// guest-side one, when the whole point is to have both.
+    [<Test>]
+    let ``the host stack trace is preserved on the inner exception`` () : unit =
+        let exn = runToFailure "CallsMissingNative.cs" callsMissingNative
+
+        match exn with
+        | :? GuestFailureException as failure ->
+            failure.InnerException.StackTrace |> shouldNotEqual null
+            failure.InnerException.StackTrace |> shouldContainText "WoofWare.PawPrint"
+        | other -> failwith $"expected a GuestFailureException, got %s{other.GetType().FullName}"
+
+    /// `executeOneStep` must not annotate an already-annotated failure. Without the guard, a
+    /// re-entrant step would nest wrappers and repeat the thread summary once per level.
+    [<Test>]
+    let ``the annotation is applied exactly once`` () : unit =
+        let exn = runToFailure "CallsMissingNative.cs" callsMissingNative
+
+        match exn with
+        | :? GuestFailureException as failure ->
+            failure.InnerException :? GuestFailureException |> shouldEqual false
+
+            let occurrences =
+                exn.Message.Split ([| "Guest was:" |], StringSplitOptions.None) |> Array.length
+
+            occurrences |> shouldEqual 2
+        | other -> failwith $"expected a GuestFailureException, got %s{other.GetType().FullName}"
+
+    /// The structured location is the reason this is an exception type rather than a string
+    /// concatenation: the App, the debugger and the harness each want to render it differently.
+    [<Test>]
+    let ``the location is carried as data, not only as text`` () : unit =
+        let exn = runToFailure "CallsMissingNative.cs" callsMissingNative
+
+        match exn with
+        | :? GuestFailureException as failure ->
+            failure.Guest |> shouldNotEqual []
+
+            // The failing thread is present and located, not merely counted.
+            failure.Guest
+            |> List.exists (fun t ->
+                match t.Position with
+                | GuestThreadPosition.AtSource _
+                | GuestThreadPosition.CalledFrom _ -> true
+                | GuestThreadPosition.NoFrame
+                | GuestThreadPosition.Unattributed _ -> false
+            )
+            |> shouldEqual true
+        | other -> failwith $"expected a GuestFailureException, got %s{other.GetType().FullName}"

--- a/WoofWare.PawPrint.Test/TestPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestPureCases.fs
@@ -271,8 +271,12 @@ public class Program
 }
 """
 
+        // `Assert.Catch`, not `Assert.Throws`, here and in the two tests below: `Assert.Throws` is
+        // an *exact* type constraint, and a failure raised while interpreting now arrives as
+        // `GuestFailureException` carrying the guest's position. These tests are about the
+        // message, not the type, so the looser assertion is the one that says what they mean.
         let exn =
-            Assert.Throws (fun () ->
+            Assert.Catch (fun () ->
                 runPawPrintSource "CalliPunnedReturn.cs" source KernelConfig.Default (fun _image _result -> ())
             )
 
@@ -301,7 +305,7 @@ public class Program
 """
 
         let exn =
-            Assert.Throws (fun () ->
+            Assert.Catch (fun () ->
                 runPawPrintSource "CalliPunnedParameter.cs" source KernelConfig.Default (fun _image _result -> ())
             )
 
@@ -339,7 +343,7 @@ public class Program
 """
 
         let exn =
-            Assert.Throws (fun () ->
+            Assert.Catch (fun () ->
                 runPawPrintSource "CalliPunnedFloatWidth.cs" source KernelConfig.Default (fun _image _result -> ())
             )
 

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -25,6 +25,7 @@
     <Compile Include="TestHarness.fs"/>
     <Compile Include="TestBoundedRun.fs" />
     <Compile Include="TestGuestLocation.fs" />
+    <Compile Include="TestGuestFailure.fs" />
     <Compile Include="CrossAssemblyHarness.fs" />
     <Compile Include="TestCrossAssemblyOracle.fs" />
     <Compile Include="TypeIdentityTestHelpers.fs" />

--- a/WoofWare.PawPrint/AbstractMachine.fs
+++ b/WoofWare.PawPrint/AbstractMachine.fs
@@ -19,7 +19,7 @@ module AbstractMachine =
     let private logger (loggerFactory : ILoggerFactory) : ILogger =
         loggerCache.GetValue (loggerFactory, fun f -> f.CreateLogger typeof<Dummy>.DeclaringType)
 
-    let private executeOneStepCore
+    let executeOneStep
         (loggerFactory : ILoggerFactory)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (state : IlMachineState)
@@ -349,53 +349,3 @@ module AbstractMachine =
         | IlOp.UnaryStringToken (unaryStringTokenIlOp, stringHandle) ->
             UnaryStringTokenIlOp.execute loggerFactory baseClassTypes unaryStringTokenIlOp stringHandle state thread
             |> ExecutionResult.stepped
-
-    /// <summary>
-    /// Where each live guest thread is, or <c>None</c> if that cannot be determined.
-    /// </summary>
-    /// <remarks>
-    /// Total by construction. This runs only while an exception is already propagating, so a
-    /// failure here would replace the diagnostic PawPrint is trying to deliver with one about the
-    /// diagnostic machinery — the single worst outcome available. <c>GuestLocation</c> is written
-    /// to be total for exactly this reason; the guard is the belt to its braces.
-    /// </remarks>
-    let private tryDescribeGuest (state : IlMachineState) : GuestThreadLocation list option =
-        try
-            Some (GuestLocation.ofState state)
-        with _ ->
-            None
-
-    /// <summary>
-    /// Interpret one IL instruction on <paramref name="thread" />.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Any host failure escaping the interpreter is annotated with where the guest was, as a
-    /// <c>GuestFailureException</c>. Doing it here rather than at the ~2,400 individual
-    /// <c>failwith</c> sites is what makes the annotation universal: the least informative
-    /// messages of all come from pure helpers inside the opcode implementations, which have no
-    /// <c>IlMachineState</c> to consult and should not grow one just to describe a failure.
-    /// </para>
-    /// <para>
-    /// The state described is the one this step *started* from. The failure happened partway
-    /// through, so there is no consistent later state to report — and the instruction about to
-    /// execute is what a reader wants to know anyway.
-    /// </para>
-    /// </remarks>
-    let executeOneStep
-        (loggerFactory : ILoggerFactory)
-        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
-        (state : IlMachineState)
-        (thread : ThreadId)
-        : ExecutionResult
-        =
-        try
-            executeOneStepCore loggerFactory baseClassTypes state thread
-        with
-        // Already annotated: a nested step would otherwise repeat the thread summary once per
-        // level, and the outermost frame's guest position is the least specific of them.
-        | :? GuestFailureException -> reraise ()
-        | e ->
-            match tryDescribeGuest state with
-            | Some guest -> raise (GuestFailureException (e, guest))
-            | None -> reraise ()

--- a/WoofWare.PawPrint/AbstractMachine.fs
+++ b/WoofWare.PawPrint/AbstractMachine.fs
@@ -19,7 +19,7 @@ module AbstractMachine =
     let private logger (loggerFactory : ILoggerFactory) : ILogger =
         loggerCache.GetValue (loggerFactory, fun f -> f.CreateLogger typeof<Dummy>.DeclaringType)
 
-    let executeOneStep
+    let private executeOneStepCore
         (loggerFactory : ILoggerFactory)
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
         (state : IlMachineState)
@@ -349,3 +349,53 @@ module AbstractMachine =
         | IlOp.UnaryStringToken (unaryStringTokenIlOp, stringHandle) ->
             UnaryStringTokenIlOp.execute loggerFactory baseClassTypes unaryStringTokenIlOp stringHandle state thread
             |> ExecutionResult.stepped
+
+    /// <summary>
+    /// Where each live guest thread is, or <c>None</c> if that cannot be determined.
+    /// </summary>
+    /// <remarks>
+    /// Total by construction. This runs only while an exception is already propagating, so a
+    /// failure here would replace the diagnostic PawPrint is trying to deliver with one about the
+    /// diagnostic machinery — the single worst outcome available. <c>GuestLocation</c> is written
+    /// to be total for exactly this reason; the guard is the belt to its braces.
+    /// </remarks>
+    let private tryDescribeGuest (state : IlMachineState) : GuestThreadLocation list option =
+        try
+            Some (GuestLocation.ofState state)
+        with _ ->
+            None
+
+    /// <summary>
+    /// Interpret one IL instruction on <paramref name="thread" />.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Any host failure escaping the interpreter is annotated with where the guest was, as a
+    /// <c>GuestFailureException</c>. Doing it here rather than at the ~2,400 individual
+    /// <c>failwith</c> sites is what makes the annotation universal: the least informative
+    /// messages of all come from pure helpers inside the opcode implementations, which have no
+    /// <c>IlMachineState</c> to consult and should not grow one just to describe a failure.
+    /// </para>
+    /// <para>
+    /// The state described is the one this step *started* from. The failure happened partway
+    /// through, so there is no consistent later state to report — and the instruction about to
+    /// execute is what a reader wants to know anyway.
+    /// </para>
+    /// </remarks>
+    let executeOneStep
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (thread : ThreadId)
+        : ExecutionResult
+        =
+        try
+            executeOneStepCore loggerFactory baseClassTypes state thread
+        with
+        // Already annotated: a nested step would otherwise repeat the thread summary once per
+        // level, and the outermost frame's guest position is the least specific of them.
+        | :? GuestFailureException -> reraise ()
+        | e ->
+            match tryDescribeGuest state with
+            | Some guest -> raise (GuestFailureException (e, guest))
+            | None -> reraise ()

--- a/WoofWare.PawPrint/GuestLocation.fs
+++ b/WoofWare.PawPrint/GuestLocation.fs
@@ -293,6 +293,22 @@ module GuestLocation =
     let describe (state : IlMachineState) : string = ofState state |> renderThreads
 
     /// <summary>
+    /// As <c>ofState</c>, but <c>None</c> rather than raising if the position cannot be
+    /// determined.
+    /// </summary>
+    /// <remarks>
+    /// For callers annotating an exception that is already propagating. A failure there would
+    /// replace the diagnostic PawPrint is trying to deliver with one about the diagnostic
+    /// machinery — the single worst outcome available. <c>ofState</c> is written to be total for
+    /// exactly this reason; this is the belt to its braces.
+    /// </remarks>
+    let tryOfState (state : IlMachineState) : GuestThreadLocation list option =
+        try
+            Some (ofState state)
+        with _ ->
+            None
+
+    /// <summary>
     /// <paramref name="message" /> with the guest's position appended.
     /// </summary>
     let annotate (message : string) (locations : GuestThreadLocation list) : string =

--- a/WoofWare.PawPrint/GuestLocation.fs
+++ b/WoofWare.PawPrint/GuestLocation.fs
@@ -293,22 +293,6 @@ module GuestLocation =
     let describe (state : IlMachineState) : string = ofState state |> renderThreads
 
     /// <summary>
-    /// As <c>ofState</c>, but <c>None</c> rather than raising if the position cannot be
-    /// determined.
-    /// </summary>
-    /// <remarks>
-    /// For callers annotating an exception that is already propagating. A failure there would
-    /// replace the diagnostic PawPrint is trying to deliver with one about the diagnostic
-    /// machinery — the single worst outcome available. <c>ofState</c> is written to be total for
-    /// exactly this reason; this is the belt to its braces.
-    /// </remarks>
-    let tryOfState (state : IlMachineState) : GuestThreadLocation list option =
-        try
-            Some (ofState state)
-        with _ ->
-            None
-
-    /// <summary>
     /// <paramref name="message" /> with the guest's position appended.
     /// </summary>
     let annotate (message : string) (locations : GuestThreadLocation list) : string =
@@ -347,3 +331,23 @@ type GuestFailureException (inner : exn, guest : GuestThreadLocation list) =
     /// Where each live guest thread was when the failure was raised.
     /// </summary>
     member _.Guest : GuestThreadLocation list = guest
+
+    /// <summary>
+    /// Annotate <paramref name="inner" /> with the guest's position at
+    /// <paramref name="state" />, or <c>None</c> if that cannot be done.
+    /// </summary>
+    /// <remarks>
+    /// Total, and deliberately covers the *construction* as well as the lookup. Callers run this
+    /// while an exception is already propagating, so anything that throws here would replace the
+    /// diagnostic PawPrint is trying to deliver with one about the diagnostic machinery — the
+    /// single worst outcome available. Building the message walks every live thread and formats
+    /// each one, so it allocates; when the failure being reported is itself
+    /// <c>OutOfMemoryException</c>, that is exactly the allocation most likely to fail. The
+    /// caller reraises the original on <c>None</c>, so the guarantee is that annotation can cost
+    /// the annotation and nothing else.
+    /// </remarks>
+    static member TryCreate (inner : exn, state : IlMachineState) : GuestFailureException option =
+        try
+            Some (GuestFailureException (inner, GuestLocation.ofState state))
+        with _ ->
+            None

--- a/WoofWare.PawPrint/GuestLocation.fs
+++ b/WoofWare.PawPrint/GuestLocation.fs
@@ -281,8 +281,53 @@ module GuestLocation =
             $"%s{prefix} in %s{renderFrame frame}, %s{from} %s{renderFrame ancestor} (%s{renderSource ancestorSource})"
 
     /// <summary>
+    /// One line per non-terminated thread, joined by <c>"; "</c>.
+    /// </summary>
+    let renderThreads (locations : GuestThreadLocation list) : string =
+        locations |> List.map renderThread |> String.concat "; "
+
+    /// <summary>
     /// One line per non-terminated thread, joined by <c>"; "</c>: the summary PawPrint prints
     /// when it gives up on a guest.
     /// </summary>
-    let describe (state : IlMachineState) : string =
-        ofState state |> List.map renderThread |> String.concat "; "
+    let describe (state : IlMachineState) : string = ofState state |> renderThreads
+
+    /// <summary>
+    /// <paramref name="message" /> with the guest's position appended.
+    /// </summary>
+    let annotate (message : string) (locations : GuestThreadLocation list) : string =
+        // On its own line, and after the original message rather than before it: the first line
+        // of an exception message is what most log lines and test runners show, and "what went
+        // wrong" outranks "where the guest was" for that slot.
+        $"%s{message}%s{System.Environment.NewLine}  Guest was: %s{renderThreads locations}"
+
+/// <summary>
+/// A host-side failure raised while interpreting guest code, annotated with where the guest was
+/// when it happened.
+/// </summary>
+/// <remarks>
+/// <para>
+/// PawPrint fails by <c>failwith</c> in some 2,400 places, and almost none of them can name the
+/// guest: the most context-free messages of all come from pure helpers deep in the opcode
+/// implementations, which have no <c>IlMachineState</c> to consult and are much better off
+/// without one. So the annotation is applied once, at the boundary in
+/// <c>AbstractMachine.executeOneStep</c>, rather than at the sites.
+/// </para>
+/// <para>
+/// The original exception is kept as <c>InnerException</c>, not flattened into text: it carries
+/// the *host* stack trace, which says where in PawPrint's own source the failure was raised.
+/// A reader debugging PawPrint needs that as much as the guest location, and the two answer
+/// different questions.
+/// </para>
+/// <para>
+/// <see cref="Guest" /> is the structured position rather than only the rendered string, because
+/// the App, the debugger server and the test harness each want to present it differently.
+/// </para>
+/// </remarks>
+type GuestFailureException (inner : exn, guest : GuestThreadLocation list) =
+    inherit System.Exception (GuestLocation.annotate inner.Message guest, inner)
+
+    /// <summary>
+    /// Where each live guest thread was when the failure was raised.
+    /// </summary>
+    member _.Guest : GuestThreadLocation list = guest

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -545,7 +545,7 @@ module Program =
     /// fold the outcome back into the thread states. `prepared` must already have been through
     /// `advanceToDecision`; running this against an inter-tick value would consult the policy
     /// about a Runnable set that a deadline or a spurious wake was about to change.
-    let private stepDecided
+    let private stepDecidedCore
         (loggerFactory : ILoggerFactory)
         (logger : ILogger)
         (prepared : PreparedProgram)
@@ -649,6 +649,46 @@ module Program =
                     whatWeDid,
                     effect
                 )
+
+    /// <summary>
+    /// One tick, with any host failure annotated by where the guest was when it happened.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// PawPrint fails by <c>failwith</c> in some 2,400 places, and almost none of them can name
+    /// the guest: the least informative messages of all come from pure helpers inside the opcode
+    /// implementations, which have no <c>IlMachineState</c> to consult and should not grow one
+    /// just to describe a failure. Annotating once here covers all of them.
+    /// </para>
+    /// <para>
+    /// The whole tick is covered, not merely <c>AbstractMachine.executeOneStep</c>. Scheduler
+    /// bookkeeping runs on either side of the instruction — <c>chooseNext</c> before it,
+    /// <c>dischargeYieldDebts</c>, <c>onStepOutcome</c> and <c>onThreadTerminated</c> after —
+    /// and those failures are just as guest-provoked. `onThreadTerminated` refusing a thread
+    /// that exited still holding a monitor is a diagnostic *about the guest*, and would be far
+    /// less useful without knowing which guest code let go of it.
+    /// </para>
+    /// <para>
+    /// The state described is the one the tick *started* from. The failure happened partway
+    /// through, so there is no consistent later state to report.
+    /// </para>
+    /// </remarks>
+    let private stepDecided
+        (loggerFactory : ILoggerFactory)
+        (logger : ILogger)
+        (prepared : PreparedProgram)
+        : ProgramStepOutcome
+        =
+        try
+            stepDecidedCore loggerFactory logger prepared
+        with
+        // Already annotated: a nested tick would otherwise repeat the thread summary once per
+        // level, and the outermost frame's guest position is the least specific of them.
+        | :? GuestFailureException -> reraise ()
+        | e ->
+            match GuestLocation.tryOfState prepared.State with
+            | Some guest -> raise (GuestFailureException (e, guest))
+            | None -> reraise ()
 
     /// Advance the machine by one scheduler tick.
     ///

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -681,8 +681,15 @@ module Program =
     /// The state described is the one the tick *started* from. The failure happened partway
     /// through, so there is no consistent later state to report.
     /// </para>
+    /// <para>
+    /// <c>inline</c> with <c>InlineIfLambda</c> because <c>stepPrepared</c> is per-tick: taking
+    /// the body as a first-class function would allocate an <c>FSharpFunc</c> capturing the
+    /// logger and the program state on every interpreted instruction — some 20 million of them
+    /// in a bounded run — purely to serve a path that normally never fires. Inlined, the caller
+    /// keeps the exception region and nothing else.
+    /// </para>
     /// </remarks>
-    let private annotating (state : IlMachineState) (tick : unit -> 'a) : 'a =
+    let inline private annotating (state : IlMachineState) ([<InlineIfLambda>] tick : unit -> 'a) : 'a =
         try
             tick ()
         with
@@ -690,8 +697,10 @@ module Program =
         // level, and the outermost frame's guest position is the least specific of them.
         | :? GuestFailureException -> reraise ()
         | e ->
-            match GuestLocation.tryOfState state with
-            | Some guest -> raise (GuestFailureException (e, guest))
+            // `TryCreate` is total over both the lookup *and* the message construction, so a
+            // failure to annotate reraises the original rather than replacing it.
+            match GuestFailureException.TryCreate (e, state) with
+            | Some annotated -> raise annotated
             | None -> reraise ()
 
     /// Advance the machine by one scheduler tick.

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -545,7 +545,7 @@ module Program =
     /// fold the outcome back into the thread states. `prepared` must already have been through
     /// `advanceToDecision`; running this against an inter-tick value would consult the policy
     /// about a Runnable set that a deadline or a spurious wake was about to change.
-    let private stepDecidedCore
+    let private stepDecided
         (loggerFactory : ILoggerFactory)
         (logger : ILogger)
         (prepared : PreparedProgram)
@@ -651,42 +651,46 @@ module Program =
                 )
 
     /// <summary>
-    /// One tick, with any host failure annotated by where the guest was when it happened.
+    /// Run <paramref name="tick" />, annotating any host failure with where the guest was at
+    /// <paramref name="state" />.
     /// </summary>
     /// <remarks>
     /// <para>
     /// PawPrint fails by <c>failwith</c> in some 2,400 places, and almost none of them can name
     /// the guest: the least informative messages of all come from pure helpers inside the opcode
     /// implementations, which have no <c>IlMachineState</c> to consult and should not grow one
-    /// just to describe a failure. Annotating once here covers all of them.
+    /// just to describe a failure. Annotating at the tick covers all of them at once.
     /// </para>
     /// <para>
-    /// The whole tick is covered, not merely <c>AbstractMachine.executeOneStep</c>. Scheduler
-    /// bookkeeping runs on either side of the instruction — <c>chooseNext</c> before it,
-    /// <c>dischargeYieldDebts</c>, <c>onStepOutcome</c> and <c>onThreadTerminated</c> after —
-    /// and those failures are just as guest-provoked. `onThreadTerminated` refusing a thread
-    /// that exited still holding a monitor is a diagnostic *about the guest*, and would be far
+    /// A *whole* tick must be inside, not just the instruction. Work that can fail sits on both
+    /// sides of it: <c>advanceToDecision</c> applies spurious wakeups and moves the virtual
+    /// clock — which faults at its horizon — before the instruction, and
+    /// <c>dischargeYieldDebts</c>, <c>onStepOutcome</c> and <c>onThreadTerminated</c> run after.
+    /// Those failures are every bit as guest-provoked: <c>onThreadTerminated</c> refusing a
+    /// worker that exited still holding a monitor is a diagnostic *about the guest*, and is far
     /// less useful without knowing which guest code let go of it.
+    /// </para>
+    /// <para>
+    /// Hence the invariant this combinator exists to make checkable: <c>advanceToDecision</c> and
+    /// <c>stepDecided</c> are both private, and *every* call to either is inside an
+    /// <c>annotating</c>. There are three such sites — <c>stepPrepared</c>, and the two in the
+    /// fork-prefix sweep — and grepping for the two names finds exactly them. Adding a fourth
+    /// call site outside a wrapper is the one way to reintroduce the gap.
     /// </para>
     /// <para>
     /// The state described is the one the tick *started* from. The failure happened partway
     /// through, so there is no consistent later state to report.
     /// </para>
     /// </remarks>
-    let private stepDecided
-        (loggerFactory : ILoggerFactory)
-        (logger : ILogger)
-        (prepared : PreparedProgram)
-        : ProgramStepOutcome
-        =
+    let private annotating (state : IlMachineState) (tick : unit -> 'a) : 'a =
         try
-            stepDecidedCore loggerFactory logger prepared
+            tick ()
         with
         // Already annotated: a nested tick would otherwise repeat the thread summary once per
         // level, and the outermost frame's guest position is the least specific of them.
         | :? GuestFailureException -> reraise ()
         | e ->
-            match GuestLocation.tryOfState prepared.State with
+            match GuestLocation.tryOfState state with
             | Some guest -> raise (GuestFailureException (e, guest))
             | None -> reraise ()
 
@@ -714,7 +718,7 @@ module Program =
         (prepared : PreparedProgram)
         : ProgramStepOutcome
         =
-        stepDecided loggerFactory logger (advanceToDecision prepared)
+        annotating prepared.State (fun () -> stepDecided loggerFactory logger (advanceToDecision prepared))
 
     let rec pumpPrepared (loggerFactory : ILoggerFactory) (logger : ILogger) (prepared : PreparedProgram) : RunOutcome =
         match stepPrepared loggerFactory logger prepared with
@@ -1393,7 +1397,7 @@ module Program =
         (prepared : PreparedProgram)
         : PrefixOutcome
         =
-        let advanced = advanceToDecision prepared
+        let advanced = annotating prepared.State (fun () -> advanceToDecision prepared)
 
         match Scheduler.tryContenders advanced.State with
         | Some contenders ->
@@ -1404,7 +1408,7 @@ module Program =
                 }
         | None ->
 
-        match stepDecided loggerFactory logger advanced with
+        match annotating advanced.State (fun () -> stepDecided loggerFactory logger advanced) with
         | ProgramStepOutcome.Completed outcome -> PrefixOutcome.NeverForked outcome
         | ProgramStepOutcome.Deadlocked (_, stuck) -> PrefixOutcome.DeadlockedBeforeFork stuck
         | ProgramStepOutcome.WorkerTerminated (next, _) -> runToNextFork loggerFactory logger next
@@ -1439,7 +1443,10 @@ module Program =
             // preamble runs twice per startup tick here, once for the probe and once inside
             // `stepStartup`; that is a handful of map operations against `executeOneStep`, and it
             // is paid once for a whole sweep rather than once per seed.
-            match Scheduler.tryContenders (advanceToDecision startup.Prepared).State with
+            let probed =
+                annotating startup.Prepared.State (fun () -> advanceToDecision startup.Prepared)
+
+            match Scheduler.tryContenders probed.State with
             | Some contenders -> PrefixOutcome.ForkedDuringStartup contenders
             | None ->
 


### PR DESCRIPTION
Follow-up to #928, which made `GuestLocation` but only wired it to the wedged/deadlocked
path. This feeds it into PawPrint's *failures*.

PawPrint fails by `failwith` in some **2,433 places across 97 files** — `Native/` alone has
712, `NullaryIlOp.fs` 254 — and almost none of them can say where the guest was. Only about a
dozen name even the executing method. The least informative of all are in pure helpers inside
the opcode implementations (`convOvfI4Un`, `divUnValues`, `locallocSizeBytes`), which have no
`IlMachineState` to consult and are much better off without one.

So the annotation goes at the boundary, not at the sites:

```
calli: call-site signature declares a return type of int64 but target .Program::Id
returns int32; these occupy different evaluation-stack representations, ...
  Guest was: thread 0 (Runnable) in PawPrintTestAssembly.Program.Main at IL offset 12
 ---> System.Exception: calli: call-site signature declares a return type of int64 ...
   at WoofWare.PawPrint.UnaryMetadataCallOps.executeCalli(...) UnaryMetadataCallOps.fs:line 1539
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)