### PR TITLE
Number the method-table slots that follow the vtable

### DIFF
--- a/WoofWare.PawPrint.Test/TestFSharpPureCases.fs
+++ b/WoofWare.PawPrint.Test/TestFSharpPureCases.fs
@@ -128,27 +128,28 @@ module TestFSharpPureCases =
     /// before recording that a case is blocked on a named primitive, un-park it and observe the
     /// failure: parking it is what stops the claim being checked.
     ///
-    /// `UnionReflection` is parked on `RuntimeMethodHandle::GetSlot` being asked about a method that
-    /// occupies no vtable slot at all. A union's case fields are read through property accessors,
-    /// and those are not virtual; CoreCLR numbers a non-virtual method in the *non-vtable* region
-    /// past `GetNumVirtuals`, which PawPrint's slot walk does not model -- it lays out the vtable
-    /// proper and nothing beyond it. How the method table is numbered past its virtual prefix is a
-    /// separate question from how the vtable itself is laid out, which is what the commit this
-    /// comment sits in implements.
+    /// `UnionReflection` is parked on writing through a `ReinterpretAs`-as-`System.Byte` view of
+    /// `System.ByReference`, a value type whose one field holds a runtime pointer and which is
+    /// therefore byte-unaddressable: there is no byte image to write into. It is reached from
+    /// `MethodBaseInvoker.InvokeDirectByRefWithFewArgs`, three frames out from FSharp.Core's
+    /// `getUnionCaseConstructor` (reflect.fs:595) -- so the union's *metadata* is now fully
+    /// readable and what remains is invoking the case constructor reflectively. That is a question
+    /// about byref-typed storage, unrelated to method tables.
     ///
-    /// Observed by un-parking it and running: the real runtime exits 0, PawPrint reports
-    /// "TODO: RuntimeMethodHandle.GetSlot: method get_width occupies no slot in the vtable of its
-    /// declaring type 362; CoreCLR would answer with a slot in the non-vtable region beyond
-    /// GetNumVirtuals, which PawPrint does not model."
+    /// Observed by un-parking it and running, not inferred: the real runtime exits 0, PawPrint
+    /// reports "TODO: write through `ReinterpretAs` as System.Byte: write through `ReinterpretAs`
+    /// over byte-unaddressable storage (value type containing runtime pointers) is not modelled",
+    /// naming `System.Private.CoreLib.System.ByReference` as the declared type.
     ///
-    /// Ten earlier blockers are already gone: decoding each case's
+    /// Eleven earlier blockers are already gone: decoding each case's
     /// `CompilationMappingAttribute(SourceConstructFlags, ...)`, whose argument is an enum;
     /// enumerating the union's nested case types; `MetadataImport::GetSigOfFieldDef`; the raw-blob
     /// path of `Signature_Init`; `MetadataImport::GetDefaultValue`; `MetadataImport::GetName`;
     /// property enumeration; `MetadataImport::GetPropertyProps`; the associates branch of
-    /// `MetadataImport::Enum`; and the fresh-slot rule for an unmatched non-NewSlot virtual, which
+    /// `MetadataImport::Enum`; the fresh-slot rule for an unmatched non-NewSlot virtual, which
     /// every F# union needs for its compiler-generated `CompareTo`/`Equals`/`GetHashCode` and which
-    /// `UnionVirtualSlots` now covers end to end.
+    /// `UnionVirtualSlots` covers end to end; and the slot region past the vtable, without which
+    /// `GetSlot` had no answer for a union case's non-virtual property accessors.
     let unimplemented : Set<string> = Set.ofList [ "UnionReflection" ]
 
     // F# test cases that legitimately throw under both runtimes. Without this set, a test

--- a/WoofWare.PawPrint.Test/TestFabricatedVtableLayout.fs
+++ b/WoofWare.PawPrint.Test/TestFabricatedVtableLayout.fs
@@ -247,7 +247,7 @@ module TestFabricatedVtableLayout =
                 il.Emit (OpCodes.Ldc_I4, 0)
                 il.Emit OpCodes.Ret
 
-            typeBuilder.CreateType () |> ignore
+            typeBuilder.CreateType () |> ignore<Type>
 
         let runtimeSpecial =
             MethodAttributes.Public
@@ -262,8 +262,35 @@ module TestFabricatedVtableLayout =
         // which is the shape a signature-blind classifier would mistake for the class constructor.
         defineMalformed "MalformedCctorReturn" ".cctor" (runtimeSpecial ||| MethodAttributes.Static) typeof<int>
 
-        // An instance runtime-special method not named `.ctor`: rejected by the name check (:5023-5026).
-        defineMalformed "MalformedSpecialName" "NotACtor" runtimeSpecial typeof<Void>
+        // An instance runtime-special method not named `.ctor`: rejected by the name check
+        // (:5023-5026). Built out longhand rather than through `defineMalformed`, because the
+        // created `Type` is needed as a base class below.
+        let malformedSpecialNameBuilder =
+            moduleBuilder.DefineType (
+                "MalformedSpecialName",
+                TypeAttributes.Public ||| TypeAttributes.Class,
+                typeof<obj>
+            )
+
+        let notACtor =
+            malformedSpecialNameBuilder.DefineMethod ("NotACtor", runtimeSpecial, typeof<Void>, Type.EmptyTypes)
+
+        (notACtor.GetILGenerator ()).Emit OpCodes.Ret
+        let malformedSpecialName = malformedSpecialNameBuilder.CreateType ()
+
+        // A perfectly well-formed type -- whose *base* is the one above. Building a MethodTable
+        // starts by building the parent's, so CoreCLR cannot load this either. Nothing in its own
+        // metadata says so, which is the point: a walk that validated only the type it was asked
+        // about would lay this one out happily and answer `GetSlot` for a type that cannot exist.
+        let derivedFromMalformed =
+            moduleBuilder.DefineType (
+                "DerivedFromMalformed",
+                TypeAttributes.Public ||| TypeAttributes.Class,
+                malformedSpecialName
+            )
+
+        definePlain derivedFromMalformed "PerfectlyOrdinary"
+        derivedFromMalformed.CreateType () |> ignore
 
         // A constructor returning non-void: rejected by the explicit return-type check (:5028-5037).
         defineMalformed "MalformedCtorReturn" ".ctor" runtimeSpecial typeof<int>
@@ -645,6 +672,10 @@ module TestFabricatedVtableLayout =
     [<TestCase "MalformedCtorReturn">]
     [<TestCase "MalformedStaticVirtual">]
     [<TestCase "MalformedGapName">]
+    // Nothing in this one's own metadata is wrong; its *base* is `MalformedSpecialName`. Building a
+    // MethodTable begins by building the parent's, so CoreCLR cannot load it either -- and a walk
+    // that validated only the type it was asked about would answer `GetSlot` for it happily.
+    [<TestCase "DerivedFromMalformed">]
     let ``a type CoreCLR refuses to load is refused here too`` (typeName : string) : unit =
         // `Assembly.Load` is lazy, so the type load -- and its failure -- happens here.
         let hostFailure =

--- a/WoofWare.PawPrint.Test/TestFabricatedVtableLayout.fs
+++ b/WoofWare.PawPrint.Test/TestFabricatedVtableLayout.fs
@@ -289,19 +289,49 @@ module TestFabricatedVtableLayout =
         let vtblGap =
             moduleBuilder.DefineType ("HasVtableGap", TypeAttributes.Public ||| TypeAttributes.Class, typeof<obj>)
 
+        // Emitted `virtual`, which is how tlbimp actually writes them -- gaps appear in COM
+        // *interfaces*, whose members are all virtual. That matters: a gap filter applied only to
+        // the region past the vtable would leave this row occupying a real vtable slot, inflating
+        // `GetNumVirtuals` and moving the origin of everything after it. A non-virtual gap row would
+        // not catch that, so this one is virtual on purpose.
         let gapMethod =
             vtblGap.DefineMethod (
                 "_VtblGap1_3",
                 MethodAttributes.Public
                 ||| MethodAttributes.SpecialName
-                ||| MethodAttributes.RTSpecialName,
+                ||| MethodAttributes.RTSpecialName
+                ||| MethodAttributes.Virtual
+                ||| MethodAttributes.NewSlot,
                 typeof<Void>,
                 Type.EmptyTypes
             )
 
         (gapMethod.GetILGenerator ()).Emit OpCodes.Ret
+
+        // An ordinary virtual after the gap, so the vtable has something whose slot number moves if
+        // the gap is wrongly placed.
+        let afterGap =
+            vtblGap.DefineMethod (
+                "VirtualAfterTheGap",
+                MethodAttributes.Public
+                ||| MethodAttributes.Virtual
+                ||| MethodAttributes.NewSlot,
+                typeof<Void>,
+                Type.EmptyTypes
+            )
+
+        (afterGap.GetILGenerator ()).Emit OpCodes.Ret
         definePlain vtblGap "AfterTheGap"
         vtblGap.CreateType () |> ignore
+
+        // `_VtblGap` with a suffix that is not the count grammar: CoreCLR recognises the prefix,
+        // fails to parse the rest, and throws rather than treating the row as an ordinary method
+        // (methodtablebuilder.cpp:2865-2907). A prefix-only match would silently drop it.
+        defineMalformed
+            "MalformedGapName"
+            "_VtblGap1_"
+            (runtimeSpecial ||| MethodAttributes.Virtual ||| MethodAttributes.NewSlot)
+            typeof<Void>
 
         use stream = new MemoryStream ()
         assemblyBuilder.Save stream
@@ -427,6 +457,16 @@ module TestFabricatedVtableLayout =
             |> Array.exactlyOne
 
         fun (method : MethodBase) -> impl.Invoke ((null : obj), [| box method |]) :?> int
+
+    /// `MethodTable::GetNumVirtuals` for a fabricated type, obtained the way TestVirtualMethodSlots
+    /// does: every method `GetMethods` reports that carries `Virtual` occupies exactly one slot.
+    let private hostNumVirtualsOf (name : string) : int =
+        match hostAssembly.GetType (name, false) with
+        | null -> failwith $"host CLR could not load fabricated type %s{name}"
+        | t ->
+            t.GetMethods (BindingFlags.Instance ||| BindingFlags.Public ||| BindingFlags.NonPublic)
+            |> Array.filter _.IsVirtual
+            |> Array.length
 
     /// The host's slots past the vtable for a fabricated type, in slot order, named the way the
     /// assertions read best -- by method name, with the parameter count appended so that the two
@@ -556,6 +596,7 @@ module TestFabricatedVtableLayout =
     [<TestCase "MalformedSpecialName">]
     [<TestCase "MalformedCtorReturn">]
     [<TestCase "MalformedStaticVirtual">]
+    [<TestCase "MalformedGapName">]
     let ``a type CoreCLR refuses to load is refused here too`` (typeName : string) : unit =
         // `Assembly.Load` is lazy, so the type load -- and its failure -- happens here.
         let hostFailure =
@@ -595,8 +636,18 @@ module TestFabricatedVtableLayout =
 
         let table = slotTableOf "HasVtableGap"
 
-        // `AfterTheGap` and the compiler-supplied default constructor, and no third entry: the gap
-        // row is absent rather than occupying a slot of its own.
+        // The gap row is virtual, so the load-bearing half of this assertion is the *vtable*: it
+        // must hold Object's four and `VirtualAfterTheGap`, and not a fifth entry for the gap.
+        // Compared against the host rather than only pinned literally, since that is what makes it
+        // a claim about CoreCLR.
+        List.length table.Vtable |> shouldEqual (hostNumVirtualsOf "HasVtableGap")
+
+        table.Vtable
+        |> List.map _.Method.Name
+        |> List.last
+        |> shouldEqual "VirtualAfterTheGap"
+
+        // And past the vtable: the default constructor and the plain method, with no gap entry.
         table.BeyondVtable
         |> List.map _.Method.Name
         |> shouldEqual [ ".ctor" ; "AfterTheGap" ]

--- a/WoofWare.PawPrint.Test/TestFabricatedVtableLayout.fs
+++ b/WoofWare.PawPrint.Test/TestFabricatedVtableLayout.fs
@@ -275,12 +275,60 @@ module TestFabricatedVtableLayout =
         //
         // Emitted `static` only; `Reflection.Emit` refuses the combination outright ("Method cannot
         // be both static and virtual"), so the `Virtual` bit is patched into the MethodDef row after
-        // the image is written. See `withVirtualBitSet` below.
+        // the image is written. See `withVirtualBitSet` above.
         defineMalformed
             "MalformedStaticVirtual"
             "StaticVirtual"
             (MethodAttributes.Public ||| MethodAttributes.Static)
             typeof<Void>
+
+        // A constructor whose return is `modopt(IsConst) void`. Also *not* malformed: CoreCLR's
+        // return-type check is `MetaSig::GetReturnType()`, which reaches `PeekElemTypeClosed` and
+        // skips custom modifiers (sigparser.h:225), so the type loads and can be instantiated. But
+        // the signature *blob* is not `ExactlyEqual` to the hard-coded `instance void ()`, so this
+        // does not become `pDefaultCtor` and gets no priority slot.
+        //
+        // That is the one place the two questions PawPrint asks about a ctor's return come apart,
+        // and it is why they are two predicates rather than one.
+        let modoptCtor =
+            moduleBuilder.DefineType ("ModoptVoidCtor", TypeAttributes.Public ||| TypeAttributes.Class, typeof<obj>)
+
+        // Declared first, so if it were wrongly promoted to the default constructor it would take
+        // the slot `Plain` must otherwise hold, and the ordering assertion below would notice.
+        definePlain modoptCtor "Plain"
+
+        let modoptCtorBuilder =
+            modoptCtor.DefineMethod (
+                ".ctor",
+                MethodAttributes.Public
+                ||| MethodAttributes.SpecialName
+                ||| MethodAttributes.RTSpecialName,
+                CallingConventions.Standard ||| CallingConventions.HasThis,
+                typeof<Void>,
+                null,
+                [| typeof<System.Runtime.CompilerServices.IsConst> |],
+                Type.EmptyTypes,
+                null,
+                null
+            )
+
+        let modoptIl = modoptCtorBuilder.GetILGenerator ()
+        modoptIl.Emit OpCodes.Ldarg_0
+        modoptIl.Emit (OpCodes.Call, typeof<obj>.GetConstructor Type.EmptyTypes)
+        modoptIl.Emit OpCodes.Ret
+
+        // A real constructor, taking an argument. Its purpose is to stop `CreateType` synthesising a
+        // parameterless one: that would be a genuine default constructor, would take the priority
+        // slot legitimately, and the assertion below could no longer tell a promoted modopt ctor
+        // from it. `DefineMethod(".ctor", ...)` above does not count as defining a constructor.
+        let modoptOtherCtor =
+            modoptCtor.DefineConstructor (MethodAttributes.Public, CallingConventions.Standard, [| typeof<int> |])
+
+        let modoptOtherIl = modoptOtherCtor.GetILGenerator ()
+        modoptOtherIl.Emit OpCodes.Ldarg_0
+        modoptOtherIl.Emit (OpCodes.Call, typeof<obj>.GetConstructor Type.EmptyTypes)
+        modoptOtherIl.Emit OpCodes.Ret
+        modoptCtor.CreateType () |> ignore
 
         // A COM vtable-gap marker: `RTSpecialName` with a `_VtblGap` name, which is *not* a
         // malformed type -- CoreCLR drops the row from the declared-method list and loads the type
@@ -611,6 +659,46 @@ module TestFabricatedVtableLayout =
         // has to show the refusal came from the rule under test.
         pawPrintFailure.Message
         |> shouldContainText "CoreCLR rejects the type at load time"
+
+    /// A `.ctor` returning `modopt(IsConst) void` loads on CoreCLR -- the return-type check skips
+    /// custom modifiers -- but is not `ExactlyEqual` to the hard-coded default-constructor
+    /// signature, so it gets no priority slot. Refusing it, which a bare `ReturnType = Void` test
+    /// does, would reject a type the real runtime instantiates happily.
+    [<Test>]
+    let ``a constructor returning modopt void is accepted but not promoted`` () : unit =
+        // The host loads *and instantiates* it, so "CoreCLR accepts this" is measured rather than
+        // read out of the C++. `GetType` with `throwOnError` would raise otherwise, as it does for
+        // each of the malformed types above.
+        let host = hostAssembly.GetType ("ModoptVoidCtor", true)
+        Activator.CreateInstance (host, [| box 1 |]) |> shouldNotEqual null
+
+        // Vacuity guard: the modifier really is on the return type in the emitted metadata. Without
+        // it the ctor is `ExactlyEqual` to the hard-coded default-constructor signature, gets the
+        // priority slot legitimately, and the ordering below would be testing nothing.
+        match fabricated.TryGetTopLevelTypeDef "" "ModoptVoidCtor" with
+        | None -> failwith "fabricated assembly has no type ModoptVoidCtor"
+        | Some typeInfo ->
+            typeInfo.Methods
+            |> List.filter (fun method -> method.Name = ".ctor" && method.Signature.ParameterTypes.IsEmpty)
+            |> List.map (fun method ->
+                match method.Signature.ReturnType with
+                | MethodReturnType.Returns (TypeDefn.Modified _) -> "modified"
+                | other -> string<MethodReturnType<TypeDefn>> other
+            )
+            |> shouldEqual [ "modified" ]
+
+        let table = slotTableOf "ModoptVoidCtor"
+
+        // Declaration order, with nothing promoted: `Plain`, the modified ctor, the real one. A
+        // `hasNullaryVoidSignature` that looked through modifiers would treat the modified ctor as
+        // the default constructor and hoist it to the front.
+        table.BeyondVtable
+        |> List.map (fun slot -> $"%s{slot.Method.Name}/%i{slot.Method.Signature.ParameterTypes.Length}")
+        |> shouldEqual [ "Plain/0" ; ".ctor/0" ; ".ctor/1" ]
+
+        // And the host agrees about that order, so it is not merely PawPrint being self-consistent.
+        hostBeyondVtableNames "ModoptVoidCtor"
+        |> shouldEqual [ "Plain/0" ; ".ctor/0" ; ".ctor/1" ]
 
     /// The counterpart to the refusals above: a COM vtable-gap marker looks like a runtime-special
     /// method that is not a constructor, but CoreCLR loads the type and simply drops the row.

--- a/WoofWare.PawPrint.Test/TestFabricatedVtableLayout.fs
+++ b/WoofWare.PawPrint.Test/TestFabricatedVtableLayout.fs
@@ -357,6 +357,41 @@ module TestFabricatedVtableLayout =
         modoptOtherIl.Emit OpCodes.Ret
         modoptCtor.CreateType () |> ignore
 
+        // The same constructor declared twice. ECMA-335 II.22.26 forbids it, CoreCLR loads it anyway,
+        // and only the *last* row becomes `pDefaultCtor` -- `ValidateMethods` records it by plain
+        // assignment inside its loop, so a later match overwrites an earlier one. The earlier
+        // duplicate is then placed in the ordinary pass like any other method, *after* `Plain`.
+        let duplicateCtor =
+            moduleBuilder.DefineType (
+                "DuplicateDefaultCtor",
+                TypeAttributes.Public ||| TypeAttributes.Class,
+                typeof<obj>
+            )
+
+        // Declared first, so it sits between the two duplicates in the final layout if -- and only
+        // if -- exactly one of them is hoisted.
+        definePlain duplicateCtor "Plain"
+
+        for _ in 1..2 do
+            let ctor =
+                duplicateCtor.DefineMethod (".ctor", runtimeSpecial, typeof<Void>, Type.EmptyTypes)
+
+            let il = ctor.GetILGenerator ()
+            il.Emit OpCodes.Ldarg_0
+            il.Emit (OpCodes.Call, typeof<obj>.GetConstructor Type.EmptyTypes)
+            il.Emit OpCodes.Ret
+
+        // Suppresses the parameterless constructor `CreateType` would otherwise synthesise, which
+        // would be a third duplicate and would itself be the last row.
+        let duplicateOther =
+            duplicateCtor.DefineConstructor (MethodAttributes.Public, CallingConventions.Standard, [| typeof<int> |])
+
+        let duplicateOtherIl = duplicateOther.GetILGenerator ()
+        duplicateOtherIl.Emit OpCodes.Ldarg_0
+        duplicateOtherIl.Emit (OpCodes.Call, typeof<obj>.GetConstructor Type.EmptyTypes)
+        duplicateOtherIl.Emit OpCodes.Ret
+        duplicateCtor.CreateType () |> ignore
+
         // A COM vtable-gap marker: `RTSpecialName` with a `_VtblGap` name, which is *not* a
         // malformed type -- CoreCLR drops the row from the declared-method list and loads the type
         // happily. It sits here beside the malformed ones precisely because it looks like one to a
@@ -572,6 +607,36 @@ module TestFabricatedVtableLayout =
             |> List.sortBy fst
             |> List.map (fun (_, method) -> $"%s{method.Name}/%i{method.GetParameters().Length}")
 
+    /// The same list as MethodDef tokens rather than names. Necessary wherever two rows of a type are
+    /// indistinguishable by name and signature -- `DuplicateDefaultCtor` declares the very same
+    /// constructor twice, and a name-based comparison cannot tell which of them was hoisted. Measured
+    /// the hard way: it let a "hoist the *first* duplicate" mutation through.
+    let private hostBeyondVtableTokens (name : string) : int list =
+        match hostAssembly.GetType (name, false) with
+        | null -> failwith $"host CLR could not load fabricated type %s{name}"
+        | t ->
+            let flags =
+                BindingFlags.DeclaredOnly
+                ||| BindingFlags.Instance
+                ||| BindingFlags.Static
+                ||| BindingFlags.Public
+                ||| BindingFlags.NonPublic
+
+            let numVirtuals =
+                t.GetMethods (BindingFlags.Instance ||| BindingFlags.Public ||| BindingFlags.NonPublic)
+                |> Array.filter _.IsVirtual
+                |> Array.length
+
+            [
+                yield! (t.GetMethods flags |> Seq.cast<MethodBase>)
+                yield! (t.GetConstructors flags |> Seq.cast<MethodBase>)
+            ]
+            |> List.distinctBy _.MetadataToken
+            |> List.map (fun method -> hostSlotOf method, method.MetadataToken)
+            |> List.filter (fun (slot, _) -> slot >= numVirtuals)
+            |> List.sortBy fst
+            |> List.map snd
+
     /// The host's vtable for a fabricated type, slot 0 upwards, named by MethodDef token.
     let private hostLayout (name : string) : int list =
         match hostAssembly.GetType (name, false) with
@@ -730,6 +795,39 @@ module TestFabricatedVtableLayout =
         // And the host agrees about that order, so it is not merely PawPrint being self-consistent.
         hostBeyondVtableNames "ModoptVoidCtor"
         |> shouldEqual [ "Plain/0" ; ".ctor/0" ; ".ctor/1" ]
+
+    /// Only one row is hoisted per constructor kind, even when a type declares the same constructor
+    /// twice: `ValidateMethods` records it by assignment inside its loop, so the last match wins and
+    /// the earlier duplicate is placed in the ordinary pass. Hoisting both -- the obvious reading of
+    /// "the constructors go first" -- moves everything after them by one.
+    [<Test>]
+    let ``a duplicated default constructor hoists only its last row`` () : unit =
+        // Loadable, despite ECMA-335 II.22.26 forbidding it; `throwOnError` would raise otherwise.
+        hostAssembly.GetType ("DuplicateDefaultCtor", true) |> shouldNotEqual null
+
+        // Vacuity guard: there really are two nullary `.ctor` rows. If the builder ever started
+        // collapsing them, the type would be ordinary and this would test nothing.
+        match fabricated.TryGetTopLevelTypeDef "" "DuplicateDefaultCtor" with
+        | None -> failwith "fabricated assembly has no type DuplicateDefaultCtor"
+        | Some typeInfo ->
+            typeInfo.Methods
+            |> List.filter (fun method -> method.Name = ".ctor" && method.Signature.ParameterTypes.IsEmpty)
+            |> List.length
+            |> shouldEqual 2
+
+        // Shape first, for legibility: the hoisted row, then declaration order for the rest --
+        // `Plain`, the *earlier* duplicate, and the one taking an argument.
+        hostBeyondVtableNames "DuplicateDefaultCtor"
+        |> shouldEqual [ ".ctor/0" ; "Plain/0" ; ".ctor/0" ; ".ctor/1" ]
+
+        // Then by MethodDef token, which is the assertion that actually bites: the two duplicates
+        // are identical in name and signature, so the list above is the same whichever of them was
+        // hoisted. Comparing rows is what distinguishes "last wins" from "first wins".
+        let expected = hostBeyondVtableTokens "DuplicateDefaultCtor"
+
+        let table = slotTableOf "DuplicateDefaultCtor"
+
+        pawPrintLayout table.BeyondVtable |> shouldEqual expected
 
     /// The counterpart to the refusals above: a COM vtable-gap marker looks like a runtime-special
     /// method that is not a constructor, but CoreCLR loads the type and simply drops the row.

--- a/WoofWare.PawPrint.Test/TestFabricatedVtableLayout.fs
+++ b/WoofWare.PawPrint.Test/TestFabricatedVtableLayout.fs
@@ -33,6 +33,49 @@ open WoofWare.PawPrint
 [<TestFixture>]
 module TestFabricatedVtableLayout =
 
+    /// Sets `MethodAttributes.Virtual` on the named MethodDef row, in the emitted bytes.
+    ///
+    /// `Reflection.Emit` validates the attribute mask and refuses `static` together with `virtual`,
+    /// so the one shape `ValidateMethods` rejects for that reason cannot be built through the
+    /// builder API. Patching the row afterwards is the only way to produce it -- and the row layout
+    /// is fixed by ECMA-335 II.22.26 (RVA:4, ImplFlags:2, Flags:2, ...), while `MetadataReader`
+    /// hands over the table's offset and row size, so this needs no guesswork about heap widths.
+    let private withVirtualBitSet (methodName : string) (image : byte array) : byte array =
+        use peStream = new MemoryStream (image)
+        use peReader = new System.Reflection.PortableExecutable.PEReader (peStream)
+
+        let reader : System.Reflection.Metadata.MetadataReader =
+            System.Reflection.Metadata.PEReaderExtensions.GetMetadataReader peReader
+
+        let handle =
+            reader.MethodDefinitions
+            |> Seq.filter (fun handle -> reader.GetString ((reader.GetMethodDefinition handle).Name) = methodName)
+            |> Seq.exactlyOne
+
+        let rowNumber =
+            System.Reflection.Metadata.Ecma335.MetadataTokens.GetRowNumber (
+                System.Reflection.Metadata.MethodDefinitionHandle.op_Implicit handle
+                : System.Reflection.Metadata.EntityHandle
+            )
+
+        let flagsOffset =
+            peReader.PEHeaders.MetadataStartOffset
+            + reader.GetTableMetadataOffset System.Reflection.Metadata.Ecma335.TableIndex.MethodDef
+            + (rowNumber - 1)
+              * reader.GetTableRowSize System.Reflection.Metadata.Ecma335.TableIndex.MethodDef
+            + 4 // RVA
+            + 2 // ImplFlags
+
+        let patched = Array.copy image
+
+        let current =
+            uint16 patched.[flagsOffset] ||| (uint16 patched.[flagsOffset + 1] <<< 8)
+
+        let updated = current ||| uint16 MethodAttributes.Virtual
+        patched.[flagsOffset] <- byte (updated &&& 0xFFus)
+        patched.[flagsOffset + 1] <- byte (updated >>> 8)
+        patched
+
     /// The fabricated image, as bytes, so that the host CLR and PawPrint read *the same* assembly
     /// rather than two separately-built ones that might differ.
     ///
@@ -225,9 +268,44 @@ module TestFabricatedVtableLayout =
         // A constructor returning non-void: rejected by the explicit return-type check (:5028-5037).
         defineMalformed "MalformedCtorReturn" ".ctor" runtimeSpecial typeof<int>
 
+        // A `static virtual` on a *class*: legal only on an interface, rejected with
+        // `IDS_CLASSLOAD_STATICVIRTUAL` (:5124-5131). Worth having because the shape is otherwise
+        // indistinguishable from an interface's static abstract, which this walk must place past
+        // the vtable -- the difference is the declaring type's kind and nothing else.
+        //
+        // Emitted `static` only; `Reflection.Emit` refuses the combination outright ("Method cannot
+        // be both static and virtual"), so the `Virtual` bit is patched into the MethodDef row after
+        // the image is written. See `withVirtualBitSet` below.
+        defineMalformed
+            "MalformedStaticVirtual"
+            "StaticVirtual"
+            (MethodAttributes.Public ||| MethodAttributes.Static)
+            typeof<Void>
+
+        // A COM vtable-gap marker: `RTSpecialName` with a `_VtblGap` name, which is *not* a
+        // malformed type -- CoreCLR drops the row from the declared-method list and loads the type
+        // happily. It sits here beside the malformed ones precisely because it looks like one to a
+        // naive reading of the RTSpecialName rules, and must not be treated as such.
+        let vtblGap =
+            moduleBuilder.DefineType ("HasVtableGap", TypeAttributes.Public ||| TypeAttributes.Class, typeof<obj>)
+
+        let gapMethod =
+            vtblGap.DefineMethod (
+                "_VtblGap1_3",
+                MethodAttributes.Public
+                ||| MethodAttributes.SpecialName
+                ||| MethodAttributes.RTSpecialName,
+                typeof<Void>,
+                Type.EmptyTypes
+            )
+
+        (gapMethod.GetILGenerator ()).Emit OpCodes.Ret
+        definePlain vtblGap "AfterTheGap"
+        vtblGap.CreateType () |> ignore
+
         use stream = new MemoryStream ()
         assemblyBuilder.Save stream
-        stream.ToArray ()
+        stream.ToArray () |> withVirtualBitSet "StaticVirtual"
 
     /// The host CLR's copy, loaded so that `RuntimeMethodHandle.GetSlot` answers about a MethodTable
     /// the real builder produced.
@@ -477,6 +555,7 @@ module TestFabricatedVtableLayout =
     [<TestCase "MalformedCctorReturn">]
     [<TestCase "MalformedSpecialName">]
     [<TestCase "MalformedCtorReturn">]
+    [<TestCase "MalformedStaticVirtual">]
     let ``a type CoreCLR refuses to load is refused here too`` (typeName : string) : unit =
         // `Assembly.Load` is lazy, so the type load -- and its failure -- happens here.
         let hostFailure =
@@ -491,6 +570,36 @@ module TestFabricatedVtableLayout =
         // has to show the refusal came from the rule under test.
         pawPrintFailure.Message
         |> shouldContainText "CoreCLR rejects the type at load time"
+
+    /// The counterpart to the refusals above: a COM vtable-gap marker looks like a runtime-special
+    /// method that is not a constructor, but CoreCLR loads the type and simply drops the row.
+    /// PawPrint must do the same -- refusing would reject an ordinary interop assembly, and placing
+    /// the row would shift every method after it.
+    [<Test>]
+    let ``a vtable-gap marker is dropped, not placed and not refused`` () : unit =
+        // The host loads it, which is what makes "CoreCLR tolerates this" a measurement rather than
+        // a reading of the C++. `GetType` with `throwOnError` would raise here otherwise, as it does
+        // for each of the malformed types above.
+        hostAssembly.GetType ("HasVtableGap", true) |> shouldNotEqual null
+
+        // The row really is in the image, so this test is not vacuous. Asked of the metadata rather
+        // than of host reflection: `Type.GetMethods` enumerates the *method table*, which is exactly
+        // what a gap row is absent from, so the host cannot witness its presence.
+        match fabricated.TryGetTopLevelTypeDef "" "HasVtableGap" with
+        | None -> failwith "fabricated assembly has no type HasVtableGap"
+        | Some typeInfo ->
+            typeInfo.Methods
+            |> List.map _.Name
+            |> List.contains "_VtblGap1_3"
+            |> shouldEqual true
+
+        let table = slotTableOf "HasVtableGap"
+
+        // `AfterTheGap` and the compiler-supplied default constructor, and no third entry: the gap
+        // row is absent rather than occupying a slot of its own.
+        table.BeyondVtable
+        |> List.map _.Method.Name
+        |> shouldEqual [ ".ctor" ; "AfterTheGap" ]
 
     /// Guards the whole fixture against going vacuous. Every assertion below is about a non-NewSlot
     /// virtual that matches nothing; if `PersistedAssemblyBuilder` ever started setting NewSlot for

--- a/WoofWare.PawPrint.Test/TestFabricatedVtableLayout.fs
+++ b/WoofWare.PawPrint.Test/TestFabricatedVtableLayout.fs
@@ -131,6 +131,100 @@ module TestFabricatedVtableLayout =
         defineOverload typeof<string> false
         conflation.CreateType () |> ignore
 
+        // `MethodTableBuilder::PlaceNonVirtualMethods` gives the class constructor and the
+        // parameterless instance constructor the first two slots past the vtable, ahead of every
+        // other method whatever the MethodDef rows say -- and it recognises them by the
+        // `RTSpecialName` *flag* plus an exact name-and-signature match, not by the name alone
+        // (`ValidateMethods`, methodtablebuilder.cpp:4995-5044).
+        //
+        // The corelib corpus in TestVirtualMethodSlots already discriminates the priority itself
+        // (`System.Type` declares its `.cctor` at a higher row than its default ctor, and both above
+        // its lowest-numbered method). What it cannot discriminate is the flag, because no compiler
+        // emits a method merely *named* `.ctor` without it: ECMA-335 II.10.5.1 requires
+        // constructors to carry `rtspecialname`, so such an image is invalid -- and CoreCLR loads it
+        // anyway, placing the impostor in the ordinary pass. CoreCLR is what PawPrint emulates, so
+        // that behaviour is the contract, and this is the only way to reach it.
+        let fakeCtor =
+            moduleBuilder.DefineType ("FakeCtorSecond", TypeAttributes.Public ||| TypeAttributes.Class, typeof<obj>)
+
+        let definePlain (typeBuilder : TypeBuilder) (name : string) : unit =
+            let method =
+                typeBuilder.DefineMethod (name, MethodAttributes.Public, typeof<Void>, Type.EmptyTypes)
+
+            (method.GetILGenerator ()).Emit OpCodes.Ret
+
+        // Declared first, so it takes the first slot past the vtable unless something outranks it.
+        definePlain fakeCtor "Plain"
+
+        // `DefineMethod`, not `DefineConstructor`: this is what withholds the `RTSpecialName` flag.
+        // A classifier keyed on the name would give this the priority slot and demote `Plain`.
+        definePlain fakeCtor ".ctor"
+
+        // A genuine constructor, RTSpecialName and all -- but not the *default* one, since it takes
+        // an argument. So it gets no priority either, and the three land in declaration order. This
+        // is what stops the test passing for an implementation that keyed on `RTSpecialName` alone
+        // without also checking the signature.
+        let realCtor =
+            fakeCtor.DefineConstructor (MethodAttributes.Public, CallingConventions.Standard, [| typeof<int> |])
+
+        let realCtorIl = realCtor.GetILGenerator ()
+        realCtorIl.Emit OpCodes.Ldarg_0
+        realCtorIl.Emit (OpCodes.Call, typeof<obj>.GetConstructor Type.EmptyTypes)
+        realCtorIl.Emit OpCodes.Ret
+        fakeCtor.CreateType () |> ignore
+
+        // Types CoreCLR **refuses to load at all**. `ValidateMethods` (methodtablebuilder.cpp:4995-5044)
+        // rejects a runtime-special-named method that is not exactly a constructor, and that
+        // rejection is what makes recognising the constructors by that flag unambiguous in the first
+        // place: without it, `.cctor(int)` would be a runtime-special-named static method that is
+        // not the class constructor, and the placement rule would have to say what happens to it.
+        //
+        // PawPrint must refuse them too rather than lay out a method table for a type the real
+        // runtime declines to build one for -- every slot number derived from it would describe a
+        // type that cannot exist. `DefineMethod` takes the attribute mask verbatim, so these are
+        // expressible here and nowhere else; no compiler emits them and no corpus contains them.
+        let defineMalformed
+            (typeName : string)
+            (methodName : string)
+            (attributes : MethodAttributes)
+            (returnType : Type)
+            : unit
+            =
+            let typeBuilder =
+                moduleBuilder.DefineType (typeName, TypeAttributes.Public ||| TypeAttributes.Class, typeof<obj>)
+
+            let method =
+                typeBuilder.DefineMethod (methodName, attributes, returnType, Type.EmptyTypes)
+
+            let il = method.GetILGenerator ()
+
+            if returnType = typeof<Void> then
+                il.Emit OpCodes.Ret
+            else
+                il.Emit (OpCodes.Ldc_I4, 0)
+                il.Emit OpCodes.Ret
+
+            typeBuilder.CreateType () |> ignore
+
+        let runtimeSpecial =
+            MethodAttributes.Public
+            ||| MethodAttributes.SpecialName
+            ||| MethodAttributes.RTSpecialName
+
+        // A virtual `.ctor`: rejected outright (methodtablebuilder.cpp:5001-5004).
+        defineMalformed "MalformedVirtualCtor" ".ctor" (runtimeSpecial ||| MethodAttributes.Virtual) typeof<Void>
+
+        // A static runtime-special method that is not `static void .cctor()`: rejected because the
+        // signature is not `ExactlyEqual` to the hard-coded one (:5011-5019). Non-void return here,
+        // which is the shape a signature-blind classifier would mistake for the class constructor.
+        defineMalformed "MalformedCctorReturn" ".cctor" (runtimeSpecial ||| MethodAttributes.Static) typeof<int>
+
+        // An instance runtime-special method not named `.ctor`: rejected by the name check (:5023-5026).
+        defineMalformed "MalformedSpecialName" "NotACtor" runtimeSpecial typeof<Void>
+
+        // A constructor returning non-void: rejected by the explicit return-type check (:5028-5037).
+        defineMalformed "MalformedCtorReturn" ".ctor" runtimeSpecial typeof<int>
+
         use stream = new MemoryStream ()
         assemblyBuilder.Save stream
         stream.ToArray ()
@@ -223,7 +317,29 @@ module TestFabricatedVtableLayout =
 
     let private vtableOf (name : string) : NativeRuntimeTypeHelpers.VtableSlot list = vtableOfClosedAt name []
 
-    let private hostSlotOf : MethodInfo -> int =
+    /// The slot table of a fabricated type, both halves.
+    let private slotTableOf (name : string) : NativeRuntimeTypeHelpers.MethodSlotTable =
+        let state = state ()
+
+        let typeInfo =
+            match fabricated.TryGetTopLevelTypeDef "" name with
+            | None -> failwith $"fabricated assembly has no type %s{name}"
+            | Some typeInfo -> typeInfo
+
+        let state, handle =
+            DumpedAssembly.typeInfoToTypeDefn' bct state._LoadedAssemblies typeInfo
+            |> IlMachineState.concretizeType
+                loggerFactory
+                bct
+                state
+                fabricated.Name
+                ImmutableArray.Empty
+                ImmutableArray.Empty
+
+        NativeRuntimeTypeHelpers.slotTableOfClosed loggerFactory bct "test" state handle
+        |> snd
+
+    let private hostSlotOf : MethodBase -> int =
         let impl =
             typeof<RuntimeMethodHandle>.GetMethods (BindingFlags.NonPublic ||| BindingFlags.Static)
             |> Array.filter (fun candidate ->
@@ -232,7 +348,36 @@ module TestFabricatedVtableLayout =
             )
             |> Array.exactlyOne
 
-        fun (method : MethodInfo) -> impl.Invoke ((null : obj), [| box method |]) :?> int
+        fun (method : MethodBase) -> impl.Invoke ((null : obj), [| box method |]) :?> int
+
+    /// The host's slots past the vtable for a fabricated type, in slot order, named the way the
+    /// assertions read best -- by method name, with the parameter count appended so that the two
+    /// `.ctor`s of `FakeCtorSecond` are told apart.
+    let private hostBeyondVtableNames (name : string) : string list =
+        match hostAssembly.GetType (name, false) with
+        | null -> failwith $"host CLR could not load fabricated type %s{name}"
+        | t ->
+            let flags =
+                BindingFlags.DeclaredOnly
+                ||| BindingFlags.Instance
+                ||| BindingFlags.Static
+                ||| BindingFlags.Public
+                ||| BindingFlags.NonPublic
+
+            let numVirtuals =
+                t.GetMethods (BindingFlags.Instance ||| BindingFlags.Public ||| BindingFlags.NonPublic)
+                |> Array.filter _.IsVirtual
+                |> Array.length
+
+            [
+                yield! (t.GetMethods flags |> Seq.cast<MethodBase>)
+                yield! (t.GetConstructors flags |> Seq.cast<MethodBase>)
+            ]
+            |> List.distinctBy _.MetadataToken
+            |> List.map (fun method -> hostSlotOf method, method)
+            |> List.filter (fun (slot, _) -> slot >= numVirtuals)
+            |> List.sortBy fst
+            |> List.map (fun (_, method) -> $"%s{method.Name}/%i{method.GetParameters().Length}")
 
     /// The host's vtable for a fabricated type, slot 0 upwards, named by MethodDef token.
     let private hostLayout (name : string) : int list =
@@ -269,6 +414,83 @@ module TestFabricatedVtableLayout =
             |> Array.sortBy fst
             |> Array.map snd
             |> List.ofArray
+
+    /// The same vacuity guard for `FakeCtorSecond`: the whole point of that type is a method named
+    /// `.ctor` *without* `RTSpecialName`, and if `PersistedAssemblyBuilder` ever started setting the
+    /// flag from the name, the type would become ordinary and its test would pass while testing
+    /// nothing. Also pins that the genuine constructor beside it does carry the flag, so the type
+    /// discriminates "keyed on the flag" from "keyed on the name" in both directions.
+    [<Test>]
+    let ``the fabricated impostor constructor really does lack RTSpecialName`` () : unit =
+        let flags =
+            BindingFlags.DeclaredOnly
+            ||| BindingFlags.Instance
+            ||| BindingFlags.Public
+            ||| BindingFlags.NonPublic
+
+        let t =
+            match hostAssembly.GetType ("FakeCtorSecond", false) with
+            | null -> failwith "host CLR could not load fabricated type FakeCtorSecond"
+            | t -> t
+
+        [
+            yield! (t.GetMethods flags |> Seq.cast<MethodBase>)
+            yield! (t.GetConstructors flags |> Seq.cast<MethodBase>)
+        ]
+        |> List.distinctBy _.MetadataToken
+        |> List.sortBy _.MetadataToken
+        |> List.map (fun method ->
+            method.Name, method.GetParameters().Length, method.Attributes.HasFlag MethodAttributes.RTSpecialName
+        )
+        |> shouldEqual [ "Plain", 0, false ; ".ctor", 0, false ; ".ctor", 1, true ]
+
+    /// The rule the corpus cannot reach: constructor priority is keyed on `RTSpecialName`, so the
+    /// impostor gets no priority and the three methods land in declaration order. A classifier that
+    /// looked at the name would put `.ctor/0` first and `Plain` second.
+    [<Test>]
+    let ``constructor priority is keyed on RTSpecialName, not on the name`` () : unit =
+        let expected = hostBeyondVtableNames "FakeCtorSecond"
+
+        // Pinned literally as well as against the host, so that a change in the host's answer shows
+        // up as a disagreement between two independent statements of it rather than as both moving
+        // together. `.ctor/1` is RTSpecialName but takes an argument, so it is not the *default*
+        // constructor and is not promoted either.
+        expected |> shouldEqual [ "Plain/0" ; ".ctor/0" ; ".ctor/1" ]
+
+        let table = slotTableOf "FakeCtorSecond"
+
+        let actual =
+            table.BeyondVtable
+            |> List.map (fun slot ->
+                let parameterCount = slot.Method.Signature.ParameterTypes.Length
+                $"%s{slot.Method.Name}/%i{parameterCount}"
+            )
+
+        actual |> shouldEqual expected
+
+    /// The four shapes `ValidateMethods` rejects. Each is checked twice over: the host CLR must
+    /// refuse to load the type, and PawPrint must refuse to lay one out. Asserting the host's
+    /// refusal is what stops these from being a guess about upstream -- it is the same bytes,
+    /// and if CoreCLR ever started tolerating one of them the first assertion would say so rather
+    /// than PawPrint silently staying stricter than the runtime it emulates.
+    [<TestCase "MalformedVirtualCtor">]
+    [<TestCase "MalformedCctorReturn">]
+    [<TestCase "MalformedSpecialName">]
+    [<TestCase "MalformedCtorReturn">]
+    let ``a type CoreCLR refuses to load is refused here too`` (typeName : string) : unit =
+        // `Assembly.Load` is lazy, so the type load -- and its failure -- happens here.
+        let hostFailure =
+            Assert.Throws<TypeLoadException> (fun () -> hostAssembly.GetType (typeName, true) |> ignore)
+
+        hostFailure |> shouldNotEqual null
+
+        let pawPrintFailure =
+            Assert.Throws<Exception> (fun () -> slotTableOf typeName |> ignore)
+
+        // Named rather than merely thrown: any bug in the fixture would also throw, so the message
+        // has to show the refusal came from the rule under test.
+        pawPrintFailure.Message
+        |> shouldContainText "CoreCLR rejects the type at load time"
 
     /// Guards the whole fixture against going vacuous. Every assertion below is about a non-NewSlot
     /// virtual that matches nothing; if `PersistedAssemblyBuilder` ever started setting NewSlot for

--- a/WoofWare.PawPrint.Test/TestVirtualMethodSlots.fs
+++ b/WoofWare.PawPrint.Test/TestVirtualMethodSlots.fs
@@ -8,9 +8,10 @@ open FsUnitTyped
 open NUnit.Framework
 open WoofWare.PawPrint
 
-/// `NativeRuntimeTypeHelpers.vtableOfClosed` is the single definition of "which vtable slot" in
-/// PawPrint: `RuntimeMethodHandle.GetSlot` is an index into it and `RuntimeTypeHandle.GetNumVirtuals`
-/// is its length. The end-to-end coverage is `sourcesPure/ReflectionVirtualMethodSlots.cs`, which
+/// `NativeRuntimeTypeHelpers.slotTableOfClosed` is the single definition of "which slot" in
+/// PawPrint: `RuntimeMethodHandle.GetSlot` is an index into it, and `RuntimeTypeHandle.GetNumVirtuals`
+/// is the length of its `Vtable` half alone. The end-to-end coverage is
+/// `sourcesPure/ReflectionVirtualMethodSlots.cs`, which
 /// pins the shapes a hand-written matcher gets wrong (overloads where only one is overridden,
 /// covariant returns, `new virtual` shadows, reabstraction, generic substitution). What that file
 /// cannot do is range over a large corpus, because its expectations have to be written out by hand.
@@ -172,6 +173,24 @@ module TestVirtualMethodSlots =
             "Dictionary`2",
             [ "System", "Int32" ; "System", "Int32" ],
             typeof<System.Collections.Generic.Dictionary<int, int>>
+            // A generic type declaring *both* constructors, with lower-numbered rows before them:
+            // `Lazy`1` has its `.cctor` at a higher row than its default ctor, and ordinary methods
+            // below both. On a generic type every other method is placed in the first of the two
+            // passes past the vtable, so without this entry a walk that gave the constructors their
+            // priority only on non-generic types would agree with the host everywhere in the corpus.
+            "System", "Lazy`1", [ "System", "Int32" ], typeof<System.Lazy<int>>
+            // An interface, and specifically one carrying `static abstract` members. Those are
+            // `virtual` *and* static, so CoreCLR places them outside the vtable -- 43 of them here,
+            // at slots 1..43. Nothing else in either corpus is an interface at all, so a placement
+            // filter written as "not virtual" rather than "not an instance virtual" would drop every
+            // one of them and no other entry would notice.
+            // Named through reflection rather than `typeof<INumberBase<int>>`: F# rejects spelling an
+            // interface with static abstract members outside a constraint position (FS3536), and
+            // suppressing that warning to write a type name would be the wrong trade.
+            "System.Numerics",
+            "INumberBase`1",
+            [ "System", "Int32" ],
+            (hostType "System.Numerics" "INumberBase`1").MakeGenericType [| typeof<int> |]
         ]
 
     /// The two corpora as one list of (label, concretiser, host type), so every check below ranges
@@ -203,7 +222,7 @@ module TestVirtualMethodSlots =
     /// internal, so this is the one place the oracle reaches past the public surface -- and it is
     /// worth it: without it the oracle can only compare vtable *lengths*, and a walk that appended a
     /// spurious slot while dropping a real one has the right length and the wrong layout.
-    let private hostSlotOf : MethodInfo -> int =
+    let private hostSlotOf : MethodBase -> int =
         let impl =
             typeof<RuntimeMethodHandle>.GetMethods (BindingFlags.NonPublic ||| BindingFlags.Static)
             |> Array.filter (fun candidate ->
@@ -212,7 +231,42 @@ module TestVirtualMethodSlots =
             )
             |> Array.exactlyOne
 
-        fun (method : MethodInfo) -> impl.Invoke ((null : obj), [| box method |]) :?> int
+        fun (method : MethodBase) -> impl.Invoke ((null : obj), [| box method |]) :?> int
+
+    /// Every MethodDef the type declares, which is what `DeclaredMethodIterator` ranges over.
+    /// `GetMethods` alone is not that: it never returns constructors, so the instance constructors
+    /// and the class constructor have to be fetched separately -- and they are exactly the methods
+    /// the placement rule gives priority to, so omitting them would leave the interesting case
+    /// untested.
+    let private hostDeclaredMethods (t : Type) : MethodBase list =
+        let flags =
+            BindingFlags.DeclaredOnly
+            ||| BindingFlags.Instance
+            ||| BindingFlags.Static
+            ||| BindingFlags.Public
+            ||| BindingFlags.NonPublic
+
+        [
+            yield! (t.GetMethods flags |> Seq.cast<MethodBase>)
+            yield! (t.GetConstructors flags |> Seq.cast<MethodBase>)
+            match t.TypeInitializer with
+            | null -> ()
+            | cctor -> yield (cctor :> MethodBase)
+        ]
+        // `GetConstructors` with `Static` in the flags also yields the class constructor, so the
+        // explicit `TypeInitializer` above can duplicate it.
+        |> List.distinctBy _.MetadataToken
+
+    /// The identity `slotIndexInTable` looks a method up by. Every corpus type is corelib's, so the
+    /// declaring assembly is corelib's; the row number comes straight from the host's metadata
+    /// token, which is the same number PawPrint read out of the same image.
+    let private identityOf
+        (method : MethodBase)
+        : string * (System.Reflection.Metadata.MethodDefinitionHandle option * SynthesisedMethod option)
+        =
+        let row = method.MetadataToken &&& 0xFFFFFF
+
+        corelib.Name.FullName, (Some (MetadataTokens.MethodDefinitionHandle row), None)
 
     /// The host's vtable as a list of MethodDef tokens, slot 0 upwards: `GetSlot` gives the index and
     /// `MetadataToken` names the occupant. This is the *layout*, not merely its size.
@@ -389,6 +443,71 @@ module TestVirtualMethodSlots =
             )
 
         exercised |> shouldEqual (List.length allCorpus)
+
+    /// The strongest form of the oracle, and the only one that pins what `RuntimeMethodHandle.GetSlot`
+    /// actually computes: for **every method a corpus type declares**, virtual or not, PawPrint's
+    /// slot number must equal the host CLR's.
+    ///
+    /// Deliberately compares numbers rather than two lists laid side by side. A list comparison of
+    /// the region past the vtable checks its *order* but never its *origin*, so an implementation
+    /// that forgot to add `numVirtuals` -- the one piece of arithmetic in the whole change -- would
+    /// pass it. Asking for the number instead puts `slotIndexInTable` itself under the oracle.
+    ///
+    /// It has to be a unit test rather than an end-to-end one. Of the five `GetSlot` call sites in
+    /// the pinned corelib, four guard on `Virtual` first and the fifth (`PopulateProperties`) only
+    /// ever compares the answer with `numVirtuals`. So no guest can observe the numbering past the
+    /// vtable at all: stubbing it to `numVirtuals + 999` gets every end-to-end case in the suite
+    /// through, measured. The host CLR is the only oracle available, and it is a thorough one.
+    [<Test>]
+    let ``every declared method's slot agrees with the host CLR`` () : unit =
+        let mutable failures = []
+        let mutable virtualsChecked = 0
+        let mutable beyondChecked = 0
+
+        for label, concretiseType, host in allCorpus do
+            let state, handle = concretiseType (state ())
+
+            let _, table =
+                NativeRuntimeTypeHelpers.slotTableOfClosed loggerFactory bct "test" state handle
+
+            let numVirtuals = List.length table.Vtable
+
+            for method in hostDeclaredMethods host do
+                let expected = hostSlotOf method
+                let actual = NativeRuntimeTypeHelpers.slotIndexInTable (identityOf method) table
+
+                match actual with
+                | None ->
+                    failures <-
+                        $"%s{label}: %s{method.Name} (row %i{method.MetadataToken &&& 0xFFFFFF}) has no slot in PawPrint's table, host says %i{expected}"
+                        :: failures
+                | Some actual ->
+                    if actual <> expected then
+                        failures <-
+                            $"%s{label}: %s{method.Name} (row %i{method.MetadataToken &&& 0xFFFFFF}) PawPrint slot %i{actual}, host %i{expected}"
+                            :: failures
+
+                if expected < numVirtuals then
+                    virtualsChecked <- virtualsChecked + 1
+                else
+                    beyondChecked <- beyondChecked + 1
+
+        if not (List.isEmpty failures) then
+            // Report every divergence at once: one wrong rule usually breaks a family of methods,
+            // and seeing the family is what identifies the rule. Truncated, because a rule that
+            // misplaces the whole region past the vtable produces thousands.
+            let shown = failures |> List.rev |> List.truncate 40
+
+            failwith (
+                $"%i{List.length failures} method slots disagree with the host CLR (first %i{List.length shown}):\n"
+                + String.Join ("\n", shown)
+            )
+
+        // Guard against the check going vacuous in either half. A corpus that stopped yielding
+        // methods past the vtable would leave the new rule untested while every assertion above
+        // still passed; the floors are well below the ~1500 and ~200 the corpus actually produces.
+        beyondChecked |> shouldBeGreaterThan 500
+        virtualsChecked |> shouldBeGreaterThan 100
 
     [<Test>]
     let ``GetNumVirtuals is exactly the vtable length`` () : unit =

--- a/WoofWare.PawPrint.Test/TestVirtualMethodSlots.fs
+++ b/WoofWare.PawPrint.Test/TestVirtualMethodSlots.fs
@@ -180,10 +180,13 @@ module TestVirtualMethodSlots =
             // priority only on non-generic types would agree with the host everywhere in the corpus.
             "System", "Lazy`1", [ "System", "Int32" ], typeof<System.Lazy<int>>
             // An interface, and specifically one carrying `static abstract` members. Those are
-            // `virtual` *and* static, so CoreCLR places them outside the vtable -- 43 of them here,
-            // at slots 1..43. Nothing else in either corpus is an interface at all, so a placement
-            // filter written as "not virtual" rather than "not an instance virtual" would drop every
-            // one of them and no other entry would notice.
+            // `virtual` *and* static, so CoreCLR places them outside the vtable. Measured here:
+            // slot 0 is an ordinary *instance* virtual (the default implementation of
+            // `IUtf8SpanFormattable.TryFormat`), slots 1-41 are the static virtuals, and slots 42-43
+            // are static but *not* virtual (`IUtf8SpanParsable<TSelf>.Parse`/`TryParse`). Nothing
+            // else in either corpus is an interface at all, so a placement filter written as "not
+            // virtual" rather than "not an instance virtual" would drop those 41 and no other entry
+            // would notice.
             // Named through reflection rather than `typeof<INumberBase<int>>`: F# rejects spelling an
             // interface with static abstract members outside a constraint position (FS3536), and
             // suppressing that warning to write a type name would be the wrong trade.

--- a/WoofWare.PawPrint.Test/sourcesPure/PropertyEnumeration.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/PropertyEnumeration.cs
@@ -10,15 +10,29 @@ using System.Reflection;
 // rejected by a name filter before any of them is constructed. Both threw before the enumeration
 // existed.
 //
-// In particular, asking for a property that *does* exist is still not observable. `AssignAssociates`
-// now runs to completion — `MetadataImport.Enum` answers its associate query, and each accessor
-// resolves — but `PopulateProperties` then suppresses vtable-slot duplicates
-// (`RuntimeType.CoreCLR.cs:1358`), which calls `RuntimeMethodHandle.GetSlot`, and that is
-// unimplemented. Checked by writing the case and running it, not inferred. So neither
-// `GetPropertyProps` nor the associates branch of `Enum` has any end-to-end coverage; both contracts
-// are pinned by TestNativeMetadataImport alone.
-// The field is load-bearing, not decoration: it is what makes case 1 below able to catch an
-// implementation that enumerated the FieldDef table instead of the PropertyMap run. Such an
+// Asking for a property that *does* exist is now observable too, which it was not until the
+// non-vtable slot region landed. `PopulateProperties` suppresses vtable-slot duplicates
+// (`RuntimeType.CoreCLR.cs:1358`) by calling `RuntimeMethodHandle.GetSlot` on each property's
+// accessor with *no* `Virtual` guard, then testing `slot < numVirtuals`. An ordinary non-virtual
+// getter occupies no vtable slot at all, so until `PlaceNonVirtualMethods` was modelled that call
+// had no answer and every case below past the first two died in it.
+//
+// Be precise about what the case below can and cannot catch, because it is much less than it looks.
+// `PopulateProperties` never reads the returned number except to compare it with `numVirtuals`, so
+// *any* answer at or above `numVirtuals` gets a guest through here — measured, by stubbing the
+// lookup to return `numVirtuals + 999` and watching this file still pass. So case 3 pins
+// reachability and nothing more: that a non-virtual accessor now gets an answer at all. Both the
+// numbering within the region and the offset that places it after the vtable are pinned by the
+// host-CLR oracle in TestVirtualMethodSlots, which compares PawPrint's slot number against the
+// host's for every method of every corpus type.
+//
+// A *virtual* property accessor would exercise more of this — `Associates.AssignAssociates` feeds
+// the slot straight back to `RuntimeTypeHandle.GetMethodAt` to find the override visible from the
+// reflected type (Associates.cs:95-99), which does read the number. That QCall is unimplemented, so
+// such a case cannot be written here yet; it is the next thing this file should grow when it lands.
+//
+// The field on `NoProperties` is load-bearing, not decoration: it is what makes case 1 below able to
+// catch an implementation that enumerated the FieldDef table instead of the PropertyMap run. Such an
 // implementation reports one "property" here, and the guest then dies trying to construct a
 // `RuntimePropertyInfo` for it.
 public class NoProperties
@@ -43,6 +57,16 @@ public class HasProperties
 
 public class PropertyEnumeration
 {
+    private static bool Has(PropertyInfo[] properties, string name)
+    {
+        foreach (PropertyInfo property in properties)
+        {
+            if (property.Name == name) return true;
+        }
+
+        return false;
+    }
+
     public static int Main(string[] argv)
     {
         // A type with members but no properties. `PopulateProperties` walks the base chain, so this
@@ -55,6 +79,20 @@ public class PropertyEnumeration
         // what makes this stronger than the empty case. It cannot, however, distinguish a correct
         // token list from a merely well-formed one; that is the unit tests' job.
         if (typeof(HasProperties).GetProperty("NoSuchName") != null) return 2;
+
+        // 3. A property that exists, on a type whose accessors are all non-virtual. Constructing the
+        // `RuntimePropertyInfo` is what reaches `GetSlot` for a method with no vtable slot.
+        PropertyInfo[] plain = typeof(HasProperties).GetProperties();
+        if (plain.Length != 2) return 3;
+        if (!Has(plain, "Alpha")) return 4;
+        if (!Has(plain, "Beta")) return 5;
+        if (typeof(HasProperties).GetProperty("Alpha") == null) return 6;
+
+        // `Alpha` has a setter as well as a getter, so three accessors are placed here, not two —
+        // which is what makes the walk's ordering visible to a debugger even though the guest cannot
+        // read the numbers back.
+        if (typeof(HasProperties).GetProperty("Alpha").GetSetMethod() == null) return 7;
+        if (typeof(HasProperties).GetProperty("Beta").GetSetMethod() != null) return 8;
 
         return 0;
     }

--- a/WoofWare.PawPrint/Native/NativeRuntimeMethodHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeMethodHandle.fs
@@ -1091,36 +1091,29 @@ module NativeRuntimeMethodHandle =
           MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) when generics.IsEmpty ->
             // CoreCLR (runtimehandles.cpp:1352): asserts non-null and returns
             // (INT32)pMethod->GetSlot(), which is a bare read of the MethodDesc's slot number as
-            // assigned once by MethodTableBuilder::PlaceVirtualMethods. PawPrint has no persisted
-            // slot number, so the layout is recomputed from the declaring type's chain; see
-            // `NativeRuntimeTypeHelpers.vtableOfClosed` for the rule and for why MethodImpls are
+            // assigned once during method-table building. PawPrint has no persisted slot number, so
+            // the layout is recomputed from the declaring type's chain; see
+            // `NativeRuntimeTypeHelpers.slotTableOfClosed` for the rule and for why MethodImpls are
             // not consulted.
             //
-            // Every caller that can reach this today asks only about a method whose metadata carries
-            // MethodAttributes.Virtual (`PopulateMethods`, RuntimeType.CoreCLR.cs:683), and on a
-            // class or value type such a method always occupies an instance vtable slot: CoreCLR
-            // rejects static+virtual outside interfaces with a TypeLoadException, and
-            // `PopulateMethods` routes interfaces down a branch that never reaches here.
+            // The number spans both halves of the method table, so this asks the slot table rather
+            // than the vtable alone. `PopulateMethods` (RuntimeType.CoreCLR.cs:683) only ever asks
+            // about a method carrying MethodAttributes.Virtual, which on a class or value type
+            // always occupies an instance vtable slot -- CoreCLR rejects static+virtual outside
+            // interfaces with a TypeLoadException, and `PopulateMethods` routes interfaces down a
+            // branch that never reaches here. But `PopulateProperties` (RuntimeType.CoreCLR.cs:1358)
+            // calls this on a property's accessor with *no* Virtual guard, testing
+            // `slot < numVirtuals` afterwards, so an ordinary non-virtual getter reaches it and
+            // CoreCLR answers with a slot in the region past the vtable.
             //
-            // Two shapes land outside the vtable. Both are recorded because they are the answer to
-            // "what would CoreCLR have returned":
-            //
-            //  - `PopulateProperties` (RuntimeType.CoreCLR.cs:1358) calls this on a property's
-            //    accessor with *no* Virtual guard, testing `slot < numVirtuals` afterwards, so an
-            //    ordinary non-virtual getter reaches it and CoreCLR answers with a non-vtable slot.
-            //    This one is **live**: it is what the parked `UnionReflection` F# case now dies on,
-            //    reporting "method get_width occupies no slot in the vtable of its declaring type".
-            //    The chain that used to block it is gone -- Property token enumeration (#921, #926),
-            //    `Associates.AssignAssociates` (#934), and most recently the vtable layout rule for
-            //    an unmatched non-NewSlot virtual, without which a union's vtable could not be built
-            //    at all. Implementing the non-vtable region is what un-parks that case; see the
-            //    parking comment in TestFSharpPureCases for the observed failure.
-            //
-            //  - For a value type, the MethodTable builder duplicates every virtual, leaving the
-            //    unboxing stub in the vtable slot and giving the unboxed copy a slot beyond
-            //    GetNumVirtuals. Those duplicates are MethodDesc-level artifacts living in the
-            //    MethodDescChunks; PawPrint enumerates metadata MethodDefs once, so it never sees
-            //    them.
+            // One shape still lands outside anything modelled here, and is recorded because it is
+            // the answer to "what would CoreCLR have returned": for a value type the MethodTable
+            // builder duplicates every virtual, leaving the unboxing stub in the vtable slot and
+            // giving the unboxed copy a slot of its own beyond the rest (`AddUnboxedMethod`,
+            // methodtablebuilder.cpp:7178). Those duplicates are MethodDesc-level artifacts living
+            // in the MethodDescChunks, and they take their numbers *after* everything placed from
+            // metadata, so they shift nothing. PawPrint enumerates metadata MethodDefs once and so
+            // never sees them; nor can a guest name one, since reflection surfaces the original.
             let operation = "RuntimeMethodHandle.GetSlot"
 
             let identity =
@@ -1130,8 +1123,8 @@ module NativeRuntimeMethodHandle =
 
             let declaringType = identity.GetDeclaringType ()
 
-            let state, vtable =
-                NativeRuntimeTypeHelpers.vtableOfClosed
+            let state, slotTable =
+                NativeRuntimeTypeHelpers.slotTableOfClosed
                     ctx.LoggerFactory
                     ctx.BaseClassTypes
                     operation
@@ -1139,15 +1132,15 @@ module NativeRuntimeMethodHandle =
                     declaringType
 
             let slot =
-                vtable
-                |> List.map NativeRuntimeTypeHelpers.slotIdentity
-                |> NativeRuntimeTypeHelpers.slotIndexOfIdentity (
-                    identity.GetAssemblyFullName (),
-                    methodInfo.IdentityKey
-                )
+                slotTable
+                |> NativeRuntimeTypeHelpers.slotIndexInTable (identity.GetAssemblyFullName (), methodInfo.IdentityKey)
                 |> Option.defaultWith (fun () ->
+                    // Every method a type declares in metadata is placed in one half or the other,
+                    // so reaching here means the method is not the declaring type's to place: a
+                    // synthesised method, which has no MethodDef row for `DeclaredMethodIterator` to
+                    // find, or an identity naming a type that does not declare it.
                     failwith
-                        $"TODO: %s{operation}: method %s{methodInfo.Name} occupies no slot in the vtable of its declaring type %O{declaringType}; CoreCLR would answer with a slot in the non-vtable region beyond GetNumVirtuals, which PawPrint does not model. If you have arrived here from property enumeration, that is the expected next step: see the comment above this handler"
+                        $"%s{operation}: method %s{methodInfo.Name} occupies no slot in the method table of its declaring type %O{declaringType}; every metadata-declared method is placed either in the vtable or in the region beyond it, so this is a method the declaring type does not declare (a runtime-synthesised method has no MethodDef row and is never placed)"
                 )
 
             let state =

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
@@ -969,10 +969,11 @@ module NativeRuntimeTypeHelpers =
     /// leave the *vtable* inflated by one slot per gap, which moves `GetNumVirtuals` and with it the
     /// origin of everything after it.
     ///
-    /// The name grammar is `_VtblGap` + optional digits + optionally `_` and at least one digit,
-    /// and CoreCLR throws `BadImageFormatException` for anything else (:2865-2907) rather than
-    /// treating it as an ordinary method -- so a prefix match alone would accept images the runtime
-    /// rejects.
+    /// The name grammar is `_VtblGap` + optional digits + optionally `_` and at least one digit, and
+    /// CoreCLR refuses to load the type for anything else (:2865-2907) rather than treating it as an
+    /// ordinary method -- so a prefix match alone would accept images the runtime rejects. Upstream
+    /// raises that as `COR_E_BADIMAGEFORMAT` with `IDS_CLASSLOAD_BADSPECIALMETHOD`, but what a guest
+    /// (and the fabricated test) observes is a `TypeLoadException`.
     let private declaredMethodsOf
         (operation : string)
         (concreteTypeInfo : ConcreteType<ConcreteTypeHandle>)
@@ -1004,7 +1005,7 @@ module NativeRuntimeTypeHelpers =
                 then
                     if not (isWellFormedGapName method.Name) then
                         failwith
-                            $"%s{operation}: method %s{method.Name} on %O{concreteTypeInfo} is marked RTSpecialName and begins `_VtblGap`, but the rest of the name is not the vtable-gap count grammar; CoreCLR rejects the type at load time with a BadImageFormatException (methodtablebuilder.cpp:2865-2907) rather than laying out a method table for it"
+                            $"%s{operation}: method %s{method.Name} on %O{concreteTypeInfo} is marked RTSpecialName and begins `_VtblGap`, but the rest of the name is not the vtable-gap count grammar; CoreCLR rejects the type at load time (methodtablebuilder.cpp:2865-2907) rather than laying out a method table for it"
 
                     None
                 else
@@ -1310,7 +1311,7 @@ module NativeRuntimeTypeHelpers =
         // is still unplaced when `PlaceNonVirtualMethods` runs. A `static virtual` -- an interface
         // static abstract -- is therefore placed here, which is what upstream's
         // `AddNonVirtualMethod` assertion `!IsMdVirtual(...) || IsMdStatic(...)` asserts. Writing
-        // this filter as "not virtual" would silently drop all 43 of `INumberBase<T>`'s static
+        // this filter as "not virtual" would silently drop all 41 of `INumberBase<T>`'s static
         // members, which is why that interface is in the layout corpus.
         let unplaced =
             declared
@@ -1343,6 +1344,28 @@ module NativeRuntimeTypeHelpers =
         let isGenericSignature (method : MethodInfo<_, _, _>) : bool =
             method.Signature.Header.Get.Attributes.HasFlag System.Reflection.Metadata.SignatureAttributes.Generic
 
+        // CoreCLR asks two different questions about a constructor's return type, and the answers
+        // come apart on exactly one shape. `ValidateMethods` rejects a ctor whose return is not void
+        // using `MetaSig::GetReturnType()`, which reaches `SigParser::PeekElemTypeClosed` and calls
+        // `SkipCustomModifiers()` first (sigparser.h:225) -- so `modopt(X) void` *is* void there, and
+        // such a type loads happily; measured on the host, which instantiates one. But
+        // `pDefaultCtor` is set by `ExactlyEqual` against the hard-coded `instance void ()`, a raw
+        // *blob* comparison, in which a modifier makes the signature different -- so the same ctor
+        // does not get the priority slot.
+        //
+        // Hence two predicates. `ModoptVoidCtor` in TestFabricatedVtableLayout is the type that
+        // needs both, and collapsing either into the other kills it.
+        let returnsVoidThroughModifiers (method : MethodInfo<_, _, _>) : bool =
+            match method.Signature.ReturnType with
+            | MethodReturnType.Void -> true
+            | MethodReturnType.Returns ty ->
+                let rec unwrap (ty : TypeDefn) : TypeDefn =
+                    match ty with
+                    | TypeDefn.Modified modified -> unwrap modified.Unmodified
+                    | ty -> ty
+
+                unwrap ty = TypeDefn.Void
+
         let hasNullaryVoidSignature (method : MethodInfo<_, _, _>) : bool =
             method.Signature.ParameterTypes.IsEmpty
             && not (isGenericSignature method)
@@ -1356,11 +1379,13 @@ module NativeRuntimeTypeHelpers =
         // derived from it would then describe a type that cannot exist -- the same reason
         // `vtableOfClosed` refuses a non-newslot virtual that matches a `final` parent slot.
         for method, facts in declared do
-            // A `static virtual` is legal only on an interface, and must be abstract there
-            // (`ValidateMethods`, methodtablebuilder.cpp:5124-5131). On a class or value type
-            // CoreCLR throws `IDS_CLASSLOAD_STATICVIRTUAL`. Without this the method would simply
-            // be placed past the vtable, since `PlaceVirtualMethods` skips it for being static --
-            // handing out a layout for a type the real runtime will not build one for.
+            // A `static virtual` is legal only on an interface: on a class or value type
+            // `ValidateMethods` throws `IDS_CLASSLOAD_STATICVIRTUAL` (methodtablebuilder.cpp:5124-5131).
+            // Only the `!IsInterface()` half is enforced there -- upstream's comment beside it also
+            // says such methods "must be abstract", but nothing checks that, and static virtuals
+            // with default bodies have been legal since .NET 7. Without this check the method would
+            // simply be placed past the vtable, since `PlaceVirtualMethods` skips it for being
+            // static -- handing out a layout for a type the real runtime will not build one for.
             if method.IsStatic && method.IsVirtual && not typeInfo.IsInterface then
                 failwith
                     $"%s{operation}: method %s{method.Name} on %O{concreteTypeInfo} is both static and virtual, which is legal only on an interface; CoreCLR rejects the type at load time (methodtablebuilder.cpp:5124-5131) rather than laying out a method table for it"
@@ -1377,7 +1402,7 @@ module NativeRuntimeTypeHelpers =
                 else if method.Name <> ".ctor" then
                     failwith
                         $"%s{operation}: instance method %s{method.Name} on %O{concreteTypeInfo} is marked RTSpecialName but is not named `.ctor`; CoreCLR rejects the type at load time (methodtablebuilder.cpp:5023-5026) rather than laying out a method table for it"
-                elif method.Signature.ReturnType <> MethodReturnType.Void then
+                elif not (returnsVoidThroughModifiers method) then
                     failwith
                         $"%s{operation}: constructor on %O{concreteTypeInfo} does not return void; CoreCLR rejects the type at load time (methodtablebuilder.cpp:5028-5037) rather than laying out a method table for it"
 

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
@@ -980,6 +980,28 @@ module NativeRuntimeTypeHelpers =
         (typeInfo : TypeInfo<GenericParamFromMetadata, TypeDefn>)
         : (MethodInfo<GenericParamFromMetadata, GenericParamFromMetadata, TypeDefn> * MetadataMethodFacts) list
         =
+        // Exactly `void`, no custom modifier: a *blob* comparison, matching `ExactlyEqual`.
+        let hasNullaryVoidSignature (method : MethodInfo<_, _, _>) : bool =
+            method.Signature.ParameterTypes.IsEmpty
+            && not (
+                method.Signature.Header.Get.Attributes.HasFlag System.Reflection.Metadata.SignatureAttributes.Generic
+            )
+            && method.Signature.Header.Get.CallingConvention = System.Reflection.Metadata.SignatureCallingConvention.Default
+            && method.Signature.ReturnType = MethodReturnType.Void
+
+        // `void` once custom modifiers are looked through, which is the other question CoreCLR asks;
+        // see `slotsBeyondVtableOfClosed` for why the two must stay separate.
+        let returnsVoidThroughModifiers (method : MethodInfo<_, _, _>) : bool =
+            match method.Signature.ReturnType with
+            | MethodReturnType.Void -> true
+            | MethodReturnType.Returns ty ->
+                let rec unwrap (ty : TypeDefn) : TypeDefn =
+                    match ty with
+                    | TypeDefn.Modified modified -> unwrap modified.Unmodified
+                    | ty -> ty
+
+                unwrap ty = TypeDefn.Void
+
         // `_VtblGap`, then the optional-number/count grammar upstream parses.
         let isWellFormedGapName (name : string) : bool =
             let suffix = name.Substring "_VtblGap".Length
@@ -1009,7 +1031,48 @@ module NativeRuntimeTypeHelpers =
 
                     None
                 else
-                    Some (method, facts)
+
+                // The load-time rejections. They live here, rather than beside the placement that
+                // needs them, so that they run for *every* type this walk touches -- including each
+                // ancestor, since `vtableOfClosed` recurses through the base chain and asks each one
+                // for its declared methods. A type whose base CoreCLR refuses to load cannot itself
+                // be loaded, because building a MethodTable begins by building the parent's, so
+                // validating only the leaf would let `GetSlot` answer for a derived type that cannot
+                // exist.
+                //
+                // They are not optional colour either: the classification below keys *on* the
+                // RTSpecialName flag, and that is only unambiguous because CoreCLR refuses to load
+                // the shapes that would make it ambiguous. Same reason `vtableOfClosed` refuses a
+                // non-newslot virtual that matches a `final` parent slot.
+
+                // A `static virtual` is legal only on an interface: on a class or value type
+                // `ValidateMethods` throws `IDS_CLASSLOAD_STATICVIRTUAL`
+                // (methodtablebuilder.cpp:5124-5131). Only the `!IsInterface()` half is enforced
+                // there -- upstream's comment beside it also says such methods "must be abstract",
+                // but nothing checks that, and static virtuals with bodies have been legal since
+                // .NET 7. Without this the method would simply be placed past the vtable, since
+                // `PlaceVirtualMethods` skips it for being static.
+                if method.IsStatic && method.IsVirtual && not typeInfo.IsInterface then
+                    failwith
+                        $"%s{operation}: method %s{method.Name} on %O{concreteTypeInfo} is both static and virtual, which is legal only on an interface; CoreCLR rejects the type at load time (methodtablebuilder.cpp:5124-5131) rather than laying out a method table for it"
+
+                if facts.MethodAttributes.HasFlag MethodAttributes.RTSpecialName then
+                    if method.IsVirtual then
+                        failwith
+                            $"%s{operation}: method %s{method.Name} on %O{concreteTypeInfo} is marked RTSpecialName and virtual; CoreCLR rejects the type at load time (methodtablebuilder.cpp:5001-5004) rather than laying out a method table for it"
+
+                    if method.IsStatic then
+                        if method.Name <> ".cctor" || not (hasNullaryVoidSignature method) then
+                            failwith
+                                $"%s{operation}: static method %s{method.Name} on %O{concreteTypeInfo} is marked RTSpecialName but is not exactly `static void .cctor()`; CoreCLR rejects the type at load time (methodtablebuilder.cpp:5011-5019) rather than laying out a method table for it"
+                    else if method.Name <> ".ctor" then
+                        failwith
+                            $"%s{operation}: instance method %s{method.Name} on %O{concreteTypeInfo} is marked RTSpecialName but is not named `.ctor`; CoreCLR rejects the type at load time (methodtablebuilder.cpp:5023-5026) rather than laying out a method table for it"
+                    elif not (returnsVoidThroughModifiers method) then
+                        failwith
+                            $"%s{operation}: constructor on %O{concreteTypeInfo} does not return void; CoreCLR rejects the type at load time (methodtablebuilder.cpp:5028-5037) rather than laying out a method table for it"
+
+                Some (method, facts)
         )
 
     /// The instance vtable of a closed type, base-first: index `i` is the method that currently
@@ -1319,18 +1382,14 @@ module NativeRuntimeTypeHelpers =
 
         // CoreCLR recognises the two constructors by `IsMdRTSpecialName` *plus* an `ExactlyEqual`
         // match -- name and raw signature blob both -- against hard-coded `static void .cctor()` and
-        // `instance void .ctor()` signatures, and `ValidateMethods` (methodtablebuilder.cpp:4995-5044)
-        // rejects the type at load time if a runtime-special-named method is anything else.
+        // `instance void .ctor()` signatures. `declaredMethodsOf` has already refused any
+        // runtime-special-named method that is neither, since CoreCLR refuses to load such a type.
         //
         // The flag is load-bearing and not implied by the name: a method merely *named* `.ctor`
         // without it skips that block entirely and is placed in the ordinary pass below.
         // `FakeCtorSecond` in TestFabricatedVtableLayout pins that against the host CLR. ECMA-335
         // II.10.5.1 requires constructors to carry `rtspecialname`, so such an image is invalid --
         // but CoreCLR loads it anyway, and CoreCLR is what this emulates.
-        //
-        // Matching the blob means the calling convention and generic arity are part of the test, not
-        // just the arity: a vararg or (illegal-but-loadable) generic `.ctor()` is not the default
-        // constructor and does not get the priority slot.
         let isRuntimeSpecialName (facts : MetadataMethodFacts) : bool =
             facts.MethodAttributes.HasFlag MethodAttributes.RTSpecialName
 
@@ -1348,63 +1407,22 @@ module NativeRuntimeTypeHelpers =
         // come apart on exactly one shape. `ValidateMethods` rejects a ctor whose return is not void
         // using `MetaSig::GetReturnType()`, which reaches `SigParser::PeekElemTypeClosed` and calls
         // `SkipCustomModifiers()` first (sigparser.h:225) -- so `modopt(X) void` *is* void there, and
-        // such a type loads happily; measured on the host, which instantiates one. But
-        // `pDefaultCtor` is set by `ExactlyEqual` against the hard-coded `instance void ()`, a raw
-        // *blob* comparison, in which a modifier makes the signature different -- so the same ctor
-        // does not get the priority slot.
+        // such a type loads happily; measured on the host, which instantiates one. That question is
+        // `declaredMethodsOf`'s, since it decides whether the type loads at all.
         //
-        // Hence two predicates. `ModoptVoidCtor` in TestFabricatedVtableLayout is the type that
-        // needs both, and collapsing either into the other kills it.
-        let returnsVoidThroughModifiers (method : MethodInfo<_, _, _>) : bool =
-            match method.Signature.ReturnType with
-            | MethodReturnType.Void -> true
-            | MethodReturnType.Returns ty ->
-                let rec unwrap (ty : TypeDefn) : TypeDefn =
-                    match ty with
-                    | TypeDefn.Modified modified -> unwrap modified.Unmodified
-                    | ty -> ty
-
-                unwrap ty = TypeDefn.Void
-
+        // This one is the other: `pDefaultCtor` is set by `ExactlyEqual` against the hard-coded
+        // `instance void ()`, a raw *blob* comparison, in which a modifier makes the signature
+        // different -- so the same constructor does not get the priority slot. `ModoptVoidCtor` in
+        // TestFabricatedVtableLayout needs both, and collapsing either into the other kills it.
+        //
+        // Matching the blob also means the calling convention and generic arity are part of the
+        // test, not just the arity: a vararg or (illegal-but-loadable) generic `.ctor()` is not the
+        // default constructor either.
         let hasNullaryVoidSignature (method : MethodInfo<_, _, _>) : bool =
             method.Signature.ParameterTypes.IsEmpty
             && not (isGenericSignature method)
             && method.Signature.Header.Get.CallingConvention = System.Reflection.Metadata.SignatureCallingConvention.Default
             && method.Signature.ReturnType = MethodReturnType.Void
-
-        // The rejections above are not optional colour. This function classifies *on* the
-        // RTSpecialName flag, and that classification is only unambiguous because CoreCLR refuses
-        // to load the shapes that would make it ambiguous. Skipping them would hand out a slot
-        // layout for a type the real runtime declines to build a MethodTable for, and every number
-        // derived from it would then describe a type that cannot exist -- the same reason
-        // `vtableOfClosed` refuses a non-newslot virtual that matches a `final` parent slot.
-        for method, facts in declared do
-            // A `static virtual` is legal only on an interface: on a class or value type
-            // `ValidateMethods` throws `IDS_CLASSLOAD_STATICVIRTUAL` (methodtablebuilder.cpp:5124-5131).
-            // Only the `!IsInterface()` half is enforced there -- upstream's comment beside it also
-            // says such methods "must be abstract", but nothing checks that, and static virtuals
-            // with default bodies have been legal since .NET 7. Without this check the method would
-            // simply be placed past the vtable, since `PlaceVirtualMethods` skips it for being
-            // static -- handing out a layout for a type the real runtime will not build one for.
-            if method.IsStatic && method.IsVirtual && not typeInfo.IsInterface then
-                failwith
-                    $"%s{operation}: method %s{method.Name} on %O{concreteTypeInfo} is both static and virtual, which is legal only on an interface; CoreCLR rejects the type at load time (methodtablebuilder.cpp:5124-5131) rather than laying out a method table for it"
-
-            if isRuntimeSpecialName facts then
-                if method.IsVirtual then
-                    failwith
-                        $"%s{operation}: method %s{method.Name} on %O{concreteTypeInfo} is marked RTSpecialName and virtual; CoreCLR rejects the type at load time (methodtablebuilder.cpp:5001-5004) rather than laying out a method table for it"
-
-                if method.IsStatic then
-                    if method.Name <> ".cctor" || not (hasNullaryVoidSignature method) then
-                        failwith
-                            $"%s{operation}: static method %s{method.Name} on %O{concreteTypeInfo} is marked RTSpecialName but is not exactly `static void .cctor()`; CoreCLR rejects the type at load time (methodtablebuilder.cpp:5011-5019) rather than laying out a method table for it"
-                else if method.Name <> ".ctor" then
-                    failwith
-                        $"%s{operation}: instance method %s{method.Name} on %O{concreteTypeInfo} is marked RTSpecialName but is not named `.ctor`; CoreCLR rejects the type at load time (methodtablebuilder.cpp:5023-5026) rather than laying out a method table for it"
-                elif not (returnsVoidThroughModifiers method) then
-                    failwith
-                        $"%s{operation}: constructor on %O{concreteTypeInfo} does not return void; CoreCLR rejects the type at load time (methodtablebuilder.cpp:5028-5037) rather than laying out a method table for it"
 
         let isClassConstructor ((method, facts) : MethodInfo<_, _, _> * MetadataMethodFacts) : bool =
             isRuntimeSpecialName facts

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
@@ -1040,6 +1040,18 @@ module NativeRuntimeTypeHelpers =
                 // validating only the leaf would let `GetSlot` answer for a derived type that cannot
                 // exist.
                 //
+                // The type and its base chain is exactly the scope, and deliberately not more.
+                // Those are the declarations that *contribute slots to the layout being computed*,
+                // so a rejection anywhere in them means the numbers this function returns describe a
+                // MethodTable that cannot exist. An implemented interface is a different matter:
+                // CoreCLR does load one while building the type (`ResolveInterfaces`) and would
+                // refuse the implementor if the interface were malformed, but no interface method
+                // enters this slot table, so nothing computed here depends on it. Chasing that
+                // dependency has no natural stopping point short of the whole type-load closure --
+                // field types, generic constraints, and so on -- which is a different feature from
+                // laying out a method table. A guest that asks about the malformed interface itself
+                // is still refused, because this same function is what answers for it.
+                //
                 // They are not optional colour either: the classification below keys *on* the
                 // RTSpecialName flag, and that is only unambiguous because CoreCLR refuses to load
                 // the shapes that would make it ambiguous. Same reason `vtableOfClosed` refuses a

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
@@ -1193,6 +1193,253 @@ module NativeRuntimeTypeHelpers =
 
             state, slots
 
+    /// The occupants of the region of a type's method table that follows its vtable, in slot order,
+    /// so that the method at index `i` holds slot `numVirtuals + i`.
+    ///
+    /// This is `MethodTableBuilder::PlaceNonVirtualMethods` (methodtablebuilder.cpp:5255-5359).
+    /// Slot numbers come from one monotonic counter shared with the vtable
+    /// (`AddNonVirtualMethod` sets the index to `pSlotTable->GetSlotCount()`,
+    /// methodtablebuilder.h:1532-1541), and only the parent's *virtual* slots are inherited --
+    /// `CopyParentVtable` (methodtablebuilder.cpp:1143) stops at the parent's `GetNumVirtuals()` --
+    /// so this region begins at exactly the type's own `GetNumVirtuals()`, however many slots its
+    /// base had beyond its vtable. Upstream machine-checks that premise: `PlaceNonVirtualMethods`
+    /// opens with `INDEBUG(bmtVT->SealVirtualSlotSection())` and every subsequent add re-seals, so
+    /// a debug build asserts that nothing appends to the vtable once this has begun.
+    ///
+    /// Nothing renumbers a declared method afterwards. `PlaceInterfaceMethods` runs later but adds
+    /// no slots -- it only fills in `bmtInterfaceSlotImpl` and the dispatch map. Do not be misled by
+    /// the comment above its call site (methodtablebuilder.cpp:1676), which still describes
+    /// creating "duplicate slots ... starting at dwCurrentDuplicateVtableSlot": that variable no
+    /// longer exists anywhere in the file. The one later addition, `AddUnboxedMethod` for a value
+    /// type's unboxed entrypoints (:7178), appends after everything placed from metadata.
+    ///
+    /// Two assumptions about what the metadata contains, both currently true and neither checked
+    /// here. Runtime-async (`g_pConfig->RuntimeAsync()`, off by default) makes
+    /// `EnumerateClassMethods` synthesise a second `bmtMDMethod` per Task-returning method, and
+    /// those consume slots alongside the declared ones; and EnC adds MethodDescs entirely outside
+    /// this file, which PawPrint may ignore because it does not support dynamic code at all (#853).
+    ///
+    /// The order is emphatically *not* MethodDef row order, and every step below is observable.
+    /// Verified against the host CLR's own `RuntimeMethodHandle.GetSlot` for every method reflection
+    /// can reach: 31064 methods over 2336 corelib types, 5499 over 1153 FSharp.Core types, and 352
+    /// over closed generic instantiations, with no disagreement.
+    let private slotsBeyondVtableOfClosed
+        (operation : string)
+        (concreteTypeInfo : ConcreteType<ConcreteTypeHandle>)
+        (typeInfo : TypeInfo<GenericParamFromMetadata, TypeDefn>)
+        : VtableSlot list
+        =
+        // `DeclaredMethodIterator` ranges over the type's MethodDef rows, so a *synthesised* method
+        // is not a candidate for a slot at all. `vtableOfClosed` excludes them only incidentally
+        // (a synthesised method is never `IsVirtual`); here the exclusion must be deliberate,
+        // because a synthesised method *is* non-virtual and would otherwise be placed -- shifting
+        // every genuine method after it by one, and so making every slot number this function hands
+        // out wrong rather than merely adding one spurious entry.
+        //
+        // No test covers this, and none can: nothing today puts a synthesised method into a
+        // `TypeInfo` (the two construction sites, in `Program.buildStartupFrame` and
+        // `StructMarshalStub`, both build one for immediate execution), so the filter is a no-op on
+        // every image that exists. It is kept because `TypeInfo.Methods` is typed to hold either
+        // kind, so the day one is inserted is the day every slot number silently moves.
+        let declared =
+            typeInfo.Methods
+            |> List.choose (fun method ->
+                match method.TryMetadata with
+                | None -> None
+                | Some facts -> Some (method, facts)
+            )
+
+        // `PlaceVirtualMethods` places exactly the declared *instance* virtuals, so everything else
+        // is still unplaced when `PlaceNonVirtualMethods` runs. A `static virtual` -- an interface
+        // static abstract -- is therefore placed here, which is what upstream's
+        // `AddNonVirtualMethod` assertion `!IsMdVirtual(...) || IsMdStatic(...)` asserts. Writing
+        // this filter as "not virtual" would silently drop all 43 of `INumberBase<T>`'s static
+        // members, which is why that interface is in the layout corpus.
+        let unplaced =
+            declared
+            |> List.filter (fun (method, _) -> not (method.IsVirtual && not method.IsStatic))
+
+        // CoreCLR recognises the two constructors by `IsMdRTSpecialName` *plus* an `ExactlyEqual`
+        // match -- name and raw signature blob both -- against hard-coded `static void .cctor()` and
+        // `instance void .ctor()` signatures, and `ValidateMethods` (methodtablebuilder.cpp:4995-5044)
+        // rejects the type at load time if a runtime-special-named method is anything else.
+        //
+        // The flag is load-bearing and not implied by the name: a method merely *named* `.ctor`
+        // without it skips that block entirely and is placed in the ordinary pass below.
+        // `FakeCtorSecond` in TestFabricatedVtableLayout pins that against the host CLR. ECMA-335
+        // II.10.5.1 requires constructors to carry `rtspecialname`, so such an image is invalid --
+        // but CoreCLR loads it anyway, and CoreCLR is what this emulates.
+        //
+        // Matching the blob means the calling convention and generic arity are part of the test, not
+        // just the arity: a vararg or (illegal-but-loadable) generic `.ctor()` is not the default
+        // constructor and does not get the priority slot.
+        let isRuntimeSpecialName (facts : MetadataMethodFacts) : bool =
+            facts.MethodAttributes.HasFlag MethodAttributes.RTSpecialName
+
+        let hasNullaryVoidSignature (method : MethodInfo<_, _, _>) : bool =
+            method.Signature.ParameterTypes.IsEmpty
+            && method.Signature.GenericParameterCount = 0
+            && method.Signature.Header.Get.CallingConvention = System.Reflection.Metadata.SignatureCallingConvention.Default
+            && method.Signature.ReturnType = MethodReturnType.Void
+
+        // The rejections above are not optional colour. This function classifies *on* the
+        // RTSpecialName flag, and that classification is only unambiguous because CoreCLR refuses
+        // to load the shapes that would make it ambiguous. Skipping them would hand out a slot
+        // layout for a type the real runtime declines to build a MethodTable for, and every number
+        // derived from it would then describe a type that cannot exist -- the same reason
+        // `vtableOfClosed` refuses a non-newslot virtual that matches a `final` parent slot.
+        for method, facts in declared do
+            if isRuntimeSpecialName facts then
+                if method.IsVirtual then
+                    failwith
+                        $"%s{operation}: method %s{method.Name} on %O{concreteTypeInfo} is marked RTSpecialName and virtual; CoreCLR rejects the type at load time (methodtablebuilder.cpp:5001-5004) rather than laying out a method table for it"
+
+                if method.IsStatic then
+                    if method.Name <> ".cctor" || not (hasNullaryVoidSignature method) then
+                        failwith
+                            $"%s{operation}: static method %s{method.Name} on %O{concreteTypeInfo} is marked RTSpecialName but is not exactly `static void .cctor()`; CoreCLR rejects the type at load time (methodtablebuilder.cpp:5011-5019) rather than laying out a method table for it"
+                else if method.Name <> ".ctor" then
+                    failwith
+                        $"%s{operation}: instance method %s{method.Name} on %O{concreteTypeInfo} is marked RTSpecialName but is not named `.ctor`; CoreCLR rejects the type at load time (methodtablebuilder.cpp:5023-5026) rather than laying out a method table for it"
+                elif method.Signature.ReturnType <> MethodReturnType.Void then
+                    failwith
+                        $"%s{operation}: constructor on %O{concreteTypeInfo} does not return void; CoreCLR rejects the type at load time (methodtablebuilder.cpp:5028-5037) rather than laying out a method table for it"
+
+        let isClassConstructor ((method, facts) : MethodInfo<_, _, _> * MetadataMethodFacts) : bool =
+            isRuntimeSpecialName facts
+            && method.IsStatic
+            && method.Name = ".cctor"
+            && hasNullaryVoidSignature method
+
+        let isDefaultConstructor ((method, facts) : MethodInfo<_, _, _> * MetadataMethodFacts) : bool =
+            isRuntimeSpecialName facts
+            && not method.IsStatic
+            && method.Name = ".ctor"
+            && hasNullaryVoidSignature method
+
+        // Steps 1 and 2: the class constructor, then the parameterless instance constructor, ahead
+        // of everything else whatever their MethodDef rows say. Upstream places them first because
+        // `MethodTable::GetCCtorSlot` and `GetDefaultCtorSlot` are *defined* as those two positions.
+        // `System.Type` is the corpus witness for both halves at once: it declares its `.cctor` at
+        // row 2639, its default ctor at row 2438, and other methods from row 2431, so it
+        // discriminates cctor-before-ctor *and* ctor-before-row-order. `Lazy`1` is the witness that
+        // the rule still holds on a generic type, where every other method is placed in the first
+        // pass below and could otherwise have swallowed the ctors with it.
+        let placedFirst =
+            (unplaced |> List.filter isClassConstructor)
+            @ (unplaced |> List.filter isDefaultConstructor)
+
+        let stillUnplaced =
+            unplaced
+            |> List.filter (fun candidate -> not (isClassConstructor candidate || isDefaultConstructor candidate))
+
+        // Steps 3 and 4: two passes, each in row order. Upstream's vocabulary for them is worth
+        // knowing, because it cuts across the name of this function: the first pass places methods
+        // that need a *real vtable slot* and freezes `bmtVT->cVtableSlots` after itself, so only
+        // pass-2 methods are what CoreCLR calls "non-vtable slots". Both regions are past
+        // `GetNumVirtuals` and both are returned here. The boundary between them is deliberately
+        // not exposed -- nothing PawPrint models reads `cVtableSlots` -- and the split is modelled
+        // only because it decides the numbering.
+        //
+        // `fCanHaveNonVtableSlots` is false for a generic type and for an interface, so both place
+        // everything in the first pass and leave the second empty. `mcInstantiated` is exactly "the
+        // signature carries `IMAGE_CEE_CS_CALLCONV_GENERIC`" (methodtablebuilder.cpp:2794, 3235-3238):
+        // the delegate and P/Invoke arms are tried first, but a generic method reaching one of them
+        // is rejected outright by the `BFA_GENERIC_METHODS_INST` guard at :3273, so on a loadable
+        // image the two coincide. `GenericParameterCount` is read from the same signature blob
+        // rather than from the GenericParam rows, so this is that predicate and not a proxy for it.
+        //
+        // So on a non-generic class a generic method is numbered *ahead* of a non-generic one
+        // declared earlier: `System.Version` puts its four generic methods at slots 12-15 and starts
+        // everything else at 16, though its lowest-numbered row is among the latter.
+        let canHaveNonVtableSlots =
+            concreteTypeInfo.Generics.IsEmpty && not typeInfo.IsInterface
+
+        let needsRealSlot ((method, _) : MethodInfo<_, _, _> * MetadataMethodFacts) : bool =
+            not canHaveNonVtableSlots || method.Signature.GenericParameterCount > 0
+
+        let realSlots, rest = stillUnplaced |> List.partition needsRealSlot
+
+        placedFirst @ realSlots @ rest
+        |> List.map (fun (method, _) ->
+            {
+                VtableSlot.Method = method
+                // Slots beyond the vtable are never inherited, so the declaring type is always this
+                // one -- unlike a vtable slot, which routinely still holds a base type's method.
+                VtableSlot.DeclaredBy = concreteTypeInfo
+            }
+        )
+
+    /// A closed type's whole method table, as CoreCLR's `bmtVT->pSlotTable`: the vtable proper,
+    /// followed by the region `PlaceNonVirtualMethods` fills. Slot numbers run across the two
+    /// without a break, and `cVirtualSlots` -- `MethodTable::GetNumVirtuals()` -- is the length of
+    /// the first.
+    ///
+    /// Kept as two lists rather than one, with `slotIndexInTable` owning the arithmetic that joins
+    /// them, because the two halves answer different questions and the BCL asks both: `GetSlot`
+    /// indexes the concatenation while `GetNumVirtuals` is the prefix length, and
+    /// `PopulateProperties` *compares* the two to decide whether an accessor is virtual. A single
+    /// flat list would lose the boundary the comparison is about; making the caller add an offset
+    /// would put the one piece of arithmetic in this change at the call site.
+    ///
+    /// The second field is named for the boundary rather than for virtualness on purpose: it holds
+    /// every `static virtual` the type declares, those being placed outside the vtable, so calling
+    /// it "non-virtual" would be false of its contents.
+    type MethodSlotTable =
+        {
+            /// Slots `0 .. Vtable.Length - 1`. This length is `MethodTable::GetNumVirtuals()`.
+            Vtable : VtableSlot list
+            /// Slots `Vtable.Length` upwards.
+            BeyondVtable : VtableSlot list
+        }
+
+    let slotTableOfClosed
+        (loggerFactory : ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (operation : string)
+        (state : IlMachineState)
+        (concreteType : ConcreteTypeHandle)
+        : IlMachineState * MethodSlotTable
+        =
+        // Only the vtable walk recurses through the base chain; the region beyond it is this type's
+        // alone, so it is computed once here rather than once per ancestor and discarded.
+        let state, virtualSlots =
+            vtableOfClosed loggerFactory baseClassTypes operation state concreteType
+
+        match concreteType with
+        | ConcreteTypeHandle.Byref _
+        | ConcreteTypeHandle.Pointer _
+        | ConcreteTypeHandle.FunctionPointer _ ->
+            // TypeDescs with no MethodTable, so genuinely no slots of either kind -- the same
+            // reason `vtableOfClosed` gives them an empty vtable.
+            state,
+            {
+                MethodSlotTable.Vtable = virtualSlots
+                MethodSlotTable.BeyondVtable = []
+            }
+        | ConcreteTypeHandle.OneDimArrayZero _
+        | ConcreteTypeHandle.Array _ ->
+            // A synthesised array MethodTable really does carry slots beyond its vtable, for the
+            // intrinsic Get/Set/Address and the ctor, and PawPrint models none of them --
+            // `introducedMethodsOfClosed` refuses the same question for the same reason. Answering
+            // "none" would be a wrong answer rather than an absent one, so refuse. Unreachable from
+            // `GetSlot` today: a method handle always resolves to a `Concrete` declaring type, there
+            // being no way to mint one naming an array intrinsic.
+            failwith
+                $"TODO: %s{operation} for synthesised array handle %O{concreteType}; the array intrinsic methods (Get/Set/Address/.ctor) occupy slots beyond the vtable that PawPrint does not model"
+        | ConcreteTypeHandle.Concrete _ ->
+            let concreteTypeInfo, typeInfo =
+                IlMachineState.tryGetConcreteTypeInfo state concreteType
+                |> Option.defaultWith (fun () ->
+                    failwith $"%s{operation}: concrete type handle was not registered: %O{concreteType}"
+                )
+
+            state,
+            {
+                MethodSlotTable.Vtable = virtualSlots
+                MethodSlotTable.BeyondVtable = slotsBeyondVtableOfClosed operation concreteTypeInfo typeInfo
+            }
+
     /// What identifies a vtable slot's occupant well enough to find it again: the full name of the
     /// assembly that declares the method, paired with the method's within-assembly identity.
     ///
@@ -1214,6 +1461,26 @@ module NativeRuntimeTypeHelpers =
         : int option
         =
         slotIdentities |> List.tryFindIndex (fun identity -> identity = target)
+
+    /// The slot CoreCLR assigns a method in its declaring type's method table -- `MethodDesc::GetSlot`
+    /// -- or `None` if the method holds no slot there at all.
+    ///
+    /// The one place the two halves of a `MethodSlotTable` are joined into a single numbering, which
+    /// is the point of routing every query through here rather than letting callers add the offset.
+    ///
+    /// `None` is not "not virtual": every method a type declares in metadata occupies a slot, in one
+    /// half or the other. It means the method is not this type's at all -- a synthesised method,
+    /// which has no MethodDef row and so is never placed, or a lookup against the wrong type.
+    let slotIndexInTable
+        (target : string * (System.Reflection.Metadata.MethodDefinitionHandle option * SynthesisedMethod option))
+        (table : MethodSlotTable)
+        : int option
+        =
+        match slotIndexOfIdentity target (table.Vtable |> List.map slotIdentity) with
+        | Some index -> Some index
+        | None ->
+            slotIndexOfIdentity target (table.BeyondVtable |> List.map slotIdentity)
+            |> Option.map (fun index -> List.length table.Vtable + index)
 
     /// The size of the instance vtable for a closed type, matching CoreCLR's
     /// `MethodTable::GetNumVirtuals()`. This is the length of `vtableOfClosed` by definition rather

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
@@ -944,6 +944,73 @@ module NativeRuntimeTypeHelpers =
 
         state, (candidateParams = slotParams && candidateRet = slotRet)
 
+    /// The methods of a type that CoreCLR's `DeclaredMethodIterator` ranges over, paired with their
+    /// metadata facts. Both halves of the method table are laid out from this one list, so that
+    /// neither can disagree with the other about what the type declares.
+    ///
+    /// Two kinds of row are absent from it.
+    ///
+    /// A *synthesised* method has no MethodDef row, so it is not a declared method at all. The
+    /// vtable walk excludes them only incidentally (a synthesised method is never `IsVirtual`);
+    /// beyond the vtable the exclusion is load-bearing, because such a method *is* non-virtual and
+    /// placing it would shift every later method's slot number by one. No test covers this and none
+    /// can: nothing today puts a synthesised method into a `TypeInfo` (the construction sites in
+    /// `Program.buildStartupFrame` and `StructMarshalStub` both build one for immediate execution),
+    /// so the filter is a no-op on every image that exists. It is kept because `TypeInfo.Methods` is
+    /// typed to hold either kind.
+    ///
+    /// A COM *vtable-gap marker* names empty slots in the COM interface vtable rather than declaring
+    /// a method. `EnumerateClassMethods` recognises it by `IsMdRTSpecialName` plus a `_VtblGap` name
+    /// prefix (methodtablebuilder.cpp:2749, corhdr.h:265-270) and `continue`s before it reaches
+    /// `rgDeclaredMethods` (:2852-2921), recording the run length in a `SparseVTableMap` that only
+    /// `FEATURE_COMINTEROP` reads -- so it occupies no slot in the CLR method table, virtual or
+    /// otherwise. Dropping it here rather than in one walk alone is the point: tlbimp emits these as
+    /// `virtual abstract` members of an interface, so a filter applied only past the vtable would
+    /// leave the *vtable* inflated by one slot per gap, which moves `GetNumVirtuals` and with it the
+    /// origin of everything after it.
+    ///
+    /// The name grammar is `_VtblGap` + optional digits + optionally `_` and at least one digit,
+    /// and CoreCLR throws `BadImageFormatException` for anything else (:2865-2907) rather than
+    /// treating it as an ordinary method -- so a prefix match alone would accept images the runtime
+    /// rejects.
+    let private declaredMethodsOf
+        (operation : string)
+        (concreteTypeInfo : ConcreteType<ConcreteTypeHandle>)
+        (typeInfo : TypeInfo<GenericParamFromMetadata, TypeDefn>)
+        : (MethodInfo<GenericParamFromMetadata, GenericParamFromMetadata, TypeDefn> * MetadataMethodFacts) list
+        =
+        // `_VtblGap`, then the optional-number/count grammar upstream parses.
+        let isWellFormedGapName (name : string) : bool =
+            let suffix = name.Substring "_VtblGap".Length
+            let afterLeadingDigits = suffix.TrimStart [| '0' .. '9' |]
+
+            if afterLeadingDigits = "" then
+                // "_VtblGap" or "_VtblGap<n>": a single empty slot, or the count-less form.
+                true
+            elif afterLeadingDigits.[0] <> '_' then
+                false
+            else
+                let count = afterLeadingDigits.Substring 1
+                count <> "" && count |> Seq.forall System.Char.IsAsciiDigit
+
+        typeInfo.Methods
+        |> List.choose (fun method ->
+            match method.TryMetadata with
+            | None -> None
+            | Some facts ->
+                if
+                    facts.MethodAttributes.HasFlag MethodAttributes.RTSpecialName
+                    && method.Name.StartsWith ("_VtblGap", System.StringComparison.Ordinal)
+                then
+                    if not (isWellFormedGapName method.Name) then
+                        failwith
+                            $"%s{operation}: method %s{method.Name} on %O{concreteTypeInfo} is marked RTSpecialName and begins `_VtblGap`, but the rest of the name is not the vtable-gap count grammar; CoreCLR rejects the type at load time with a BadImageFormatException (methodtablebuilder.cpp:2865-2907) rather than laying out a method table for it"
+
+                    None
+                else
+                    Some (method, facts)
+        )
+
     /// The instance vtable of a closed type, base-first: index `i` is the method that currently
     /// occupies slot `i`. A type inherits its base's layout, replaces the entries its own
     /// non-newslot virtuals override, and appends a slot for each `newslot` virtual it introduces.
@@ -1007,11 +1074,14 @@ module NativeRuntimeTypeHelpers =
                 | None -> state, []
                 | Some bh -> vtableOfClosed loggerFactory baseClassTypes operation state bh
 
-            // A synthesised method occupies no vtable slot and overrides nothing, so `IsVirtual`
-            // and `IsNewSlot` are both false for one; the filter below excludes them structurally.
+            // Shared with the walk past the vtable, so that the two cannot disagree about what the
+            // type declares -- see `declaredMethodsOf` for what it drops and why. Upstream's
+            // `PlaceVirtualMethods` takes exactly the declared *instance* virtuals from that same
+            // list; a `static virtual` is placed past the vtable instead.
             let instanceVirtuals =
-                typeInfo.Methods
-                |> List.filter (fun method -> not method.IsStatic && method.IsVirtual)
+                declaredMethodsOf operation concreteTypeInfo typeInfo
+                |> List.filter (fun (method, _) -> not method.IsStatic && method.IsVirtual)
+                |> List.map fst
 
             // Upstream is a single pass over the declared methods in MethodDef row order
             // (`DeclaredMethodIterator` over the array `EnumerateClassMethods` fills in row order),
@@ -1229,41 +1299,12 @@ module NativeRuntimeTypeHelpers =
         (typeInfo : TypeInfo<GenericParamFromMetadata, TypeDefn>)
         : VtableSlot list
         =
-        // `DeclaredMethodIterator` ranges over the type's MethodDef rows, so a *synthesised* method
-        // is not a candidate for a slot at all. `vtableOfClosed` excludes them only incidentally
-        // (a synthesised method is never `IsVirtual`); here the exclusion must be deliberate,
-        // because a synthesised method *is* non-virtual and would otherwise be placed -- shifting
-        // every genuine method after it by one, and so making every slot number this function hands
-        // out wrong rather than merely adding one spurious entry.
-        //
-        // No test covers this, and none can: nothing today puts a synthesised method into a
-        // `TypeInfo` (the two construction sites, in `Program.buildStartupFrame` and
-        // `StructMarshalStub`, both build one for immediate execution), so the filter is a no-op on
-        // every image that exists. It is kept because `TypeInfo.Methods` is typed to hold either
-        // kind, so the day one is inserted is the day every slot number silently moves.
-        let declared =
-            typeInfo.Methods
-            |> List.choose (fun method ->
-                match method.TryMetadata with
-                | None -> None
-                | Some facts -> Some (method, facts)
-            )
-            // A COM vtable-gap marker is a MethodDef row that names empty slots in the *COM*
-            // interface vtable rather than declaring a method. `EnumerateClassMethods` recognises it
-            // by `IsMdRTSpecialName` plus a `_VtblGap` name prefix (methodtablebuilder.cpp:2749,
-            // corhdr.h:265-270) and `continue`s before it ever reaches `rgDeclaredMethods`
-            // (:2852-2921), recording the run length in a `SparseVTableMap` that only
-            // `FEATURE_COMINTEROP` reads. So it consumes no slot in the method table and is not a
-            // declared method at all -- dropping it here is what agrees with upstream, both for the
-            // validation below (which would otherwise see a runtime-special-named method that is
-            // not a constructor, and wrongly report that CoreCLR rejects the type) and for the
-            // placement (which would otherwise shift every later method by one).
-            |> List.filter (fun (method, facts) ->
-                not (
-                    facts.MethodAttributes.HasFlag MethodAttributes.RTSpecialName
-                    && method.Name.StartsWith ("_VtblGap", System.StringComparison.Ordinal)
-                )
-            )
+        // The same list the vtable walk is laid out from, so the two cannot disagree about what the
+        // type declares; `declaredMethodsOf` documents which rows it drops and why. In particular a
+        // vtable-gap marker never reaches the validation below, which would otherwise see a
+        // runtime-special-named method that is not a constructor and wrongly report that CoreCLR
+        // rejects the type.
+        let declared = declaredMethodsOf operation concreteTypeInfo typeInfo
 
         // `PlaceVirtualMethods` places exactly the declared *instance* virtuals, so everything else
         // is still unplaced when `PlaceNonVirtualMethods` runs. A `static virtual` -- an interface

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
@@ -1248,6 +1248,22 @@ module NativeRuntimeTypeHelpers =
                 | None -> None
                 | Some facts -> Some (method, facts)
             )
+            // A COM vtable-gap marker is a MethodDef row that names empty slots in the *COM*
+            // interface vtable rather than declaring a method. `EnumerateClassMethods` recognises it
+            // by `IsMdRTSpecialName` plus a `_VtblGap` name prefix (methodtablebuilder.cpp:2749,
+            // corhdr.h:265-270) and `continue`s before it ever reaches `rgDeclaredMethods`
+            // (:2852-2921), recording the run length in a `SparseVTableMap` that only
+            // `FEATURE_COMINTEROP` reads. So it consumes no slot in the method table and is not a
+            // declared method at all -- dropping it here is what agrees with upstream, both for the
+            // validation below (which would otherwise see a runtime-special-named method that is
+            // not a constructor, and wrongly report that CoreCLR rejects the type) and for the
+            // placement (which would otherwise shift every later method by one).
+            |> List.filter (fun (method, facts) ->
+                not (
+                    facts.MethodAttributes.HasFlag MethodAttributes.RTSpecialName
+                    && method.Name.StartsWith ("_VtblGap", System.StringComparison.Ordinal)
+                )
+            )
 
         // `PlaceVirtualMethods` places exactly the declared *instance* virtuals, so everything else
         // is still unplaced when `PlaceNonVirtualMethods` runs. A `static virtual` -- an interface
@@ -1276,9 +1292,19 @@ module NativeRuntimeTypeHelpers =
         let isRuntimeSpecialName (facts : MetadataMethodFacts) : bool =
             facts.MethodAttributes.HasFlag MethodAttributes.RTSpecialName
 
+        // "The signature carries `IMAGE_CEE_CS_CALLCONV_GENERIC`", which is the bit
+        // `EnumerateClassMethods` reads to decide `hasGenericMethodArgs`
+        // (methodtablebuilder.cpp:2794) -- *not* "the encoded generic arity is positive". ECMA-335
+        // requires that arity to be at least 1 when the bit is set, so the two agree on every valid
+        // image and no test here distinguishes them; on an invalid-but-loadable one with the bit set
+        // and a count of zero, CoreCLR goes by the bit, and the method's pass below would differ.
+        // Spelled the faithful way because it costs nothing, not because anything has measured it.
+        let isGenericSignature (method : MethodInfo<_, _, _>) : bool =
+            method.Signature.Header.Get.Attributes.HasFlag System.Reflection.Metadata.SignatureAttributes.Generic
+
         let hasNullaryVoidSignature (method : MethodInfo<_, _, _>) : bool =
             method.Signature.ParameterTypes.IsEmpty
-            && method.Signature.GenericParameterCount = 0
+            && not (isGenericSignature method)
             && method.Signature.Header.Get.CallingConvention = System.Reflection.Metadata.SignatureCallingConvention.Default
             && method.Signature.ReturnType = MethodReturnType.Void
 
@@ -1289,6 +1315,15 @@ module NativeRuntimeTypeHelpers =
         // derived from it would then describe a type that cannot exist -- the same reason
         // `vtableOfClosed` refuses a non-newslot virtual that matches a `final` parent slot.
         for method, facts in declared do
+            // A `static virtual` is legal only on an interface, and must be abstract there
+            // (`ValidateMethods`, methodtablebuilder.cpp:5124-5131). On a class or value type
+            // CoreCLR throws `IDS_CLASSLOAD_STATICVIRTUAL`. Without this the method would simply
+            // be placed past the vtable, since `PlaceVirtualMethods` skips it for being static --
+            // handing out a layout for a type the real runtime will not build one for.
+            if method.IsStatic && method.IsVirtual && not typeInfo.IsInterface then
+                failwith
+                    $"%s{operation}: method %s{method.Name} on %O{concreteTypeInfo} is both static and virtual, which is legal only on an interface; CoreCLR rejects the type at load time (methodtablebuilder.cpp:5124-5131) rather than laying out a method table for it"
+
             if isRuntimeSpecialName facts then
                 if method.IsVirtual then
                     failwith
@@ -1356,7 +1391,7 @@ module NativeRuntimeTypeHelpers =
             concreteTypeInfo.Generics.IsEmpty && not typeInfo.IsInterface
 
         let needsRealSlot ((method, _) : MethodInfo<_, _, _> * MetadataMethodFacts) : bool =
-            not canHaveNonVtableSlots || method.Signature.GenericParameterCount > 0
+            not canHaveNonVtableSlots || isGenericSignature method
 
         let realSlots, rest = stillUnplaced |> List.partition needsRealSlot
 

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeHelpers.fs
@@ -1444,13 +1444,26 @@ module NativeRuntimeTypeHelpers =
         // discriminates cctor-before-ctor *and* ctor-before-row-order. `Lazy`1` is the witness that
         // the rule still holds on a generic type, where every other method is placed in the first
         // pass below and could otherwise have swallowed the ctors with it.
+        //
+        // At most *one* row is hoisted for each. `ValidateMethods` records them by plain assignment
+        // inside its loop -- `bmtVT->pCCtor = *it` (methodtablebuilder.cpp:5019) and
+        // `bmtVT->pDefaultCtor = *it` (:5042) -- so when a type declares the same constructor twice,
+        // which ECMA-335 II.22.26 forbids but CoreCLR loads anyway, the *last* matching row wins and
+        // the earlier ones are placed in the ordinary pass like any other method. Measured: a type
+        // with `Plain` then two identical `.ctor()` rows gives the last `.ctor` slot 4 and leaves the
+        // earlier one at slot 6, *after* `Plain`. Hoisting both would move everything after them.
+        let lastMatching (predicate : MethodInfo<_, _, _> * MetadataMethodFacts -> bool) =
+            unplaced |> List.filter predicate |> List.tryLast
+
         let placedFirst =
-            (unplaced |> List.filter isClassConstructor)
-            @ (unplaced |> List.filter isDefaultConstructor)
+            [ lastMatching isClassConstructor ; lastMatching isDefaultConstructor ]
+            |> List.choose id
+
+        let hoisted = placedFirst |> List.map (fun (method, _) -> method.IdentityKey)
 
         let stillUnplaced =
             unplaced
-            |> List.filter (fun candidate -> not (isClassConstructor candidate || isDefaultConstructor candidate))
+            |> List.filter (fun (method, _) -> not (hoisted |> List.contains method.IdentityKey))
 
         // Steps 3 and 4: two passes, each in row order. Upstream's vocabulary for them is worth
         // knowing, because it cuts across the name of this function: the first pass places methods


### PR DESCRIPTION
Implements `MethodTableBuilder::PlaceNonVirtualMethods` — the region of a type's method table that
follows its vtable — so `RuntimeMethodHandle::GetSlot` can answer for a method that occupies no
vtable slot.

`RuntimeType.PopulateProperties` (RuntimeType.CoreCLR.cs:1358) calls `GetSlot` on a property's
accessor with **no `Virtual` guard**, then tests `slot < numVirtuals`. An F# union's case fields are
read through ordinary non-virtual getters, so it reached a method with no vtable slot and
`vtableOfClosed`'s lookup returned `None`.

## The rule

Slot numbers come from one counter shared with the vtable (`AddNonVirtualMethod` assigns
`pSlotTable->GetSlotCount()`), and `CopyParentVtable` stops at the parent's `GetNumVirtuals()`, so a
type's region past the vtable begins at exactly its own. Upstream machine-checks that premise:
`PlaceNonVirtualMethods` opens with `INDEBUG(SealVirtualSlotSection())`.

The order is **not** MethodDef row order:

1. the `.cctor`;
2. the parameterless instance ctor — both first because `GetCCtorSlot`/`GetDefaultCtorSlot` are
   *defined* as those positions;
3. everything needing a "real" slot, in row order (all of it on a generic type or an interface;
   otherwise just the generic methods);
4. the rest, in row order.

Measured against the host CLR's own `RuntimeMethodHandle.GetSlot` before writing any of it:

| corpus | types | methods | disagreements |
|---|---|---|---|
| System.Private.CoreLib | 2336 | 31064 | **0** |
| FSharp.Core | 1153 | 5499 | **0** |
| closed generic instantiations | 19 | 352 | **0** |

`System.Version` is the worked example: slot 11 is `.ctor()` at row 10657 — not its lowest row —
slots 12-15 are its four generic methods, and everything else starts at 16.

## Design

`GetSlot` now asks `slotTableOfClosed`, which returns `{ Vtable ; BeyondVtable }` with
`slotIndexInTable` owning the arithmetic that joins them. `GetNumVirtuals` is untouched, being the
first list's length.

Two lists rather than one because the BCL asks both questions and *compares* the answers; a flat list
would lose the boundary the comparison is about. The offset lives inside the structure rather than at
the call site — the same reasoning that made #945 carry inherited and fresh vtable slots separately.
The second field is named for the boundary, not for virtualness, because it holds every `static
virtual` the type declares.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
