### PR TITLE
Read non-array heap objects through accessors

### DIFF
--- a/WoofWare.PawPrint.Test/TestManagedHeap.fs
+++ b/WoofWare.PawPrint.Test/TestManagedHeap.fs
@@ -1005,3 +1005,87 @@ module TestManagedHeap =
             )
 
         dangling.Message |> shouldContainText "not a live managed heap allocation"
+
+    // ---------------------------------------------------------------------
+    // Non-array reads.
+    //
+    // `tryGet` / `get` / `isLive` are the read half of the non-array seam,
+    // the counterparts of `tryGetArrayShape` / `getArrayShape` / `isArray`.
+    // Before them, seventeen sites indexed `NonArrayObjects` directly, so a
+    // read of a guest object was not an identifiable event and the
+    // "array" / "never allocated" distinction was open-coded where it was
+    // made at all.
+    // ---------------------------------------------------------------------
+
+    [<Test>]
+    let ``tryGet answers only for non-array objects`` () : unit =
+        // Deliberately `None` for a live array rather than throwing: an array has no
+        // `AllocatedNonArrayObject` payload at all, so "not here" is the honest answer, and
+        // callers that care which it is have `isArray` next door.
+        let objAddr, heap = ManagedHeap.allocateNonArray stubNonArray ManagedHeap.empty
+        let arrAddr, heap = ManagedHeap.allocateArray (stubArray 3) heap
+
+        (ManagedHeap.tryGet objAddr heap).IsSome |> shouldEqual true
+        ManagedHeap.tryGet arrAddr heap |> shouldEqual None
+        ManagedHeap.tryGet (ManagedHeapAddress 99) heap |> shouldEqual None
+
+    [<Test>]
+    let ``get fails loudly, and distinguishably, for an array and for a dangling address`` () : unit =
+        // Same discrimination as `getArrayShape`, and for the same reason: an array address
+        // means the caller misjudged the kind of reference it holds, whereas an unallocated
+        // address means the reference itself is bogus. This used to be a bare
+        // `KeyNotFoundException` from indexing the map, which distinguished neither.
+        let arrAddr, heap = ManagedHeap.allocateArray (stubArray 1) ManagedHeap.empty
+
+        let isArray =
+            Assert.Throws<System.Exception> (fun () -> ManagedHeap.get arrAddr heap |> ignore)
+
+        isArray.Message |> shouldContainText "is an array"
+
+        let dangling =
+            Assert.Throws<System.Exception> (fun () -> ManagedHeap.get (ManagedHeapAddress 99) heap |> ignore)
+
+        dangling.Message |> shouldContainText "not a live managed heap allocation"
+
+    [<Test>]
+    let ``isLive covers both payload kinds, and nothing else`` () : unit =
+        let objAddr, heap = ManagedHeap.allocateNonArray stubNonArray ManagedHeap.empty
+        let arrAddr, heap = ManagedHeap.allocateArray (stubArray 2) heap
+
+        ManagedHeap.isLive objAddr heap |> shouldEqual true
+        ManagedHeap.isLive arrAddr heap |> shouldEqual true
+        ManagedHeap.isLive (ManagedHeapAddress 99) heap |> shouldEqual false
+
+    [<Test>]
+    let ``isLive agrees with the object-header key set`` () : unit =
+        // An independent oracle for `isLive`, which is computed from the two *payload* maps.
+        // `SyncBlocks`' documented invariant is that its key set is exactly their union, so
+        // the header table answers the same question by a different route. Keeping the two
+        // routes separate is deliberate: had `isLive` been implemented on `SyncBlocks`, this
+        // would be a tautology instead of a check, and a broken invariant would show up as a
+        // wrong liveness answer rather than a failing test.
+        let property (ops : bool list) : bool =
+            let ops = ops |> List.truncate 12
+
+            let heap =
+                ops
+                |> List.fold
+                    (fun heap isArray ->
+                        if isArray then
+                            ManagedHeap.allocateArray (stubArray 1) heap |> snd
+                        else
+                            ManagedHeap.allocateNonArray stubNonArray heap |> snd
+                    )
+                    ManagedHeap.empty
+
+            // Probe past the end too, so a always-true implementation fails.
+            [ 1 .. ops.Length + 3 ]
+            |> List.forall (fun addr ->
+                let addr = ManagedHeapAddress addr
+                ManagedHeap.isLive addr heap = heap.SyncBlocks.ContainsKey addr
+            )
+
+        Check.One (
+            Config.QuickThrowOnFailure.WithMaxTest 200,
+            Prop.forAll (ArbMap.defaults |> ArbMap.arbitrary) property
+        )

--- a/WoofWare.PawPrint/AbstractMachine.fs
+++ b/WoofWare.PawPrint/AbstractMachine.fs
@@ -176,7 +176,7 @@ module AbstractMachine =
                 | CliType.ObjectRef (Some addr) -> addr
                 | _ -> failwith "expected a managed object ref to delegate"
 
-            let delegateToRun = state.ManagedHeap.NonArrayObjects.[delegateToRunAddr]
+            let delegateToRun = ManagedHeap.get delegateToRunAddr state.ManagedHeap
 
             let delegateTypeHandle =
                 AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes baseClassTypes.DelegateType

--- a/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
+++ b/WoofWare.PawPrint/IlMachineRuntimeMetadata.fs
@@ -921,7 +921,7 @@ module IlMachineRuntimeMetadata =
         : IlMachineState
         =
         match
-            state.ManagedHeap.NonArrayObjects |> Map.tryFind exceptionAddr,
+            ManagedHeap.tryGet exceptionAddr state.ManagedHeap,
             AllConcreteTypes.findExistingNonGenericConcreteType state.ConcreteTypes baseClassTypes.Exception.Identity
         with
         | Some _, Some exceptionHandle ->
@@ -958,7 +958,7 @@ module IlMachineRuntimeMetadata =
             // Low-level dispatch tests sometimes use synthetic exception addresses in skeletal states.
             // Full guest execution has both pieces, so only then can we project into the managed object.
             match
-                state.ManagedHeap.NonArrayObjects |> Map.tryFind exceptionAddr,
+                ManagedHeap.tryGet exceptionAddr state.ManagedHeap,
                 AllConcreteTypes.findExistingNonGenericConcreteType
                     state.ConcreteTypes
                     baseClassTypes.Exception.Identity
@@ -1010,7 +1010,7 @@ module IlMachineRuntimeMetadata =
         : ManagedHeapAddress option
         =
         let exceptionObj =
-            match state.ManagedHeap.NonArrayObjects |> Map.tryFind exceptionAddr with
+            match ManagedHeap.tryGet exceptionAddr state.ManagedHeap with
             | Some obj -> obj
             | None ->
                 failwith
@@ -1103,7 +1103,7 @@ module IlMachineRuntimeMetadata =
         // Mirrors `setExceptionStackTraceString`: skeletal states in low-level dispatch tests may
         // lack either piece, and there is nothing to project into in that case.
         match
-            state.ManagedHeap.NonArrayObjects |> Map.tryFind exceptionAddr,
+            ManagedHeap.tryGet exceptionAddr state.ManagedHeap,
             AllConcreteTypes.findExistingNonGenericConcreteType state.ConcreteTypes baseClassTypes.Exception.Identity
         with
         | Some _, Some exceptionHandle ->

--- a/WoofWare.PawPrint/IlMachineThreadState.fs
+++ b/WoofWare.PawPrint/IlMachineThreadState.fs
@@ -219,14 +219,14 @@ module IlMachineThreadState =
                 // This ctor was constructing a runtime-synthesised exception object.
                 // Don't push it onto the eval stack; signal to the caller that exception
                 // dispatch should occur.
-                let constructed = state.ManagedHeap.NonArrayObjects.[constructing]
+                let constructed = ManagedHeap.get constructing state.ManagedHeap
                 ReturnFrameResult.DispatchException (state, constructing, constructed.ConcreteType, message)
             | ConstructedObjectDisposition.PushToCaller ->
 
             // Assumption: a constructor can't also return a value.
             // If we were constructing a reference type, we push a reference to it.
             // Otherwise, extract the now-complete object from the heap and push it to the stack directly.
-            let constructed = state.ManagedHeap.NonArrayObjects.[constructing]
+            let constructed = ManagedHeap.get constructing state.ManagedHeap
 
             let _, ty' =
                 AllConcreteTypes.tryTypeInfo state._LoadedAssemblies state.ConcreteTypes constructed.ConcreteType
@@ -700,7 +700,7 @@ module IlMachineThreadState =
         match state.ManagedHeap.Arrays.TryGetValue source with
         | false, _ ->
             let what =
-                if state.ManagedHeap.NonArrayObjects.ContainsKey source then
+                if (ManagedHeap.tryGet source state.ManagedHeap).IsSome then
                     "a non-array object"
                 else
                     "not allocated"
@@ -731,8 +731,8 @@ module IlMachineThreadState =
     /// The clone gets a fresh address, so it has its own identity for reference equality, for the
     /// synthesised pointer hash, and for monitors.
     let cloneObject (source : ManagedHeapAddress) (state : IlMachineState) : ManagedHeapAddress * IlMachineState =
-        match state.ManagedHeap.NonArrayObjects.TryGetValue source with
-        | true, sourceObj ->
+        match ManagedHeap.tryGet source state.ManagedHeap with
+        | Some sourceObj ->
             // `StringContents` is keyed by heap address, so a cloned string would land at a fresh
             // address with no character data behind it. Nothing can reach that: `MemberwiseClone`
             // is `protected internal`, `System.String` is sealed and never calls it, and PawPrint
@@ -750,7 +750,7 @@ module IlMachineThreadState =
                 }
 
             alloc, state
-        | false, _ ->
+        | None ->
 
         // `Array.Clone`'s managed body is `MemberwiseClone()`, so arrays are in scope even though
         // PawPrint intercepts `Array.Clone` itself and nothing can derive from `System.Array`.

--- a/WoofWare.PawPrint/IntrinsicHelpers.fs
+++ b/WoofWare.PawPrint/IntrinsicHelpers.fs
@@ -930,7 +930,7 @@ module internal IntrinsicHelpers =
             match wasConstructing with
             | ConstructionState.NotConstructing -> state
             | ConstructionState.Constructing constructing ->
-                let constructed = state.ManagedHeap.NonArrayObjects.[constructing]
+                let constructed = ManagedHeap.get constructing state.ManagedHeap
 
                 state
                 |> IlMachineState.pushToEvalStack (CliType.ValueType constructed.Contents) currentThread

--- a/WoofWare.PawPrint/ManagedHeap.fs
+++ b/WoofWare.PawPrint/ManagedHeap.fs
@@ -384,6 +384,16 @@ module ManagedHeap =
     /// address that was never allocated; use `tryGetObjectConcreteType` to tell those apart.
     let isArray (addr : ManagedHeapAddress) (heap : ManagedHeap) : bool = heap.Arrays.ContainsKey addr
 
+    /// Whether `addr` is a live heap allocation of either kind.
+    ///
+    /// Asked by callers that only need to know a reference points at *something* — the
+    /// object's kind and payload are then somebody else's question. Deliberately derived
+    /// from the two payload maps rather than from `SyncBlocks`, whose key set is documented
+    /// to be their union: that invariant is asserted elsewhere, and an accessor that assumed
+    /// it would turn a broken invariant into a wrong answer instead of a caught one.
+    let isLive (addr : ManagedHeapAddress) (heap : ManagedHeap) : bool =
+        heap.NonArrayObjects.ContainsKey addr || heap.Arrays.ContainsKey addr
+
     /// The dimensions and element type of the array at `addr`, or `None` if `addr` is not
     /// a live array. Carries no cells: see `ArrayShape`.
     let tryGetArrayShape (addr : ManagedHeapAddress) (heap : ManagedHeap) : ArrayShape option =
@@ -425,9 +435,27 @@ module ManagedHeap =
 
         arr.Elements.[offset]
 
+    /// The non-array object at `addr`, or `None` if there is no live non-array object there.
+    /// `None` for a live *array* too — an array has no `AllocatedNonArrayObject` payload;
+    /// `isArray` and `tryGetArrayShape` answer for those.
+    let tryGet (alloc : ManagedHeapAddress) (heap : ManagedHeap) : AllocatedNonArrayObject option =
+        match heap.NonArrayObjects.TryGetValue alloc with
+        | true, v -> Some v
+        | false, _ -> None
+
+    /// The non-array object at `addr`.
+    ///
+    /// The two rejection cases are reported differently for the same reason `getArrayShape`
+    /// separates them: an array address means the caller misjudged the kind of the reference
+    /// it was handed, whereas an unallocated address means the reference itself is bogus.
     let get (alloc : ManagedHeapAddress) (heap : ManagedHeap) : AllocatedNonArrayObject =
-        // TODO: arrays too
-        heap.NonArrayObjects.[alloc]
+        match tryGet alloc heap with
+        | Some v -> v
+        | None ->
+            if heap.Arrays.ContainsKey alloc then
+                failwith $"get: %O{alloc} is an array, so has no non-array object payload"
+            else
+                failwith $"get: %O{alloc} is not a live managed heap allocation"
 
     /// Replace the entire payload of the non-array object at `alloc`. Rejects an address
     /// that is not already a live non-array object rather than conjuring one there:

--- a/WoofWare.PawPrint/Native/NativeThreading.fs
+++ b/WoofWare.PawPrint/Native/NativeThreading.fs
@@ -60,7 +60,7 @@ module NativeThreading =
         |> Map.toSeq
         |> Seq.tryPick (fun (tid, addr) -> if addr = threadAddr then Some tid else None)
         |> Option.defaultWith (fun () ->
-            match state.ManagedHeap.NonArrayObjects |> Map.tryFind threadAddr with
+            match ManagedHeap.tryGet threadAddr state.ManagedHeap with
             | Some _ ->
                 failwith
                     $"%s{operation}: Thread object at {threadAddr} was never Start()ed. The real CLR raises ThreadStateException here; PawPrint doesn't synthesise that yet, so this is a guest bug we can't currently report structurally."

--- a/WoofWare.PawPrint/NullaryIlOp.fs
+++ b/WoofWare.PawPrint/NullaryIlOp.fs
@@ -2687,7 +2687,7 @@ module NullaryIlOp =
 
             // Get exception type from heap object
             let heapObject =
-                match state.ManagedHeap.NonArrayObjects |> Map.tryFind addr with
+                match ManagedHeap.tryGet addr state.ManagedHeap with
                 | Some obj -> obj
                 | None -> failwith "Exception object not found in heap"
 

--- a/WoofWare.PawPrint/RuntimeFieldProjection.fs
+++ b/WoofWare.PawPrint/RuntimeFieldProjection.fs
@@ -121,11 +121,7 @@ module internal RuntimeFieldProjection =
     /// Per-byte safety is enforced when the byref is read or written, so the projection
     /// itself only needs to confirm a heap object exists.
     let private requireHeapObject (addr : ManagedHeapAddress) (state : IlMachineState) : unit =
-        let exists =
-            state.ManagedHeap.NonArrayObjects.ContainsKey addr
-            || ManagedHeap.isArray addr state.ManagedHeap
-
-        if not exists then
+        if not (ManagedHeap.isLive addr state.ManagedHeap) then
             failwith $"RawData::Data projection expected heap object at %O{addr}, but no such object exists"
 
     /// Size of `nint` on the guest. PawPrint targets 64-bit guests exclusively, so this is

--- a/WoofWare.PawPrint/UnaryMetadataFieldOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataFieldOps.fs
@@ -375,13 +375,15 @@ module internal UnaryMetadataFieldOps =
                 match RuntimeFieldProjection.tryProjectFieldLoad baseClassTypes field managedHeapAddress state with
                 | Some value -> IlMachineState.pushToEvalStack value thread state
                 | None ->
-                    match state.ManagedHeap.NonArrayObjects.TryGetValue managedHeapAddress with
-                    | false, _ -> failwith $"todo: array {managedHeapAddress}"
-                    | true, v ->
-                        IlMachineState.pushToEvalStack
-                            (AllocatedNonArrayObject.DereferenceFieldById fieldId v)
-                            thread
-                            state
+                    // `get` discriminates "this is an array" from "this address is not
+                    // allocated at all", which the message this replaces asserted was always
+                    // the former.
+                    IlMachineState.pushToEvalStack
+                        (AllocatedNonArrayObject.DereferenceFieldById
+                            fieldId
+                            (ManagedHeap.get managedHeapAddress state.ManagedHeap))
+                        thread
+                        state
             | EvalStackValue.ManagedPointer src ->
                 let currentValue =
                     IlMachineState.readManagedByrefField baseClassTypes state src fieldId

--- a/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataObjectOps.fs
@@ -852,9 +852,9 @@ module internal UnaryMetadataObjectOps =
         | EvalStackValue.NullObjectRef -> state, UnboxTypeTest.NullOperand
         | EvalStackValue.ObjectRef addr ->
             let boxedOpt =
-                match state.ManagedHeap.NonArrayObjects.TryGetValue addr with
-                | true, v -> Some v
-                | false, _ ->
+                match ManagedHeap.tryGet addr state.ManagedHeap with
+                | Some v -> Some v
+                | None ->
                     // An array is never a boxed value type, so per the CLR this is an ordinary
                     // type mismatch rather than an interpreter abort.
                     if ManagedHeap.isArray addr state.ManagedHeap then
@@ -987,9 +987,9 @@ module internal UnaryMetadataObjectOps =
                 |> Tuple.withRight WhatWeDid.Executed
             | EvalStackValue.ObjectRef addr ->
                 let boxedOpt =
-                    match state.ManagedHeap.NonArrayObjects.TryGetValue addr with
-                    | true, v -> Some v
-                    | false, _ ->
+                    match ManagedHeap.tryGet addr state.ManagedHeap with
+                    | Some v -> Some v
+                    | None ->
                         // An array can never be a boxed T for any T that Nullable admits.
                         if ManagedHeap.isArray addr state.ManagedHeap then
                             None


### PR DESCRIPTION
Slice B of the guest-memory access seam (after #938, #940, #942, #943, #948). The non-array counterpart of the array work: seventeen sites indexed `ManagedHeap.NonArrayObjects` directly, so a read of a guest object was not an identifiable event.

## Two accessors cover all of them

**`tryGet`** — the eleven `TryGetValue` / `Map.tryFind` sites. It answers `None` for a live *array* as well as for a dangling address: an array has no `AllocatedNonArrayObject` payload, so "not here" is the honest answer rather than a throw, and `isArray` sits next door for callers who care which case they are in. Two callers do care, and both already ask.

**`isLive`** — for callers that only need to know a reference points at *something*, the object's kind being somebody else's question. `RuntimeFieldProjection.requireHeapObject` was open-coding it as `NonArrayObjects.ContainsKey || isArray`.

It is deliberately computed from the two payload maps and **not** from `SyncBlocks`, even though that would be one lookup instead of two and `SyncBlocks`' key set is documented to be exactly their union. That invariant is asserted by a property test; an accessor that *assumed* it would convert a broken invariant into a silently wrong liveness answer instead of a caught one.

That separation is what lets the new property test use the header table as a genuine outside oracle for `isLive` rather than a tautology.

After this, every `NonArrayObjects` access in the library is inside `ManagedHeap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
