### PR TITLE
Give an array's shape a type that cannot reach its cells

### DIFF
--- a/WoofWare.PawPrint.App/DebuggerServer.fs
+++ b/WoofWare.PawPrint.App/DebuggerServer.fs
@@ -809,8 +809,8 @@ module DebuggerServer =
             match state.ManagedHeap.Arrays |> Map.tryFind address with
             | Some array ->
                 writer.WriteString ("kind", "array")
-                writer.WriteString ("concreteType", string array.ConcreteType)
-                writer.WriteNumber ("length", array.Length)
+                writer.WriteString ("concreteType", string array.Shape.ConcreteType)
+                writer.WriteNumber ("length", array.Shape.Length)
                 writeValueArray writer "elements" array.Elements writeCliType
                 // Arrays carry an object header exactly like any other heap object, so a
                 // `lock (array)` is visible here too.

--- a/WoofWare.PawPrint.Test/TestAssemblyNativeQCalls.fs
+++ b/WoofWare.PawPrint.Test/TestAssemblyNativeQCalls.fs
@@ -1013,7 +1013,7 @@ public static class StreamVersionLibrary
         let byteHandle =
             AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes baseClassTypes.Byte
 
-        array.ConcreteType
+        array.Shape.ConcreteType
         |> shouldEqual (ConcreteTypeHandle.OneDimArrayZero byteHandle)
 
         let actual =

--- a/WoofWare.PawPrint.Test/TestBinaryArithmetic.fs
+++ b/WoofWare.PawPrint.Test/TestBinaryArithmetic.fs
@@ -67,9 +67,12 @@ module TestBinaryArithmetic =
             |> ImmutableArray.CreateRange
 
         {
-            ConcreteType = ConcreteTypeHandle.OneDimArrayZero int32Handle
-            Length = values.Length
-            Lengths = ImmutableArray.Create values.Length
+            Shape =
+                {
+                    ConcreteType = ConcreteTypeHandle.OneDimArrayZero int32Handle
+                    Length = values.Length
+                    Lengths = ImmutableArray.Create values.Length
+                }
             Elements = elements
         }
 

--- a/WoofWare.PawPrint.Test/TestManagedHeap.fs
+++ b/WoofWare.PawPrint.Test/TestManagedHeap.fs
@@ -43,25 +43,34 @@ module TestManagedHeap =
 
         let intArray : AllocatedArray =
             {
-                ConcreteType = intArrayHandle
-                Length = 0
-                Lengths = ImmutableArray.Create 0
+                Shape =
+                    {
+                        ConcreteType = intArrayHandle
+                        Length = 0
+                        Lengths = ImmutableArray.Create 0
+                    }
                 Elements = ImmutableArray.Empty
             }
 
         let stringArray : AllocatedArray =
             {
-                ConcreteType = stringArrayHandle
-                Length = 0
-                Lengths = ImmutableArray.Create 0
+                Shape =
+                    {
+                        ConcreteType = stringArrayHandle
+                        Length = 0
+                        Lengths = ImmutableArray.Create 0
+                    }
                 Elements = ImmutableArray.Empty
             }
 
         let intArrayAddr, heap = ManagedHeap.allocateArray intArray ManagedHeap.empty
         let stringArrayAddr, heap = ManagedHeap.allocateArray stringArray heap
 
-        heap.Arrays.[intArrayAddr].ConcreteType |> shouldEqual intArrayHandle
-        heap.Arrays.[stringArrayAddr].ConcreteType |> shouldEqual stringArrayHandle
+        (ManagedHeap.getArrayShape intArrayAddr heap).ConcreteType
+        |> shouldEqual intArrayHandle
+
+        (ManagedHeap.getArrayShape stringArrayAddr heap).ConcreteType
+        |> shouldEqual stringArrayHandle
 
     [<Test>]
     let ``getObjectConcreteType returns concrete array type`` () : unit =
@@ -70,9 +79,12 @@ module TestManagedHeap =
 
         let array : AllocatedArray =
             {
-                ConcreteType = arrayHandle
-                Length = 0
-                Lengths = ImmutableArray.Create 0
+                Shape =
+                    {
+                        ConcreteType = arrayHandle
+                        Length = 0
+                        Lengths = ImmutableArray.Create 0
+                    }
                 Elements = ImmutableArray.Empty
             }
 
@@ -230,9 +242,9 @@ module TestManagedHeap =
             IlMachineState.allocateMultiDimArray arrayHandle (fun () -> zero) lengths state
 
         let array = state.ManagedHeap.Arrays.[addr]
-        array.ConcreteType |> shouldEqual arrayHandle
-        array.Length |> shouldEqual 12
-        array.Lengths |> shouldEqual lengths
+        array.Shape.ConcreteType |> shouldEqual arrayHandle
+        array.Shape.Length |> shouldEqual 12
+        array.Shape.Lengths |> shouldEqual lengths
         array.Elements.Length |> shouldEqual 12
 
         for i = 0 to 11 do
@@ -252,8 +264,8 @@ module TestManagedHeap =
             IlMachineState.allocateMultiDimArray arrayHandle (fun () -> zero) lengths state
 
         let array = state.ManagedHeap.Arrays.[addr]
-        array.Length |> shouldEqual 0
-        array.Lengths |> shouldEqual lengths
+        array.Shape.Length |> shouldEqual 0
+        array.Shape.Lengths |> shouldEqual lengths
         array.Elements.Length |> shouldEqual 0
 
     [<Test>]
@@ -295,8 +307,8 @@ module TestManagedHeap =
             IlMachineState.allocateMultiDimArray arrayHandle (fun () -> zero) lengths state
 
         let array = state.ManagedHeap.Arrays.[addr]
-        array.Length |> shouldEqual 0
-        array.Lengths |> shouldEqual lengths
+        array.Shape.Length |> shouldEqual 0
+        array.Shape.Lengths |> shouldEqual lengths
         array.Elements.Length |> shouldEqual 0
 
     [<Test>]
@@ -373,9 +385,12 @@ module TestManagedHeap =
 
     let private stubArray (length : int) : AllocatedArray =
         {
-            ConcreteType = ConcreteTypeHandle.OneDimArrayZero (ConcreteTypeHandle.Concrete 1)
-            Length = length
-            Lengths = ImmutableArray.Create length
+            Shape =
+                {
+                    ConcreteType = ConcreteTypeHandle.OneDimArrayZero (ConcreteTypeHandle.Concrete 1)
+                    Length = length
+                    Lengths = ImmutableArray.Create length
+                }
             Elements =
                 Seq.replicate length (CliType.Numeric (CliNumericType.Int32 0))
                 |> ImmutableArray.CreateRange
@@ -524,6 +539,111 @@ module TestManagedHeap =
             && live.Count = ops.Length
             && live
                |> Set.forall (fun addr -> ManagedHeap.getSyncBlock addr heap = SyncBlock.Empty)
+
+        Check.One (
+            Config.QuickThrowOnFailure.WithMaxTest 200,
+            Prop.forAll (ArbMap.defaults |> ArbMap.arbitrary) property
+        )
+
+    // ---------------------------------------------------------------------
+    // Array shape.
+    //
+    // `ArrayShape` is everything about an array *except* its contents: the
+    // identity and dimensions fixed at allocation. It deliberately has no
+    // `Elements`, so a caller that only wants the rank or the length cannot
+    // reach a cell — reading a cell is a guest-visible memory access and has
+    // to go through `getArrayValue`.
+    // ---------------------------------------------------------------------
+
+    [<Test>]
+    let ``getArrayShape reports the allocation's dimensions and type`` () : unit =
+        let elementHandle = ConcreteTypeHandle.Concrete 1
+        let arrayHandle = ConcreteTypeHandle.Array (elementHandle, 2)
+        let lengths = ImmutableArray.CreateRange [ 3 ; 4 ]
+
+        let allocation : AllocatedArray =
+            {
+                Shape =
+                    {
+                        ConcreteType = arrayHandle
+                        Length = 12
+                        Lengths = lengths
+                    }
+                Elements =
+                    Seq.replicate 12 (CliType.Numeric (CliNumericType.Int32 0))
+                    |> ImmutableArray.CreateRange
+            }
+
+        let addr, heap = ManagedHeap.allocateArray allocation ManagedHeap.empty
+        let shape = ManagedHeap.getArrayShape addr heap
+
+        shape.ConcreteType |> shouldEqual arrayHandle
+        shape.Length |> shouldEqual 12
+        shape.Lengths |> shouldEqual lengths
+
+    [<Test>]
+    let ``getArrayShape fails loudly, and distinguishably, for a non-array object`` () : unit =
+        // Same discrimination as `setFieldById`, for the same reason: a non-array address
+        // means the caller misjudged the type of the reference it holds, whereas an
+        // unallocated address means the reference itself is bogus.
+        let objAddr, heap = ManagedHeap.allocateNonArray stubNonArray ManagedHeap.empty
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> ManagedHeap.getArrayShape objAddr heap |> ignore)
+
+        exn.Message |> shouldContainText "is not an array"
+
+    [<Test>]
+    let ``getArrayShape fails loudly for an address that was never allocated`` () : unit =
+        let exn =
+            Assert.Throws<System.Exception> (fun () ->
+                ManagedHeap.getArrayShape (ManagedHeapAddress 42) ManagedHeap.empty |> ignore
+            )
+
+        exn.Message |> shouldContainText "not a live managed heap allocation"
+
+    [<Test>]
+    let ``tryGetArrayShape and isArray answer only for arrays`` () : unit =
+        let arrAddr, heap = ManagedHeap.allocateArray (stubArray 3) ManagedHeap.empty
+        let objAddr, heap = ManagedHeap.allocateNonArray stubNonArray heap
+        let danglingAddr = ManagedHeapAddress 99
+
+        ManagedHeap.isArray arrAddr heap |> shouldEqual true
+        ManagedHeap.isArray objAddr heap |> shouldEqual false
+        ManagedHeap.isArray danglingAddr heap |> shouldEqual false
+
+        (ManagedHeap.tryGetArrayShape arrAddr heap).IsSome |> shouldEqual true
+        ManagedHeap.tryGetArrayShape objAddr heap |> shouldEqual None
+        ManagedHeap.tryGetArrayShape danglingAddr heap |> shouldEqual None
+
+    [<Test>]
+    let ``array shape is exactly the allocation minus its elements`` () : unit =
+        // The oracle is the allocation record itself: `getArrayShape` must project it
+        // field-for-field, never derive or normalise. `Length` in particular is stored,
+        // not recomputed from `Lengths`, and the projection must not start recomputing it.
+        let property (lengths : int list) : bool =
+            let lengths = lengths |> List.map (fun n -> (abs n) % 5)
+            let total = lengths |> List.fold (*) 1
+
+            let allocation : AllocatedArray =
+                {
+                    Shape =
+                        {
+                            ConcreteType = ConcreteTypeHandle.Array (ConcreteTypeHandle.Concrete 1, lengths.Length)
+                            Length = total
+                            Lengths = ImmutableArray.CreateRange lengths
+                        }
+                    Elements =
+                        Seq.replicate total (CliType.Numeric (CliNumericType.Int32 0))
+                        |> ImmutableArray.CreateRange
+                }
+
+            let addr, heap = ManagedHeap.allocateArray allocation ManagedHeap.empty
+            let shape = ManagedHeap.getArrayShape addr heap
+
+            shape.ConcreteType = allocation.Shape.ConcreteType
+            && shape.Length = allocation.Shape.Length
+            && shape.Lengths = allocation.Shape.Lengths
 
         Check.One (
             Config.QuickThrowOnFailure.WithMaxTest 200,

--- a/WoofWare.PawPrint.Test/TestNativeEnum.fs
+++ b/WoofWare.PawPrint.Test/TestNativeEnum.fs
@@ -341,7 +341,7 @@ public static class Entry
 
         let array = state.ManagedHeap.Arrays.[arrayAddr]
 
-        array.ConcreteType
+        array.Shape.ConcreteType
         |> shouldEqual (ConcreteTypeHandle.OneDimArrayZero expectedElementHandle)
 
         array.Elements |> Seq.toList |> shouldEqual expectedElements

--- a/WoofWare.PawPrint.Test/TestNativeSignature.fs
+++ b/WoofWare.PawPrint.Test/TestNativeSignature.fs
@@ -698,7 +698,7 @@ public sealed class MethodSignatureHost
             | false, _ -> failwith $"_arguments pointed at %O{arrayAddr}, which is not an array"
 
         [
-            for index in 0 .. array.Length - 1 do
+            for index in 0 .. array.Shape.Length - 1 do
                 match IlMachineState.getArrayValue arrayAddr index state with
                 | CliType.ObjectRef (Some addr) ->
                     NativeCall.runtimeTypeHandleTargetOfRuntimeTypeRef

--- a/WoofWare.PawPrint.Test/TestSyncBlockMonitor.fs
+++ b/WoofWare.PawPrint.Test/TestSyncBlockMonitor.fs
@@ -101,9 +101,12 @@ module TestSyncBlockMonitor =
     let private allocateHeapArray (state : IlMachineState) : ManagedHeapAddress * IlMachineState =
         let stub : AllocatedArray =
             {
-                ConcreteType = ConcreteTypeHandle.OneDimArrayZero (ConcreteTypeHandle.Concrete 0)
-                Length = 0
-                Lengths = ImmutableArray.Create 0
+                Shape =
+                    {
+                        ConcreteType = ConcreteTypeHandle.OneDimArrayZero (ConcreteTypeHandle.Concrete 0)
+                        Length = 0
+                        Lengths = ImmutableArray.Create 0
+                    }
                 Elements = ImmutableArray.Empty
             }
 

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -647,7 +647,7 @@ module IlMachineManagedByref =
         let targetSize = CliType.sizeOf targetTemplate
         let arrObj = state.ManagedHeap.Arrays.[arr]
 
-        if arrObj.Length = 0 then
+        if arrObj.Shape.Length = 0 then
             failwith $"TODO: byte-view read from empty array %O{arr} at index %d{index} offset %d{byteOffset}"
 
         // Compute cell size with `CliType.sizeOf` (not `byteAddressableCellSize`)
@@ -666,9 +666,9 @@ module IlMachineManagedByref =
             if inCellStart = 0 && targetSize = firstCellSize then
                 let targetCell = index + cellAdvance
 
-                if targetCell < 0 || targetCell >= arrObj.Length then
+                if targetCell < 0 || targetCell >= arrObj.Shape.Length then
                     failwith
-                        $"TODO: byte-view read past array bounds at cell %d{targetCell} of length %d{arrObj.Length}"
+                        $"TODO: byte-view read past array bounds at cell %d{targetCell} of length %d{arrObj.Shape.Length}"
 
                 let cellValue = arrObj.Elements.[targetCell]
 
@@ -701,7 +701,7 @@ module IlMachineManagedByref =
 
             let targetCell = index + cellAdvance
 
-            if targetCell < 0 || targetCell >= arrObj.Length then
+            if targetCell < 0 || targetCell >= arrObj.Shape.Length then
                 ValueNone
             else
 
@@ -721,9 +721,9 @@ module IlMachineManagedByref =
             let mutable inCellOffset = inCellStart
 
             while filled < targetSize do
-                if cell < 0 || cell >= arrObj.Length then
+                if cell < 0 || cell >= arrObj.Shape.Length then
                     failwith
-                        $"TODO: byte-view read past array bounds at cell %d{cell} of length %d{arrObj.Length} while gathering %d{targetSize} bytes"
+                        $"TODO: byte-view read past array bounds at cell %d{cell} of length %d{arrObj.Shape.Length} while gathering %d{targetSize} bytes"
 
                 let cellSize =
                     byteAddressableCellSize $"array %O{arr} element %d{cell}" arrObj.Elements.[cell]
@@ -1625,7 +1625,7 @@ module IlMachineManagedByref =
         =
         let arrObj = state.ManagedHeap.Arrays.[arr]
 
-        if arrObj.Length = 0 then
+        if arrObj.Shape.Length = 0 then
             failwith $"TODO: byte-view write to empty array %O{arr} at index %d{index} offset %d{byteOffset}"
 
         // Use `CliType.sizeOf` (not `byteAddressableCellSize`) for the stride.
@@ -1644,8 +1644,8 @@ module IlMachineManagedByref =
         let mutable inCellOffset = inCellStart
 
         while filled < bytes.Length do
-            if cell < 0 || cell >= arrObj.Length then
-                failwith $"TODO: byte-view write past array bounds at cell %d{cell} of length %d{arrObj.Length}"
+            if cell < 0 || cell >= arrObj.Shape.Length then
+                failwith $"TODO: byte-view write past array bounds at cell %d{cell} of length %d{arrObj.Shape.Length}"
 
             let existing = state.ManagedHeap.Arrays.[arr].Elements.[cell]
 
@@ -2006,7 +2006,7 @@ module IlMachineManagedByref =
 
         let arrObj = state.ManagedHeap.Arrays.[arr]
 
-        if index < 0 || index >= arrObj.Length then
+        if index < 0 || index >= arrObj.Shape.Length then
             None
         else
 
@@ -2237,7 +2237,7 @@ module IlMachineManagedByref =
                 | ValueSome (ByrefRoot.ArrayElement (arr, index), [], byteOffset) ->
                     let arrObj = state.ManagedHeap.Arrays.[arr]
 
-                    if arrObj.Length = 0 then
+                    if arrObj.Shape.Length = 0 then
                         None
                     else
                         let cellSize = CliType.sizeOf arrObj.Elements.[0]
@@ -2251,7 +2251,7 @@ module IlMachineManagedByref =
                         then
                             let targetCell = index + cellAdvance
 
-                            if targetCell < 0 || targetCell >= arrObj.Length then
+                            if targetCell < 0 || targetCell >= arrObj.Shape.Length then
                                 None
                             else
                                 Some (IlMachineThreadState.setArrayValue arr newValue targetCell state)
@@ -3003,7 +3003,7 @@ module IlMachineManagedByref =
                 // renderable provenance.
                 let arrObj = state.ManagedHeap.Arrays.[arr]
 
-                if arrObj.Length = 0 then
+                if arrObj.Shape.Length = 0 then
                     failwith
                         $"TODO: byte-view typed store into empty array %O{arr} at index %d{index} offset %d{byteOffset}"
 
@@ -3018,9 +3018,9 @@ module IlMachineManagedByref =
                 then
                     let targetCell = index + cellAdvance
 
-                    if targetCell < 0 || targetCell >= arrObj.Length then
+                    if targetCell < 0 || targetCell >= arrObj.Shape.Length then
                         failwith
-                            $"TODO: byte-view typed store past array bounds at cell %d{targetCell} of length %d{arrObj.Length}"
+                            $"TODO: byte-view typed store past array bounds at cell %d{targetCell} of length %d{arrObj.Shape.Length}"
 
                     IlMachineThreadState.setArrayValue arr newValue targetCell state
                 else
@@ -3173,7 +3173,7 @@ module IlMachineManagedByref =
                     let arrObj = state.ManagedHeap.Arrays.[arr]
 
                     let typedCellOverride =
-                        if arrObj.Length = 0 then
+                        if arrObj.Shape.Length = 0 then
                             ValueNone
                         else
                             let cellSize = CliType.sizeOf arrObj.Elements.[0]
@@ -3182,7 +3182,7 @@ module IlMachineManagedByref =
                             if inCellStart = 0 && CliType.sizeOf newValue = cellSize then
                                 let targetCell = index + cellAdvance
 
-                                if targetCell >= 0 && targetCell < arrObj.Length then
+                                if targetCell >= 0 && targetCell < arrObj.Shape.Length then
                                     // Same destination-side test as the non-array arm below: the
                                     // *routing* question is about the cell, so both sites must
                                     // ask it the same way. (What the two do once routed still

--- a/WoofWare.PawPrint/IlMachineStateExecution.fs
+++ b/WoofWare.PawPrint/IlMachineStateExecution.fs
@@ -2548,9 +2548,9 @@ module IlMachineStateExecution =
         : ArrayStoreVarianceCheck
         =
         let arrayObj =
-            match state.ManagedHeap.Arrays.TryGetValue arrayAddress with
-            | true, v -> v
-            | false, _ ->
+            match ManagedHeap.tryGetArrayShape arrayAddress state.ManagedHeap with
+            | Some v -> v
+            | None ->
                 failwith
                     $"checkArrayStoreVariance: no array allocation at %O{arrayAddress}; helper called with a non-array heap address"
 

--- a/WoofWare.PawPrint/IlMachineThreadState.fs
+++ b/WoofWare.PawPrint/IlMachineThreadState.fs
@@ -595,9 +595,12 @@ module IlMachineThreadState =
 
         let o : AllocatedArray =
             {
-                ConcreteType = arrayType
-                Length = len
-                Lengths = ImmutableArray.Create len
+                Shape =
+                    {
+                        ConcreteType = arrayType
+                        Length = len
+                        Lengths = ImmutableArray.Create len
+                    }
                 Elements = initialisation
             }
 
@@ -663,9 +666,12 @@ module IlMachineThreadState =
 
         let o : AllocatedArray =
             {
-                ConcreteType = arrayType
-                Length = totalLength
-                Lengths = dimensionLengths
+                Shape =
+                    {
+                        ConcreteType = arrayType
+                        Length = totalLength
+                        Lengths = dimensionLengths
+                    }
                 Elements = initialisation
             }
 
@@ -743,7 +749,7 @@ module IlMachineThreadState =
 
         // `Array.Clone`'s managed body is `MemberwiseClone()`, so arrays are in scope even though
         // PawPrint intercepts `Array.Clone` itself and nothing can derive from `System.Array`.
-        match state.ManagedHeap.Arrays.ContainsKey source with
+        match ManagedHeap.isArray source state.ManagedHeap with
         | true -> cloneArray source state
         | false ->
             failwith $"cloneObject: address %O{source} is not allocated on the managed heap, so has nothing to clone"

--- a/WoofWare.PawPrint/IntrinsicHelpers.fs
+++ b/WoofWare.PawPrint/IntrinsicHelpers.fs
@@ -276,7 +276,7 @@ module internal IntrinsicHelpers =
                 let arrElementSize =
                     let arrObj = state.ManagedHeap.Arrays.[arr]
 
-                    if arrObj.Length = 0 then
+                    if arrObj.Shape.Length = 0 then
                         tSize
                     else
                         CliType.sizeOf arrObj.Elements.[0]
@@ -326,7 +326,7 @@ module internal IntrinsicHelpers =
                     let baseSrc = ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, i), projs)
 
                     let normalisationElementSize =
-                        let obj = state.ManagedHeap.Arrays.[arr]
+                        let obj = ManagedHeap.getArrayShape arr state.ManagedHeap
 
                         if obj.Length = 0 then 0 else arrElementSize
 

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -2034,10 +2034,14 @@ module Intrinsics =
                 )
             | Some rvaData ->
 
+            // Keeps the whole allocation: the RVA-decoding fold below reads element `i` as a
+            // *template* for `readPeByteRangeBytesAs`, which is a type query rather than a
+            // guest-visible cell read. Splitting that out is left to the follow-up that
+            // introduces a dedicated accessor for cell-type witnesses.
             let arr = state.ManagedHeap.Arrays.[arrayAddr]
 
             let elementHandle : ConcreteTypeHandle =
-                match arr.ConcreteType with
+                match arr.Shape.ConcreteType with
                 | ConcreteTypeHandle.OneDimArrayZero element -> element
                 | ConcreteTypeHandle.Array (element, _) -> element
                 | other ->
@@ -2120,7 +2124,7 @@ module Intrinsics =
                 IlMachineState.cliTypeZeroOfHandle state baseClassTypes elementHandle
 
             let elementStride : int = CliType.sizeOf elementZero
-            let totalSize : int64 = int64 elementStride * int64 arr.Length
+            let totalSize : int64 = int64 elementStride * int64 arr.Shape.Length
 
             // `// make certain you don't go off the end of the rva static
             //  if (totalSize > size) throw new ArgumentException(SR.Argument_BadFieldForInitializeArray);`
@@ -2146,7 +2150,7 @@ module Intrinsics =
             // arrays are stored flat in row-major order, matching the CLR's own layout, so the
             // same flat walk serves them.
             let state =
-                (state, seq { 0 .. arr.Length - 1 })
+                (state, seq { 0 .. arr.Shape.Length - 1 })
                 ||> Seq.fold (fun (state : IlMachineState) (i : int) ->
                     let decoded =
                         IlMachineState.readPeByteRangeBytesAs state rvaData (i * elementStride) arr.Elements.[i]
@@ -2689,7 +2693,7 @@ module Intrinsics =
                     let elementSize =
                         let obj = state.ManagedHeap.Arrays.[arr]
 
-                        if obj.Length = 0 then
+                        if obj.Shape.Length = 0 then
                             0
                         else
                             CliType.sizeOf obj.Elements.[0]
@@ -2718,7 +2722,7 @@ module Intrinsics =
                         | ByrefRoot.ArrayElement (arr, i), [] ->
                             let arrObj = state.ManagedHeap.Arrays.[arr]
 
-                            if arrObj.Length = 0 then
+                            if arrObj.Shape.Length = 0 then
                                 None
                             else
                                 let elementSize = CliType.sizeOf arrObj.Elements.[0]
@@ -2840,7 +2844,7 @@ module Intrinsics =
                     let arrObj = state.ManagedHeap.Arrays.[arr]
 
                     let elementSize =
-                        if arrObj.Length = 0 then
+                        if arrObj.Shape.Length = 0 then
                             tSize
                         else
                             CliType.sizeOf arrObj.Elements.[0]
@@ -3090,7 +3094,7 @@ module Intrinsics =
             | EvalStackValue.Float _ -> failwith "expected reference"
             | EvalStackValue.NativeInt nativeIntSource -> failwith "todo"
             | EvalStackValue.ObjectRef addr ->
-                if not (state.ManagedHeap.Arrays.ContainsKey addr) then
+                if not (ManagedHeap.isArray addr state.ManagedHeap) then
                     failwith "array not found"
 
                 let toPush =
@@ -3194,9 +3198,9 @@ module Intrinsics =
             match receiver with
             | EvalStackValue.ObjectRef addr ->
                 let arr =
-                    match state.ManagedHeap.Arrays.TryGetValue addr with
-                    | true, arr -> arr
-                    | false, _ -> failwith $"Array.%s{boundKind}: no array allocated at %O{addr}"
+                    match ManagedHeap.tryGetArrayShape addr state.ManagedHeap with
+                    | Some arr -> arr
+                    | None -> failwith $"Array.%s{boundKind}: no array allocated at %O{addr}"
 
                 // The stored shape and the receiver's concrete type must agree on rank. Both are
                 // written together by `allocateArray` / `allocateMultiDimArray`, so this cannot

--- a/WoofWare.PawPrint/ManagedHeap.fs
+++ b/WoofWare.PawPrint/ManagedHeap.fs
@@ -84,15 +84,30 @@ type AllocatedNonArrayObject =
             Contents = CliValueType.WithFieldSetById field v f.Contents
         }
 
-type AllocatedArray =
+/// Everything about an array except its contents: the element type, the total element
+/// count, and the per-dimension lengths. All three are fixed when the array is allocated
+/// and never change afterwards, so reading them is not a guest-visible memory access —
+/// unlike reading a cell, which is.
+///
+/// The absence of an `Elements` field is the point. A caller that needs only the rank or
+/// the length holds a value from which no cell can be reached, so a shape query cannot
+/// silently become a data read as the code around it changes. Cell reads go through
+/// `ManagedHeap.getArrayValue`.
+type ArrayShape =
     {
         ConcreteType : ConcreteTypeHandle
-        /// Total element count, equal to the product of `Lengths`. For szarrays this is just
-        /// the array length; for multi-dim arrays it is the size of the flat backing store.
+        /// Total element count, equal to the product of `Lengths`.
         Length : int
-        /// Per-dimension lengths in row-major order. Length is 1 for szarrays, equal to the
-        /// rank for multi-dim arrays. Multiplying these produces `Length`.
+        /// Per-dimension lengths in row-major order; length 1 for szarrays, else the rank.
         Lengths : ImmutableArray<int>
+    }
+
+type AllocatedArray =
+    {
+        /// Identity and dimensions, fixed at allocation. Held as a nested record rather
+        /// than inlined so that a caller wanting only the shape can be handed a value
+        /// from which no cell is reachable; see `ArrayShape`.
+        Shape : ArrayShape
         /// Backing store in row-major order. For multi-dim arrays the element at
         /// `(i_0, ..., i_{n-1})` lives at flat offset
         /// `((((i_0)*d_1)+i_1)*d_2 + i_2)*...*d_{n-1} + i_{n-1}`, where `d_k = Lengths.[k]`.
@@ -183,7 +198,7 @@ module ManagedHeap =
         | true, obj -> Some obj.ConcreteType
         | false, _ ->
             match heap.Arrays.TryGetValue alloc with
-            | true, arr -> Some arr.ConcreteType
+            | true, arr -> Some arr.Shape.ConcreteType
             | false, _ -> None
 
     let getObjectConcreteType (alloc : ManagedHeapAddress) (heap : ManagedHeap) : ConcreteTypeHandle =
@@ -328,6 +343,32 @@ module ManagedHeap =
                 failwith
                     $"stringsEqual: one or both addresses %O{a1}, %O{a2} are not registered strings; cannot compare contents"
 
+    /// Whether `addr` is a live array. False for a live non-array object and for an
+    /// address that was never allocated; use `tryGetObjectConcreteType` to tell those apart.
+    let isArray (addr : ManagedHeapAddress) (heap : ManagedHeap) : bool = heap.Arrays.ContainsKey addr
+
+    /// The dimensions and element type of the array at `addr`, or `None` if `addr` is not
+    /// a live array. Carries no cells: see `ArrayShape`.
+    let tryGetArrayShape (addr : ManagedHeapAddress) (heap : ManagedHeap) : ArrayShape option =
+        match heap.Arrays.TryGetValue addr with
+        | true, arr -> Some arr.Shape
+        | false, _ -> None
+
+    /// The dimensions and element type of the array at `addr`. Carries no cells: see
+    /// `ArrayShape`.
+    ///
+    /// The two rejection cases are reported differently because they are different bugs:
+    /// a non-array address means the caller misjudged the type of the reference it was
+    /// handed, whereas an unallocated address means the reference itself is bogus.
+    let getArrayShape (addr : ManagedHeapAddress) (heap : ManagedHeap) : ArrayShape =
+        match tryGetArrayShape addr heap with
+        | Some shape -> shape
+        | None ->
+            if heap.NonArrayObjects.ContainsKey addr then
+                failwith $"getArrayShape: %O{addr} is not an array, so has no array shape"
+            else
+                failwith $"getArrayShape: %O{addr} is not a live managed heap allocation, so has no array shape"
+
     let getArrayValue (alloc : ManagedHeapAddress) (offset : int) (heap : ManagedHeap) : CliType =
         match heap.Arrays.TryGetValue alloc with
         | false, _ -> failwith $"TODO: array not on heap (no array registered at %O{alloc})"
@@ -335,10 +376,10 @@ module ManagedHeap =
 
         if offset < 0 then
             failwith
-                $"TODO: raise IndexOutOfRangeException: negative array index %d{offset} on array at %O{alloc} (length %d{arr.Length}). A negative index here typically means a byref obtained via `RawData::Data` on an array was read without first applying the canonical `+sizeof(nint)` skip past the length-header region; if you intended to read the length, use `RawArrayData::Length` instead."
-        elif offset >= arr.Length then
+                $"TODO: raise IndexOutOfRangeException: negative array index %d{offset} on array at %O{alloc} (length %d{arr.Shape.Length}). A negative index here typically means a byref obtained via `RawData::Data` on an array was read without first applying the canonical `+sizeof(nint)` skip past the length-header region; if you intended to read the length, use `RawArrayData::Length` instead."
+        elif offset >= arr.Shape.Length then
             failwith
-                $"TODO: raise IndexOutOfRangeException: array index %d{offset} >= length %d{arr.Length} on array at %O{alloc}"
+                $"TODO: raise IndexOutOfRangeException: array index %d{offset} >= length %d{arr.Shape.Length} on array at %O{alloc}"
 
         arr.Elements.[offset]
 

--- a/WoofWare.PawPrint/ManagedPointerByteView.fs
+++ b/WoofWare.PawPrint/ManagedPointerByteView.fs
@@ -2,7 +2,7 @@ namespace WoofWare.PawPrint
 
 [<RequireQualifiedAccess>]
 module ManagedPointerByteView =
-    let private arrayElementHandle (arrObj : AllocatedArray) : ConcreteTypeHandle =
+    let private arrayElementHandle (arrObj : ArrayShape) : ConcreteTypeHandle =
         match arrObj.ConcreteType with
         | ConcreteTypeHandle.OneDimArrayZero element -> element
         | ConcreteTypeHandle.Array (element, _) -> element
@@ -20,7 +20,7 @@ module ManagedPointerByteView =
         =
         let obj = state.ManagedHeap.Arrays.[arr]
 
-        if obj.Length > 0 then
+        if obj.Shape.Length > 0 then
             CliType.sizeOf obj.Elements.[0]
         else
             // Deliberately the non-loading walk: this returns a bare `int`, with nowhere to put
@@ -33,7 +33,7 @@ module ManagedPointerByteView =
                     state.ConcreteTypes
                     state._LoadedAssemblies
                     baseClassTypes
-                    (arrayElementHandle obj)
+                    (arrayElementHandle obj.Shape)
 
             CliType.sizeOf zero
 
@@ -47,8 +47,8 @@ module ManagedPointerByteView =
         (arr : ManagedHeapAddress)
         : ConcreteType<ConcreteTypeHandle> option
         =
-        let obj = state.ManagedHeap.Arrays.[arr]
-        let handle = arrayElementHandle obj
+        let handle = arrayElementHandle (ManagedHeap.getArrayShape arr state.ManagedHeap)
+
         AllConcreteTypes.lookup handle state.ConcreteTypes
 
     let arrayBytePosition
@@ -175,8 +175,7 @@ module ManagedPointerByteView =
 
         match ptr with
         | ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, _), []) ->
-            let arrObj = state.ManagedHeap.Arrays.[arr]
-            let handle = arrayElementHandle arrObj
+            let handle = arrayElementHandle (ManagedHeap.getArrayShape arr state.ManagedHeap)
 
             match handle with
             | ConcreteTypeHandle.Concrete _ ->

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
@@ -2613,9 +2613,9 @@ module NativeRuntimeTypeHelpers =
         | CliType.ObjectRef None -> None
         | CliType.ObjectRef (Some arrayAddr) ->
             let array =
-                match state.ManagedHeap.Arrays.TryGetValue arrayAddr with
-                | true, array -> array
-                | false, _ ->
+                match ManagedHeap.tryGetArrayShape arrayAddr state.ManagedHeap with
+                | Some array -> array
+                | None ->
                     failwith
                         $"%s{operation}: %s{argName} points at %O{arrayAddr}, which is not an array on the managed heap"
 

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -48,7 +48,7 @@ module NullaryIlOp =
                 let arrObj = state.ManagedHeap.Arrays.[arr]
 
                 let elementSize =
-                    if arrObj.Length = 0 then
+                    if arrObj.Shape.Length = 0 then
                         // Array.Empty<T>() has no representative element from
                         // which to read the byte stride. The only stable address
                         // we can derive without the element type is index zero.
@@ -1511,7 +1511,7 @@ module NullaryIlOp =
             | EvalStackValue.NullObjectRef -> failwith "TODO: throw NRE"
             | _ -> failwith $"Invalid array: %O{arr}"
 
-        let arr = state.ManagedHeap.Arrays.[arrAddr]
+        let arr = ManagedHeap.getArrayShape arrAddr state.ManagedHeap
 
         if index < 0 || index >= arr.Length then
             failwith "TODO: throw IndexOutOfRangeException"
@@ -1537,7 +1537,7 @@ module NullaryIlOp =
         // the same handle either way today; deriving it from the current state keeps that a
         // property we rely on locally rather than one a reader has to go and confirm.)
         let elementHandle =
-            match state.ManagedHeap.Arrays.[arrAddr].ConcreteType with
+            match (ManagedHeap.getArrayShape arrAddr state.ManagedHeap).ConcreteType with
             | ConcreteTypeHandle.OneDimArrayZero element -> element
             | other ->
                 failwith
@@ -2470,7 +2470,7 @@ module NullaryIlOp =
                 | EvalStackValue.ObjectRef addr -> addr
                 | _ -> failwith $"can't get len of {popped}"
 
-            let popped = state.ManagedHeap.Arrays.[popped]
+            let popped = ManagedHeap.getArrayShape popped state.ManagedHeap
 
             IlMachineState.pushToEvalStack'
                 (EvalStackValue.Int32 (Int32Source.Verbatim popped.Length))

--- a/WoofWare.PawPrint/RawArrayDataProjection.fs
+++ b/WoofWare.PawPrint/RawArrayDataProjection.fs
@@ -47,7 +47,7 @@ module internal RawArrayDataProjection =
             let arr = arrayOrFail addr state
 
             match field.Name with
-            | "Length" -> Some (uint32Field (uint32 arr.Length))
+            | "Length" -> Some (uint32Field (uint32 arr.Shape.Length))
             | "Data" ->
                 failwith
                     $"TODO: RawArrayData::Data value load for array object %O{addr}; this is the shape emitted by reading Unsafe.As<RawArrayData>(array).Data, but only ldflda address projection is implemented"

--- a/WoofWare.PawPrint/RuntimeFieldProjection.fs
+++ b/WoofWare.PawPrint/RuntimeFieldProjection.fs
@@ -123,7 +123,7 @@ module internal RuntimeFieldProjection =
     let private requireHeapObject (addr : ManagedHeapAddress) (state : IlMachineState) : unit =
         let exists =
             state.ManagedHeap.NonArrayObjects.ContainsKey addr
-            || state.ManagedHeap.Arrays.ContainsKey addr
+            || ManagedHeap.isArray addr state.ManagedHeap
 
         if not exists then
             failwith $"RawData::Data projection expected heap object at %O{addr}, but no such object exists"
@@ -150,8 +150,8 @@ module internal RuntimeFieldProjection =
 
                 let byteView = ByrefProjection.ReinterpretAs (byteConcreteType baseClassTypes state)
 
-                match state.ManagedHeap.Arrays.TryGetValue addr with
-                | true, arr ->
+                match ManagedHeap.tryGetArrayShape addr state.ManagedHeap with
+                | Some arr ->
                     // CoreCLR's `Unsafe.As<RawData>(arr).Data` is a byref to the array's
                     // length-and-padding header, `sizeof(nint)` bytes before the first
                     // element on SZ arrays. We model that "before-element-0" position by
@@ -185,7 +185,7 @@ module internal RuntimeFieldProjection =
                     | other ->
                         failwith
                             $"RawData::Data projection encountered array at %O{addr} whose ConcreteType is not an array handle: %O{other}"
-                | false, _ ->
+                | None ->
                     // Non-array heap object: byref to the start of instance data.
                     // Payload byte-view safety, including object-reference and layout
                     // checks, is enforced when the byref is read or written.

--- a/WoofWare.PawPrint/UnaryMetadataArrayOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataArrayOps.fs
@@ -179,7 +179,7 @@ module internal UnaryMetadataArrayOps =
             | Some addr -> addr
             | None -> failwith "TODO: throw NRE"
 
-        let arrAlloc = state.ManagedHeap.Arrays.[arrAddr]
+        let arrAlloc = ManagedHeap.getArrayShape arrAddr state.ManagedHeap
 
         if index < 0 || index >= arrAlloc.Length then
             failwith "TODO: throw IndexOutOfRangeException"
@@ -283,9 +283,9 @@ module internal UnaryMetadataArrayOps =
         // check, matching CoreCLR ordering (e.g. `Store<object>(new string[0], 0, new object())`
         // must raise IndexOutOfRangeException, not ArrayTypeMismatchException).
         let arrAlloc =
-            match state.ManagedHeap.Arrays.TryGetValue arr with
-            | true, v -> v
-            | false, _ -> failwith $"executeStelem: array allocation not found at %O{arr}"
+            match ManagedHeap.tryGetArrayShape arr state.ManagedHeap with
+            | Some v -> v
+            | None -> failwith $"executeStelem: array allocation not found at %O{arr}"
 
         if index < 0 || index >= arrAlloc.Length then
             // Don't advance PC: exception dispatch needs the faulting instruction's offset.

--- a/WoofWare.PawPrint/UnaryMetadataCallOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataCallOps.fs
@@ -117,9 +117,9 @@ module internal UnaryMetadataCallOps =
         | Some arrAddr ->
 
         let arrObj =
-            match state.ManagedHeap.Arrays.TryGetValue arrAddr with
-            | true, v -> v
-            | false, _ -> failwith $"multi-dim array Set: array allocation not found at %O{arrAddr}"
+            match ManagedHeap.tryGetArrayShape arrAddr state.ManagedHeap with
+            | Some v -> v
+            | None -> failwith $"multi-dim array Set: array allocation not found at %O{arrAddr}"
 
         if arrObj.Lengths.Length <> rank then
             failwith
@@ -213,9 +213,9 @@ module internal UnaryMetadataCallOps =
         | Some arrAddr ->
 
         let arrObj =
-            match state.ManagedHeap.Arrays.TryGetValue arrAddr with
-            | true, v -> v
-            | false, _ -> failwith $"multi-dim array Get: array allocation not found at %O{arrAddr}"
+            match ManagedHeap.tryGetArrayShape arrAddr state.ManagedHeap with
+            | Some v -> v
+            | None -> failwith $"multi-dim array Get: array allocation not found at %O{arrAddr}"
 
         if arrObj.Lengths.Length <> rank then
             failwith
@@ -234,7 +234,7 @@ module internal UnaryMetadataCallOps =
 
         let state =
             state
-            |> IlMachineState.pushToEvalStack arrObj.Elements.[flat] thread
+            |> IlMachineState.pushToEvalStack (IlMachineState.getArrayValue arrAddr flat state) thread
             |> IlMachineState.advanceProgramCounter thread
 
         state, WhatWeDid.Executed
@@ -317,9 +317,9 @@ module internal UnaryMetadataCallOps =
         | Some arrAddr ->
 
         let arrObj =
-            match state.ManagedHeap.Arrays.TryGetValue arrAddr with
-            | true, v -> v
-            | false, _ -> failwith $"multi-dim array Address: array allocation not found at %O{arrAddr}"
+            match ManagedHeap.tryGetArrayShape arrAddr state.ManagedHeap with
+            | Some v -> v
+            | None -> failwith $"multi-dim array Address: array allocation not found at %O{arrAddr}"
 
         if arrObj.Lengths.Length <> rank then
             failwith

--- a/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
@@ -867,11 +867,12 @@ module internal UnaryMetadataObjectOps =
                 match state.ManagedHeap.NonArrayObjects.TryGetValue addr with
                 | true, v -> Some v
                 | false, _ ->
-                    match state.ManagedHeap.Arrays.TryGetValue addr with
                     // An array is never a boxed value type, so per the CLR this is an ordinary
                     // type mismatch rather than an interpreter abort.
-                    | true, _ -> None
-                    | false, _ -> failwith $"%s{opName}: could not find managed object with address {addr}"
+                    if ManagedHeap.isArray addr state.ManagedHeap then
+                        None
+                    else
+                        failwith $"%s{opName}: could not find managed object with address {addr}"
 
             match boxedOpt with
             | None -> state, UnboxTypeTest.WrongType
@@ -1001,10 +1002,11 @@ module internal UnaryMetadataObjectOps =
                     match state.ManagedHeap.NonArrayObjects.TryGetValue addr with
                     | true, v -> Some v
                     | false, _ ->
-                        match state.ManagedHeap.Arrays.TryGetValue addr with
                         // An array can never be a boxed T for any T that Nullable admits.
-                        | true, _ -> None
-                        | false, _ -> failwith $"Unbox_Any: could not find managed object with address {addr}"
+                        if ManagedHeap.isArray addr state.ManagedHeap then
+                            None
+                        else
+                            failwith $"Unbox_Any: could not find managed object with address {addr}"
 
                 match boxedOpt with
                 | Some boxed when boxed.ConcreteType = underlyingHandle ->


### PR DESCRIPTION
**Stage 0, PR 2 of 4** of closing the guest-memory access seam in `ManagedHeap` (PR 1 was #938). Groundwork for a happens-before race detector that could flag schedule-sensitivity from one successful run; the prerequisite is that memory accesses are identifiable at all.

## The distinction this draws

Reading an array's rank, length, or element type is **not** a guest-visible memory access — all three are fixed at allocation and never change. Reading a cell **is**. Until now both went through the same `AllocatedArray` record, so the two were indistinguishable at every call site.

`ArrayShape` carries element type, total length, and per-dimension lengths, and deliberately **no `Elements`**. A caller handed a shape holds a value from which no cell is reachable, so a shape query cannot quietly become a data read as the code around it changes.

## Why nested rather than inlined

`ArrayShape` is nested inside `AllocatedArray` rather than the three fields being duplicated across both records. Duplicating them makes F# field inference ambiguous — the compiler reports FS3566 and silently resolves a construction site to whichever type it picked. I hit this during the migration. Nesting makes the ambiguity unrepresentable.

That is the source of most of the diff's line count: `arr.Length` becomes `arr.Shape.Length` at the sites not yet migrated, and the two allocation sites plus the test constructions gain a level of nesting.

## What is deliberately *not* migrated

Eight sites of the form:

```fsharp
if arrObj.Length = 0 then _ else CliType.sizeOf arrObj.Elements.[0]
```

These read a cell only to learn its **type**. That is an artifact of PawPrint storing types per cell — real hardware derives element stride statically from the type — so they are not guest-visible reads either, and instrumenting them as such would produce false reports. But they need an accessor of their own and a decision about what to call the contract, which deserves its own review rather than being bundled here. They keep direct map access until then, and `Intrinsics.fs` carries a comment saying so.

Genuine cell reads (`ldelem`, multi-dim `Array::Get`) also remain, except where the swap to `getArrayValue` was exact — `Array::Get` was migrated, `ldelem` was not, because its bounds-check diagnostics differ from `getArrayValue`'s and changing those is a separate decision.

## Testing

Five tests, written first and observed failing for the right reason. The load-bearing one is a property whose oracle is the allocation record itself: `getArrayShape` must project it field-for-field, never derive or normalise — `Length` in particular is stored, not recomputed from `Lengths`, and the projection must not start recomputing it.

Each new function was mutation-tested, one arm at a time:

| Mutation | Killed by |
|---|---|
| Collapse `getArrayShape`'s not-an-array/never-allocated discrimination | 1 test |
| Corrupt the projected shape (`Length = 0`) | 2 tests, including the property |
| Point `isArray` at the non-array map | 1 test |

Behaviour is otherwise unchanged. Full suite: 2763 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
