### PR TITLE
Give every debugger frame a source location

### DIFF
--- a/.agents/skills/pawprint-debugger-server/SKILL.md
+++ b/.agents/skills/pawprint-debugger-server/SKILL.md
@@ -104,11 +104,20 @@ case for the entire shared framework (it ships without PDBs), for synthesised st
 IL the compiler marked as having no source. Only assemblies built with debug information
 resolve. Do not report a null here as a defect.
 
-**`ilOffset` inside the location is not always the frame's `ilOffset`.** For the active frame
-they agree. For any *caller*, the frame's own `ilOffset` is where it will resume — the
-instruction after the call — so the location is instead resolved at the call site, and says
-which offset it used. Read the source line from `sourceLocation`, not by looking up the
-frame's `ilOffset` yourself, or every caller will appear one statement further on than it is.
+**`ilOffset` inside the location is often not the frame's `ilOffset`, and that is not a bug.**
+The frame's `ilOffset` is its program counter; the location's is where the source was actually
+looked up. They differ in two cases, both deliberate:
+
+- For any *caller*, the frame's `ilOffset` is where it will resume — the instruction after the
+  call — so the location is resolved at the call site instead.
+- For an active frame on a thread blocked in a QCall (`blockedOnJoin`, the monitor,
+  wait-handle and sleep statuses), the program counter has already advanced past the call that
+  blocked it, so the location steps back onto that call. This is exactly the case you are most
+  likely to be inspecting, so expect the two to disagree there.
+
+Read the source line from `sourceLocation`. Never look the frame's own `ilOffset` up in the
+PDB yourself: callers would appear one statement further on than they are, and a blocked thread
+would appear to be on the statement after the one it is blocked in.
 
 `documentPath` is recorded exactly as the compiler saw it, so it names paths on whichever
 machine built the assembly. It may well not exist on this one.

--- a/.agents/skills/pawprint-debugger-server/SKILL.md
+++ b/.agents/skills/pawprint-debugger-server/SKILL.md
@@ -79,12 +79,39 @@ Endpoint summary:
 - `GET /state`: session status, step count, loaded assemblies, thread summaries, heap counts.
 - `POST /step?count=N`: execute up to `N` scheduler steps and return each event plus the new summary.
 - `POST /run?maxSteps=N`: execute at most `N` steps and return recent events. Use this to move forward safely, not to prove termination. If `/stop` cancels an active run, the response includes `cancelled: true`.
-- `GET /thread/{id}`: full frame list for a thread, including active frame, IL offset, current instruction, eval stack, args, and locals.
+- `GET /thread/{id}`: full frame list for a thread, including active frame, IL offset, current instruction, source location, eval stack, args, and locals.
 - `GET /thread/{id}/stack-summary`: compact stack summary for deep stacks. Optional query parameters: `edgeFrames` (default 12, max 100) and `topMethods` (default 8, max 100).
 - `GET /thread/{id}/active-method/il`: IL for the thread's active frame, including resolved metadata-token text and the active instruction. Optional query parameter: `context` instructions before/after the active offset (omitted means full method, max 500).
 - `GET /heap/{address}`: inspect an object or array at a managed heap address. Use structured `objectAddress` fields from stack, argument, local, and array-element values when available.
 - `POST /reset`: recreate the debugger session from the original DLL and arguments.
 - `POST /stop`: stop the server cleanly.
+
+### Source locations
+
+Every frame carries a `sourceLocation`, which is `null` or an object:
+
+```json
+"sourceLocation": {
+  "ilOffset": 13, "documentPath": "/src/Program.cs",
+  "startLine": 8, "startColumn": 28, "endLine": 8, "endColumn": 29
+}
+```
+
+Two things to know before relying on it.
+
+**`null` is ordinary, not a bug.** It means "no source is known for this frame", which is the
+case for the entire shared framework (it ships without PDBs), for synthesised stubs, and for
+IL the compiler marked as having no source. Only assemblies built with debug information
+resolve. Do not report a null here as a defect.
+
+**`ilOffset` inside the location is not always the frame's `ilOffset`.** For the active frame
+they agree. For any *caller*, the frame's own `ilOffset` is where it will resume — the
+instruction after the call — so the location is instead resolved at the call site, and says
+which offset it used. Read the source line from `sourceLocation`, not by looking up the
+frame's `ilOffset` yourself, or every caller will appear one statement further on than it is.
+
+`documentPath` is recorded exactly as the compiler saw it, so it names paths on whichever
+machine built the assembly. It may well not exist on this one.
 
 The sandbox may block localhost HTTP calls. If `curl` fails with `Operation not permitted`, rerun the exact same command with escalated permissions; do not request a persisted broad `curl` prefix rule.
 
@@ -111,8 +138,8 @@ jq '{
   frameCount:(.frames|length),
   active:(.frames[]|select(.active)),
   topMethods:(.frames|group_by(.method)|map({method:.[0].method,count:length})|sort_by(-.count)[:8]),
-  firstFrames:(.frames[:12]|map({id,method,ilOffset,instruction})),
-  lastFrames:(.frames[-12:]|map({id,method,ilOffset,instruction}))
+  firstFrames:(.frames[:12]|map({id,method,ilOffset,instruction,source:(.sourceLocation|if . then "\(.documentPath):\(.startLine)" else null end)})),
+  lastFrames:(.frames[-12:]|map({id,method,ilOffset,instruction,source:(.sourceLocation|if . then "\(.documentPath):\(.startLine)" else null end)}))
 }' /tmp/pawprint-thread.json
 ```
 

--- a/WoofWare.PawPrint.App/DebuggerServer.fs
+++ b/WoofWare.PawPrint.App/DebuggerServer.fs
@@ -162,8 +162,43 @@ module DebuggerServer =
         | ThreadStatus.Terminated -> writer.WriteStringValue "terminated"
         | ThreadStatus.Parked -> writer.WriteStringValue "parked"
 
+    /// The source span the compiler attributed to `sourceIlOffset` in `frame`, or `null`.
+    ///
+    /// `null` is ordinary rather than exceptional: the whole shared framework ships without
+    /// PDBs, a synthesised stub has no metadata row to key one by, and a compiler may mark a
+    /// range as having no source at all. A consumer must treat its absence as "not known here",
+    /// never as a defect.
+    ///
+    /// The span carries the offset it was resolved at, which for anything but the active frame
+    /// is deliberately *not* the frame's `ilOffset`: see `GuestLocation.attributionOffsets`.
+    /// Emitting it makes the two impossible to confuse.
+    let private writeSourceLocation
+        (writer : Utf8JsonWriter)
+        (state : IlMachineState)
+        (sourceIlOffset : int)
+        (frame : MethodState)
+        : unit
+        =
+        writer.WritePropertyName "sourceLocation"
+
+        match GuestLocation.trySourceOf state frame.ExecutingMethod sourceIlOffset with
+        | None -> writer.WriteNullValue ()
+        | Some location ->
+            writer.WriteStartObject ()
+            writer.WriteNumber ("ilOffset", sourceIlOffset)
+            // Exactly as the PDB records it — an absolute path on whichever machine built the
+            // assembly. Deliberately not resolved against this filesystem; see `SourceLocation`.
+            writer.WriteString ("documentPath", location.DocumentPath)
+            writer.WriteNumber ("startLine", location.StartLine)
+            writer.WriteNumber ("startColumn", location.StartColumn)
+            writer.WriteNumber ("endLine", location.EndLine)
+            writer.WriteNumber ("endColumn", location.EndColumn)
+            writer.WriteEndObject ()
+
     let private writeFrameProperties
         (writer : Utf8JsonWriter)
+        (state : IlMachineState)
+        (sourceIlOffset : int)
         (includeActive : bool)
         (activeFrame : FrameId)
         (frameId : FrameId)
@@ -178,22 +213,31 @@ module DebuggerServer =
         writer.WriteString ("method", string frame.ExecutingMethod)
         writer.WriteNumber ("ilOffset", frame.IlOpIndex)
         writeOptionalString writer "instruction" (currentInstruction frame)
+        writeSourceLocation writer state sourceIlOffset frame
         writer.WriteNumber ("evalStackDepth", frame.EvaluationStack.Values.Length)
         writer.WriteNumber ("argumentCount", frame.Arguments.Length)
         writer.WriteNumber ("localCount", frame.LocalVariables.Length)
 
     let private writeFrameSummary
         (writer : Utf8JsonWriter)
+        (state : IlMachineState)
+        (sourceIlOffset : int)
         (activeFrame : FrameId)
         (frameId : FrameId)
         (frame : MethodState)
         : unit
         =
         writer.WriteStartObject ()
-        writeFrameProperties writer false activeFrame frameId frame
+        writeFrameProperties writer state sourceIlOffset false activeFrame frameId frame
         writer.WriteEndObject ()
 
-    let private writeThreadSummary (writer : Utf8JsonWriter) (threadId : ThreadId) (threadState : ThreadState) : unit =
+    let private writeThreadSummary
+        (writer : Utf8JsonWriter)
+        (state : IlMachineState)
+        (threadId : ThreadId)
+        (threadState : ThreadState)
+        : unit
+        =
         writer.WriteStartObject ()
         writer.WriteNumber ("id", threadIdValue threadId)
         writer.WritePropertyName "status"
@@ -212,7 +256,16 @@ module DebuggerServer =
             writer.WriteString ("activeAssembly", threadState.ActiveAssembly.FullName)
             writer.WriteNumber ("activeFrame", frameIdValue threadState.ActiveMethodState)
             writer.WritePropertyName "activeFrameSummary"
-            writeFrameSummary writer threadState.ActiveMethodState threadState.ActiveMethodState threadState.MethodState
+
+            let offsets = GuestLocation.attributionOffsets threadState
+
+            writeFrameSummary
+                writer
+                state
+                (Map.find threadState.ActiveMethodState offsets)
+                threadState.ActiveMethodState
+                threadState.ActiveMethodState
+                threadState.MethodState
 
         writer.WriteEndObject ()
 
@@ -263,13 +316,15 @@ module DebuggerServer =
 
     let private writeFrameDetails
         (writer : Utf8JsonWriter)
+        (state : IlMachineState)
+        (sourceIlOffset : int)
         (activeFrame : FrameId)
         (frameId : FrameId)
         (frame : MethodState)
         : unit
         =
         writer.WriteStartObject ()
-        writeFrameProperties writer true activeFrame frameId frame
+        writeFrameProperties writer state sourceIlOffset true activeFrame frameId frame
         writeValueArray writer "evalStack" frame.EvaluationStack.Values writeEvalStackValue
         writeValueArray writer "arguments" frame.Arguments writeCliType
         writeValueArray writer "locals" frame.LocalVariables writeCliType
@@ -512,7 +567,7 @@ module DebuggerServer =
             writer
             "threads"
             (state.ThreadState |> Map.toSeq)
-            (fun writer (threadId, threadState) -> writeThreadSummary writer threadId threadState)
+            (fun writer (threadId, threadState) -> writeThreadSummary writer state threadId threadState)
 
         writer.WriteEndObject ()
 
@@ -542,11 +597,21 @@ module DebuggerServer =
                 writer.WriteString ("activeAssembly", threadState.ActiveAssembly.FullName)
                 writer.WriteNumber ("activeFrame", frameIdValue threadState.ActiveMethodState)
 
+            let offsets = GuestLocation.attributionOffsets threadState
+
             writeValueArray
                 writer
                 "frames"
                 (threadState.MethodStates |> Map.toSeq)
-                (fun writer (frameId, frame) -> writeFrameDetails writer threadState.ActiveMethodState frameId frame)
+                (fun writer (frameId, frame) ->
+                    writeFrameDetails
+                        writer
+                        state
+                        (Map.find frameId offsets)
+                        threadState.ActiveMethodState
+                        frameId
+                        frame
+                )
 
             writer.WriteEndObject ()
 
@@ -610,6 +675,7 @@ module DebuggerServer =
             let firstFrames = frames |> Array.truncate edgeFrames
             let lastFrames = frames |> Array.skip (frames.Length - edgeFrames)
             let methodCounts = methodCounts frames topMethods
+            let offsets = GuestLocation.attributionOffsets threadState
 
             writer.WriteStartObject ()
             writer.WriteNumber ("id", threadIdValue threadId)
@@ -629,6 +695,8 @@ module DebuggerServer =
 
                 writeFrameSummary
                     writer
+                    state
+                    (Map.find threadState.ActiveMethodState offsets)
                     threadState.ActiveMethodState
                     threadState.ActiveMethodState
                     threadState.MethodState
@@ -639,13 +707,29 @@ module DebuggerServer =
                 writer
                 "firstFrames"
                 firstFrames
-                (fun writer (frameId, frame) -> writeFrameSummary writer threadState.ActiveMethodState frameId frame)
+                (fun writer (frameId, frame) ->
+                    writeFrameSummary
+                        writer
+                        state
+                        (Map.find frameId offsets)
+                        threadState.ActiveMethodState
+                        frameId
+                        frame
+                )
 
             writeValueArray
                 writer
                 "lastFrames"
                 lastFrames
-                (fun writer (frameId, frame) -> writeFrameSummary writer threadState.ActiveMethodState frameId frame)
+                (fun writer (frameId, frame) ->
+                    writeFrameSummary
+                        writer
+                        state
+                        (Map.find frameId offsets)
+                        threadState.ActiveMethodState
+                        frameId
+                        frame
+                )
 
             writer.WriteEndObject ()
 

--- a/WoofWare.PawPrint.App/DebuggerServer.fs
+++ b/WoofWare.PawPrint.App/DebuggerServer.fs
@@ -257,12 +257,13 @@ module DebuggerServer =
             writer.WriteNumber ("activeFrame", frameIdValue threadState.ActiveMethodState)
             writer.WritePropertyName "activeFrameSummary"
 
-            let offsets = GuestLocation.attributionOffsets threadState
-
+            // Only the active frame is rendered here, so ask for only its offset. `/state` is
+            // emitted on every step, and building the whole stack's map each time would make
+            // single-stepping a deeply recursive guest cost time quadratic in its depth.
             writeFrameSummary
                 writer
                 state
-                (Map.find threadState.ActiveMethodState offsets)
+                (GuestLocation.activeAttributionOffset threadState)
                 threadState.ActiveMethodState
                 threadState.ActiveMethodState
                 threadState.MethodState

--- a/WoofWare.PawPrint.Domain/MethodInfo.fs
+++ b/WoofWare.PawPrint.Domain/MethodInfo.fs
@@ -278,6 +278,27 @@ type SynthesisedMethod =
     /// <c>MarshalNative_TryGetStructMarshalStub</c>'s has-layout-non-blittable arm.
     | StructMarshalStub
 
+    /// <summary>
+    /// The placeholder frame the entry thread carries before <c>Main</c> is installed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>Program.buildStartupFrame</c> needs a frame on the entry thread while startup runs
+    /// class initialisers, and shapes it like the entry point — same name, declaring type and
+    /// signature — so that everything reading a frame sees something sensible. Its *body*,
+    /// though, is a bare <c>ret</c>: `Main` has not run and must not.
+    /// </para>
+    /// <para>
+    /// Synthesised rather than metadata-flavoured precisely because of that substitution. Its
+    /// body is not the body the entry point's MethodDef row describes, so nothing keyed by that
+    /// row describes this frame either — and a consumer that resolved its IL offsets against the
+    /// real <c>Main</c>'s debug information would report source lines for code that has not
+    /// executed. Carrying no metadata handle makes that unrepresentable rather than merely
+    /// discouraged.
+    /// </para>
+    /// </remarks>
+    | EntryPointPlaceholder
+
 [<RequireQualifiedAccess>]
 module SynthesisedMethod =
     /// Whether calling this method obliges the runtime to initialise its declaring type first, as
@@ -298,6 +319,12 @@ module SynthesisedMethod =
     let initialisesDeclaringType (kind : SynthesisedMethod) : bool =
         match kind with
         | SynthesisedMethod.StructMarshalStub -> false
+        // Never reached: the placeholder is pushed onto the entry thread directly rather than
+        // called, so no call site asks. Answering `false` states the semantics anyway — startup
+        // drives the entry type's initialiser as part of its own class-init sweep, and having
+        // this frame demand it as a side effect of being entered would be a second, unrelated
+        // reason for the same work to happen.
+        | SynthesisedMethod.EntryPointPlaceholder -> false
 
 /// The facts that exist only because a method was read from a MethodDef row.
 ///

--- a/WoofWare.PawPrint.Test/TestDebuggerServer.fs
+++ b/WoofWare.PawPrint.Test/TestDebuggerServer.fs
@@ -739,3 +739,50 @@ class Program
             thread.GetProperty("activeFrameSummary").GetProperty("sourceLocation").GetProperty("startLine").GetInt32 ()
             |> shouldEqual spin
         }
+
+    /// Before `Main` is installed the entry thread carries a placeholder frame: shaped like the
+    /// entry point so that everything reading a frame sees something sensible, but with a bare
+    /// `ret` body, because `Main` has not run.
+    ///
+    /// It must therefore report no source location. Resolving its offsets against the real
+    /// `Main`'s debug information would name a line of code that has not executed — and this is
+    /// reachable, not theoretical: a static initialiser that throws leaves the guest here, and
+    /// `/state` is the first call the debugging workflow tells you to make.
+    [<Test>]
+    let ``the pre-Main placeholder frame reports no source location`` () : Task =
+        task {
+            let source =
+                """
+class Program
+{
+    static readonly int Boom = int.Parse("not a number");
+
+    static int Main(string[] args)
+    {
+        return Boom;
+    }
+}
+"""
+
+            use server = startServerWithSymbols source
+            use client = client server (Some token)
+
+            let! state = client.GetAsync "state"
+            state.StatusCode |> shouldEqual HttpStatusCode.OK
+            use! stateJson = jsonDocument state
+
+            let thread =
+                stateJson.RootElement.GetProperty("session").GetProperty("threads").EnumerateArray ()
+                |> Seq.head
+
+            let frame = thread.GetProperty "activeFrameSummary"
+
+            // Asserted so the test cannot pass by the frame having become unrecognisable: it is
+            // still the entry-point-shaped placeholder, sitting at offset 0 of its `ret` body.
+            frame.GetProperty("method").GetString ()
+            |> shouldEqual "PawPrintTestAssembly.Program.Main"
+
+            frame.GetProperty("ilOffset").GetInt32 () |> shouldEqual 0
+
+            frame.GetProperty("sourceLocation").ValueKind |> shouldEqual JsonValueKind.Null
+        }

--- a/WoofWare.PawPrint.Test/TestDebuggerServer.fs
+++ b/WoofWare.PawPrint.Test/TestDebuggerServer.fs
@@ -110,6 +110,47 @@ class Program
 }
 """
 
+    /// As `recursiveSource`, but with the lines the source-location assertions care about
+    /// marked, so those tests derive the expected line from the text rather than counting.
+    ///
+    /// Compiled with symbols. Every other guest in this file is deliberately PDB-less — which is
+    /// itself the subject of a test below, since a null `sourceLocation` is the ordinary case for
+    /// anything the compiler did not emit debug information for.
+    let private recursiveSourceWithSymbols =
+        """
+class Program
+{
+    static int Recurse(int remaining)
+    {
+        if (remaining == 0)
+        {
+            while (true) { } // SPIN
+        }
+
+        return Recurse(remaining - 1); // RECURSE
+    }
+
+    static int Main(string[] args)
+    {
+        return Recurse(4); // ENTRY
+    }
+}
+"""
+
+    /// The line of the single source line containing `marker`, 1-based as a PDB counts lines.
+    let private lineContaining (marker : string) (source : string) : int =
+        let lines = source.Replace("\r\n", "\n").Split '\n'
+
+        match
+            lines
+            |> Array.mapi (fun i l -> i, l)
+            |> Array.filter (fun (_, l) -> l.Contains marker)
+        with
+        | [| (i, _) |] -> i + 1
+        | [||] -> failwith $"guest source contains no line matching %s{marker}; the test's oracle is broken"
+        | many ->
+            failwith $"guest source has %d{many.Length} lines matching %s{marker}, so the expected line is ambiguous"
+
     let private objectOnStackSource =
         """
 class Program
@@ -147,7 +188,7 @@ class Program
                 with _ ->
                     ()
 
-    let private compileToTempDll (source : string) : string * string =
+    let private compileToTempDllWith (compile : string list -> byte[]) (source : string) : string * string =
         let suffix = Guid.NewGuid().ToString "N"
 
         let tempDir =
@@ -155,11 +196,11 @@ class Program
 
         Directory.CreateDirectory tempDir |> ignore<DirectoryInfo>
         let dllPath = Path.Combine (tempDir, "DebuggerHttpTest.dll")
-        File.WriteAllBytes (dllPath, Roslyn.compile [ source ])
+        File.WriteAllBytes (dllPath, compile [ source ])
         tempDir, dllPath
 
-    let private startServer (source : string) : RunningServer =
-        let tempDir, dllPath = compileToTempDll source
+    let private startServerWith (compile : string list -> byte[]) (source : string) : RunningServer =
+        let tempDir, dllPath = compileToTempDllWith compile source
 
         let dotnetRuntimes =
             DotnetRuntime.SelectForDll typeof<RunResult>.Assembly.Location
@@ -187,6 +228,14 @@ class Program
             BaseUrl = DebuggerServer.baseUrl app
             TempDir = tempDir
         }
+
+    let private startServer (source : string) : RunningServer = startServerWith Roslyn.compile source
+
+    /// As `startServer`, but the guest image carries an embedded portable PDB, so its frames
+    /// resolve to source. Opt-in per case: see `Roslyn.DebugSymbols` for why symbols are not the
+    /// default.
+    let private startServerWithSymbols (source : string) : RunningServer =
+        startServerWith Roslyn.compileWithSymbols source
 
     let private client (server : RunningServer) (token : string option) : HttpClient =
         let client = new HttpClient ()
@@ -555,4 +604,138 @@ class Program
 
             runJson.RootElement.GetProperty("session").GetProperty("status").GetString ()
             |> shouldEqual "running"
+        }
+
+    /// The frame a thread is actually executing must name the line it is on. Without this the
+    /// debugger reports `Assembly.Type.Method` plus an IL offset, which does not tell a reader
+    /// which of a method's statements they are looking at.
+    [<Test>]
+    let ``a frame carries the source line it is executing`` () : Task =
+        task {
+            use server = startServerWithSymbols recursiveSourceWithSymbols
+            use client = client server (Some token)
+
+            let! run = client.PostAsync ("run?maxSteps=200", emptyContent ())
+            run.StatusCode |> shouldEqual HttpStatusCode.OK
+
+            let! thread = client.GetAsync "thread/0"
+            thread.StatusCode |> shouldEqual HttpStatusCode.OK
+
+            use! threadJson = jsonDocument thread
+            let active = activeFrame threadJson.RootElement
+            let location = active.GetProperty "sourceLocation"
+
+            location.ValueKind |> shouldNotEqual JsonValueKind.Null
+
+            location.GetProperty("documentPath").GetString () |> shouldEqual "File0.cs"
+
+            location.GetProperty("startLine").GetInt32 ()
+            |> shouldEqual (lineContaining "// SPIN" recursiveSourceWithSymbols)
+        }
+
+    /// The decision this field's shape exists to make unambiguous. A caller's `ilOffset` is its
+    /// *resume* point — the instruction after the call — so attributing it there reports every
+    /// frame but the innermost one statement late. `sourceLocation` is instead resolved at the
+    /// call site, and carries the offset it used so the two can never be confused.
+    [<Test>]
+    let ``a caller frame is attributed to its call site, not its resume point`` () : Task =
+        task {
+            use server = startServerWithSymbols recursiveSourceWithSymbols
+            use client = client server (Some token)
+
+            let! run = client.PostAsync ("run?maxSteps=200", emptyContent ())
+            run.StatusCode |> shouldEqual HttpStatusCode.OK
+
+            let! thread = client.GetAsync "thread/0"
+            thread.StatusCode |> shouldEqual HttpStatusCode.OK
+
+            use! threadJson = jsonDocument thread
+
+            let frames =
+                threadJson.RootElement.GetProperty("frames").EnumerateArray () |> Seq.toList
+
+            let callers =
+                frames
+                |> List.filter (fun frame -> not (frame.GetProperty("active").GetBoolean ()))
+
+            // `Recurse(4)` plus `Main`, so there is something to be a caller.
+            callers |> List.isEmpty |> shouldEqual false
+
+            let expectedFor (method : string) : int =
+                if method.EndsWith "Main" then
+                    lineContaining "// ENTRY" recursiveSourceWithSymbols
+                else
+                    lineContaining "// RECURSE" recursiveSourceWithSymbols
+
+            for caller in callers do
+                let location = caller.GetProperty "sourceLocation"
+                location.ValueKind |> shouldNotEqual JsonValueKind.Null
+
+                location.GetProperty("startLine").GetInt32 ()
+                |> shouldEqual (expectedFor (caller.GetProperty("method").GetString ()))
+
+                // The discriminator, and the reason the offset is emitted: in a debug build the
+                // call site and the resume point often share a line — the compiler puts a `nop`
+                // after the call carrying the call's own sequence point — so equal lines would
+                // not prove the attribution happened. Differing offsets do.
+                location.GetProperty("ilOffset").GetInt32 ()
+                |> shouldNotEqual (caller.GetProperty("ilOffset").GetInt32 ())
+        }
+
+    /// A null location is the ordinary case, not a defect: the entire shared framework ships
+    /// without PDBs. The key must still be present, so a consumer can tell "not known here" from
+    /// "this server does not report locations".
+    [<Test>]
+    let ``a frame from an assembly without symbols reports a null source location`` () : Task =
+        task {
+            use server = startServer recursiveSource
+            use client = client server (Some token)
+
+            let! run = client.PostAsync ("run?maxSteps=200", emptyContent ())
+            run.StatusCode |> shouldEqual HttpStatusCode.OK
+
+            let! thread = client.GetAsync "thread/0"
+            thread.StatusCode |> shouldEqual HttpStatusCode.OK
+
+            use! threadJson = jsonDocument thread
+            let active = activeFrame threadJson.RootElement
+
+            active.GetProperty("sourceLocation").ValueKind |> shouldEqual JsonValueKind.Null
+        }
+
+    /// The field must reach every response that renders a frame, not only `GET /thread/{id}`.
+    /// They go through one writer precisely so this cannot drift apart.
+    [<Test>]
+    let ``the stack summary and state responses carry source locations too`` () : Task =
+        task {
+            use server = startServerWithSymbols recursiveSourceWithSymbols
+            use client = client server (Some token)
+
+            let! run = client.PostAsync ("run?maxSteps=200", emptyContent ())
+            run.StatusCode |> shouldEqual HttpStatusCode.OK
+
+            let spin = lineContaining "// SPIN" recursiveSourceWithSymbols
+
+            let! summary = client.GetAsync "thread/0/stack-summary?edgeFrames=2&topMethods=1"
+            summary.StatusCode |> shouldEqual HttpStatusCode.OK
+            use! summaryJson = jsonDocument summary
+
+            summaryJson.RootElement
+                .GetProperty("activeFrameSummary")
+                .GetProperty("sourceLocation")
+                .GetProperty("startLine")
+                .GetInt32 ()
+            |> shouldEqual spin
+
+            let! state = client.GetAsync "state"
+            state.StatusCode |> shouldEqual HttpStatusCode.OK
+            use! stateJson = jsonDocument state
+
+            // `heap` and `threads` sit inside the `session` object, not at the root.
+            let thread =
+                stateJson.RootElement.GetProperty("session").GetProperty("threads").EnumerateArray ()
+                |> Seq.head
+
+            thread.GetProperty("activeFrameSummary").GetProperty("sourceLocation").GetProperty("startLine").GetInt32 ()
+            |> shouldEqual spin
         }

--- a/WoofWare.PawPrint/GuestLocation.fs
+++ b/WoofWare.PawPrint/GuestLocation.fs
@@ -260,6 +260,23 @@ module GuestLocation =
     /// than raise.
     /// </para>
     /// </remarks>
+    /// <summary>
+    /// The IL offset at which <paramref name="thread" />'s *active* frame should be attributed to
+    /// source: its program counter, stepped back onto the blocking call if the thread parked past
+    /// one.
+    /// </summary>
+    /// <remarks>
+    /// The same answer <c>attributionOffsets</c> gives for that one frame, without building a map
+    /// over the whole stack. Callers that want only the active frame — the thread summaries on
+    /// every state-bearing response — should use this: they are hit once per step, and a guest
+    /// recursing deeply would otherwise make single-stepping cost time quadratic in stack depth.
+    ///
+    /// Requires <paramref name="thread" /> to have a live frame, exactly as
+    /// <c>ThreadState.MethodState</c> does; guard with <c>ThreadStatus.hasNoActiveFrame</c>.
+    /// </remarks>
+    let activeAttributionOffset (thread : ThreadState) : int =
+        reportableOffset thread.Status thread.MethodState
+
     let attributionOffsets (thread : ThreadState) : Map<FrameId, int> =
         let callSites =
             thread.MethodStates

--- a/WoofWare.PawPrint/GuestLocation.fs
+++ b/WoofWare.PawPrint/GuestLocation.fs
@@ -108,7 +108,7 @@ module GuestLocation =
     /// other loaded assembly would silently name a different method's lines. A synthesised method
     /// (a marshalling or delegate stub) has no row at all and so is legitimately unattributable.
     /// </remarks>
-    let private trySourceOf
+    let trySourceOf
         (state : IlMachineState)
         (method : MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>)
         (ilOffset : int)
@@ -237,6 +237,49 @@ module GuestLocation =
     /// Where every thread that has not terminated is. Terminated threads are omitted: they are
     /// not why the guest is stuck, and a long-running guest accumulates many of them.
     /// </summary>
+    /// <summary>
+    /// The IL offset at which each of <paramref name="thread" />'s live frames should be
+    /// attributed to source, keyed by frame.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// For the active frame that is its program counter — stepped back onto the blocking call if
+    /// the thread parked past one, exactly as <c>positionOfThread</c> does.
+    /// </para>
+    /// <para>
+    /// For every enclosing frame it is instead the *call site* recorded by the frame it called,
+    /// not the offset it will resume at. The two differ: the resume point is the instruction
+    /// after the call, so for a call that ends a statement it belongs to the *next* statement.
+    /// A stack rendered from resume points therefore reports every caller one statement late,
+    /// which is the same error <c>positionOfThread</c> avoids when it walks outwards.
+    /// </para>
+    /// <para>
+    /// A frame that is neither active nor called by anything falls back to its own program
+    /// counter. That should not arise — a thread's frames form a chain from the active frame
+    /// outwards — but this is a diagnostic, so an unexpected shape must cost precision rather
+    /// than raise.
+    /// </para>
+    /// </remarks>
+    let attributionOffsets (thread : ThreadState) : Map<FrameId, int> =
+        let callSites =
+            thread.MethodStates
+            |> Map.toSeq
+            |> Seq.choose (fun (_, frame) ->
+                frame.ReturnState
+                |> Option.map (fun returnState -> returnState.JumpTo, returnState.CallSiteIlOpIndex)
+            )
+            |> Map.ofSeq
+
+        thread.MethodStates
+        |> Map.map (fun frameId frame ->
+            if frameId = thread.ActiveMethodState then
+                reportableOffset thread.Status frame
+            else
+                match Map.tryFind frameId callSites with
+                | Some callSite -> callSite
+                | None -> frame.IlOpIndex
+        )
+
     let ofState (state : IlMachineState) : GuestThreadLocation list =
         state.ThreadState
         |> Map.toList

--- a/WoofWare.PawPrint/Program.fs
+++ b/WoofWare.PawPrint/Program.fs
@@ -919,12 +919,17 @@ module Program =
                     loggerFactory
                     baseTypes
                     ImmutableArray.Empty // No type generics for main method's declaring type
-                    (rawMainMethod
-                     |> MethodInfo.mapCore (fun core ->
-                         { core with
-                             Body = MethodBody.Il (MethodInstructions.onlyRet ())
-                         }
-                     ))
+                    // Synthesised, not the entry point with its body swapped: the substituted
+                    // body is not what `Main`'s MethodDef row describes, so carrying that row's
+                    // identity would let anything keyed by it — debug information above all —
+                    // describe this frame as though `Main` were running. It is not; `Main` has
+                    // not been installed yet.
+                    (MethodInfo.Synthesised (
+                        { rawMainMethod.Core with
+                            Body = MethodBody.Il (MethodInstructions.onlyRet ())
+                        },
+                        SynthesisedMethod.EntryPointPlaceholder
+                    ))
                     None
                     dumped.Name
                     ImmutableArray.Empty


### PR DESCRIPTION
Third of the follow-ups to #928. The debugger server reported each frame as
`Assembly.Type.Method` plus an IL offset, which does not say *which* of a method's statements
you are looking at. Every frame object now carries a `sourceLocation`:

```json
"sourceLocation": {
  "ilOffset": 13, "documentPath": "/src/Program.cs",
  "startLine": 8, "startColumn": 28, "endLine": 8, "endColumn": 29
}
```

Every response that renders a frame goes through `writeFrameProperties`, so adding it once
covers `/state`, `/thread/{id}`, `/thread/{id}/stack-summary`, `/step`, `/run`, `/reset` and
the error body. Four writers gain the state; all three call chains already bind
`let state = sessionState session`, so no HTTP handler changes.

## Which offset a location describes

This is the load-bearing decision. A caller's `ilOffset` is its *resume* point — the
instruction after the call — so attributing it there reports every frame but the innermost one
statement late, the same error the wedged-guest walk in #928 exists to avoid. So
`GuestLocation.attributionOffsets` gives the active frame its program counter (stepped back
onto the blocking call if the thread parked past one) and every enclosing frame the call site
recorded by the frame it called.

That leaves the frame's `ilOffset` and the location disagreeing, which would be a trap. So the
location **carries the offset it was resolved at**: a reader sees both numbers and neither is a
lie. Verified by mutation — attributing every frame at its own program counter fails the
call-site test and only that test.

## `null` is the ordinary case

The whole shared framework ships without PDBs, synthesised stubs have no metadata row, and a
compiler may mark a range as having no source. Tests pin it both ways: a symbol-bearing guest
resolves, the existing PDB-less guests report `null` with the key still present.

## The pre-Main placeholder (Codex)

Codex found, and I reproduced, that a symbol-bearing guest whose static initialiser throws had
`/state` reporting the entry thread as `Program.Main` at `File0.cs:7`. `Main` had not run — the
guest was stuck in its cctor — and the frame was the bare-`ret` startup placeholder.
`buildStartupFrame` kept the entry point's metadata identity while replacing its body, so its
offsets resolved against the real `Main`'s debug information.

Fixed at the source rather than in the debugger: the frame is now `MethodInfo.Synthesised` with
a new `SynthesisedMethod.EntryPointPlaceholder`, carrying no MethodDef handle — so attributing
it is unrepresentable rather than merely discouraged, and every consumer is fixed at once
(the #928 diagnostic had the same hole). The full suite passes with no other change, which was
the open question: `renderExceptionStackFrame` renders a metadata-less frame differently, so a
placeholder reaching a guest-visible trace would have shown up in the differential cases.
Verified by mutation, and the test also asserts the frame is still named `Program.Main` at
offset 0 so it cannot pass by the placeholder having become unrecognisable.

## Other review findings

- **Quadratic summaries.** `writeThreadSummary` renders one frame but called
  `attributionOffsets`, which maps every live frame. `/state` is emitted on every step, so
  single-stepping a deeply recursive guest paid time quadratic in depth on the endpoint that
  exists to be cheap. `activeAttributionOffset` gives that one frame's answer directly; the two
  full-stack callers keep the map, and were already O(frames) via `methodCounts`.
- **A docs claim that was simply wrong.** I had written that the two offsets agree for the
  active frame. They do not for a thread blocked in a QCall, where the location steps back onto
  the blocking call — precisely the case a debugger user is most likely inspecting.

## Docs

`.agents/skills/pawprint-debugger-server/SKILL.md` gains a section on both traps, since an
agent reading `null` as a defect, or looking a frame's own `ilOffset` up in the PDB itself, is
exactly what this shape is designed to prevent. The `jq` recipe now surfaces `file:line`.

## Checks

- Full suite green: 2768 passed, 0 failed, on the rebased branch.
- `codex review` run three times; final review clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)