### PR TITLE
Give an unmatched non-newslot virtual a fresh vtable slot

### DIFF
--- a/WoofWare.PawPrint.Test.FSharpPureCases/Main.fs
+++ b/WoofWare.PawPrint.Test.FSharpPureCases/Main.fs
@@ -9,5 +9,6 @@ let main (argv : string array) : int =
     | "AbstractDispatch" -> AbstractDispatch.main argv.[1..]
     | "ByrefDispatch" -> ByrefDispatch.main argv.[1..]
     | "SprintfBasic" -> SprintfBasic.main argv.[1..]
+    | "UnionVirtualSlots" -> UnionVirtualSlots.main argv.[1..]
     | "UnionReflection" -> UnionReflection.main argv.[1..]
     | name -> failwith $"Unknown test case: {name}"

--- a/WoofWare.PawPrint.Test.FSharpPureCases/UnionVirtualSlots.fs
+++ b/WoofWare.PawPrint.Test.FSharpPureCases/UnionVirtualSlots.fs
@@ -1,0 +1,62 @@
+module UnionVirtualSlots
+
+open System.Reflection
+
+/// F# emits the structural equality and comparison members of a union as `Public, Final, Virtual,
+/// HideBySig` with **no** NewSlot. Six of them match nothing on `Object`, so laying out this type's
+/// vtable needs CoreCLR's rule that an unmatched non-NewSlot virtual is given a fresh slot
+/// (`MethodTableBuilder::PlaceVirtualMethods`). Before that was implemented, reflecting over any F#
+/// union at all failed outright.
+///
+/// `RuntimeType.PopulateMethods` asks `RuntimeMethodHandle.GetSlot` for each virtual and uses the
+/// answer to index `overrides[slot]`, suppressing a base declaration something further down already
+/// overrode. So a vtable with a slot too many or too few does not merely mis-number things: it
+/// suppresses the wrong declaration, and the method list below comes back wrong. That is what makes
+/// this observable from a guest, which cannot see slot numbers directly.
+///
+/// The counts are pinned rather than merely compared against each other, so that a compiler change
+/// which stopped emitting these members is a failure rather than a silent weakening. The real
+/// runtime checks them too -- it runs this same guest -- so a wrong expectation here fails the test
+/// rather than being adopted as truth.
+type Shape =
+    | Point
+    | Circle of radius : int
+    | Rectangle of width : int * height : int
+
+let main (_argv : string array) : int =
+    let virtuals =
+        typeof<Shape>.GetMethods (BindingFlags.Instance ||| BindingFlags.Public ||| BindingFlags.NonPublic)
+        |> Array.filter (fun method -> method.IsVirtual)
+
+    let named (name : string) : int =
+        virtuals |> Array.filter (fun method -> method.Name = name) |> Array.length
+
+    // The three that land on `Object`'s own slots, so they exercise the matching half of the rule
+    // rather than the fallback.
+    if named "Finalize" <> 1 then
+        1
+    elif named "ToString" <> 1 then
+        2
+    // `Equals(object)` matches `Object.Equals`; `Equals(Shape)` and `Equals(object, IEqualityComparer)`
+    // match nothing and take fresh slots.
+    elif named "Equals" <> 3 then
+        3
+    // `GetHashCode()` matches; `GetHashCode(IEqualityComparer)` does not.
+    elif named "GetHashCode" <> 2 then
+        4
+    // None of the three `CompareTo` overloads matches anything on `Object`: all are fallbacks.
+    elif named "CompareTo" <> 3 then
+        5
+    // No slot may go missing or spare: the five names above are the whole vtable, so a spurious
+    // append shows up here even though its own name would be one of the five.
+    elif virtuals.Length <> 10 then
+        6
+    else
+
+    // Every one of them must report the union as its declaring type or `Object`; a slot bound to the
+    // wrong occupant would show up as some third type.
+    let wrongOwner =
+        virtuals
+        |> Array.filter (fun method -> method.DeclaringType <> typeof<Shape> && method.DeclaringType <> typeof<obj>)
+
+    if wrongOwner.Length <> 0 then 7 else 0

--- a/WoofWare.PawPrint.Test.FSharpPureCases/WoofWare.PawPrint.Test.FSharpPureCases.fsproj
+++ b/WoofWare.PawPrint.Test.FSharpPureCases/WoofWare.PawPrint.Test.FSharpPureCases.fsproj
@@ -13,6 +13,7 @@
     <Compile Include="AbstractDispatch.fs" />
     <Compile Include="ByrefDispatch.fs" />
     <Compile Include="SprintfBasic.fs" />
+    <Compile Include="UnionVirtualSlots.fs" />
     <Compile Include="UnionReflection.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>

--- a/WoofWare.PawPrint.Test/TestFSharpPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestFSharpPureCases.fs
@@ -117,6 +117,7 @@ module TestFSharpPureCases =
             "AbstractDispatch"
             "ByrefDispatch"
             "SprintfBasic"
+            "UnionVirtualSlots"
             "UnionReflection"
         ]
 
@@ -127,22 +128,27 @@ module TestFSharpPureCases =
     /// before recording that a case is blocked on a named primitive, un-park it and observe the
     /// failure: parking it is what stops the claim being checked.
     ///
-    /// `UnionReflection` is parked on the `RuntimeMethodHandle::GetSlot` InternalCall.
-    /// `Associates.AssignAssociates` now runs to completion, so `RuntimeType.PopulateProperties`
-    /// reaches its *next* step: suppressing properties whose accessor occupies a vtable slot already
-    /// claimed by a more derived one (`RuntimeType.CoreCLR.cs:1345-1368`), which asks each accessor
-    /// for its slot number. That is a question about the method table rather than about metadata,
-    /// which is why it is a separate feature from everything before it on this path.
+    /// `UnionReflection` is parked on `RuntimeMethodHandle::GetSlot` being asked about a method that
+    /// occupies no vtable slot at all. A union's case fields are read through property accessors,
+    /// and those are not virtual; CoreCLR numbers a non-virtual method in the *non-vtable* region
+    /// past `GetNumVirtuals`, which PawPrint's slot walk does not model -- it lays out the vtable
+    /// proper and nothing beyond it. How the method table is numbered past its virtual prefix is a
+    /// separate question from how the vtable itself is laid out, which is what the commit this
+    /// comment sits in implements.
     ///
     /// Observed by un-parking it and running: the real runtime exits 0, PawPrint reports
-    /// "Unimplemented native method (InternalCall): System.RuntimeMethodHandle::GetSlot".
+    /// "TODO: RuntimeMethodHandle.GetSlot: method get_width occupies no slot in the vtable of its
+    /// declaring type 362; CoreCLR would answer with a slot in the non-vtable region beyond
+    /// GetNumVirtuals, which PawPrint does not model."
     ///
-    /// Nine earlier blockers are already gone: decoding each case's
+    /// Ten earlier blockers are already gone: decoding each case's
     /// `CompilationMappingAttribute(SourceConstructFlags, ...)`, whose argument is an enum;
     /// enumerating the union's nested case types; `MetadataImport::GetSigOfFieldDef`; the raw-blob
     /// path of `Signature_Init`; `MetadataImport::GetDefaultValue`; `MetadataImport::GetName`;
-    /// property enumeration; `MetadataImport::GetPropertyProps`; and the associates branch of
-    /// `MetadataImport::Enum`, which the commit this comment sits in implements.
+    /// property enumeration; `MetadataImport::GetPropertyProps`; the associates branch of
+    /// `MetadataImport::Enum`; and the fresh-slot rule for an unmatched non-NewSlot virtual, which
+    /// every F# union needs for its compiler-generated `CompareTo`/`Equals`/`GetHashCode` and which
+    /// `UnionVirtualSlots` now covers end to end.
     let unimplemented : Set<string> = Set.ofList [ "UnionReflection" ]
 
     // F# test cases that legitimately throw under both runtimes. Without this set, a test

--- a/WoofWare.PawPrint.Test/TestFabricatedVtableLayout.fs
+++ b/WoofWare.PawPrint.Test/TestFabricatedVtableLayout.fs
@@ -93,12 +93,55 @@ module TestFabricatedVtableLayout =
         defineVirtual multiple "FallbackGamma" false
         multiple.CreateType () |> ignore
 
+        // Two methods whose signature *blobs* differ -- `!0` and `string` -- but which become
+        // indistinguishable once the type is closed at `T = string`. CoreCLR lays slots out on the
+        // generic definition, where they are plainly two methods, so both get slots of their own.
+        //
+        // This is what makes the search window load-bearing rather than defensive. Placing `M(T)`
+        // appends it; `M(string)` is then compared against the window, and `candidateFillsSlot`
+        // works on *concretised* signatures, so it would match the slot just appended and replace it
+        // -- one slot short, disagreeing with the host. Capping the search at the parent's slots is
+        // what stops that, and this type is the reason the cap cannot simply be dropped.
+        let conflation =
+            moduleBuilder.DefineType (
+                "GenericConflation`1",
+                TypeAttributes.Public ||| TypeAttributes.Class,
+                typeof<obj>
+            )
+
+        let typeParameter = (conflation.DefineGenericParameters [| "T" |]).[0]
+
+        let defineOverload (parameterType : Type) (isNewSlot : bool) : unit =
+            let attributes =
+                if isNewSlot then
+                    MethodAttributes.Public
+                    ||| MethodAttributes.Virtual
+                    ||| MethodAttributes.NewSlot
+                else
+                    MethodAttributes.Public ||| MethodAttributes.Virtual
+
+            let method =
+                conflation.DefineMethod ("Conflated", attributes, typeof<int>, [| parameterType |])
+
+            let il = method.GetILGenerator ()
+            il.Emit (OpCodes.Ldc_I4, 0)
+            il.Emit OpCodes.Ret
+
+        defineOverload (typeParameter :> Type) true
+        defineOverload typeof<string> false
+        conflation.CreateType () |> ignore
+
         use stream = new MemoryStream ()
         assemblyBuilder.Save stream
         stream.ToArray ()
 
-    /// The host CLR's copy. `Assembly.Load` of a byte array lands in the default load context, which
-    /// is what makes `RuntimeMethodHandle.GetSlot` answer about a fully built MethodTable.
+    /// The host CLR's copy, loaded so that `RuntimeMethodHandle.GetSlot` answers about a MethodTable
+    /// the real builder produced.
+    ///
+    /// `Assembly.Load` of a byte array puts it in a fresh `IndividualAssemblyLoadContext`
+    /// (Assembly.cs:267), not the default one, which is what keeps it from colliding with anything
+    /// else in the suite: it is invisible to default-context name resolution, and these type names
+    /// are deliberately plain enough to be worth saying so.
     let private hostAssembly : Assembly = Assembly.Load image
 
     // Undisposed on purpose, as in TestVirtualMethodSlots: the DumpedAssembly's logger closes over
@@ -127,7 +170,13 @@ module TestFabricatedVtableLayout =
             _LoadedAssemblies = loaded
         }
 
-    let private vtableOf (name : string) : NativeRuntimeTypeHelpers.VtableSlot list =
+    /// The vtable of a fabricated type, closed at the given corelib type arguments (none, for the
+    /// non-generic ones).
+    let private vtableOfClosedAt
+        (name : string)
+        (typeArguments : (string * string) list)
+        : NativeRuntimeTypeHelpers.VtableSlot list
+        =
         let state = state ()
 
         let typeInfo =
@@ -135,6 +184,30 @@ module TestFabricatedVtableLayout =
             | None -> failwith $"fabricated assembly has no type %s{name}"
             | Some typeInfo -> typeInfo
 
+        let state, argumentHandles =
+            ((state, []), typeArguments)
+            ||> List.fold (fun (state, acc) (argumentNamespace, argumentName) ->
+                let argumentTypeInfo =
+                    match corelib.TryGetTopLevelTypeDef argumentNamespace argumentName with
+                    | None -> failwith $"%s{argumentNamespace}.%s{argumentName} not found in corelib"
+                    | Some typeInfo -> typeInfo
+
+                let state, handle =
+                    DumpedAssembly.typeInfoToTypeDefn' bct state._LoadedAssemblies argumentTypeInfo
+                    |> IlMachineState.concretizeType
+                        loggerFactory
+                        bct
+                        state
+                        corelib.Name
+                        ImmutableArray.Empty
+                        ImmutableArray.Empty
+
+                state, handle :: acc
+            )
+
+        // As in TestVirtualMethodSlots: `typeInfoToTypeDefn'` already yields the instantiation shape
+        // `T`n<!0, ..>`, so close it by supplying the arguments as the type-generic context rather
+        // than by wrapping it again.
         let state, handle =
             DumpedAssembly.typeInfoToTypeDefn' bct state._LoadedAssemblies typeInfo
             |> IlMachineState.concretizeType
@@ -142,11 +215,13 @@ module TestFabricatedVtableLayout =
                 bct
                 state
                 fabricated.Name
-                ImmutableArray.Empty
+                (ImmutableArray.CreateRange (List.rev argumentHandles))
                 ImmutableArray.Empty
 
         NativeRuntimeTypeHelpers.vtableOfClosed loggerFactory bct "test" state handle
         |> snd
+
+    let private vtableOf (name : string) : NativeRuntimeTypeHelpers.VtableSlot list = vtableOfClosedAt name []
 
     let private hostSlotOf : MethodInfo -> int =
         let impl =
@@ -277,3 +352,43 @@ module TestFabricatedVtableLayout =
             // Everything past the inherited prefix is declared by the fabricated type itself.
             for slot in List.skip (List.length objectLayout) slots do
                 slot.DeclaredBy.Assembly.FullName |> shouldEqual fabricated.Name.FullName
+
+    /// Why the override search is capped at the parent's slot count rather than ranging over the
+    /// list as it grows.
+    ///
+    /// `GenericConflation`1` declares `Conflated(!0)` as NewSlot and then `Conflated(string)`
+    /// without it. The signature blobs differ, so this is a legal type -- ECMA-335 II.22.26 only
+    /// forbids two rows sharing a name *and* signature -- but at `T = string` the two become
+    /// indistinguishable to a matcher that compares concretised signatures, which is what
+    /// `candidateFillsSlot` does by design (it is how an ordinary override of a generic base matches
+    /// at all).
+    ///
+    /// CoreCLR lays slots out on the generic definition, where the two are plainly distinct, and
+    /// gives each its own. Without the cap, `Conflated(string)` would find the slot `Conflated(!0)`
+    /// had just been appended to and replace it, yielding a vtable one slot short. So the cap is
+    /// load-bearing on a legal image, not defensive insurance against a hypothetical matcher bug.
+    [<Test>]
+    let ``a later virtual cannot land on a slot this type just appended`` () : unit =
+        let closed =
+            match hostAssembly.GetType ("GenericConflation`1", false) with
+            | null -> failwith "host CLR could not load fabricated type GenericConflation`1"
+            | t -> t.MakeGenericType typeof<string>
+
+        let expected =
+            closed.GetMethods (BindingFlags.Instance ||| BindingFlags.Public ||| BindingFlags.NonPublic)
+            |> Array.filter _.IsVirtual
+            |> Array.map (fun method -> hostSlotOf method, method.MetadataToken)
+            |> Array.sortBy fst
+            |> Array.map snd
+            |> List.ofArray
+
+        // Guard against the type going uninteresting: the whole point is that both overloads get
+        // slots of their own, so `Object`'s four must be joined by exactly two more.
+        expected |> List.length |> shouldEqual 6
+
+        let actual =
+            pawPrintLayout (vtableOfClosedAt "GenericConflation`1" [ "System", "String" ])
+
+        if actual <> expected then
+            failwith
+                $"GenericConflation`1[String]: PawPrint layout %A{actual} disagrees with the host CLR's %A{expected}"

--- a/WoofWare.PawPrint.Test/TestFabricatedVtableLayout.fs
+++ b/WoofWare.PawPrint.Test/TestFabricatedVtableLayout.fs
@@ -1,0 +1,279 @@
+namespace WoofWare.PawPrint.Test
+
+open System
+open System.Collections.Immutable
+open System.IO
+open System.Reflection
+open System.Reflection.Emit
+open System.Reflection.Metadata.Ecma335
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+/// `MethodTableBuilder::PlaceVirtualMethods` gives an instance virtual that is *not* marked NewSlot
+/// and matches nothing in the parent vtable a fresh slot of its own
+/// (methodtablebuilder.cpp:5466-5482). No C# compiler emits that shape -- measured, 0 of corelib's
+/// 1470 non-generic classes trigger it -- but F# emits it constantly, because that is how it writes
+/// the structural equality and comparison members of every union and record.
+///
+/// Testing the rule needs types no compiler will produce, so this fixture *fabricates* them. Two
+/// things make that work where loading a real F# assembly does not:
+///
+///  - `MethodAttributes.NewSlot` is an opt-in bit, and `PersistedAssemblyBuilder` writes exactly what
+///    it is given: `Public, Virtual` stays reuse-slot rather than being silently promoted. So the
+///    interesting shape is directly expressible.
+///  - Built against `typeof<obj>.Assembly`, the image references System.Private.CoreLib *directly*.
+///    That is what the unit harness can resolve. FSharp.Core, whose TypeRefs go through the
+///    System.Runtime facade, fails in `getTypeRef` for want of the rest of the framework closure --
+///    which is why the natural corpus is unavailable here and fabrication is the way in.
+///
+/// The oracle is the host CLR: it loads the very same bytes and lays them out in C++ with the real
+/// MethodTable builder, and its `RuntimeMethodHandle.GetSlot` is the same function the BCL's
+/// `PopulateMethods` calls. Nothing derived from PawPrint's own walk feeds the expected values.
+[<TestFixture>]
+module TestFabricatedVtableLayout =
+
+    /// The fabricated image, as bytes, so that the host CLR and PawPrint read *the same* assembly
+    /// rather than two separately-built ones that might differ.
+    ///
+    /// Method declaration order is load-bearing throughout: it is the order CoreCLR places slots in,
+    /// so it is what the layout assertions are about. `DefineMethod` emits MethodDef rows in call
+    /// order.
+    let private image : byte array =
+        let assemblyBuilder =
+            PersistedAssemblyBuilder (AssemblyName "PawPrintFabricatedVtable", typeof<obj>.Assembly)
+
+        let moduleBuilder =
+            assemblyBuilder.DefineDynamicModule "PawPrintFabricatedVtable.dll"
+
+        let defineVirtual (typeBuilder : TypeBuilder) (name : string) (isNewSlot : bool) : unit =
+            let attributes =
+                if isNewSlot then
+                    MethodAttributes.Public
+                    ||| MethodAttributes.Virtual
+                    ||| MethodAttributes.NewSlot
+                else
+                    MethodAttributes.Public ||| MethodAttributes.Virtual
+
+            let method =
+                typeBuilder.DefineMethod (name, attributes, typeof<int>, Type.EmptyTypes)
+
+            let il = method.GetILGenerator ()
+            il.Emit (OpCodes.Ldc_I4, 0)
+            il.Emit OpCodes.Ret
+
+        // The discriminator. A NewSlot virtual matching nothing, declared *before* a non-NewSlot
+        // virtual matching nothing. CoreCLR's single declaration-order pass gives `NewSlotFirst` the
+        // lower slot; any scheme that places the fallbacks in a separate pass from the NewSlot
+        // methods -- in either order -- disagrees. This is the only shape that tells those apart, and
+        // there are none in corelib or FSharp.Core, which is why it is built here.
+        let discriminator =
+            moduleBuilder.DefineType ("Discriminator", TypeAttributes.Public ||| TypeAttributes.Class, typeof<obj>)
+
+        defineVirtual discriminator "NewSlotFirst" true
+        defineVirtual discriminator "FallbackSecond" false
+        discriminator.CreateType () |> ignore
+
+        // The mirror image, so that neither ordering can pass by being hardcoded: here the fallback
+        // is declared first and must take the lower slot.
+        let reversed =
+            moduleBuilder.DefineType ("Reversed", TypeAttributes.Public ||| TypeAttributes.Class, typeof<obj>)
+
+        defineVirtual reversed "FallbackFirst" false
+        defineVirtual reversed "NewSlotSecond" true
+        reversed.CreateType () |> ignore
+
+        // Several fallbacks in a row, pinning their order relative to each other rather than only
+        // relative to the NewSlot ones.
+        let multiple =
+            moduleBuilder.DefineType ("MultipleFallbacks", TypeAttributes.Public ||| TypeAttributes.Class, typeof<obj>)
+
+        defineVirtual multiple "FallbackAlpha" false
+        defineVirtual multiple "FallbackBeta" false
+        defineVirtual multiple "FallbackGamma" false
+        multiple.CreateType () |> ignore
+
+        use stream = new MemoryStream ()
+        assemblyBuilder.Save stream
+        stream.ToArray ()
+
+    /// The host CLR's copy. `Assembly.Load` of a byte array lands in the default load context, which
+    /// is what makes `RuntimeMethodHandle.GetSlot` answer about a fully built MethodTable.
+    let private hostAssembly : Assembly = Assembly.Load image
+
+    // Undisposed on purpose, as in TestVirtualMethodSlots: the DumpedAssembly's logger closes over
+    // its sinks, and disposing while the assembly is live would drop events.
+    let private corelib : DumpedAssembly =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        Assembly.readFile loggerFactory (typeof<obj>.Assembly.Location)
+
+    let private fabricated : DumpedAssembly =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        Assembly.read loggerFactory None (new MemoryStream (image))
+
+    let private bct : BaseClassTypes<DumpedAssembly> = Corelib.getBaseTypes corelib
+
+    let private loaded : LoadedAssemblies =
+        LoadedAssemblies.ofAssemblies [ corelib ; fabricated ]
+
+    let private concreteTypes : AllConcreteTypes =
+        Corelib.concretizeAll loaded bct AllConcreteTypes.Empty
+
+    let private loggerFactory = snd (LoggerFactory.makeTest ())
+
+    let private state () : IlMachineState =
+        { IlMachineState.initial loggerFactory ImmutableArray.Empty corelib with
+            ConcreteTypes = concreteTypes
+            _LoadedAssemblies = loaded
+        }
+
+    let private vtableOf (name : string) : NativeRuntimeTypeHelpers.VtableSlot list =
+        let state = state ()
+
+        let typeInfo =
+            match fabricated.TryGetTopLevelTypeDef "" name with
+            | None -> failwith $"fabricated assembly has no type %s{name}"
+            | Some typeInfo -> typeInfo
+
+        let state, handle =
+            DumpedAssembly.typeInfoToTypeDefn' bct state._LoadedAssemblies typeInfo
+            |> IlMachineState.concretizeType
+                loggerFactory
+                bct
+                state
+                fabricated.Name
+                ImmutableArray.Empty
+                ImmutableArray.Empty
+
+        NativeRuntimeTypeHelpers.vtableOfClosed loggerFactory bct "test" state handle
+        |> snd
+
+    let private hostSlotOf : MethodInfo -> int =
+        let impl =
+            typeof<RuntimeMethodHandle>.GetMethods (BindingFlags.NonPublic ||| BindingFlags.Static)
+            |> Array.filter (fun candidate ->
+                candidate.Name = "GetSlot"
+                && candidate.GetParameters().[0].ParameterType.Name = "IRuntimeMethodInfo"
+            )
+            |> Array.exactlyOne
+
+        fun (method : MethodInfo) -> impl.Invoke ((null : obj), [| box method |]) :?> int
+
+    /// The host's vtable for a fabricated type, slot 0 upwards, named by MethodDef token.
+    let private hostLayout (name : string) : int list =
+        match hostAssembly.GetType (name, false) with
+        | null -> failwith $"host CLR could not load fabricated type %s{name}"
+        | t ->
+            t.GetMethods (BindingFlags.Instance ||| BindingFlags.Public ||| BindingFlags.NonPublic)
+            |> Array.filter _.IsVirtual
+            |> Array.map (fun method -> hostSlotOf method, method.MetadataToken)
+            |> Array.sortBy fst
+            |> Array.map snd
+            |> List.ofArray
+
+    let private pawPrintLayout (slots : NativeRuntimeTypeHelpers.VtableSlot list) : int list =
+        slots
+        |> List.map (fun slot ->
+            match fst slot.Method.IdentityKey with
+            | Some handle ->
+                MetadataTokens.GetToken (
+                    System.Reflection.Metadata.MethodDefinitionHandle.op_Implicit handle
+                    : System.Reflection.Metadata.EntityHandle
+                )
+            | None -> -1
+        )
+
+    /// The names in slot order, for assertions that read better as names than as tokens.
+    let private hostNames (name : string) : string list =
+        match hostAssembly.GetType (name, false) with
+        | null -> failwith $"host CLR could not load fabricated type %s{name}"
+        | t ->
+            t.GetMethods (BindingFlags.Instance ||| BindingFlags.Public ||| BindingFlags.NonPublic)
+            |> Array.filter _.IsVirtual
+            |> Array.map (fun method -> hostSlotOf method, method.Name)
+            |> Array.sortBy fst
+            |> Array.map snd
+            |> List.ofArray
+
+    /// Guards the whole fixture against going vacuous. Every assertion below is about a non-NewSlot
+    /// virtual that matches nothing; if `PersistedAssemblyBuilder` ever started setting NewSlot for
+    /// us, the fabricated types would be ordinary and every test here would pass while testing
+    /// nothing at all.
+    [<Test>]
+    let ``the fabricated methods really do lack NewSlot`` () : unit =
+        let attributesOf (typeName : string) : (string * bool) list =
+            match hostAssembly.GetType (typeName, false) with
+            | null -> failwith $"host CLR could not load fabricated type %s{typeName}"
+            | t ->
+                t.GetMethods (BindingFlags.Instance ||| BindingFlags.Public ||| BindingFlags.DeclaredOnly)
+                |> Array.filter _.IsVirtual
+                |> Array.map (fun method -> method.Name, method.Attributes.HasFlag MethodAttributes.NewSlot)
+                |> List.ofArray
+
+        attributesOf "Discriminator"
+        |> shouldEqual [ "NewSlotFirst", true ; "FallbackSecond", false ]
+
+        attributesOf "Reversed"
+        |> shouldEqual [ "FallbackFirst", false ; "NewSlotSecond", true ]
+
+        attributesOf "MultipleFallbacks"
+        |> shouldEqual [ "FallbackAlpha", false ; "FallbackBeta", false ; "FallbackGamma", false ]
+
+    /// The rule itself: an unmatched non-NewSlot virtual gets a slot rather than being rejected.
+    /// Before this was implemented, reaching any of these types was a `failwith`.
+    [<Test>]
+    let ``an unmatched non-newslot virtual is given a fresh slot`` () : unit =
+        for typeName in [ "Discriminator" ; "Reversed" ; "MultipleFallbacks" ] do
+            let actual = pawPrintLayout (vtableOf typeName)
+            let expected = hostLayout typeName
+
+            if actual <> expected then
+                failwith $"%s{typeName}: PawPrint layout %A{actual} disagrees with the host CLR's %A{expected}"
+
+    /// The ordering claim, stated in names so that a failure says which rule broke. CoreCLR runs one
+    /// declaration-order pass, so the *declaration* order of the two appended methods decides their
+    /// slots -- not which of them is NewSlot. `Discriminator` and `Reversed` declare the same pair in
+    /// opposite orders, so a scheme that grouped the fallbacks separately from the NewSlot methods
+    /// gets exactly one of these two wrong whichever group it puts first.
+    [<Test>]
+    let ``appended slots follow declaration order, not NewSlot grouping`` () : unit =
+        let objectSlots = 4
+
+        hostNames "Discriminator"
+        |> List.skip objectSlots
+        |> shouldEqual [ "NewSlotFirst" ; "FallbackSecond" ]
+
+        hostNames "Reversed"
+        |> List.skip objectSlots
+        |> shouldEqual [ "FallbackFirst" ; "NewSlotSecond" ]
+
+        hostNames "MultipleFallbacks"
+        |> List.skip objectSlots
+        |> shouldEqual [ "FallbackAlpha" ; "FallbackBeta" ; "FallbackGamma" ]
+
+        // And PawPrint agrees with all three. Asserted through the host's own answer rather than
+        // against the literal lists above, so that this stays a differential check.
+        for typeName in [ "Discriminator" ; "Reversed" ; "MultipleFallbacks" ] do
+            pawPrintLayout (vtableOf typeName) |> shouldEqual (hostLayout typeName)
+
+    /// A fallback slot is an ordinary slot: it sits after every inherited one, and the inherited
+    /// prefix is untouched. `Object`'s four slots must still be `Object`'s.
+    [<Test>]
+    let ``fresh slots are appended after the inherited ones`` () : unit =
+        let objectLayout =
+            typeof<obj>.GetMethods (BindingFlags.Instance ||| BindingFlags.Public ||| BindingFlags.NonPublic)
+            |> Array.filter _.IsVirtual
+            |> Array.map (fun method -> hostSlotOf method, method.MetadataToken)
+            |> Array.sortBy fst
+            |> Array.map snd
+            |> List.ofArray
+
+        for typeName in [ "Discriminator" ; "Reversed" ; "MultipleFallbacks" ] do
+            let slots = vtableOf typeName
+            let layout = pawPrintLayout slots
+
+            List.truncate (List.length objectLayout) layout |> shouldEqual objectLayout
+
+            // Everything past the inherited prefix is declared by the fabricated type itself.
+            for slot in List.skip (List.length objectLayout) slots do
+                slot.DeclaredBy.Assembly.FullName |> shouldEqual fabricated.Name.FullName

--- a/WoofWare.PawPrint.Test/TestVirtualMethodSlots.fs
+++ b/WoofWare.PawPrint.Test/TestVirtualMethodSlots.fs
@@ -199,6 +199,46 @@ module TestVirtualMethodSlots =
         |> Array.filter _.IsVirtual
         |> Array.length
 
+    /// The host CLR's own `RuntimeMethodHandle.GetSlot`, which is what `PopulateMethods` calls. It is
+    /// internal, so this is the one place the oracle reaches past the public surface -- and it is
+    /// worth it: without it the oracle can only compare vtable *lengths*, and a walk that appended a
+    /// spurious slot while dropping a real one has the right length and the wrong layout.
+    let private hostSlotOf : MethodInfo -> int =
+        let impl =
+            typeof<RuntimeMethodHandle>.GetMethods (BindingFlags.NonPublic ||| BindingFlags.Static)
+            |> Array.filter (fun candidate ->
+                candidate.Name = "GetSlot"
+                && candidate.GetParameters().[0].ParameterType.Name = "IRuntimeMethodInfo"
+            )
+            |> Array.exactlyOne
+
+        fun (method : MethodInfo) -> impl.Invoke ((null : obj), [| box method |]) :?> int
+
+    /// The host's vtable as a list of MethodDef tokens, slot 0 upwards: `GetSlot` gives the index and
+    /// `MetadataToken` names the occupant. This is the *layout*, not merely its size.
+    let private hostSlotLayout (t : Type) : int list =
+        t.GetMethods (BindingFlags.Instance ||| BindingFlags.Public ||| BindingFlags.NonPublic)
+        |> Array.filter _.IsVirtual
+        |> Array.map (fun method -> hostSlotOf method, method.MetadataToken)
+        |> Array.sortBy fst
+        |> Array.map snd
+        |> List.ofArray
+
+    /// The same list for PawPrint: each slot's occupant named by its MethodDef token.
+    let private pawPrintSlotLayout (slots : NativeRuntimeTypeHelpers.VtableSlot list) : int list =
+        slots
+        |> List.map (fun slot ->
+            match fst slot.Method.IdentityKey with
+            | Some handle ->
+                MetadataTokens.GetToken (
+                    System.Reflection.Metadata.MethodDefinitionHandle.op_Implicit handle
+                    : System.Reflection.Metadata.EntityHandle
+                )
+            // A synthesised method has no MethodDef row. None occupies a slot in any corpus type
+            // here, and -1 makes it a loud mismatch rather than a silent match if one ever does.
+            | None -> -1
+        )
+
     /// `GetSlot` finds its answer by locating the method in its declaring type's vtable, and a
     /// vtable spans assemblies: a guest type's own slots sit on top of corelib's. `IdentityKey` is
     /// a MethodDef *row number*, unique only within its own module, so row 6 of the guest and row 6
@@ -228,6 +268,11 @@ module TestVirtualMethodSlots =
     /// that makes the difference visible: `INumberBase<T>` declares
     /// `System.IUtf8SpanFormattable.TryFormat` as `Private, Final, Virtual, HideBySig` with no
     /// NewSlot. Treating it as an override would look for a base vtable that does not exist.
+    ///
+    /// `vtableOfClosed` has no interface-specific branch: with no base slots to search, the general
+    /// rule finds no match and gives the method a fresh slot, which is the same answer. This test is
+    /// what holds that equivalence down -- it was a hard-coded special case until the fresh-slot rule
+    /// existed to subsume it.
     [<Test>]
     let ``every instance virtual an interface declares gets its own slot`` () : unit =
         let state = state ()
@@ -257,7 +302,8 @@ module TestVirtualMethodSlots =
         let state, slots = vtable state handle
 
         // No base class, so the vtable is exactly the instance virtuals the interface declares --
-        // including the reuse-slot one, which is what the NewSlot partition would have dropped.
+        // including the reuse-slot one, which an implementation that refused to place an unmatched
+        // non-NewSlot virtual would have rejected outright.
         let declared =
             typeInfo.Methods
             |> List.filter (fun method -> not method.IsStatic && method.IsVirtual)
@@ -292,6 +338,42 @@ module TestVirtualMethodSlots =
         if not (List.isEmpty failures) then
             failwith (
                 "vtable size disagrees with the host CLR:\n"
+                + String.Join ("\n", List.rev failures)
+            )
+
+        exercised |> shouldEqual (List.length allCorpus)
+
+    /// Strictly stronger than the length check above, and the reason it is worth reaching for an
+    /// internal API: placing a method in the wrong slot, or appending a spurious slot while failing
+    /// to place a real one, leaves the length right and the layout wrong. That matters more now that
+    /// an unmatched non-newslot virtual *appends* instead of failing loudly -- a gap in
+    /// `candidateFillsSlot` no longer announces itself, and this is what catches it instead.
+    [<Test>]
+    let ``vtable layout agrees with the host CLR slot for slot`` () : unit =
+        let mutable exercised = 0
+        let mutable failures = []
+
+        for label, concretiseType, host in allCorpus do
+            let state, handle = concretiseType (state ())
+            let _, slots = vtable state handle
+
+            let actual = pawPrintSlotLayout slots
+            let expected = hostSlotLayout host
+
+            if actual <> expected then
+                let firstDivergence =
+                    List.zip (List.truncate (List.length expected) actual) expected
+                    |> List.tryFindIndex (fun ((a : int), (b : int)) -> a <> b)
+
+                failures <-
+                    $"%s{label}: PawPrint %i{List.length actual} slots, host %i{List.length expected}, first differing slot %A{firstDivergence}"
+                    :: failures
+
+            exercised <- exercised + 1
+
+        if not (List.isEmpty failures) then
+            failwith (
+                "vtable layout disagrees with the host CLR:\n"
                 + String.Join ("\n", List.rev failures)
             )
 

--- a/WoofWare.PawPrint.Test/TestVirtualMethodSlots.fs
+++ b/WoofWare.PawPrint.Test/TestVirtualMethodSlots.fs
@@ -361,12 +361,23 @@ module TestVirtualMethodSlots =
             let expected = hostSlotLayout host
 
             if actual <> expected then
+                // Truncate *both* to the common prefix: a walk that drops a slot makes `actual`
+                // the shorter list, and zipping a short list against a long one throws, which
+                // would replace the diagnostic with an ArgumentException and lose the rest of the
+                // corpus's results along with it.
+                let common = min (List.length actual) (List.length expected)
+
                 let firstDivergence =
-                    List.zip (List.truncate (List.length expected) actual) expected
+                    List.zip (List.truncate common actual) (List.truncate common expected)
                     |> List.tryFindIndex (fun ((a : int), (b : int)) -> a <> b)
 
+                let divergence =
+                    match firstDivergence with
+                    | Some i -> $"first differing slot %i{i}"
+                    | None -> "identical up to the shorter length; only the lengths differ"
+
                 failures <-
-                    $"%s{label}: PawPrint %i{List.length actual} slots, host %i{List.length expected}, first differing slot %A{firstDivergence}"
+                    $"%s{label}: PawPrint %i{List.length actual} slots, host %i{List.length expected}, %s{divergence}"
                     :: failures
 
             exercised <- exercised + 1

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -141,6 +141,7 @@
     <Compile Include="TestNativeMdUtf8String.fs" />
     <Compile Include="TestNativeRuntimeMethodHandle.fs" />
     <Compile Include="TestVirtualMethodSlots.fs" />
+    <Compile Include="TestFabricatedVtableLayout.fs" />
     <Compile Include="TestLinuxCoreLibFlavour.fs" />
     <Compile Include="TestInlineArrayLayout.fs" />
     <Compile Include="TestReinterpretCellAccess.fs" />

--- a/WoofWare.PawPrint/Native/NativeRuntimeMethodHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeMethodHandle.fs
@@ -1102,19 +1102,19 @@ module NativeRuntimeMethodHandle =
             // rejects static+virtual outside interfaces with a TypeLoadException, and
             // `PopulateMethods` routes interfaces down a branch that never reaches here.
             //
-            // Two shapes would land outside the vtable, and neither is reachable yet. Both are
-            // recorded because they are the answer to "what would CoreCLR have returned":
+            // Two shapes land outside the vtable. Both are recorded because they are the answer to
+            // "what would CoreCLR have returned":
             //
             //  - `PopulateProperties` (RuntimeType.CoreCLR.cs:1358) calls this on a property's
             //    accessor with *no* Virtual guard, testing `slot < numVirtuals` afterwards, so an
             //    ordinary non-virtual getter reaches it and CoreCLR answers with a non-vtable slot.
-            //    This is much the closer of the two to being live, and is getting closer: property
-            //    enumeration is no longer blocked on Property token enumeration (#921, #926) nor on
-            //    `Associates.AssignAssociates` (#934), and the duplicate check that reaches here is
-            //    exactly what was waiting on `GetSlot`. What still blocks it is parsing an ECMA
-            //    II.23.2.5 PropertySig -- see the `PropertySignatureBlob` arm of NativeSignature.fs,
-            //    which tracks the current state of that chain. Whoever lands PropertySig parsing
-            //    should expect to arrive here, and will need the non-vtable region.
+            //    This one is **live**: it is what the parked `UnionReflection` F# case now dies on,
+            //    reporting "method get_width occupies no slot in the vtable of its declaring type".
+            //    The chain that used to block it is gone -- Property token enumeration (#921, #926),
+            //    `Associates.AssignAssociates` (#934), and most recently the vtable layout rule for
+            //    an unmatched non-NewSlot virtual, without which a union's vtable could not be built
+            //    at all. Implementing the non-vtable region is what un-parks that case; see the
+            //    parking comment in TestFSharpPureCases for the observed failure.
             //
             //  - For a value type, the MethodTable builder duplicates every virtual, leaving the
             //    unboxing stub in the vtable slot and giving the unboxed copy a slot beyond

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
@@ -1032,15 +1032,15 @@ module NativeRuntimeTypeHelpers =
             // placed. A slot appended by an earlier method of *this* type is therefore not something
             // a later one can land on.
             //
-            // No test can kill this cap, and the reason is worth stating rather than leaving for
-            // someone to rediscover: reaching past `baseSlotCount` needs a later method whose name
-            // and signature match one this same type already appended, and two MethodDef rows of one
-            // type may not share a name and signature (ECMA-335 II.22.26), so no legal image
-            // contains the shape. It is kept because it stops being a no-op exactly when
-            // `candidateFillsSlot` conflates two signatures that are really distinct -- the failure
-            // mode #939 found and refused for arrays. With the cap, a conflation appends both, which
-            // is CoreCLR's answer; without it, the second silently swallows the first's slot and the
-            // vtable comes out a slot short.
+            // That cap is load-bearing on legal metadata, not defensive insurance. ECMA-335 II.22.26
+            // stops a type repeating a method blob-for-blob, but `candidateFillsSlot` compares
+            // *concretised* signatures -- which is what lets an ordinary override of a generic base
+            // match at all -- and that conflates blobs which genuinely differ. The worked example is
+            // `GenericConflation`1` in TestFabricatedVtableLayout: it declares `Conflated(!0)` as
+            // NewSlot and `Conflated(string)` without it, and closing it at `T = string` makes the
+            // second match the slot the first was just appended to. CoreCLR lays slots out on the
+            // generic definition, where the two are distinct, and gives each its own; uncapped, the
+            // second replaces the first and the vtable comes out a slot short.
             let baseSlotCount = List.length baseSlots
 
             let state, slots =

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
@@ -1013,22 +1013,38 @@ module NativeRuntimeTypeHelpers =
                 typeInfo.Methods
                 |> List.filter (fun method -> not method.IsStatic && method.IsVirtual)
 
-            let overrides, newSlots =
-                if typeInfo.IsInterface then
-                    // `MethodTableBuilder::PlaceVirtualMethods` adds every instance virtual an
-                    // interface declares unconditionally, without consulting NewSlot -- an
-                    // interface has no base class whose slots it could be reusing. The distinction
-                    // is not academic: corelib's `INumberBase<T>` declares
-                    // `System.IUtf8SpanFormattable.TryFormat` as `Private, Final, Virtual,
-                    // HideBySig` with no NewSlot -- measured, the only such method in corelib -- so
-                    // partitioning on NewSlot here would classify it as an override and then fail
-                    // for want of a base vtable to match it against.
-                    [], instanceVirtuals
-                else
-                    instanceVirtuals |> List.partition (fun method -> not method.IsNewSlot)
+            // Upstream is a single pass over the declared methods in MethodDef row order
+            // (`DeclaredMethodIterator` over the array `EnumerateClassMethods` fills in row order),
+            // and each method either replaces a parent slot or takes the next free one
+            // (`MethodTableBuilder::PlaceVirtualMethods`, methodtablebuilder.cpp:5405-5482). So
+            // overrides and fresh slots interleave, and it is *declaration* order -- not NewSlot --
+            // that decides the order of the fresh ones. Partitioning on NewSlot and appending the
+            // groups separately would agree only while fresh slots were the exclusive preserve of
+            // NewSlot methods, which stopped being true the moment the unmatched case below started
+            // allocating one. Measured on a fabricated type declaring an unmatched NewSlot virtual
+            // before an unmatched non-NewSlot one: the host CLR gives the NewSlot method the lower
+            // slot, and a NewSlot-grouped layout gets it backwards (TestFabricatedVtableLayout).
+            //
+            // Only the *parent's* slots are candidates for a match, which is why the search is capped
+            // at `baseSlotCount` rather than ranging over the list as it grows: upstream searches
+            // `bmtParent->pParentMethodHash`, built once from the parent MethodTable
+            // (methodtablebuilder.cpp:174-193) and never extended as this type's own methods are
+            // placed. A slot appended by an earlier method of *this* type is therefore not something
+            // a later one can land on.
+            //
+            // No test can kill this cap, and the reason is worth stating rather than leaving for
+            // someone to rediscover: reaching past `baseSlotCount` needs a later method whose name
+            // and signature match one this same type already appended, and two MethodDef rows of one
+            // type may not share a name and signature (ECMA-335 II.22.26), so no legal image
+            // contains the shape. It is kept because it stops being a no-op exactly when
+            // `candidateFillsSlot` conflates two signatures that are really distinct -- the failure
+            // mode #939 found and refused for arrays. With the cap, a conflation appends both, which
+            // is CoreCLR's answer; without it, the second silently swallows the first's slot and the
+            // vtable comes out a slot short.
+            let baseSlotCount = List.length baseSlots
 
             let state, slots =
-                ((state, baseSlots), overrides)
+                ((state, baseSlots), instanceVirtuals)
                 ||> List.fold (fun (state, slots) method ->
                     let candidate =
                         {
@@ -1037,13 +1053,26 @@ module NativeRuntimeTypeHelpers =
                         }
 
                     let state, matched =
-                        ((state, []), List.indexed slots)
-                        ||> List.fold (fun (state, acc) (i, slot) ->
-                            let state, fills =
-                                candidateFillsSlot loggerFactory baseClassTypes operation state candidate slot
+                        if method.IsNewSlot then
+                            // "If the member is marked with a new slot we do not need to find it in
+                            // the parent" -- it is asking for a slot of its own by construction.
+                            state, []
+                        else
+                            // An interface reaches here with `baseSlotCount = 0`, so the search is
+                            // empty and every method it declares appends -- which is exactly what
+                            // upstream's `IsInterface` arm does, an interface having no parent whose
+                            // slots it could reuse. That arm needs no special case here, but it does
+                            // need the unmatched case below to allocate rather than fail: corelib's
+                            // `INumberBase<T>` declares `System.IUtf8SpanFormattable.TryFormat` as
+                            // `Private, Final, Virtual, HideBySig` with no NewSlot -- measured, the
+                            // only such method in corelib -- and it takes this path.
+                            ((state, []), List.indexed slots |> List.truncate baseSlotCount)
+                            ||> List.fold (fun (state, acc) (i, slot) ->
+                                let state, fills =
+                                    candidateFillsSlot loggerFactory baseClassTypes operation state candidate slot
 
-                            state, (if fills then i :: acc else acc)
-                        )
+                                state, (if fills then i :: acc else acc)
+                            )
 
                     // More than one slot can legitimately match: `A` declares `virtual M()`, `B :
                     // A` declares `new virtual M()` with the identical signature, and `C : B`
@@ -1125,30 +1154,33 @@ module NativeRuntimeTypeHelpers =
 
                         state, slots |> List.mapi (fun j slot -> if j = mostDerived then candidate else slot)
                     | [] ->
-                        // CoreCLR does not fail here: `MethodTableBuilder` gives an unmatched
-                        // non-newslot virtual a fresh slot. That fallback is not dead code
-                        // upstream, and the shape is not confined to corrupt images: assembly
-                        // version skew produces it, because a derived assembly compiled against a
-                        // base that has since removed or changed the virtual still carries the
-                        // non-newslot bit, and CoreCLR loads and runs that app. Roslyn does not
-                        // emit it against the assemblies it compiled against, so PawPrint has
-                        // never had a case to walk; fail with the method named rather than model a
-                        // layout no test exercises, since silently appending would shift every
-                        // later slot and corrupt the dedupe key `PopulateMethods` indexes with.
-                        failwith
-                            $"TODO: %s{operation}: virtual method %s{method.Name} on %O{concreteTypeInfo} is not marked newslot but matches no slot in the base vtable; PawPrint does not model CoreCLR's fallback of allocating it a fresh slot"
+                        // "Else, place the method in the next available empty vtable slot"
+                        // (methodtablebuilder.cpp:5401). Both kinds of method arrive here: one
+                        // marked NewSlot, which skipped the search and is asking for a slot of its
+                        // own, and one *not* marked NewSlot whose search came up empty. Upstream
+                        // makes no distinction between them -- both go to `AddVirtualMethod` -- and
+                        // neither does this.
+                        //
+                        // The second kind is what F# emits constantly: the structural equality and
+                        // comparison members of a union or record are `Public, Final, Virtual,
+                        // HideBySig` with no NewSlot, so `Equals(T)` and `CompareTo(object,
+                        // IComparer)` match nothing on `Object` and land here. Roslyn never emits
+                        // it -- 0 of corelib's 1470 non-generic classes trigger it, measured -- which
+                        // is why it looked like a contingency for corrupt or version-skewed images
+                        // for as long as PawPrint only ever read C#.
+                        //
+                        // Appending is the whole of the rule, but it costs a diagnostic: this used
+                        // to be a `failwith` naming the method, which is what a gap in
+                        // `candidateFillsSlot` announced itself as. A gap now shows up as a
+                        // spurious extra slot instead, so what catches one is the slot-by-slot
+                        // comparison against the host CLR's own `GetSlot` in TestVirtualMethodSlots
+                        // -- a check on the layout rather than merely on its length, because a walk
+                        // that appends one slot too many while dropping a real one has the right
+                        // length.
+                        state, slots @ [ candidate ]
                 )
 
-            let newSlots =
-                newSlots
-                |> List.map (fun method ->
-                    {
-                        VtableSlot.Method = method
-                        VtableSlot.DeclaredBy = concreteTypeInfo
-                    }
-                )
-
-            state, slots @ newSlots
+            state, slots
 
     /// What identifies a vtable slot's occupant well enough to find it again: the full name of the
     /// assembly that declares the method, paired with the method's within-assembly identity.

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
@@ -1025,27 +1025,34 @@ module NativeRuntimeTypeHelpers =
             // before an unmatched non-NewSlot one: the host CLR gives the NewSlot method the lower
             // slot, and a NewSlot-grouped layout gets it backwards (TestFabricatedVtableLayout).
             //
-            // Only the *parent's* slots are candidates for a match, which is why the search is capped
-            // at `baseSlotCount` rather than ranging over the list as it grows: upstream searches
+            // Only the *parent's* slots are candidates for a match: upstream searches
             // `bmtParent->pParentMethodHash`, built once from the parent MethodTable
             // (methodtablebuilder.cpp:174-193) and never extended as this type's own methods are
             // placed. A slot appended by an earlier method of *this* type is therefore not something
             // a later one can land on.
             //
-            // That cap is load-bearing on legal metadata, not defensive insurance. ECMA-335 II.22.26
-            // stops a type repeating a method blob-for-blob, but `candidateFillsSlot` compares
-            // *concretised* signatures -- which is what lets an ordinary override of a generic base
-            // match at all -- and that conflates blobs which genuinely differ. The worked example is
-            // `GenericConflation`1` in TestFabricatedVtableLayout: it declares `Conflated(!0)` as
-            // NewSlot and `Conflated(string)` without it, and closing it at `T = string` makes the
-            // second match the slot the first was just appended to. CoreCLR lays slots out on the
-            // generic definition, where the two are distinct, and gives each its own; uncapped, the
-            // second replaces the first and the vtable comes out a slot short.
-            let baseSlotCount = List.length baseSlots
-
-            let state, slots =
-                ((state, baseSlots), instanceVirtuals)
-                ||> List.fold (fun (state, slots) method ->
+            // That is why the fold below carries the inherited slots and the fresh ones as two
+            // values rather than one growing list. `inherited` only ever has entries *replaced*, so
+            // it stays exactly the parent's vtable and the search cannot reach a fresh slot however
+            // the search is written. Threading one list and capping the search at the parent's length
+            // would compute the same answer, but this way the invariant is a property of the shape
+            // rather than of remembering to cap; it also keeps appending O(1) rather than copying the
+            // accumulated vtable per method, which for an interface -- where every member appends --
+            // is the difference between a linear layout and a quadratic one.
+            //
+            // The restriction is load-bearing on legal metadata, not defensive insurance. ECMA-335
+            // II.22.26 stops a type repeating a method blob-for-blob, but `candidateFillsSlot`
+            // compares *concretised* signatures -- which is what lets an ordinary override of a
+            // generic base match at all -- and that conflates blobs which genuinely differ. The
+            // worked example is `GenericConflation`1` in TestFabricatedVtableLayout: it declares
+            // `Conflated(!0)` as NewSlot and `Conflated(string)` without it, and closing it at
+            // `T = string` makes the second match the slot the first was just appended to. CoreCLR
+            // lays slots out on the generic definition, where the two are distinct, and gives each
+            // its own; a search that could see fresh slots would have the second replace the first
+            // and the vtable would come out a slot short.
+            let state, inherited, freshReversed =
+                ((state, baseSlots, []), instanceVirtuals)
+                ||> List.fold (fun (state, slots, fresh) method ->
                     let candidate =
                         {
                             VtableSlot.Method = method
@@ -1058,7 +1065,7 @@ module NativeRuntimeTypeHelpers =
                             // the parent" -- it is asking for a slot of its own by construction.
                             state, []
                         else
-                            // An interface reaches here with `baseSlotCount = 0`, so the search is
+                            // An interface reaches here with no inherited slots, so the search is
                             // empty and every method it declares appends -- which is exactly what
                             // upstream's `IsInterface` arm does, an interface having no parent whose
                             // slots it could reuse. That arm needs no special case here, but it does
@@ -1066,7 +1073,7 @@ module NativeRuntimeTypeHelpers =
                             // `INumberBase<T>` declares `System.IUtf8SpanFormattable.TryFormat` as
                             // `Private, Final, Virtual, HideBySig` with no NewSlot -- measured, the
                             // only such method in corelib -- and it takes this path.
-                            ((state, []), List.indexed slots |> List.truncate baseSlotCount)
+                            ((state, []), List.indexed slots)
                             ||> List.fold (fun (state, acc) (i, slot) ->
                                 let state, fills =
                                     candidateFillsSlot loggerFactory baseClassTypes operation state candidate slot
@@ -1152,7 +1159,7 @@ module NativeRuntimeTypeHelpers =
                             failwith
                                 $"%s{operation}: virtual method %s{method.Name} on %O{concreteTypeInfo} is not marked newslot and matches vtable slot %i{mostDerived}, which is occupied by the final method %s{occupant.Method.Name} declared by %O{occupant.DeclaredBy}; CoreCLR rejects this type at load time with a TypeLoadException rather than laying out a vtable for it"
 
-                        state, slots |> List.mapi (fun j slot -> if j = mostDerived then candidate else slot)
+                        state, (slots |> List.mapi (fun j slot -> if j = mostDerived then candidate else slot)), fresh
                     | [] ->
                         // "Else, place the method in the next available empty vtable slot"
                         // (methodtablebuilder.cpp:5401). Both kinds of method arrive here: one
@@ -1177,8 +1184,12 @@ module NativeRuntimeTypeHelpers =
                         // -- a check on the layout rather than merely on its length, because a walk
                         // that appends one slot too many while dropping a real one has the right
                         // length.
-                        state, slots @ [ candidate ]
+                        state, slots, candidate :: fresh
                 )
+
+            // The fresh slots were accumulated head-first, so undo that once here rather than
+            // copying the accumulated vtable on every append.
+            let slots = inherited @ List.rev freshReversed
 
             state, slots
 


### PR DESCRIPTION
Implements `MethodTableBuilder::PlaceVirtualMethods`' rule that an instance virtual which is *not*
marked NewSlot and matches nothing in the parent vtable gets a fresh slot. Tenth blocker on the
`UnionReflection` path, re-observed by un-parking the case and running it.

`vtableOfClosed` used to `failwith` here, on the reasoning that "Roslyn does not emit it against the
assemblies it compiled against, so PawPrint has never had a case to walk". True about Roslyn — **0**
of corelib's 1470 non-generic classes trigger it — and wrong about the world. F# emits it constantly:
the structural equality and comparison members of every union and record are `Public, Final, Virtual,
HideBySig` with no NewSlot, so six of `Shape`'s virtuals match nothing on `Object`. Reflecting over
any F# union at all died here.

| assembly | classes scanned | hitting the fallback | fresh slots |
|---|---|---|---|
| System.Private.CoreLib | 1470 | **0** | 0 |
| FSharp.Core | 220 | 6 | 15 |

(Measured host-side: `numVirtuals(T) - numVirtuals(base) - #newslot-declared` is exactly the fallback
count.)

## Decision 1: one declaration-order pass, not a partition

Upstream is a single `DeclaredMethodIterator` loop in MethodDef row order, each method either
replacing a parent slot or taking the next free one (methodtablebuilder.cpp:5405-5482). So overrides
and fresh slots interleave, and *declaration* order — not NewSlot — decides the order of the fresh
ones.

PawPrint partitioned on NewSlot, folded the overrides, and concatenated the rest. That agreed with
upstream only while fresh slots were the exclusive preserve of NewSlot methods, which this change
ends. Rather than thread declaration order back through a concat, the walk becomes upstream's loop.

Two things fall out. It **subsumes the `IsInterface` special case**, which existed only because an
unmatched non-NewSlot virtual used to be fatal: an interface has no base slots, so the general rule
finds no match and appends, which is the same answer — corelib's one reuse-slot interface method,
`INumberBase<T>.System.IUtf8SpanFormattable.TryFormat`, now goes through the general path. And the
blast radius is contained: the only consumers are `GetSlot` (an index) and `GetNumVirtuals` (a
length), both reflection-only — `callvirt` does not dispatch through this walk — so a layout change
cannot alter guest control flow behind our backs.

## Decision 2: the search sees only inherited slots

Upstream searches `bmtParent->pParentMethodHash`, built once from the parent MethodTable and never
extended as this type's methods are placed. The fold therefore carries the inherited slots and the
fresh ones as two values: `inherited` only ever has entries *replaced*, so a fresh slot is not in the
list the search ranges over at all. The invariant is a property of the shape rather than of
remembering to cap a search — and, per Codex, it also keeps appending O(1) instead of copying the
accumulated vtable per method, which for an interface (every member appends) is the difference
between a linear layout and a quadratic one.

I first wrote this as a `List.truncate` cap and claimed in a comment that no legal image could tell
it from an uncapped search, since ECMA-335 II.22.26 forbids two rows sharing a name and signature.
**That was wrong**, and Fable refuted it by construction: `candidateFillsSlot` compares *concretised*
signatures — which is what lets an ordinary override of a generic base match at all — so blobs that
genuinely differ still conflate. `GenericConflation`1` declares `Conflated(!0)` as NewSlot and
`Conflated(string)` without it; two distinct blobs, a legal type, and at `T = string` the second
matches the slot the first was just appended to. CoreCLR lays slots out on the generic definition and
gives each its own. It is now a test, and it kills the mutation that previously survived the entire
suite.

## Tests

**The fallback needed types no compiler emits**, and loading a real F# assembly into the unit harness
fails in `getTypeRef` — FSharp.Core's TypeRefs go through the System.Runtime facade, which the
harness has no closure for. So `TestFabricatedVtableLayout` fabricates them with
`PersistedAssemblyBuilder`, which passes the NewSlot bit through verbatim (`Public, Virtual` stays
reuse-slot). Built against `typeof<obj>.Assembly`, the image references System.Private.CoreLib
*directly*, which is what the harness can resolve. The host CLR loads the same bytes and its own
`RuntimeMethodHandle.GetSlot` — the function `PopulateMethods` calls — is the oracle; nothing from
PawPrint's walk feeds the expected values. A guard test pins that the NewSlot bits really are absent,
so the fixture cannot go vacuous.

`Discriminator` and `Reversed` declare the same pair of methods in opposite orders, so a
NewSlot-grouped layout gets exactly one of them wrong whichever group it puts first.

**The corpus oracle moves from vtable length to slot-by-slot layout.** Appending costs a diagnostic —
a gap in `candidateFillsSlot` used to announce itself as a `failwith` and now shows up as a spurious
slot — and length is invariant under permutation, so length alone is too weak. Measured: it passed
unchanged over the existing 33-type corpus before the rule changed, so it is a strict strengthening
that uncovered no pre-existing divergence.

**`UnionVirtualSlots`** is the end-to-end differential guest: reflecting over an F# union's virtual
methods, with the real runtime checking the pinned counts rather than them being adopted as truth.

### Mutations

| Mutation | Killed by |
|---|---|
| Prepend instead of append | 7 tests |
| NewSlot grouping instead of declaration order | **exactly the 2 fabricated layout tests**, nothing else in 2765 |
| Search can see the fresh slots | **1** — `GenericConflation`1` alone |
| NewSlot methods search for a match too | corelib corpus (length *and* layout) |
| Reverse declaration order | **layout only** — the length check waves it through |

The second row is the whole justification for fabricating: without that fixture the ordering choice
would have been unfalsifiable, which is exactly what the plan originally claimed before Fable pushed
back on it. The last row is the justification for the oracle upgrade.

## Scope

`UnionReflection` **stays parked**, now on `GetSlot` being asked about a method with no vtable slot at
all: a union's case fields are read through non-virtual property accessors, which CoreCLR numbers in
the non-vtable region past `GetNumVirtuals`. That is a question about numbering beyond the virtual
prefix rather than about vtable layout, so it is the next slice and not this one. Laying out the
union's vtable is what made that shape reachable, so the `GetSlot` handler's comment describing it as
"not reachable yet, blocked on parsing a PropertySig" is corrected here.

## Review

Plan and branch both went to Fable, and the branch to `codex review` twice. Fable's plan review
changed the work twice over: it argued the layout mitigation didn't actually verify the new append
path (it didn't — hence the fabricated fixture), and that a discriminating type was constructible
rather than the plan's claimed "unfalsifiable" (it was). Its branch review then refuted the search-cap
comment above, and found the layout test's diagnostic path threw `ArgumentException` whenever
PawPrint's list was the *shorter* one — i.e. precisely the slot-dropping regression it exists to
report would have lost its message. Codex's second pass found the append complexity regression.

Full suite: 2770/2770 on 311e57d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
