### PR TITLE
Address Codex review of the array-shape seam

### DIFF
--- a/WoofWare.PawPrint.Test/TestManagedHeap.fs
+++ b/WoofWare.PawPrint.Test/TestManagedHeap.fs
@@ -621,8 +621,16 @@ module TestManagedHeap =
         // The oracle is the allocation record itself: `getArrayShape` must project it
         // field-for-field, never derive or normalise. `Length` in particular is stored,
         // not recomputed from `Lengths`, and the projection must not start recomputing it.
+        //
+        // The backing store is deliberately left empty while `Length` is not. That is an
+        // inconsistent allocation, which is the point: it distinguishes a projection that
+        // reads the stored `Length` from one that derives it from `Elements.Length`, and
+        // it keeps the generator from ever materialising a large array. Bounding the rank
+        // to 6 dimensions of at most 4 keeps the product well inside Int32 too, so no
+        // seed can make this test fail for reasons unrelated to the property.
         let property (lengths : int list) : bool =
-            let lengths = lengths |> List.map (fun n -> (abs n) % 5)
+            let lengths = lengths |> List.truncate 6 |> List.map (fun n -> (abs (n % 5)))
+
             let total = lengths |> List.fold (*) 1
 
             let allocation : AllocatedArray =
@@ -633,9 +641,7 @@ module TestManagedHeap =
                             Length = total
                             Lengths = ImmutableArray.CreateRange lengths
                         }
-                    Elements =
-                        Seq.replicate total (CliType.Numeric (CliNumericType.Int32 0))
-                        |> ImmutableArray.CreateRange
+                    Elements = ImmutableArray.Empty
                 }
 
             let addr, heap = ManagedHeap.allocateArray allocation ManagedHeap.empty

--- a/WoofWare.PawPrint/RawArrayDataProjection.fs
+++ b/WoofWare.PawPrint/RawArrayDataProjection.fs
@@ -17,10 +17,13 @@ module internal RawArrayDataProjection =
         && field.DeclaringType.Name = "RawArrayData"
         && field.DeclaringType.Generics.IsEmpty
 
-    let private arrayOrFail (addr : ManagedHeapAddress) (state : IlMachineState) : AllocatedArray =
-        match state.ManagedHeap.Arrays.TryGetValue addr with
-        | true, arr -> arr
-        | false, _ -> failwith $"RawArrayData projection expected array object at %O{addr}"
+    /// Both callers want only the dimensions — one reads `Length`, the other merely
+    /// asserts that the address really is an array — so this hands back a shape, from
+    /// which no cell is reachable.
+    let private arrayOrFail (addr : ManagedHeapAddress) (state : IlMachineState) : ArrayShape =
+        match ManagedHeap.tryGetArrayShape addr state.ManagedHeap with
+        | Some arr -> arr
+        | None -> failwith $"RawArrayData projection expected array object at %O{addr}"
 
     let private byteConcreteType
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
@@ -47,7 +50,7 @@ module internal RawArrayDataProjection =
             let arr = arrayOrFail addr state
 
             match field.Name with
-            | "Length" -> Some (uint32Field (uint32 arr.Shape.Length))
+            | "Length" -> Some (uint32Field (uint32 arr.Length))
             | "Data" ->
                 failwith
                     $"TODO: RawArrayData::Data value load for array object %O{addr}; this is the shape emitted by reading Unsafe.As<RawArrayData>(array).Data, but only ldflda address projection is implemented"


### PR DESCRIPTION
Follow-up to #940, which merged before I had pushed the review fixes. Two Codex findings, both correct.

## `RawArrayData` bypassed the new seam

`RawArrayDataProjection.arrayOrFail` still returned the whole `AllocatedArray`, even though both its callers want only the dimensions — one reads `Length`, the other merely asserts the address really is an array. Leaving `Elements` reachable from a shape-only path defeats exactly the guarantee #940 exists to provide. It now returns an `ArrayShape`.

## The new property test could take the test host down

It built a backing store of `total` elements, where `total` is the product of the generated dimensions. A seed with enough non-zero dimensions and no zero — fifteen values mapping to 4 gives 2^30 — would have tried to materialise a billion `CliType` cells. Under the suite's GC heap hard limit that surfaces as "Test host process crashed" with no stderr, which is a genuinely nasty thing to debug.

It passed 200 cases only because `(abs n) % 5` hits zero about one draw in five, so a long list almost always contains a zero and collapses the product. That is a latent flake, which is precisely what this project exists to eliminate.

The allocation now uses an **empty** backing store while `Length` stays as generated, and the rank is bounded to 6 dimensions of at most 4.

### The fix makes the property strictly stronger

That inconsistency — `Length` non-zero, `Elements` empty — is deliberate. It distinguishes a projection that reads the *stored* `Length` from one that derives it from `Elements.Length`.

Verified by mutation: replacing the projection with

```fsharp
| true, arr -> Some { arr.Shape with Length = arr.Elements.Length }
```

fails this test — and **would have passed** the version Codex reviewed, whose `Elements` had exactly `total` entries. So the finding closed a real hole in the test's coverage, not just a resource risk.

Also switched `abs n % 5` to `abs (n % 5)`, so an `Int32.MinValue` draw cannot raise `OverflowException`.

Full suite: 2763 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
