### PR TITLE
Give an empty array the same byref arithmetic as a populated one

### DIFF
--- a/WoofWare.PawPrint.Test/TestEmptyArrayByrefWalks.fs
+++ b/WoofWare.PawPrint.Test/TestEmptyArrayByrefWalks.fs
@@ -121,3 +121,60 @@ module TestEmptyArrayByrefWalks =
         match snd populated with
         | [ ByrefProjection.ReinterpretAs _ ; ByrefProjection.ByteOffset 2 ] -> ()
         | other -> failwith $"expected a trailing 2-byte cursor, got %O{other}"
+
+    /// An array whose element stride is `stride`, with no cells. `allocateArray`'s
+    /// stride-versus-cell-0 check is skipped when there are no cells, which is what lets a
+    /// test mint an odd stride without a matching 3-byte element type in corelib.
+    let private emptyArrayWithStride (stride : int) (heap : ManagedHeap) : ManagedHeapAddress * ManagedHeap =
+        let allocation : AllocatedArray =
+            {
+                Shape =
+                    {
+                        ConcreteType = ConcreteTypeHandle.OneDimArrayZero (handleFor baseClassTypes.Byte)
+                        Length = 0
+                        Lengths = ImmutableArray.Create 0
+                        ElementStride = stride
+                    }
+                Elements = ImmutableArray.Empty
+            }
+
+        ManagedHeap.allocateArray allocation heap
+
+    [<Test>]
+    let ``a byte cursor at the int32 floor normalises without overflowing`` () : unit =
+        // `Int32.MinValue` bytes into an array whose stride does not divide it. Folding used
+        // to recover the residual as `n - cellAdvance * cellSize`, whose product is
+        // -2147483649 here: outside int32, and `ManagedPointerSource` is `Checked`, so it
+        // raised `OverflowException` over an intermediate even though the residual it was
+        // computing is 1.
+        //
+        // Reachable only now that an empty array supplies a real stride to normalisation;
+        // before, a zero stride meant the fold was skipped entirely.
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+        let state = state loggerFactory
+
+        let arr, heap = emptyArrayWithStride 3 state.ManagedHeap
+
+        let state =
+            { state with
+                ManagedHeap = heap
+            }
+
+        let src =
+            ManagedPointerSource.Byref (
+                ByrefRoot.ArrayElement (arr, 0),
+                [ ByrefProjection.ReinterpretAs (concreteTypeFor baseClassTypes.Byte) ]
+            )
+
+        let result =
+            ManagedPointerByteView.addByteOffsetToByteView state System.Int32.MinValue src
+
+        // -2147483648 = 3 * -715827883 + 1, with the residual in [0, 3) as floor division
+        // requires.
+        match result with
+        | ManagedPointerSource.Byref (ByrefRoot.ArrayElement (_, index),
+                                      [ ByrefProjection.ReinterpretAs _ ; ByrefProjection.ByteOffset residual ]) ->
+            index |> shouldEqual -715827883
+            residual |> shouldEqual 1
+        | other -> failwith $"expected a folded array-element byref with a 1-byte residual, got %O{other}"

--- a/WoofWare.PawPrint.Test/TestEmptyArrayByrefWalks.fs
+++ b/WoofWare.PawPrint.Test/TestEmptyArrayByrefWalks.fs
@@ -1,0 +1,123 @@
+namespace WoofWare.PawPrint.Test
+
+open System.Collections.Immutable
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+/// An empty array is still an array of something. Byref arithmetic over one must therefore
+/// give the same answer as over a populated array of the same element type — the walk is a
+/// question about the element type, not about how many cells happen to exist.
+///
+/// Before the stride was recorded on `ArrayShape`, it could only be recovered by measuring a
+/// stored cell, so every one of these paths carried an empty-array fallback that substituted
+/// something else: `sizeof(T)` from the *calling* method, or a zero that silently disabled
+/// byte-offset normalisation. Those fallbacks disagreed with the populated case, which is
+/// what these tests pin.
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestEmptyArrayByrefWalks =
+    let private corelib : DumpedAssembly =
+        let corelibPath = typeof<obj>.Assembly.Location
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        Assembly.readFile loggerFactory corelibPath
+
+    let private baseClassTypes : BaseClassTypes<DumpedAssembly> =
+        Corelib.getBaseTypes corelib
+
+    let private loadedAssemblies : LoadedAssemblies =
+        LoadedAssemblies.ofAssemblies [ corelib ]
+
+    let private concreteTypes : AllConcreteTypes =
+        Corelib.concretizeAll loadedAssemblies baseClassTypes AllConcreteTypes.Empty
+
+    let private state (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory) : IlMachineState =
+        { IlMachineState.initial loggerFactory ImmutableArray.Empty corelib with
+            ConcreteTypes = concreteTypes
+        }
+
+    let private handleFor (ty : TypeInfo<GenericParamFromMetadata, TypeDefn>) : ConcreteTypeHandle =
+        AllConcreteTypes.getRequiredNonGenericHandle concreteTypes ty
+
+    let private concreteTypeFor (ty : TypeInfo<GenericParamFromMetadata, TypeDefn>) : ConcreteType<ConcreteTypeHandle> =
+        match AllConcreteTypes.lookup (handleFor ty) concreteTypes with
+        | Some t -> t
+        | None -> failwith $"%s{ty.Name} is not concretized"
+
+    /// Walk `offset` elements of `elementType` from index 0 of a fresh `int[len]`, through a
+    /// byref carrying `projections`, and report the resulting cell index and projections.
+    /// The array address is dropped so that the empty and populated cases are comparable.
+    let private walk
+        (len : int)
+        (elementType : TypeInfo<GenericParamFromMetadata, TypeDefn>)
+        (projections : ByrefProjection list)
+        (offset : int64)
+        : int * ByrefProjection list
+        =
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+        let state = state loggerFactory
+
+        let int32Handle = handleFor baseClassTypes.Int32
+
+        let zero, state =
+            IlMachineState.cliTypeZeroOfHandle state baseClassTypes int32Handle
+
+        let arr, state =
+            IlMachineState.allocateArray (ConcreteTypeHandle.OneDimArrayZero int32Handle) (fun () -> zero) len state
+
+        let src =
+            ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, 0), projections)
+            |> EvalStackValue.ManagedPointer
+
+        let result, _ =
+            IntrinsicHelpers.offsetManagedPointerByElements baseClassTypes state (handleFor elementType) offset src
+
+        match result with
+        | EvalStackValue.ManagedPointer (ManagedPointerSource.Byref (ByrefRoot.ArrayElement (_, index), projs)) ->
+            index, projs
+        | other -> failwith $"expected an array-element byref, got %O{other}"
+
+    [<Test>]
+    let ``walking an empty array agrees with a populated one, at the element type`` () : unit =
+        // `T` is the element type, so cell-index arithmetic applies to both.
+        walk 0 baseClassTypes.Int32 [] 3L
+        |> shouldEqual (walk 8 baseClassTypes.Int32 [] 3L)
+
+    [<Test>]
+    let ``walking an empty array agrees with a populated one, under a byte view`` () : unit =
+        // The case the old empty-array fallback got wrong. `T` is `byte` while the array's
+        // element is `int`, so eight elements of `T` is eight *bytes* — two cells, not eight.
+        //
+        // Substituting `sizeof(T)` for the stride of an empty array made the two sizes compare
+        // equal, which sent this down the cell-index branch and produced cell 8: four times too
+        // far, and silently, since an empty array has no cell whose contents would contradict
+        // it. The populated array took the byte-cursor branch and correctly reached cell 2.
+        let byteView =
+            [ ByrefProjection.ReinterpretAs (concreteTypeFor baseClassTypes.Byte) ]
+
+        let populated = walk 8 baseClassTypes.Byte byteView 8L
+        let empty = walk 0 baseClassTypes.Byte byteView 8L
+
+        empty |> shouldEqual populated
+
+        // Pin the value too, so that "they agree" cannot be satisfied by both being wrong.
+        fst populated |> shouldEqual 2
+
+    [<Test>]
+    let ``a byte-view walk that lands mid-cell keeps the remainder as a byte cursor`` () : unit =
+        // Same reasoning one step further: 6 bytes is one whole cell plus 2, so normalisation
+        // folds one cell and keeps the remainder. Distinguishes correct normalisation from a
+        // rule that merely divides and discards.
+        let byteView =
+            [ ByrefProjection.ReinterpretAs (concreteTypeFor baseClassTypes.Byte) ]
+
+        let populated = walk 8 baseClassTypes.Byte byteView 6L
+        let empty = walk 0 baseClassTypes.Byte byteView 6L
+
+        empty |> shouldEqual populated
+        fst populated |> shouldEqual 1
+
+        match snd populated with
+        | [ ByrefProjection.ReinterpretAs _ ; ByrefProjection.ByteOffset 2 ] -> ()
+        | other -> failwith $"expected a trailing 2-byte cursor, got %O{other}"

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -50,6 +50,7 @@
     <Compile Include="TestStructLayout.fs" />
     <Compile Include="TestMarshalLayout.fs" />
     <Compile Include="TestManagedHeap.fs" />
+    <Compile Include="TestEmptyArrayByrefWalks.fs" />
     <Compile Include="TestBinaryArithmetic.fs" />
     <Compile Include="TestContextSwitchPrior.fs" />
     <Compile Include="TestNullaryIlOp.fs" />

--- a/WoofWare.PawPrint/IntrinsicHelpers.fs
+++ b/WoofWare.PawPrint/IntrinsicHelpers.fs
@@ -273,13 +273,12 @@ module internal IntrinsicHelpers =
         let ptr : EvalStackValue =
             match src with
             | EvalStackValue.ManagedPointer (ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, i), projs)) ->
-                let arrElementSize =
-                    let arrObj = state.ManagedHeap.Arrays.[arr]
-
-                    if arrObj.Shape.Length = 0 then
-                        tSize
-                    else
-                        arrObj.Shape.ElementStride
+                // The array's own stride, for an empty array as much as a populated one. This
+                // used to substitute `sizeof(T)` when the array was empty, which made the
+                // `tSize <> arrElementSize` test below trivially false and so always chose
+                // cell-index arithmetic — silently producing a cell index that is only a
+                // correct byte position when `T` *is* the element type.
+                let arrElementSize = (ManagedHeap.getArrayShape arr state.ManagedHeap).ElementStride
 
                 // Choose between cell-index and byte-cursor walks:
                 //   - If the byref already carries a `ByteOffset` tail, we
@@ -325,13 +324,11 @@ module internal IntrinsicHelpers =
                     let byteDelta = byteDelta ()
                     let baseSrc = ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, i), projs)
 
-                    let normalisationElementSize =
-                        let obj = ManagedHeap.getArrayShape arr state.ManagedHeap
-
-                        if obj.Length = 0 then 0 else arrElementSize
-
+                    // Zero here would have meant "do not normalise" (the fold guards on
+                    // `cellSize > 0`), so an empty array used to keep a raw byte cursor where a
+                    // populated one of the same element type folded it into the cell index.
                     let normalisation =
-                        ByteOffsetNormalisationContext.withArrayElementSize arr normalisationElementSize
+                        ByteOffsetNormalisationContext.withArrayElementSize arr arrElementSize
 
                     baseSrc
                     |> ManagedPointerSource.addByteOffsetToByteView normalisation byteDelta

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -2735,10 +2735,12 @@ module Intrinsics =
                             // represent, as `IntrinsicHelpers.offsetManagedPointerByElements`
                             // already does for the same arithmetic.
                             //
-                            // Declining the shortcut instead would not help: the byte-view
-                            // fallback normalises the resulting cursor back into the cell index
-                            // through `normaliseTrailingByteOffset`, whose `advanceRoot` does
-                            // the same unchecked addition.
+                            // Declining the shortcut instead would not give a right answer
+                            // either: the byte-view fallback normalises the resulting cursor
+                            // back into the cell index through `normaliseTrailingByteOffset`,
+                            // which performs the same addition. That file is `Checked`, so it
+                            // raises `OverflowException` rather than wrapping — a crash, but
+                            // one naming neither the byref nor the walk that produced it.
                             let folded = int64<int> i + int64<int> (offset / elementSize)
 
                             if

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -2690,10 +2690,10 @@ module Intrinsics =
             let normalisation =
                 match srcPtr with
                 | ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, _), _) ->
-                    let elementSize =
-                        let obj = state.ManagedHeap.Arrays.[arr]
-
-                        if obj.Shape.Length = 0 then 0 else obj.Shape.ElementStride
+                    // See `IntrinsicHelpers.offsetManagedPointerByElements`: a zero here means
+                    // "do not normalise", so an empty array used to keep a raw byte cursor
+                    // where a populated one folded it into the cell index.
+                    let elementSize = (ManagedHeap.getArrayShape arr state.ManagedHeap).ElementStride
 
                     ByteOffsetNormalisationContext.withArrayElementSize arr elementSize
                 | _ -> ByteOffsetNormalisationContext.fixedStrideRootsOnly
@@ -2717,22 +2717,21 @@ module Intrinsics =
                     else
                         match root, projs with
                         | ByrefRoot.ArrayElement (arr, i), [] ->
-                            let arrObj = state.ManagedHeap.Arrays.[arr]
+                            // `ElementStride` is strictly positive by construction (see
+                            // `ArrayShape`), so no divisor check is needed and an empty array
+                            // needs no special case: the whole-cell test is a question about
+                            // the element type, which an empty array has just like any other.
+                            let elementSize = (ManagedHeap.getArrayShape arr state.ManagedHeap).ElementStride
 
-                            if arrObj.Shape.Length = 0 then
-                                None
-                            else
-                                let elementSize = arrObj.Shape.ElementStride
-
-                                if elementSize > 0 && offset % elementSize = 0 then
-                                    Some (
-                                        ManagedPointerSource.Byref (
-                                            ByrefRoot.ArrayElement (arr, i + offset / elementSize),
-                                            []
-                                        )
+                            if offset % elementSize = 0 then
+                                Some (
+                                    ManagedPointerSource.Byref (
+                                        ByrefRoot.ArrayElement (arr, i + offset / elementSize),
+                                        []
                                     )
-                                else
-                                    None
+                                )
+                            else
+                                None
                         | _ -> None
                 | _ -> None
 
@@ -2834,17 +2833,12 @@ module Intrinsics =
                 | ManagedPointerSource.Byref (ByrefRoot.StaticField (declaringType, field, owner), projs) ->
                     ByteStorageIdentity.StaticField (declaringType, field, owner), projectionByteOffset projs
                 | ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, i), projs) ->
-                    // `Array.Empty<T>()` carries no stored element to read a
-                    // size from, but the statically-declared `T` on the method
-                    // gives the same answer for any byref the caller could
-                    // legally have obtained: both parameters are `ref T`.
-                    let arrObj = state.ManagedHeap.Arrays.[arr]
-
-                    let elementSize =
-                        if arrObj.Shape.Length = 0 then
-                            tSize
-                        else
-                            arrObj.Shape.ElementStride
+                    // The cell index is a position in *this array's* layout, so the array's
+                    // stride is what converts it to bytes — not `sizeof(T)` from the calling
+                    // method, which is only the same number when `T` is the element type.
+                    // `Array.Empty<T>()` needs no special case: it has no stored element to
+                    // measure, but it has a recorded stride like any other array.
+                    let elementSize = (ManagedHeap.getArrayShape arr state.ManagedHeap).ElementStride
 
                     ByteStorageIdentity.Array arr, int64 i * int64 elementSize + projectionByteOffset projs
                 | ManagedPointerSource.Byref (ByrefRoot.StringCharAt (str, charIndex), projs) ->

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -2723,15 +2723,32 @@ module Intrinsics =
                             // the element type, which an empty array has just like any other.
                             let elementSize = (ManagedHeap.getArrayShape arr state.ManagedHeap).ElementStride
 
-                            if offset % elementSize = 0 then
-                                Some (
-                                    ManagedPointerSource.Byref (
-                                        ByrefRoot.ArrayElement (arr, i + offset / elementSize),
-                                        []
-                                    )
-                                )
-                            else
+                            if offset % elementSize <> 0 then
                                 None
+                            else
+
+                            // `ArrayElement` stores an int32 cell index, so a fold that does
+                            // not fit in one cannot be represented — and wrapping would not
+                            // merely lose precision, it would put the byref on the *wrong side*
+                            // of its own root, so `Unsafe.ByteOffset` would report
+                            // -8589934592 bytes instead of +8589934592. Refuse what we cannot
+                            // represent, as `IntrinsicHelpers.offsetManagedPointerByElements`
+                            // already does for the same arithmetic.
+                            //
+                            // Declining the shortcut instead would not help: the byte-view
+                            // fallback normalises the resulting cursor back into the cell index
+                            // through `normaliseTrailingByteOffset`, whose `advanceRoot` does
+                            // the same unchecked addition.
+                            let folded = int64<int> i + int64<int> (offset / elementSize)
+
+                            if
+                                folded < int64<int> System.Int32.MinValue
+                                || folded > int64<int> System.Int32.MaxValue
+                            then
+                                failwith
+                                    $"TODO: Unsafe.AddByteOffset: advancing the byref at cell %d{i} of array %O{arr} by %d{offset} bytes reaches cell %d{folded}, which does not fit in the int32 PawPrint stores for a cell index; a byref this far from its root is not modelled"
+
+                            Some (ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arr, int32<int64> folded), []))
                         | _ -> None
                 | _ -> None
 

--- a/WoofWare.PawPrint/ManagedPointerSource.fs
+++ b/WoofWare.PawPrint/ManagedPointerSource.fs
@@ -801,15 +801,23 @@ module ManagedPointerSource =
             match List.rev projs, tryGetCellSize root with
             | ByrefProjection.ByteOffset n :: ByrefProjection.ReinterpretAs ty :: rest, Some cellSize when cellSize > 0 ->
                 // Floor-division so negatives land in `[0, cellSize)`.
-                let cellAdvance =
+                //
+                // The residual is carried out of the division rather than recovered
+                // afterwards as `n - cellAdvance * cellSize`. That product overflows int32
+                // whenever `n` is `Int32.MinValue` and `cellSize` does not divide it — a
+                // 3-byte element gives -2147483649 — and this file is `Checked`, so it would
+                // abort the guest over an intermediate, even though the residual being
+                // computed is by construction smaller than `cellSize`. The truncated
+                // remainder `r` is always in `(-cellSize, cellSize)`, so correcting it is
+                // safe; `q - 1` is too, since `r < 0` implies `q` is not `Int32.MinValue`.
+                let cellAdvance, newOffset =
                     let q = n / cellSize
                     let r = n - q * cellSize
-                    if r < 0 then q - 1 else q
+                    if r < 0 then q - 1, r + cellSize else q, r
 
                 match advanceRoot root cellAdvance with
                 | None -> src
                 | Some newRoot ->
-                    let newOffset = n - cellAdvance * cellSize
                     let prefix = List.rev rest
 
                     let tail =


### PR DESCRIPTION
Slice C1 of the guest-memory access seam (after #938, #940, #942, #943, #948, #950). This one turned out to contain a real bug rather than the cleanup I expected, so the investigation is worth reading before the diff.

## The invariant

An empty array is still an array of *something*. A byref walk over one must give the same answer as over a populated array of the same element type — the walk is a question about the element type, not about how many cells happen to exist.

Five sites disagreed. Each derived the stride by measuring cell 0, which an empty array does not have, so each carried a fallback substituting something else:

- **`sizeof(T)` from the calling method** — `offsetManagedPointerByElements`, `Unsafe.ByteOffset`. Only the same number when `T` *is* the element type.
- **zero** — which the normalisation fold reads as "do not normalise" (it guards on `cellSize > 0`), so an empty array kept a raw byte cursor where a populated one folded it into the cell index.

Now that `ArrayShape` records the stride (#948), all five just read it.

## The `sizeof(T)` substitution was silently wrong

Not merely conservative, which is what I assumed going in. Walking eight `byte`s from a `ref byte` into an empty `int[]`:

| | old | new |
|---|---|---|
| empty `int[]` | cell **8** | cell 2 |
| populated `int[8]` | cell 2 | cell 2 |

Substituting `sizeof(T)` made `tSize <> arrElementSize` compare equal, which chose cell-index arithmetic instead of the byte cursor and walked **four times too far** — and undetectably, because an empty array has no cell whose contents would contradict it.

`TestEmptyArrayByrefWalks` pins this. Put the fallback back and it fails with `(8, …)` against expected `(2, …)`, and `(6, …)` against `(1, …)` for the mid-cell case. It also asserts the absolute values, so "the two agree" cannot be satisfied by both being wrong.

## How the five sites were classified

I did not trust reading alone; two of my initial guesses were wrong.

**Reachability**, by making each empty-array branch `failwith` and running the suite:

| Branch | Reached by |
|---|---|
| `offsetManagedPointerByElements` stride | `UnsafeArrayArithmetic.cs` |
| normalisation context in `Intrinsics` | 3 tests incl. `ArrayClear.cs`, `IntSpanEndsWithBitwise.cs` |
| `Unsafe.ByteOffset` stride | `SprintfBasic` |
| `offsetManagedPointerByElements` normalisation | **not reached** |
| whole-cell shortcut | **not reached** |

**Equivalence**: with all the reachable fallbacks removed, the suite was green — so wherever they are actually reached, the recorded stride gives the same answer. The divergence is confined to the `T` ≠ element-type case, which is what the new tests cover.

The two unreached fallbacks are removed rather than kept as untested conservatism: same cause, same fix, and an arm no test can kill is not worth keeping.

## Corrections to what I said when planning this

- I claimed the `else 0` site meant "every index normalises to offset 0". **Wrong** — `normaliseTrailingByteOffset` guards on `cellSize > 0`, so zero is a no-op. That site was conservative, not buggy.
- I said C1 was six sites. It is **four** `.Arrays` accesses containing five fallbacks; the two `IlMachineManagedByref` sites I had assigned here also read `Elements`, so they belong to the cell-accessor slice.

## Also

Drops the now-dead `elementSize > 0` divisor guard — `ElementStride` is strictly positive by construction (#948) — and replaces a comment whose premise ("`Array.Empty<T>()` carries no stored element to read a size from") is no longer true.

Full suite: 2815 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
