### PR TITLE
Report source locations in the instruction trace

### DIFF
--- a/WoofWare.PawPrint.Domain/Assembly.fs
+++ b/WoofWare.PawPrint.Domain/Assembly.fs
@@ -4,6 +4,7 @@ open System
 open System.Collections.Concurrent
 open System.Collections.Generic
 open System.Collections.Immutable
+open System.Diagnostics
 open System.IO
 open System.Reflection
 open System.Reflection.Metadata
@@ -766,6 +767,35 @@ type DumpedAssembly =
         match this.SequencePoints.TryGetValue (ComparableMethodDefinitionHandle.Make method) with
         | false, _ -> None
         | true, points -> MethodSequencePoints.resolve ilOffset points
+
+    /// <summary>
+    /// The source span the compiler attributed to <paramref name="ilOffset" /> within
+    /// <paramref name="method" />, which must be a method this assembly declares.
+    /// </summary>
+    /// <remarks>
+    /// <c>None</c> for a method the runtime synthesised, which is the honest answer rather than a
+    /// missing feature: a synthesised method has no declaration, so there is no source for a
+    /// compiler to have attributed anything to. <c>MethodInfo.TryMetadata</c> is shaped to force
+    /// that question to be answered rather than forgotten.
+    /// </remarks>
+    member this.TryResolveMethodSource
+        (method : MethodInfo<'typeGen, 'methodGen, 'methodVars>)
+        (ilOffset : int)
+        : SourceLocation option
+        =
+        // A MethodDefinitionHandle means nothing outside the assembly that declares it, and this
+        // one indexes `this.SequencePoints`. Passing a foreign method would not fail — it would
+        // quietly report some unrelated method's source. Callers resolve the assembly *from the
+        // method's declaring type*, which makes the mismatch unreachable; assert it rather than
+        // trusting it, at no cost in release.
+        Debug.Assert (
+            method.DeclaringType.Assembly.FullName = this.Name.FullName,
+            $"TryResolveMethodSource: {method.Name} is declared by {method.DeclaringType.Assembly.FullName}, not {this.Name.FullName}"
+        )
+
+        match method.TryMetadata with
+        | None -> None
+        | Some metadata -> this.TryResolveSourceLocation metadata.Handle ilOffset
 
     interface IDisposable with
         member this.Dispose () =

--- a/WoofWare.PawPrint.Domain/SequencePoint.fs
+++ b/WoofWare.PawPrint.Domain/SequencePoint.fs
@@ -29,6 +29,20 @@ type SourceLocation =
         EndColumn : int
     }
 
+    /// <summary>
+    /// <c>path:line</c>, the rendering diagnostics want: greppable, and pasteable into an editor
+    /// or an IDE's go-to-line. Columns and the end position are deliberately dropped — they are
+    /// available on the record for anyone who needs them, and would only make a line of a
+    /// rendered stack harder to read.
+    /// </summary>
+    /// <remarks>
+    /// For prose. Structured output should carry the fields themselves rather than this, so that a
+    /// consumer gets a line number it can compare against rather than text it has to parse; see the
+    /// per-step trace log in <c>AbstractMachine</c> and the debugger server's frame JSON.
+    /// </remarks>
+    override this.ToString () : string =
+        $"%s{this.DocumentPath}:%i{this.StartLine}"
+
 /// <summary>
 /// One portable-PDB sequence point: the start of a range of IL which the compiler has either
 /// attributed to a source span, or explicitly declared to have none.

--- a/WoofWare.PawPrint.Test/TestSequencePoints.fs
+++ b/WoofWare.PawPrint.Test/TestSequencePoints.fs
@@ -110,6 +110,45 @@ module TestSequencePoints =
         assy.Methods
         |> Seq.pick (fun kvp -> if kvp.Value.Name = "Triple" then Some kvp.Key else None)
 
+    let private tripleMethod
+        (assy : DumpedAssembly)
+        : MethodInfo<GenericParamFromMetadata, GenericParamFromMetadata, TypeDefn>
+        =
+        assy.Methods
+        |> Seq.pick (fun kvp -> if kvp.Value.Name = "Triple" then Some kvp.Value else None)
+
+    /// The rendering prose diagnostics use — `GuestLocation`'s thread summaries. Column
+    /// information is deliberately dropped: the line wants to be greppable and to paste into an
+    /// editor, and `path:line` is what does that.
+    [<Test>]
+    let ``a source location renders as path and line`` () : unit =
+        let location =
+            {
+                DocumentPath = "/src/Foo.cs"
+                StartLine = 17
+                StartColumn = 5
+                EndLine = 19
+                EndColumn = 30
+            }
+
+        string location |> shouldEqual "/src/Foo.cs:17"
+
+    [<Test>]
+    let ``TryResolveMethodSource resolves a metadata-backed method`` () : unit =
+        let assy = readImage (Roslyn.compileWithSymbols [ source ])
+
+        match assy.TryResolveMethodSource (tripleMethod assy) 0 with
+        | None -> failwith "expected a source location for Triple's first instruction"
+        | Some location ->
+            location.DocumentPath |> shouldEqual "File0.cs"
+            location.StartLine |> shouldEqual 4
+
+    [<Test>]
+    let ``TryResolveMethodSource has nothing to say without symbols`` () : unit =
+        let assy = readImage (Roslyn.compile [ source ])
+
+        assy.TryResolveMethodSource (tripleMethod assy) 0 |> shouldEqual None
+
     [<Test>]
     let ``an image compiled with symbols exposes its sequence points`` () : unit =
         let assy = readImage (Roslyn.compileWithSymbols [ source ])

--- a/WoofWare.PawPrint.Test/TestTraceSourceLocations.fs
+++ b/WoofWare.PawPrint.Test/TestTraceSourceLocations.fs
@@ -1,0 +1,197 @@
+namespace WoofWare.PawPrint.Test
+
+open System
+open System.Collections.Generic
+open System.Collections.Immutable
+open System.IO
+open FsUnitTyped
+open Microsoft.Extensions.Logging
+open NUnit.Framework
+open WoofWare.DotnetRuntimeLocator
+open WoofWare.PawPrint
+
+/// Covers the wiring between the sequence points an assembly carries and the trace log that
+/// reports them. The resolution itself is unit-tested in `TestSequencePoints`; what can only be
+/// seen by running a guest is that the *executing* method's own assembly is the one consulted.
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestTraceSourceLocations =
+
+    let private assy = typeof<RunResult>.Assembly
+
+    /// `Triple` occupies lines 3-7 and `Main` lines 8-11; both are the guest's own code, and so
+    /// both should be attributed to File0.cs.
+    let private source : string =
+        String.concat
+            "\n"
+            [
+                "public static class Sut" // 1
+                "{" // 2
+                "    public static int Triple(int x)" // 3
+                "    {" // 4
+                "        int y = x * 3;" // 5
+                "        return y;" // 6
+                "    }" // 7
+                "    public static int Main()" // 8
+                "    {" // 9
+                "        return Triple(0) ;" // 10
+                "    }" // 11
+                "}" // 12
+            ]
+
+    /// One step of the trace log, as a structured consumer sees it: the extent of the executing
+    /// method's body, and the source the step was attributed to if any.
+    ///
+    /// `MaxIlOpIndex` identifies a line as a step of the trace rather than any other message, and
+    /// is retained because it distinguishes bodies that a line number cannot — see the synthetic
+    /// startup frame below.
+    type private TracedStep =
+        {
+            MaxIlOpIndex : int
+            Source : (string * int) option
+        }
+
+    /// Harvests the distinct <c>TracedStep</c>s the trace log emits.
+    ///
+    /// Reads the structured state rather than the formatted message, and keeps a *set*: the trace
+    /// log fires once per interpreted IL instruction, so formatting each message — or retaining
+    /// one record per instruction — would dominate this test's time and memory. Distinct steps are
+    /// bounded by the sequence points of the methods actually executed.
+    let private harvestingLoggerFactory () : (unit -> TracedStep list) * ILoggerFactory =
+        let seen = HashSet<TracedStep> ()
+
+        let logger =
+            { new ILogger with
+                member _.BeginScope _state =
+                    { new IDisposable with
+                        member _.Dispose () = ()
+                    }
+
+                member _.IsEnabled (level : LogLevel) : bool = level >= LogLevel.Trace
+
+                member _.Log (_level, _eventId, state, _ex, _formatter) =
+                    match box state with
+                    | :? IReadOnlyList<KeyValuePair<string, obj>> as pairs ->
+                        let mutable maxIlOpIndex = None
+                        let mutable file = None
+                        let mutable line = None
+
+                        for pair in pairs do
+                            match pair.Key, pair.Value with
+                            | "MaxIlOpIndex", (:? int as value) -> maxIlOpIndex <- Some value
+                            | "SourceFile", (:? string as value) -> file <- Some value
+                            | "SourceLine", (:? int as value) -> line <- Some value
+                            | _ -> ()
+
+                        match maxIlOpIndex with
+                        | None -> ()
+                        | Some maxIlOpIndex ->
+                            let step =
+                                {
+                                    MaxIlOpIndex = maxIlOpIndex
+                                    // The two holes are emitted together or not at all, so
+                                    // anything else is the message template and the arguments
+                                    // having drifted apart; say so rather than silently
+                                    // reporting "no source".
+                                    Source =
+                                        match file, line with
+                                        | Some file, Some line -> Some (file, line)
+                                        | None, None -> None
+                                        | Some file, None -> failwith $"trace step reported file %s{file}, no line"
+                                        | None, Some line -> failwith $"trace step reported line %d{line}, no file"
+                                }
+
+                            lock seen (fun () -> seen.Add step |> ignore<bool>)
+                    | _ -> ()
+            }
+
+        let getSeen () = lock seen (fun () -> List.ofSeq seen)
+
+        getSeen,
+        { new ILoggerFactory with
+            member _.CreateLogger _categoryName = logger
+            member _.AddProvider _provider = ()
+            member _.Dispose () = ()
+        }
+
+    /// Run the guest under a trace-enabled harvesting logger.
+    ///
+    /// Shared by the tests below rather than run per test: interpreting a guest with the trace log
+    /// on is by far the most expensive thing here, and both tests want the same run.
+    let private tracedRun : Lazy<TracedStep list> =
+        lazy
+            (let image = Roslyn.compileWithSymbols [ source ]
+             let seen, loggerFactory = harvestingLoggerFactory ()
+
+             let dotnetRuntimes =
+                 DotnetRuntime.SelectForDll assy.Location |> ImmutableArray.CreateRange
+
+             use peImage = new MemoryStream (image)
+
+             let outcome =
+                 Program.run loggerFactory (Some "TraceSourceLocations.cs") peImage (HostConfig.Default dotnetRuntimes)
+
+             match outcome with
+             | RunOutcome.NormalExit _ -> ()
+             | other -> failwith $"expected the guest to exit normally, got %O{other}"
+
+             seen ())
+
+    [<Test>]
+    let ``the trace log attributes guest instructions to guest source`` () : unit =
+        let steps = tracedRun.Value
+
+        // The framework assemblies ship no symbols, so almost every step of the run has no source
+        // at all; that some step reports none is what tells us the unattributed path is live
+        // rather than dead.
+        steps |> List.exists (fun step -> step.Source.IsNone) |> shouldEqual true
+
+        // The guest's own methods do carry symbols, and are the point of the exercise. Asserting
+        // on specific *lines* rather than merely on the file keeps this from passing if the
+        // offset-to-location lookup degenerated to "the first sequence point of the method".
+        let guestLines =
+            steps
+            |> List.choose (fun step ->
+                match step.Source with
+                | Some ("File0.cs", line) -> Some line
+                | Some _
+                | None -> None
+            )
+            |> List.distinct
+            |> List.sort
+
+        guestLines |> List.isEmpty |> shouldEqual false
+        // Statements of Triple (5, 6) and of Main (10), whichever else the compiler attributes.
+        guestLines |> List.contains 5 |> shouldEqual true
+        guestLines |> List.contains 6 |> shouldEqual true
+        guestLines |> List.contains 10 |> shouldEqual true
+        // Nothing outside the two methods the guest declares.
+        guestLines |> List.filter (fun line -> line < 3 || line > 11) |> shouldEqual []
+
+    /// `Program.buildStartupFrame` pumps class initialisers from a frame whose body is a lone
+    /// `ret`. That frame once kept `Main`'s metadata identity, so the `ret` resolved against
+    /// `Main`'s sequence points and the trace claimed a guest instruction had run when none had;
+    /// `SynthesisedMethod.EntryPointPlaceholder` now denies it a handle to resolve against.
+    ///
+    /// The tell is the body's extent rather than the line: the synthetic body has exactly one
+    /// instruction, so `MaxIlOpIndex` is 0, whereas real `Main` is longer. A line-based assertion
+    /// cannot see this at all — real `Main` reports its opening brace too, from the same offset.
+    [<Test>]
+    let ``the synthetic startup frame claims no guest source`` () : unit =
+        let steps = tracedRun.Value
+
+        // The bug this guards is only reachable if a one-instruction body is executed at all;
+        // without this the test passes vacuously against an interpreter that never runs one.
+        steps |> List.exists (fun step -> step.MaxIlOpIndex = 0) |> shouldEqual true
+
+        let offenders =
+            steps
+            |> List.filter (fun step ->
+                match step.MaxIlOpIndex, step.Source with
+                | 0, Some ("File0.cs", _) -> true
+                | _ -> false
+            )
+
+        match offenders with
+        | [] -> ()
+        | offenders -> failwith $"one-instruction synthetic bodies were attributed to guest source: %A{offenders}"

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -147,6 +147,7 @@
     <Compile Include="TestInlineArrayLayout.fs" />
     <Compile Include="TestReinterpretCellAccess.fs" />
     <Compile Include="TestBulkMoveCellAccess.fs" />
+    <Compile Include="TestTraceSourceLocations.fs" />
     <Compile Include="TestPureCases.fs" />
     <Compile Include="TestFSharpPureCases.fs" />
     <Compile Include="TestImpureCases.fs" />

--- a/WoofWare.PawPrint/AbstractMachine.fs
+++ b/WoofWare.PawPrint/AbstractMachine.fs
@@ -338,22 +338,62 @@ module AbstractMachine =
         // map, and the parameterised `LogTrace` overload boxes each argument into an `obj[]`
         // before any provider gets to decide whether it wants the message.
         if logger.IsEnabled LogLevel.Trace then
+            // One lookup serves both the type name and the source location. The assembly is
+            // resolved from the executing method's *declaring type*, which is what makes it the
+            // assembly whose metadata handles that method's `TryResolveMethodSource` indexes.
+            let declaringAssembly =
+                state.LoadedAssembly instruction.ExecutingMethod.DeclaringType.Assembly
+
             let executingInType =
-                match state.LoadedAssembly instruction.ExecutingMethod.DeclaringType.Assembly with
+                match declaringAssembly with
                 | None -> "<unloaded assembly>"
                 | Some assy ->
                     match assy.TypeDefs.TryGetValue instruction.ExecutingMethod.DeclaringType.Definition.Get with
                     | true, v -> v.Name
                     | false, _ -> "<unrecognised type>"
 
-            logger.LogTrace (
-                "Executing one step (index {ExecutingIlOpIndex}, max {MaxIlOpIndex}, in method {ExecutingMethodType}.{ExecutingMethodName}): {ExecutingIlOp}",
-                instruction.IlOpIndex,
-                (Map.maxKeyValue instructions.Locations |> fst),
-                executingInType,
-                instruction.ExecutingMethod.Name,
-                executingInstruction
-            )
+            let maxIlOpIndex = Map.maxKeyValue instructions.Locations |> fst
+
+            // The raw program counter, with none of the stepping-back `GuestLocation` does. That
+            // exists because a *stuck* thread has already advanced past the call it is parked in;
+            // here the instruction is the one about to run, so the offset is exactly the one to
+            // attribute.
+            let source =
+                declaringAssembly
+                |> Option.bind (fun assy ->
+                    assy.TryResolveMethodSource instruction.ExecutingMethod instruction.IlOpIndex
+                )
+
+            // Two templates rather than one carrying a "no source" sentinel. Absence is then the
+            // absence of the fields, which a structured consumer can filter on without knowing a
+            // magic string, and `SourceLine` stays a number rather than text to be parsed back out
+            // of `path:line`. It also keeps the rendered message clean in the overwhelmingly
+            // common case: the framework assemblies ship no symbols, so most instructions have no
+            // source and would otherwise all carry a dangling `at <no source>`.
+            //
+            // Unlike the `<unloaded assembly>` sentinel above, which fills a field that must always
+            // name *something*, there is nothing here that a reader needs in place of the location.
+            match source with
+            | None ->
+                logger.LogTrace (
+                    "Executing one step (index {ExecutingIlOpIndex}, max {MaxIlOpIndex}, in method {ExecutingMethodType}.{ExecutingMethodName}): {ExecutingIlOp}",
+                    instruction.IlOpIndex,
+                    maxIlOpIndex,
+                    executingInType,
+                    instruction.ExecutingMethod.Name,
+                    executingInstruction
+                )
+            | Some source ->
+                logger.LogTrace (
+                    "Executing one step (index {ExecutingIlOpIndex}, max {MaxIlOpIndex}, in method {ExecutingMethodType}.{ExecutingMethodName} at {SourceFile}:{SourceLine}): {ExecutingIlOp}",
+                    instruction.IlOpIndex,
+                    maxIlOpIndex,
+                    executingInType,
+                    instruction.ExecutingMethod.Name,
+                    source.DocumentPath,
+                    source.StartLine,
+                    executingInstruction
+                )
 
         // `executingInstruction` is the value `TryGetValue` above already produced for this
         // index; re-indexing `Locations` would be a second lookup for the same key.

--- a/WoofWare.PawPrint/GuestLocation.fs
+++ b/WoofWare.PawPrint/GuestLocation.fs
@@ -103,10 +103,9 @@ module GuestLocation =
     /// <paramref name="method" />, if that method's assembly came with debug information.
     /// </summary>
     /// <remarks>
-    /// The <c>MethodDefinitionHandle</c> is a row index scoped to the assembly it came from, so it
-    /// must be resolved against the *declaring type's* assembly and no other; pairing it with any
-    /// other loaded assembly would silently name a different method's lines. A synthesised method
-    /// (a marshalling or delegate stub) has no row at all and so is legitimately unattributable.
+    /// Resolution is <c>DumpedAssembly.TryResolveMethodSource</c>'s job, including its rule that a
+    /// synthesised method has no source; all this adds is finding the one assembly that may be
+    /// asked, which is the one the method's declaring type came from and no other.
     /// </remarks>
     let trySourceOf
         (state : IlMachineState)
@@ -114,11 +113,8 @@ module GuestLocation =
         (ilOffset : int)
         : SourceLocation option
         =
-        match method.TryMetadata with
-        | None -> None
-        | Some facts ->
-            state.LoadedAssembly method.DeclaringType.Assembly
-            |> Option.bind (fun assy -> assy.TryResolveSourceLocation facts.Handle ilOffset)
+        state.LoadedAssembly method.DeclaringType.Assembly
+        |> Option.bind (fun assy -> assy.TryResolveMethodSource method ilOffset)
 
     /// <summary>
     /// The offset of the instruction immediately before <paramref name="ilOffset" /> in
@@ -234,9 +230,22 @@ module GuestLocation =
         walk 1 active
 
     /// <summary>
-    /// Where every thread that has not terminated is. Terminated threads are omitted: they are
-    /// not why the guest is stuck, and a long-running guest accumulates many of them.
+    /// The IL offset at which <paramref name="thread" />'s *active* frame should be attributed to
+    /// source: its program counter, stepped back onto the blocking call if the thread parked past
+    /// one.
     /// </summary>
+    /// <remarks>
+    /// The same answer <c>attributionOffsets</c> gives for that one frame, without building a map
+    /// over the whole stack. Callers that want only the active frame — the thread summaries on
+    /// every state-bearing response — should use this: they are hit once per step, and a guest
+    /// recursing deeply would otherwise make single-stepping cost time quadratic in stack depth.
+    ///
+    /// Requires <paramref name="thread" /> to have a live frame, exactly as
+    /// <c>ThreadState.MethodState</c> does; guard with <c>ThreadStatus.hasNoActiveFrame</c>.
+    /// </remarks>
+    let activeAttributionOffset (thread : ThreadState) : int =
+        reportableOffset thread.Status thread.MethodState
+
     /// <summary>
     /// The IL offset at which each of <paramref name="thread" />'s live frames should be
     /// attributed to source, keyed by frame.
@@ -260,23 +269,6 @@ module GuestLocation =
     /// than raise.
     /// </para>
     /// </remarks>
-    /// <summary>
-    /// The IL offset at which <paramref name="thread" />'s *active* frame should be attributed to
-    /// source: its program counter, stepped back onto the blocking call if the thread parked past
-    /// one.
-    /// </summary>
-    /// <remarks>
-    /// The same answer <c>attributionOffsets</c> gives for that one frame, without building a map
-    /// over the whole stack. Callers that want only the active frame — the thread summaries on
-    /// every state-bearing response — should use this: they are hit once per step, and a guest
-    /// recursing deeply would otherwise make single-stepping cost time quadratic in stack depth.
-    ///
-    /// Requires <paramref name="thread" /> to have a live frame, exactly as
-    /// <c>ThreadState.MethodState</c> does; guard with <c>ThreadStatus.hasNoActiveFrame</c>.
-    /// </remarks>
-    let activeAttributionOffset (thread : ThreadState) : int =
-        reportableOffset thread.Status thread.MethodState
-
     let attributionOffsets (thread : ThreadState) : Map<FrameId, int> =
         let callSites =
             thread.MethodStates
@@ -297,6 +289,10 @@ module GuestLocation =
                 | None -> frame.IlOpIndex
         )
 
+    /// <summary>
+    /// Where every thread that has not terminated is. Terminated threads are omitted: they are
+    /// not why the guest is stuck, and a long-running guest accumulates many of them.
+    /// </summary>
     let ofState (state : IlMachineState) : GuestThreadLocation list =
         state.ThreadState
         |> Map.toList
@@ -309,13 +305,6 @@ module GuestLocation =
             }
         )
 
-    let private renderSource (source : SourceLocation) : string =
-        // The document path exactly as the PDB records it, unshortened: it names the machine
-        // that built the guest, which is information, and two `Program.cs` in different
-        // directories are otherwise indistinguishable. Only the start line is rendered — the
-        // span's end is rarely what a reader wants and doubles the length of every frame.
-        $"%s{source.DocumentPath}:%d{source.StartLine}"
-
     let private renderFrame (frame : GuestFrame) : string =
         $"%s{frame.Method} at IL offset %d{frame.IlOffset}"
 
@@ -326,8 +315,7 @@ module GuestLocation =
         match location.Position with
         | GuestThreadPosition.NoFrame -> prefix
         | GuestThreadPosition.Unattributed frame -> $"%s{prefix} in %s{renderFrame frame}"
-        | GuestThreadPosition.AtSource (frame, source) ->
-            $"%s{prefix} in %s{renderFrame frame} (%s{renderSource source})"
+        | GuestThreadPosition.AtSource (frame, source) -> $"%s{prefix} in %s{renderFrame frame} (%O{source})"
         | GuestThreadPosition.CalledFrom (frame, framesOut, ancestor, ancestorSource) ->
             let from =
                 if framesOut = 1 then
@@ -338,7 +326,7 @@ module GuestLocation =
                     // into this" and "this is buried deep in framework code".
                     $"called %d{framesOut} frames out from"
 
-            $"%s{prefix} in %s{renderFrame frame}, %s{from} %s{renderFrame ancestor} (%s{renderSource ancestorSource})"
+            $"%s{prefix} in %s{renderFrame frame}, %s{from} %s{renderFrame ancestor} (%O{ancestorSource})"
 
     /// <summary>
     /// One line per non-terminated thread, joined by <c>"; "</c>.

--- a/docs/user/log-to-loki.md
+++ b/docs/user/log-to-loki.md
@@ -22,3 +22,20 @@ Each logger sink writes to a GUID-suffixed file opened with `CreateNew`, so conc
 Use `docs/observability/alloy.river` with a local Alloy process configured to send to `http://localhost:3100/loki/api/v1/push`. The sample config labels only `component` and `level`; `run_id`, `user_run_id`, and `logger` are sent as structured metadata to avoid high-cardinality labels. It leaves the original JSON event as the Loki log line, so query-time parsing can still inspect `fields` and `properties`. PawPrint-owned fields are top-level; caller-supplied static properties such as `source_file` and `entry_assembly` are nested under `properties` so they cannot collide with reserved event fields such as `level` or `message`.
 
 The sample Alloy config assumes `PAWPRINT_LOG_DIR=/tmp/pawprint-logs`. If you use a different root, update the `__path__` glob in `docs/observability/alloy.river` to match.
+
+## Guest source locations in the instruction trace
+
+At `PAWPRINT_LOG_LEVEL=Trace` the interpreter emits one event per interpreted IL instruction. When the executing method's assembly was built with debug information, that event also carries the source the compiler attributed to the instruction:
+
+```json
+{"message": "Executing one step (index 7, max 12, in method Sut.Triple at File0.cs:5): ...",
+ "fields": {"ExecutingIlOpIndex": 7, "MaxIlOpIndex": 12, "SourceFile": "File0.cs", "SourceLine": 5}}
+```
+
+(abridged: the event also carries the executing method's type and name, and the decoded instruction)
+
+`SourceLine` is a number, so ranges work: `jq 'select(.fields.SourceLine >= 40 and .fields.SourceLine <= 50)'`.
+
+Most steps have neither field. That is the ordinary case rather than a failure: the shared framework ships without PDBs, so every instruction inside it — the overwhelming majority of any run — has no source to name, and those events use a message template without the two holes. Filter on `message_template` if you want to separate the two.
+
+`SourceFile` is the document path exactly as the compiler recorded it, which names paths on whichever machine built the assembly.


### PR DESCRIPTION
The last of the three source-location consumers, after #928 (wedged-guest reports) and #944 (debugger frame JSON). At `Trace` level, the per-step log now says which source line the instruction it is about to execute belongs to.

```
Executing one step (index 7, max 12, in method Sut.Triple at File0.cs:5): ...
```

The JSON-lines sink keeps message-template holes as fields, so `fields.SourceLine` is a number a consumer can compare against — `jq 'select(.fields.SourceLine >= 40 and .fields.SourceLine <= 50)'`. Documented in `docs/user/log-to-loki.md`.

### Absence is the absence of the fields

Most steps have no source: the shared framework ships without PDBs, so the overwhelming majority of any run is unattributable. Those use a second message template without the two holes, rather than one template carrying a `<no source>` sentinel — a structured consumer can then filter on it without knowing a magic string, `SourceLine` stays a number rather than text to be parsed out of `path:line`, and the rendered message does not carry a dangling `at <no source>` on nearly every line. (Unlike `<unloaded assembly>` in the same message, which fills a field that must always name *something*.)

### Consolidation

`DumpedAssembly.TryResolveMethodSource` now owns the "a synthesised method has no source" decision; `GuestLocation.trySourceOf` was making it separately and defers. `SourceLocation.ToString` replaces `GuestLocation`'s identical private renderer, and is documented as being for prose — structured output carries the fields.

The assembly is resolved once for both the type name and the location, where the block previously resolved it for the type name alone. That lookup is keyed by `AssemblyName`, whose `FullName` rebuilds a public key token each call, and this runs once per interpreted instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
