### PR TITLE
Mint dynamic methods in ModuleHandle_GetDynamicMethod

### DIFF
--- a/WoofWare.PawPrint.Test/TestImpureCases.fs
+++ b/WoofWare.PawPrint.Test/TestImpureCases.fs
@@ -291,6 +291,26 @@ module TestImpureCases =
                 AssertTerminalState = None
             }
             {
+                // `ModuleHandle_GetDynamicMethod`, the QCall behind
+                // `DynamicMethod.GetMethodDescriptor()`. Registered with the switch overridden to
+                // true, which is the only way to ask PawPrint to exercise a dynamic-code path --
+                // exactly the escape hatch `DynamicCodeSupportedOverride.cs` pins the existence of.
+                // The guest's comment explains why the QCall's effect is observable without
+                // executing the dynamic method, and what each non-zero exit code means.
+                FileName = "DynamicMethodStubFromModule.cs"
+                ExpectedReturnCode = 0
+                KernelConfig = KernelConfig.Default
+                AppContext =
+                    AppContextProperties.ofMap (
+                        Map.ofList
+                            [
+                                "System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported", "true"
+                            ]
+                    )
+                ExpectsUnhandledException = false
+                AssertTerminalState = None
+            }
+            {
                 // `SystemNative_GetCwd` must classify its error returns before
                 // resolving the caller's buffer to storage, because the C
                 // decides them without dereferencing it. Impure because the

--- a/WoofWare.PawPrint.Test/TestMethodHandleRegistry.fs
+++ b/WoofWare.PawPrint.Test/TestMethodHandleRegistry.fs
@@ -379,6 +379,8 @@ public static class GenericMethodHolder
         let resolved =
             match MethodHandleRegistry.resolveMethodFromId registryId registry with
             | Some (MethodHandle.FromMetadata identity) -> identity
+            | Some (MethodHandle.FromDynamic handle) ->
+                failwith $"registry id %d{registryId} resolved to %O{handle}, but a metadata method was registered"
             | None -> failwith $"registry id %d{registryId} did not resolve"
 
         resolved.GetMethodDefinitionHandle ()
@@ -1004,6 +1006,8 @@ public static class InstantiationHolder
         // `getOrAllocateInternalHandle` mints the definition: empty MethodGenerics.
         match MethodHandleRegistry.resolveMethodFromId 1L registry with
         | Some (MethodHandle.FromMetadata identity) -> identity.GetMethodGenerics () |> shouldEqual []
+        | Some (MethodHandle.FromDynamic handle) ->
+            failwith $"registry id 1 resolved to %O{handle}, but a metadata method was registered"
         | None -> failwith "expected the freshly minted handle to resolve"
 
         let state =

--- a/WoofWare.PawPrint.Test/TestNativeGetDynamicMethod.fs
+++ b/WoofWare.PawPrint.Test/TestNativeGetDynamicMethod.fs
@@ -1,0 +1,550 @@
+namespace WoofWare.PawPrint.Test
+
+open System.Collections.Immutable
+open System.IO
+open System.Reflection.Metadata
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.DotnetRuntimeLocator
+open WoofWare.PawPrint
+
+/// `ModuleHandle_GetDynamicMethod` (coreclr/vm/runtimehandles.cpp:2388), the QCall behind
+/// `DynamicMethod.GetMethodDescriptor()`. It mints CoreCLR's no-metadata `DynamicMethodDesc` --
+/// the thing `MethodDesc::IsNoMetadata()`, and so `RuntimeMethodHandle.IsDynamicMethod`, exists to
+/// distinguish -- attaches the managed `DynamicResolver`, and writes back a
+/// `RuntimeMethodInfoStub` naming it.
+///
+/// The outside oracle for this QCall is the guest-level case
+/// (`sourcesImpure/DynamicMethodStubFromModule.cs`), which is differential against real .NET; but
+/// all it can see is *that* a non-null stub came back. Nothing yet reads the name, the signature
+/// or the resolver back out, so no guest can observe them, and this file pins them instead.
+///
+/// Read honestly, that makes these consistency checks rather than appeals to CoreCLR: they assert
+/// that the QCall handler and the rest of PawPrint agree, not that either matches the real
+/// runtime. One consequence is worth stating because no test here can catch it: these tests build
+/// the six native arguments at the same indices the handler reads them from, so a handler and a
+/// test that agreed on the *wrong* index for `name` versus `sig` would both pass, and the guest
+/// case would too, since nothing downstream observes either value. The order was checked by hand
+/// against the pinned managed signature (RuntimeHandles.cs:1773-1780). Whoever implements the
+/// first consumer of the recorded name or signature should bring a differential guest assertion
+/// with it.
+[<TestFixture>]
+module TestNativeGetDynamicMethod =
+
+    /// A trivial guest; nothing here reads it, but `Program.prepare` needs an entry assembly and
+    /// the QCall needs a loaded assembly to scope the minted method to.
+    let private guestSource =
+        """
+public static class Entry
+{
+    public static int Main(string[] args)
+    {
+        return 0;
+    }
+}
+"""
+
+    let private prepareGuest
+        (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
+        (image : byte[])
+        : Program.PreparedProgram
+        =
+        let dotnetRuntimes =
+            DotnetRuntime.SelectForDll (typeof<RunResult>.Assembly.Location)
+            |> ImmutableArray.CreateRange
+
+        use peImage = new MemoryStream (image)
+
+        match
+            Program.prepare loggerFactory (Some "DynamicMethodTestGuest.cs") peImage (HostConfig.Default dotnetRuntimes)
+        with
+        | Program.ProgramStartResult.Ready prepared -> prepared
+        | Program.ProgramStartResult.CompletedBeforeMain outcome ->
+            failwith $"expected guest to be ready before Main, but got %O{outcome}"
+
+    let private requiredTopLevelType
+        (assembly : DumpedAssembly)
+        (namespaceName : string)
+        (typeName : string)
+        : TypeInfo<GenericParamFromMetadata, TypeDefn>
+        =
+        assembly.TryGetTopLevelTypeDef namespaceName typeName
+        |> Option.defaultWith (fun () ->
+            failwith $"type %s{namespaceName}.%s{typeName} not found in %s{assembly.Name.Name}"
+        )
+
+    let private moduleHandle = ("System", "ModuleHandle")
+
+    let private runtimeMethodHandle = ("System", "RuntimeMethodHandle")
+
+    /// Locates the QCall entry point on its declaring type and concretizes it, so the handler sees
+    /// the same `ExecutingMethod` signature the interpreter would have handed it.
+    let private qCallMethod
+        (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (declaringNamespace : string, declaringTypeName : string)
+        (entryPoint : string)
+        (state : IlMachineState)
+        : IlMachineState *
+          TypeInfo<GenericParamFromMetadata, TypeDefn> *
+          MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>
+        =
+        let declaringType =
+            requiredTopLevelType baseClassTypes.Corelib declaringNamespace declaringTypeName
+
+        let rawMethod =
+            declaringType.Methods
+            |> List.filter (fun method ->
+                match method.TryNativeImport with
+                | Some import -> import.ModuleName = "QCall" && import.EntryPointName = entryPoint
+                | None -> false
+            )
+            |> function
+                | [ method ] -> method
+                | [] -> failwith $"QCall entry point %s{entryPoint} not found on %s{declaringTypeName}"
+                | methods ->
+                    failwith
+                        $"QCall entry point %s{entryPoint} was ambiguous on %s{declaringTypeName}: %d{methods.Length} matches"
+
+        let state, method, _ =
+            ExecutionConcretization.concretizeMethodWithTypeGenerics
+                loggerFactory
+                baseClassTypes
+                ImmutableArray.Empty
+                rawMethod
+                None
+                baseClassTypes.Corelib.Name
+                ImmutableArray.Empty
+                state
+
+        state, declaringType, method
+
+    /// Locates a non-QCall (FCall / `InternalCall`) method by name on its declaring type. Used for
+    /// `RuntimeMethodHandle.IsDynamicMethod`.
+    let private fcallMethod
+        (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (declaringNamespace : string, declaringTypeName : string)
+        (methodName : string)
+        (state : IlMachineState)
+        : IlMachineState *
+          TypeInfo<GenericParamFromMetadata, TypeDefn> *
+          MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>
+        =
+        let declaringType =
+            requiredTopLevelType baseClassTypes.Corelib declaringNamespace declaringTypeName
+
+        let rawMethod =
+            declaringType.Methods
+            |> List.filter (fun method -> method.Name = methodName)
+            |> function
+                | [ method ] -> method
+                | [] -> failwith $"method %s{methodName} not found on %s{declaringTypeName}"
+                | methods -> failwith $"method %s{methodName} was ambiguous on %s{declaringTypeName}"
+
+        let state, method, _ =
+            ExecutionConcretization.concretizeMethodWithTypeGenerics
+                loggerFactory
+                baseClassTypes
+                ImmutableArray.Empty
+                rawMethod
+                None
+                baseClassTypes.Corelib.Name
+                ImmutableArray.Empty
+                state
+
+        state, declaringType, method
+
+    let private concreteValueTypeZero
+        (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (typeInfo : TypeInfo<GenericParamFromMetadata, TypeDefn>)
+        : ConcreteTypeHandle * CliType * IlMachineState
+        =
+        let state, handle =
+            IlMachineState.concretizeType
+                loggerFactory
+                baseClassTypes
+                state
+                baseClassTypes.Corelib.Name
+                ImmutableArray.Empty
+                ImmutableArray.Empty
+                (TypeDefn.FromDefinition (typeInfo.Identity, SignatureTypeKind.ValueType))
+
+        let zero, state = IlMachineState.cliTypeZeroOfHandle state baseClassTypes handle
+        handle, zero, state
+
+    /// `struct QCallModule { void* _ptr; IntPtr _module; }`. PawPrint models one module per
+    /// assembly, so `_module` carries the assembly's full name.
+    let private qCallModuleValue
+        (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (assemblyFullName : string)
+        (state : IlMachineState)
+        : CliType * IlMachineState
+        =
+        let qCallModuleType =
+            requiredTopLevelType baseClassTypes.Corelib "System.Runtime.CompilerServices" "QCallModule"
+
+        let handle, zero, state =
+            concreteValueTypeZero loggerFactory baseClassTypes state qCallModuleType
+
+        match zero with
+        | CliType.ValueType vt ->
+            let moduleField = IlMachineState.requiredOwnInstanceFieldId state handle "_module"
+
+            CliValueType.WithFieldSetById
+                moduleField
+                (CliType.Numeric (CliNumericType.NativeInt (NativeIntSource.ModuleHandle assemblyFullName)))
+                vt
+            |> CliType.ValueType,
+            state
+        | other -> failwith $"QCallModule zero value was not a value type: %O{other}"
+
+    /// `new ObjectHandleOnStack(ref local)`: a lone `void* _ptr` wrapping a byref to the caller's
+    /// slot. The `object[1]` cell stands in for that slot, and starts null exactly as the C#
+    /// wrapper's `IRuntimeMethodInfo? methodInfo = null` does.
+    let private objectHandleOnStackValue
+        (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (contents : ManagedHeapAddress option)
+        (state : IlMachineState)
+        : CliType * ManagedPointerSource * IlMachineState
+        =
+        let objectHandle =
+            AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes baseClassTypes.Object
+
+        let arrayAddr, state =
+            IlMachineState.allocateArray
+                (ConcreteTypeHandle.OneDimArrayZero objectHandle)
+                (fun () -> CliType.ObjectRef contents)
+                1
+                state
+
+        let target = ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arrayAddr, 0), [])
+
+        let handleType =
+            requiredTopLevelType baseClassTypes.Corelib "System.Runtime.CompilerServices" "ObjectHandleOnStack"
+
+        let handle, zero, state =
+            concreteValueTypeZero loggerFactory baseClassTypes state handleType
+
+        match zero with
+        | CliType.ValueType vt ->
+            let ptrField = IlMachineState.requiredOwnInstanceFieldId state handle "_ptr"
+
+            let value =
+                CliValueType.WithFieldSetById ptrField (CliType.RuntimePointer (CliRuntimePointer.Managed target)) vt
+                |> CliType.ValueType
+
+            value, target, state
+        | other -> failwith $"ObjectHandleOnStack zero value was not a value type: %O{other}"
+
+    /// A `byte*` into a freshly allocated `byte[]`, standing in for what the `LibraryImport` stub
+    /// hands the QCall: `Utf8StringMarshaller`'s buffer for `name`, and the pinned `byte[]` for
+    /// `sig`.
+    let private bytePointer
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (bytes : byte array)
+        (state : IlMachineState)
+        : CliType * IlMachineState
+        =
+        let ptr, state = NativeCall.allocateBlobByteArray baseClassTypes bytes state
+        CliType.RuntimePointer (CliRuntimePointer.Managed ptr), state
+
+    /// A NUL-terminated `char*`, as `StringMarshalling.Utf8` produces for the `name` parameter.
+    let private utf8StringPointer
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (value : string)
+        (state : IlMachineState)
+        : CliType * IlMachineState
+        =
+        let bytes = Array.append (System.Text.Encoding.UTF8.GetBytes value) [| 0uy |]
+        bytePointer baseClassTypes bytes state
+
+    /// Runs `entryPoint` against the entry thread. Deliberately through `NativeQCall.tryExecute`
+    /// rather than straight at `NativeModuleHandle.tryExecuteQCall`: that is the path the
+    /// interpreter takes, and it derives the entry point from the method's own import metadata, so
+    /// this also fails if the handler exists but was never registered in the dispatch table --
+    /// which is otherwise an entirely silent mistake.
+    let private invokeQCall
+        (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
+        (prepared : Program.PreparedProgram)
+        (declaringType : string * string)
+        (entryPoint : string)
+        (arguments : CliType list)
+        (state : IlMachineState)
+        : IlMachineState
+        =
+        let baseClassTypes = prepared.BaseClassTypes
+
+        let state, declaringTypeInfo, method =
+            qCallMethod loggerFactory baseClassTypes declaringType entryPoint state
+
+        let instruction =
+            { state.ThreadState.[prepared.EntryThread].MethodState with
+                ExecutingMethod = method
+                Arguments = ImmutableArray.CreateRange arguments
+            }
+
+        let ctx : NativeCallContext =
+            {
+                LoggerFactory = loggerFactory
+                BaseClassTypes = baseClassTypes
+                Thread = prepared.EntryThread
+                State = state
+                Instruction = instruction
+                TargetAssembly = baseClassTypes.Corelib
+                TargetType = declaringTypeInfo
+            }
+
+        match NativeQCall.tryExecute ctx with
+        | Some (NativeHandlerResult.Completed (state, _)) -> state
+        | Some result -> failwith $"unexpected %s{entryPoint} execution result: %O{result}"
+        | None -> failwith $"%s{entryPoint} QCall did not match, or is not registered in NativeQCall"
+
+    /// Runs the `RuntimeMethodHandle.IsDynamicMethod` FCall over a `RuntimeMethodHandleInternal`.
+    ///
+    /// This is PawPrint's model of `MethodDesc::IsNoMetadata()` — the bit
+    /// `RuntimeType.GetMethodBase` branches on first, precisely because such a method has no token
+    /// to look up — so asserting through it pins that the QCall handler and that FCall handler
+    /// agree. It is a cross-component consistency check, not an outside oracle; what makes it
+    /// non-vacuous is that the polarity is pinned in both directions, by the pre-existing
+    /// `IsDynamicMethod is false for a registry-minted handle` in `TestMethodHandleRegistry.fs`.
+    let private invokeIsDynamicMethod
+        (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
+        (prepared : Program.PreparedProgram)
+        (internalHandle : CliType)
+        (state : IlMachineState)
+        : EvalStackValue
+        =
+        let baseClassTypes = prepared.BaseClassTypes
+
+        let state, declaringTypeInfo, method =
+            fcallMethod loggerFactory baseClassTypes runtimeMethodHandle "IsDynamicMethod" state
+
+        let instruction =
+            { state.ThreadState.[prepared.EntryThread].MethodState with
+                ExecutingMethod = method
+                Arguments = ImmutableArray.CreateRange [ internalHandle ]
+            }
+
+        let ctx : NativeCallContext =
+            {
+                LoggerFactory = loggerFactory
+                BaseClassTypes = baseClassTypes
+                Thread = prepared.EntryThread
+                State = state
+                Instruction = instruction
+                TargetAssembly = baseClassTypes.Corelib
+                TargetType = declaringTypeInfo
+            }
+
+        match NativeDispatch.tryExecute ctx with
+        | Some (NativeHandlerResult.Completed (state, _)) ->
+            IlMachineState.popEvalStack prepared.EntryThread state |> fst
+        | Some result -> failwith $"unexpected IsDynamicMethod execution result: %O{result}"
+        | None -> failwith "IsDynamicMethod did not match any native handler"
+
+    /// A signature blob deliberately containing interior zero bytes. A real method signature does:
+    /// `void` is `ELEMENT_TYPE_VOID` = 0x01, but `ELEMENT_TYPE_END` is 0x00 and padded blobs and
+    /// nested type tokens routinely carry zeroes, so a handler that read `sig` with a
+    /// null-terminated scan rather than the supplied length would truncate here.
+    let private signatureWithInteriorNuls =
+        [| 0x00uy ; 0x01uy ; 0x00uy ; 0x01uy ; 0x00uy |]
+
+    /// The `RuntimeMethodHandleInternal` in the `m_value` field of the `RuntimeMethodInfoStub` the
+    /// QCall wrote back — i.e. what the managed caller would hand on as an `IRuntimeMethodInfo`.
+    let private internalHandleOfStub (state : IlMachineState) (stubAddress : ManagedHeapAddress) : CliType =
+        let stub : AllocatedNonArrayObject = ManagedHeap.get stubAddress state.ManagedHeap
+
+        let mValueField =
+            IlMachineState.requiredOwnInstanceFieldId state stub.ConcreteType "m_value"
+
+        CliValueType.DereferenceFieldById mValueField stub.Contents
+
+    /// Reads back what the QCall recorded about the single dynamic method behind `stubAddress`.
+    let private definitionBehindStub
+        (state : IlMachineState)
+        (stubAddress : ManagedHeapAddress)
+        : DynamicMethodHandle * DynamicMethodDefinition
+        =
+        let registryId =
+            internalHandleOfStub state stubAddress
+            |> NativeCall.methodHandleIdOfRuntimeMethodHandleInternal "test"
+            |> Option.defaultWith (fun () -> failwith "stub carried a null RuntimeMethodHandleInternal")
+
+        match MethodHandleRegistry.resolveMethodFromId registryId state.MethodHandles with
+        | Some (MethodHandle.FromDynamic handle) ->
+            let definition =
+                MethodHandleRegistry.resolveDynamicMethod handle state.MethodHandles
+                |> Option.defaultWith (fun () -> failwith $"%O{handle} had no recorded definition")
+
+            handle, definition
+        | other -> failwith $"registry id %d{registryId} did not resolve to a dynamic method: %O{other}"
+
+    /// Mints one dynamic method through the QCall and returns the stub the handler wrote, along
+    /// with the resolver object it was given.
+    let private mintOne
+        (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
+        (prepared : Program.PreparedProgram)
+        (name : string)
+        (signature : byte array)
+        (state : IlMachineState)
+        : ManagedHeapAddress * ManagedHeapAddress * IlMachineState
+        =
+        let baseClassTypes = prepared.BaseClassTypes
+
+        let qCallModule, state =
+            qCallModuleValue loggerFactory baseClassTypes state.EntryAssembly.FullName state
+
+        let namePtr, state = utf8StringPointer baseClassTypes name state
+        let sigPtr, state = bytePointer baseClassTypes signature state
+
+        // Stands in for the `DynamicResolver`. The QCall records whatever object it is handed --
+        // CoreCLR's `resolver.Get()` is an untyped OBJECTREF too -- so any heap object will do.
+        let objectHandle =
+            AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes baseClassTypes.Object
+
+        let resolverObj, state =
+            IlMachineState.allocateArray
+                (ConcreteTypeHandle.OneDimArrayZero objectHandle)
+                (fun () -> CliType.ObjectRef None)
+                1
+                state
+
+        let resolverHandle, _, state =
+            objectHandleOnStackValue loggerFactory baseClassTypes (Some resolverObj) state
+
+        let resultHandle, resultSlot, state =
+            objectHandleOnStackValue loggerFactory baseClassTypes None state
+
+        let state =
+            invokeQCall
+                loggerFactory
+                prepared
+                moduleHandle
+                "ModuleHandle_GetDynamicMethod"
+                [
+                    qCallModule
+                    namePtr
+                    sigPtr
+                    CliType.Numeric (CliNumericType.Int32 signature.Length)
+                    resolverHandle
+                    resultHandle
+                ]
+                state
+
+        let stubAddress =
+            match
+                IlMachineState.readManagedByref prepared.BaseClassTypes state resultSlot
+                |> CliType.unwrapPrimitiveLikeDeep
+            with
+            | CliType.ObjectRef (Some address) -> address
+            | CliType.ObjectRef None -> failwith "ModuleHandle_GetDynamicMethod left the result handle null"
+            | other -> failwith $"expected an object reference in the result handle, got %O{other}"
+
+        stubAddress, resolverObj, state
+
+    let private loadFixture () =
+        let image = Roslyn.compile [ guestSource ]
+
+        let _, loggerFactory = LoggerFactory.makeTestWithProperties []
+
+        let prepared = prepareGuest loggerFactory image
+        loggerFactory, prepared, prepared.State
+
+    [<Test>]
+    let ``the minted handle is a dynamic method`` () : unit =
+        let loggerFactory, prepared, state = loadFixture ()
+
+        let stubAddress, _, state =
+            mintOne loggerFactory prepared "Probe" signatureWithInteriorNuls state
+
+        // The whole point. Before this QCall existed, every handle the registry could mint
+        // answered `false` here, because `MethodHandle` had no case that could denote a
+        // no-metadata method.
+        invokeIsDynamicMethod loggerFactory prepared (internalHandleOfStub state stubAddress) state
+        |> shouldEqual (EvalStackValue.Int32 (Int32Source.Verbatim 1))
+
+    [<Test>]
+    let ``the name and signature round-trip`` () : unit =
+        let loggerFactory, prepared, state = loadFixture ()
+
+        let stubAddress, _, state =
+            mintOne loggerFactory prepared "Probe" signatureWithInteriorNuls state
+
+        let _, definition = definitionBehindStub state stubAddress
+
+        definition.GetName () |> shouldEqual "Probe"
+
+        // Counted, not terminated: reading to the first NUL would yield an empty array here.
+        definition.GetSignature ()
+        |> Seq.toArray
+        |> shouldEqual signatureWithInteriorNuls
+
+    [<Test>]
+    let ``the scope is the module's assembly`` () : unit =
+        let loggerFactory, prepared, state = loadFixture ()
+
+        let stubAddress, _, state =
+            mintOne loggerFactory prepared "Probe" [| 0x01uy |] state
+
+        let _, definition = definitionBehindStub state stubAddress
+
+        definition.GetScopeAssemblyFullName ()
+        |> shouldEqual state.EntryAssembly.FullName
+
+    [<Test>]
+    let ``the resolver is recorded`` () : unit =
+        let loggerFactory, prepared, state = loadFixture ()
+
+        let stubAddress, resolverObj, state =
+            mintOne loggerFactory prepared "Probe" [| 0x01uy |] state
+
+        let _, definition = definitionBehindStub state stubAddress
+
+        definition.GetResolver () |> shouldEqual (Some resolverObj)
+
+    /// The property Option B of the design exists to get right. CoreCLR mints a fresh
+    /// `DynamicMethodDesc` per call, so two `DynamicMethod`s agreeing on name, signature and
+    /// module are still different methods; a registry that deduped them structurally would fuse
+    /// two guest objects into one and make `dm1.CreateDelegate` and `dm2.CreateDelegate` run the
+    /// same IL.
+    [<Test>]
+    let ``two mints with identical inputs are distinct methods`` () : unit =
+        let loggerFactory, prepared, state = loadFixture ()
+
+        let firstStub, _, state =
+            mintOne loggerFactory prepared "Same" signatureWithInteriorNuls state
+
+        let secondStub, _, state =
+            mintOne loggerFactory prepared "Same" signatureWithInteriorNuls state
+
+        firstStub |> shouldNotEqual secondStub
+
+        let firstHandle, _ = definitionBehindStub state firstStub
+        let secondHandle, _ = definitionBehindStub state secondStub
+
+        firstHandle |> shouldNotEqual secondHandle
+
+    /// A no-metadata method has no MethodDef token, so every native that reads one must refuse
+    /// rather than fabricate. `resolveMetadataIdentityFromArg` is the single funnel they share.
+    [<Test>]
+    let ``a metadata query on a dynamic method fails loudly`` () : unit =
+        let loggerFactory, prepared, state = loadFixture ()
+
+        let stubAddress, _, state =
+            mintOne loggerFactory prepared "Probe" signatureWithInteriorNuls state
+
+        let internalHandle = internalHandleOfStub state stubAddress
+
+        let ex =
+            Assert.Throws<System.Exception> (fun () ->
+                NativeRuntimeMethodHandle.resolveMetadataIdentityFromArg "test" state internalHandle
+                |> ignore<MetadataMethodIdentity>
+            )
+
+        ex.Message |> shouldContainText "no MethodDef token to read"
+        ex.Message |> shouldContainText "Probe"

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -86,6 +86,7 @@
     <Compile Include="TestAssemblyNativeQCalls.fs" />
     <Compile Include="TestNativeEnum.fs" />
     <Compile Include="TestMethodHandleRegistry.fs" />
+    <Compile Include="TestNativeGetDynamicMethod.fs" />
     <Compile Include="TestMethodReturnType.fs" />
     <Compile Include="TestFunctionPointerConcretization.fs" />
     <Compile Include="Netstandard21FSharpCore.fs" />

--- a/WoofWare.PawPrint.Test/sourcesImpure/DynamicMethodStubFromModule.cs
+++ b/WoofWare.PawPrint.Test/sourcesImpure/DynamicMethodStubFromModule.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Reflection.Emit;
+
+public class Program
+{
+    // `ModuleHandle_GetDynamicMethod` is the QCall behind `DynamicMethod.GetMethodDescriptor()`:
+    // it mints CoreCLR's no-metadata `DynamicMethodDesc` and writes back a `RuntimeMethodInfoStub`
+    // naming it. PawPrint mints the method but cannot yet *execute* one, so a guest cannot observe
+    // the QCall by calling the dynamic method: that path stops one primitive later, in
+    // `RuntimeTypeHandle_InternalAlloc` (measured, not guessed — `Delegate.CreateDelegateNoSecurityCheck`
+    // allocates the delegate before it binds anything).
+    //
+    // It is observable exactly, though, and this is why. `CreateDelegate` evaluates
+    // `GetMethodDescriptor()` as an *argument expression*, so the QCall runs before
+    // `CreateDelegateNoSecurityCheck` performs any of its checks (Delegate.CoreCLR.cs:367-393), and
+    // every step between the QCall returning and the first check that can fail is pure managed
+    // code. Handing it a non-delegate type therefore reaches
+    // `ArgumentException(Arg_MustBeDelegate, "type")` — but only if the QCall dispatched,
+    // unmarshalled all six of its arguments, and wrote a *non-null* stub through its `result`
+    // handle. A handler that wrote nothing is caught by the arm above it: `method.IsNullHandle()`
+    // is tested first and raises `ArgumentNullException(nameof(method))`, which is a subclass of
+    // `ArgumentException` and so must be caught separately to be distinguished.
+    //
+    // Impure because PawPrint declares dynamic code unsupported by default, and the harness
+    // registers this case with the switch overridden to true — standing in for a
+    // `runtimeconfig.json` that says so, which is a supported configuration a real host honours.
+    // Real .NET launched with that same override exits 0 here.
+    public static int Main(string[] args)
+    {
+        DynamicMethod dm = new DynamicMethod("Probe", typeof(void), Type.EmptyTypes, typeof(Program).Module);
+
+        // `GetMethodDescriptor` refuses a body it never wrote to (`ILOffset == 0`) with
+        // `InvalidOperationException`, so the QCall is only reached if something is emitted.
+        ILGenerator il = dm.GetILGenerator();
+        il.Emit(OpCodes.Ret);
+
+        try
+        {
+            dm.CreateDelegate(typeof(string));
+            return 1;
+        }
+        catch (ArgumentNullException)
+        {
+            return 2;
+        }
+        catch (ArgumentException e)
+        {
+            return e.ParamName == "type" ? 0 : 3;
+        }
+    }
+}

--- a/WoofWare.PawPrint/MethodHandleRegistry.fs
+++ b/WoofWare.PawPrint/MethodHandleRegistry.fs
@@ -21,6 +21,55 @@ type MetadataMethodIdentity =
     member this.GetMethodDefinitionHandle () : ComparableMethodDefinitionHandle = this.MethodDefinition
     member this.GetMethodGenerics () : ConcreteTypeHandle list = this.MethodGenerics
 
+/// The identity of a method minted at runtime by `Reflection.Emit` rather than read out of any
+/// assembly's metadata: CoreCLR's `DynamicMethodDesc`, which is exactly what
+/// `MethodDesc::IsNoMetadata()` answers `true` for.
+///
+/// The payload is deliberately nothing but the registry id. Two `DynamicMethod`s built with the
+/// same name, the same signature and the same module are *different methods*, and CoreCLR's
+/// identity for one is its `DynamicMethodDesc`'s address: distinct for any two methods that are
+/// live at once, though `DynamicMethodTable::GetDynamicMethod` (dynamicmethod.cpp:218) recycles a
+/// desc off its free list once the method it belonged to has died, so an address can be reused
+/// across generations. PawPrint never frees, so a monotone counter is the faithful projection of
+/// that. Either way nothing descriptive may participate in equality here, or two distinct dynamic
+/// methods would collide in the registry's maps. What the method is called, and what its signature
+/// says, live in `MethodHandleRegistry.DynamicMethods` keyed by this.
+type DynamicMethodHandle =
+    private
+        {
+            RegistryId : int64
+        }
+
+    member this.GetRegistryId () : int64 = this.RegistryId
+
+    override this.ToString () : string = $"dynamic method #%d{this.RegistryId}"
+
+/// Everything `ModuleHandle_GetDynamicMethod` (runtimehandles.cpp:2388) was told about a dynamic
+/// method: the name and signature blob CoreCLR copies onto the loader heap beside the fresh
+/// `DynamicMethodDesc`, the module the method is scoped to, and the managed `DynamicResolver` it
+/// attaches to the `LCGMethodResolver`.
+///
+/// The resolver is held here as a plain address, where CoreCLR holds a *long weak* handle
+/// (`AppDomain::GetCurrentDomain()->CreateLongWeakHandle`) so that the runtime does not keep the
+/// resolver alive. That difference is unobservable in PawPrint: its interpreter never performs a
+/// garbage collection, of any kind, ever (see `Native/NativeGc.fs`), so nothing a weak handle
+/// would permit to be collected ever is, and the guest cannot ask after the handle's strength --
+/// `GetLCGMethodResolver` is reachable only from native code. Should a collector ever land, this
+/// is one of the places that has to grow a real weak reference.
+type DynamicMethodDefinition =
+    private
+        {
+            Name : string
+            Signature : ImmutableArray<byte>
+            ScopeAssemblyFullName : string
+            Resolver : ManagedHeapAddress option
+        }
+
+    member this.GetName () : string = this.Name
+    member this.GetSignature () : ImmutableArray<byte> = this.Signature
+    member this.GetScopeAssemblyFullName () : string = this.ScopeAssemblyFullName
+    member this.GetResolver () : ManagedHeapAddress option = this.Resolver
+
 /// What a `RuntimeMethodHandleInternal` registry id can name.
 ///
 /// The cases are public (the payloads are not) specifically so that consumers must match, and so
@@ -28,24 +77,38 @@ type MetadataMethodIdentity =
 /// a reader. CoreCLR's `MethodDesc` covers both metadata-backed methods and "no metadata" ones --
 /// `DynamicMethod`/LCG stubs, which have no MethodDef token and no defining assembly, and which
 /// `RuntimeMethodHandle.IsDynamicMethod` (`MethodDesc::IsNoMetadata()`) exists to distinguish.
-/// PawPrint models no such methods today, so `FromMetadata` is currently the only case; when
-/// `DynamicMethod` support lands it gains a sibling, and every `match` on this type stops compiling
-/// until that case has been considered there.
-type MethodHandle = | FromMetadata of MetadataMethodIdentity
+type MethodHandle =
+    | FromMetadata of MetadataMethodIdentity
+    | FromDynamic of DynamicMethodHandle
 
 type MethodHandleRegistry =
     private
         {
+            /// Dedup index over *structural* method identities, so that asking twice for the
+            /// handle of the same method yields the same id. Only `FromMetadata` handles appear
+            /// here: a dynamic method has no structural identity to dedup on (see
+            /// `DynamicMethodHandle`), so `mintDynamicMethod` deliberately does not populate it.
             MethodHandleToId : Map<MethodHandle, int64>
-            /// Reverse of `MethodHandleToId`. Used by callers (e.g., the introduced-method
-            /// iterator on `RuntimeTypeHandle`) that hold a bare `RuntimeMethodHandleInternal`
-            /// id and need to recover the underlying `MethodHandle`.
+            /// Every id this registry has minted, mapped to what it names. A superset of the
+            /// reverse of `MethodHandleToId`: it is the only *handle-resolution* map a dynamic
+            /// method appears in, since the two dedup indices are keyed on a structural identity
+            /// it does not have. Used by callers (e.g., the introduced-method iterator on
+            /// `RuntimeTypeHandle`) that hold a bare `RuntimeMethodHandleInternal` id and need
+            /// to recover the underlying `MethodHandle`.
             IdToMethodHandle : Map<int64, MethodHandle>
+            /// What each minted dynamic method was built from. Keyed by the same id that
+            /// `IdToMethodHandle` uses, because for a dynamic method the registry id *is* the
+            /// identity, exactly as the `DynamicMethodDesc*` is in CoreCLR.
+            DynamicMethods : Map<DynamicMethodHandle, DynamicMethodDefinition>
             /// Dedup cache for `getOrAllocate`: when an F# caller asks for the stub address
             /// of a method we've previously allocated through this same path, return that
             /// existing address rather than minting a fresh stub. Note that this dedup is
             /// scoped to F#-side allocations — stubs the BCL constructs in managed code (via
-            /// `new RuntimeMethodInfoStub(...)`) bypass this registry entirely.
+            /// `new RuntimeMethodInfoStub(...)`) bypass this registry entirely. Like
+            /// `MethodHandleToId`, this holds only `FromMetadata` handles: CoreCLR allocates a
+            /// fresh stub per `ModuleHandle_GetDynamicMethod` call, and the managed lock in
+            /// `DynamicMethod.GetMethodDescriptor` means there is exactly one such call per
+            /// `DynamicMethod`, so there is nothing to reuse.
             MethodToHandle : Map<MethodHandle, ManagedHeapAddress>
             NextHandle : int64
         }
@@ -57,6 +120,7 @@ module MethodHandleRegistry =
             MethodToHandle = Map.empty
             MethodHandleToId = Map.empty
             IdToMethodHandle = Map.empty
+            DynamicMethods = Map.empty
             NextHandle = 1L
         }
 
@@ -283,6 +347,133 @@ module MethodHandleRegistry =
         | TypeDefn.GenericMethodParameter _
         | TypeDefn.Void -> false
 
+    /// Build the `RuntimeMethodInfoStub` value CoreCLR's `MethodDesc::AllocateStubMethodInfo`
+    /// (method.cpp:3809) hands back: an object whose `m_value` is the given
+    /// `RuntimeMethodHandleInternal` and whose every other field is null.
+    ///
+    /// CoreCLR's only other assignment there is `m_keepalive`, which it sets to the
+    /// LoaderAllocator's exposed object when — and only when — that allocator is collectible.
+    /// PawPrint models no collectible loader allocator, so leaving it null is faithful rather
+    /// than a simplification.
+    let private buildRuntimeMethodInfoStub
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (allConcreteTypes : AllConcreteTypes)
+        (runtimeMethodHandleInternal : CliType)
+        : CliValueType
+        =
+        let objType =
+            AllConcreteTypes.getRequiredNonGenericHandle allConcreteTypes baseClassTypes.Object
+
+        let runtimeMethodHandleInternalType =
+            AllConcreteTypes.getRequiredNonGenericHandle allConcreteTypes baseClassTypes.RuntimeMethodHandleInternal
+
+        let runtimeMethodInfoStubHandle =
+            AllConcreteTypes.getRequiredNonGenericHandle allConcreteTypes baseClassTypes.RuntimeMethodInfoStub
+
+        let valueField =
+            FieldIdentity.requiredOwnInstanceField baseClassTypes.RuntimeMethodInfoStub "m_value"
+
+        let fields =
+            baseClassTypes.RuntimeMethodInfoStub.Fields
+            |> List.filter (fun field -> not field.IsStatic)
+            |> List.map (fun field ->
+                if field.Handle = valueField.Handle then
+                    FieldIdentity.cliField
+                        runtimeMethodInfoStubHandle
+                        field
+                        runtimeMethodHandleInternal
+                        runtimeMethodHandleInternalType
+                else
+                    if not (isReferenceShaped field.Signature) then
+                        failwith
+                            $"RuntimeMethodInfoStub field %s{field.Name} was expected to be reference-shaped, got %O{field.Signature}"
+
+                    FieldIdentity.cliField runtimeMethodInfoStubHandle field (CliType.ObjectRef None) objType
+            )
+
+        if
+            fields
+            |> List.exists (fun field ->
+                FieldId.exactlyEqual field.Id (FieldIdentity.fieldId runtimeMethodInfoStubHandle valueField)
+            )
+            |> not
+        then
+            failwith "RuntimeMethodInfoStub did not contain the expected m_value field"
+
+        fields
+        |> CliValueType.OfFields
+            baseClassTypes
+            allConcreteTypes
+            runtimeMethodInfoStubHandle
+            Layout.Default
+            (CharSetMetadata.ofTypeAttributes baseClassTypes.RuntimeMethodInfoStub.TypeAttributes)
+
+    /// Mint a fresh no-metadata method — CoreCLR's `DynamicMethodTable::GetDynamicMethod`
+    /// followed by `AllocateStubMethodInfo` — and return the address of the
+    /// `RuntimeMethodInfoStub` naming it, which is what `ModuleHandle_GetDynamicMethod` writes
+    /// through its `result` handle.
+    ///
+    /// Unconditionally fresh: there is no dedup step and none is wanted. Each call to the QCall
+    /// produces a method distinct from every other one alive, so two dynamic methods that happen
+    /// to agree on name, signature and scope must not collapse into one here. Correspondingly
+    /// this touches neither `MethodHandleToId` nor `MethodToHandle`, both of which are dedup
+    /// indices keyed on a structural identity that a dynamic method does not have.
+    let mintDynamicMethod
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (allConcreteTypes : AllConcreteTypes)
+        (allocState : 'allocState)
+        (allocate : CliValueType -> 'allocState -> ManagedHeapAddress * 'allocState)
+        (name : string)
+        (signature : ImmutableArray<byte>)
+        (scopeAssemblyFullName : string)
+        (resolver : ManagedHeapAddress option)
+        (reg : MethodHandleRegistry)
+        : ManagedHeapAddress * MethodHandleRegistry * 'allocState
+        =
+        let registryId = reg.NextHandle
+
+        let dynamicHandle =
+            {
+                RegistryId = registryId
+            }
+            : DynamicMethodHandle
+
+        let definition =
+            {
+                Name = name
+                Signature = signature
+                ScopeAssemblyFullName = scopeAssemblyFullName
+                Resolver = resolver
+            }
+            : DynamicMethodDefinition
+
+        let reg =
+            { reg with
+                IdToMethodHandle =
+                    reg.IdToMethodHandle
+                    |> Map.add registryId (MethodHandle.FromDynamic dynamicHandle)
+                DynamicMethods = reg.DynamicMethods |> Map.add dynamicHandle definition
+                NextHandle = registryId + 1L
+            }
+
+        let stub =
+            CliType.RuntimePointer (CliRuntimePointer.MethodRegistryHandle registryId)
+            |> buildRuntimeMethodHandleInternal baseClassTypes allConcreteTypes
+            |> CliType.ValueType
+            |> buildRuntimeMethodInfoStub baseClassTypes allConcreteTypes
+
+        let address, allocState = allocate stub allocState
+
+        address, reg, allocState
+
+    /// What the given dynamic method was built from, or `None` if this registry never minted it.
+    let resolveDynamicMethod
+        (handle : DynamicMethodHandle)
+        (reg : MethodHandleRegistry)
+        : DynamicMethodDefinition option
+        =
+        Map.tryFind handle reg.DynamicMethods
+
     /// Returns a (struct) System.RuntimeMethodHandle, with its contents (reference type) freshly allocated if necessary.
     let getOrAllocate
         (baseClassTypes : BaseClassTypes<DumpedAssembly>)
@@ -349,52 +540,7 @@ module MethodHandleRegistry =
             |> CliType.ValueType
 
         let runtimeMethodInfoStub =
-            let objType =
-                AllConcreteTypes.getRequiredNonGenericHandle allConcreteTypes baseClassTypes.Object
-
-            let runtimeMethodHandleInternalType =
-                AllConcreteTypes.getRequiredNonGenericHandle allConcreteTypes baseClassTypes.RuntimeMethodHandleInternal
-
-            let runtimeMethodInfoStubHandle =
-                AllConcreteTypes.getRequiredNonGenericHandle allConcreteTypes baseClassTypes.RuntimeMethodInfoStub
-
-            let valueField =
-                FieldIdentity.requiredOwnInstanceField baseClassTypes.RuntimeMethodInfoStub "m_value"
-
-            let fields =
-                baseClassTypes.RuntimeMethodInfoStub.Fields
-                |> List.filter (fun field -> not field.IsStatic)
-                |> List.map (fun field ->
-                    if field.Handle = valueField.Handle then
-                        FieldIdentity.cliField
-                            runtimeMethodInfoStubHandle
-                            field
-                            runtimeMethodHandleInternal
-                            runtimeMethodHandleInternalType
-                    else
-                        if not (isReferenceShaped field.Signature) then
-                            failwith
-                                $"RuntimeMethodInfoStub field %s{field.Name} was expected to be reference-shaped, got %O{field.Signature}"
-
-                        FieldIdentity.cliField runtimeMethodInfoStubHandle field (CliType.ObjectRef None) objType
-                )
-
-            if
-                fields
-                |> List.exists (fun field ->
-                    FieldId.exactlyEqual field.Id (FieldIdentity.fieldId runtimeMethodInfoStubHandle valueField)
-                )
-                |> not
-            then
-                failwith "RuntimeMethodInfoStub did not contain the expected m_value field"
-
-            fields
-            |> CliValueType.OfFields
-                baseClassTypes
-                allConcreteTypes
-                runtimeMethodInfoStubHandle
-                Layout.Default
-                (CharSetMetadata.ofTypeAttributes baseClassTypes.RuntimeMethodInfoStub.TypeAttributes)
+            buildRuntimeMethodInfoStub baseClassTypes allConcreteTypes runtimeMethodHandleInternal
 
         let alloc, state = allocate runtimeMethodInfoStub allocState
 

--- a/WoofWare.PawPrint/Native/NativeCustomAttribute.fs
+++ b/WoofWare.PawPrint/Native/NativeCustomAttribute.fs
@@ -334,6 +334,9 @@ module NativeCustomAttribute =
                 let identity =
                     match MethodHandleRegistry.resolveMethodFromId methodRegistryId state.MethodHandles with
                     | Some (MethodHandle.FromMetadata identity) -> identity
+                    | Some (MethodHandle.FromDynamic dynamicHandle) ->
+                        failwith
+                            $"%s{operation}: RuntimeMethodHandleInternal id %d{methodRegistryId} (from stub at %O{ctorStubAddr}) names %O{dynamicHandle}, a Reflection.Emit method; an attribute constructor is named by a token in the blob being decoded, so this is a bug in whatever produced the stub"
                     | None ->
                         failwith
                             $"%s{operation}: RuntimeMethodHandleInternal id %d{methodRegistryId} (from stub at %O{ctorStubAddr}) did not resolve to a registered MethodHandle"

--- a/WoofWare.PawPrint/Native/NativeModuleHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeModuleHandle.fs
@@ -1,5 +1,6 @@
 namespace WoofWare.PawPrint
 
+open System.Collections.Immutable
 open System.Reflection.PortableExecutable
 
 /// <summary>
@@ -14,10 +15,10 @@ type PEKindAndMachine =
     }
 
 /// <summary>
-/// QCalls on <c>System.ModuleHandle</c> that answer questions about the module's image
-/// rather than resolving anything out of it. The <c>ModuleHandle_Resolve*</c> entry points
-/// live in <c>NativeRuntimeTypeQCall</c> instead, next to the type-resolution machinery
-/// they share.
+/// QCalls on <c>System.ModuleHandle</c> that do not resolve a metadata token out of the
+/// module: two that answer questions about its image, and one that mints a method scoped to
+/// it. The <c>ModuleHandle_Resolve*</c> entry points live in <c>NativeRuntimeTypeQCall</c>
+/// instead, next to the type-resolution machinery they share.
 /// </summary>
 [<RequireQualifiedAccess>]
 module NativeModuleHandle =
@@ -220,6 +221,118 @@ module NativeModuleHandle =
                 state
                 |> writeOut 1 "peKind" kindAndMachine.PEKind
                 |> writeOut 2 "machine" kindAndMachine.Machine
+
+            NativeHandlerResult.completed state |> Some
+        | "ModuleHandle_GetDynamicMethod",
+          "System.Private.CoreLib",
+          "System",
+          "ModuleHandle",
+          [ ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "QCallModule",
+                                              qCallModuleGenerics)
+            ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.Byte)
+            ConcretePointer (ConcretePrimitive state.ConcreteTypes PrimitiveType.Byte)
+            ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32
+            ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "ObjectHandleOnStack",
+                                              resolverHandleGenerics)
+            ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "ObjectHandleOnStack",
+                                              resultHandleGenerics) ],
+          MethodReturnType.Void when
+            qCallModuleGenerics.IsEmpty
+            && resolverHandleGenerics.IsEmpty
+            && resultHandleGenerics.IsEmpty
+            ->
+            // `ModuleHandle_GetDynamicMethod` (coreclr/vm/runtimehandles.cpp:2388), the QCall
+            // behind `DynamicMethod.GetMethodDescriptor()`. CoreCLR copies the name and signature
+            // onto the loader heap, asks the module's `DynamicMethodTable` for a fresh
+            // `DynamicMethodDesc`, attaches the managed `DynamicResolver` to its
+            // `LCGMethodResolver`, and writes back `pNewMD->AllocateStubMethodInfo()`.
+            //
+            // This mints the method and hands back the stub. It does *not* make the method
+            // executable: the IL lives in the resolver, and nothing yet reads it back. A guest
+            // that goes on to bind or invoke the result therefore stops at the next primitive,
+            // loudly and by name, rather than running the wrong code.
+            let operation = "ModuleHandle_GetDynamicMethod"
+
+            if instruction.Arguments.Length <> 6 then
+                failwith $"%s{operation}: expected six native arguments, got %d{instruction.Arguments.Length}"
+
+            let scopeAssemblyFullName =
+                NativeCall.qCallModuleToAssemblyFullName
+                    operation
+                    state
+                    (instruction.Arguments.[0] |> EvalStackValue.ofCliType)
+
+            // CoreCLR copies the name with `strlen`/`memcpy`, so a name containing an interior NUL
+            // is truncated there. Reading to the terminator reproduces that exactly; do not
+            // "fix" it into a counted read, which would be a divergence rather than a repair.
+            let name =
+                NativeCall.managedPointerOfPointerArgument operation "name" instruction.Arguments.[1]
+                |> NativeCall.readNullTerminatedUtf8 operation ctx.BaseClassTypes state
+
+            let signatureLength = NativeCall.int32Argument operation instruction.Arguments.[3]
+
+            // CoreCLR's `DynamicMethodTable::GetDynamicMethod` carries
+            // `PRECONDITION(sigSize > 0)` (dynamicmethod.cpp:229), which is debug-only there but
+            // is a real invariant: `SignatureHelper` always emits at least a calling-convention
+            // byte, so no managed caller can produce an empty one. Refuse rather than record a
+            // signature-less method that nothing downstream could interpret.
+            if signatureLength <= 0 then
+                failwith
+                    $"%s{operation}: signature length %d{signatureLength} is not positive; every method signature blob has at least a calling-convention byte"
+
+            // Counted, not terminated: a method signature blob is arbitrary bytes and routinely
+            // contains a zero (ELEMENT_TYPE_END, and every `void` return), so scanning for a
+            // terminator would truncate almost every signature at its first `void`.
+            let signature =
+                NativeCall.managedPointerOfPointerArgument operation "sig" instruction.Arguments.[2]
+                |> fun ptr -> NativeCall.readCountedUtf8Bytes operation ctx.BaseClassTypes state ptr signatureLength
+                |> ImmutableArray.CreateRange
+
+            let resolver =
+                NativeCall.objectHandleOnStackTarget operation state "resolver" instruction.Arguments.[4]
+                |> IlMachineState.readManagedByref ctx.BaseClassTypes state
+                |> fun value ->
+                    match CliType.unwrapPrimitiveLikeDeep value with
+                    | CliType.ObjectRef target -> target
+                    | other -> failwith $"%s{operation}: expected resolver to be an object reference, got %O{other}"
+
+            let result =
+                NativeCall.objectHandleOnStackTarget operation state "result" instruction.Arguments.[5]
+
+            let runtimeMethodInfoStubType =
+                AllConcreteTypes.getRequiredNonGenericHandle
+                    state.ConcreteTypes
+                    ctx.BaseClassTypes.RuntimeMethodInfoStub
+
+            let stubAddress, registry, state =
+                MethodHandleRegistry.mintDynamicMethod
+                    ctx.BaseClassTypes
+                    state.ConcreteTypes
+                    state
+                    (fun fields state -> IlMachineState.allocateManagedObject runtimeMethodInfoStubType fields state)
+                    name
+                    signature
+                    scopeAssemblyFullName
+                    resolver
+                    state.MethodHandles
+
+            let state =
+                { state with
+                    MethodHandles = registry
+                }
+
+            let state =
+                IlMachineState.writeManagedByrefWithBase
+                    ctx.BaseClassTypes
+                    state
+                    result
+                    (CliType.ObjectRef (Some stubAddress))
 
             NativeHandlerResult.completed state |> Some
         | _ -> None

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -47,6 +47,7 @@ module NativeQCall =
             "RuntimeTypeHandle_Instantiate", NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_Instantiate"
             "ModuleHandle_GetMDStreamVersion", NativeModuleHandle.tryExecuteQCall "ModuleHandle_GetMDStreamVersion"
             "ModuleHandle_GetPEKind", NativeModuleHandle.tryExecuteQCall "ModuleHandle_GetPEKind"
+            "ModuleHandle_GetDynamicMethod", NativeModuleHandle.tryExecuteQCall "ModuleHandle_GetDynamicMethod"
             "ModuleHandle_ResolveType", NativeRuntimeType.tryExecuteQCall "ModuleHandle_ResolveType"
             "ModuleHandle_ResolveMethod", NativeRuntimeType.tryExecuteQCall "ModuleHandle_ResolveMethod"
             "MethodTable_CanCompareBitsOrUseFastGetHashCode",

--- a/WoofWare.PawPrint/Native/NativeReflectionInvocation.fs
+++ b/WoofWare.PawPrint/Native/NativeReflectionInvocation.fs
@@ -78,6 +78,12 @@ module internal NativeReflectionInvocation =
         let identity =
             match MethodHandleRegistry.resolveMethodFromId methodHandleId state.MethodHandles with
             | Some (MethodHandle.FromMetadata identity) -> identity
+            | Some (MethodHandle.FromDynamic dynamicHandle) ->
+                // Legal in CoreCLR: invoking a `DynamicMethod` runs the IL its `DynamicResolver`
+                // hands back. PawPrint mints the method in `ModuleHandle_GetDynamicMethod` but has
+                // no interpretable body for it yet, so there is nothing to invoke.
+                failwith
+                    $"TODO: %s{operation} was asked to invoke %O{dynamicHandle}, a Reflection.Emit method; PawPrint cannot yet execute a method with no metadata body"
             | None ->
                 failwith $"%s{operation}: method-registry id %d{methodHandleId} did not resolve to a known MethodHandle"
 

--- a/WoofWare.PawPrint/Native/NativeRuntimeMethodHandle.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeMethodHandle.fs
@@ -97,13 +97,13 @@ module NativeRuntimeMethodHandle =
     /// it instead recovers the `DynamicMethod` from the handle's `Resolver`. Every other reflection
     /// native in this file assumes the metadata branch was taken.
     ///
-    /// PawPrint has no `Reflection.Emit`, so every handle its registry can mint is metadata-backed
-    /// and this is `false` throughout. That is a fact about the *representation*, not a policy
-    /// choice: `MethodHandle` has no case that could denote a no-metadata method. When one is
-    /// added, this match stops compiling.
+    /// PawPrint mints a no-metadata handle in exactly one place -- `ModuleHandle_GetDynamicMethod`,
+    /// the QCall behind `DynamicMethod.GetMethodDescriptor()` -- so this is `true` for precisely
+    /// those and `false` for everything read out of metadata.
     let isDynamicMethod (handle : MethodHandle) : bool =
         match handle with
         | MethodHandle.FromMetadata _ -> false
+        | MethodHandle.FromDynamic _ -> true
 
     /// The `MethodTable*` CoreCLR's `RuntimeMethodHandle::GetMethodTable` FCall
     /// (runtimehandles.cpp:1344) returns: `pMethod->GetMethodTable()`, i.e. the MethodTable of the
@@ -432,8 +432,13 @@ module NativeRuntimeMethodHandle =
     /// Resolve a `RuntimeMethodHandleInternal` argument to the metadata identity it denotes.
     /// Every native that reads a MethodDef token, a declaring assembly, or a method instantiation
     /// needs one of these, and none of them has an answer for a no-metadata (`DynamicMethod`)
-    /// handle -- so when that case lands, this match is one of the sites that must decide what to
-    /// do rather than silently reading a token that does not exist.
+    /// handle: there is no token to read.
+    ///
+    /// Several of the operations funnelled through here are perfectly legal on a dynamic method in
+    /// CoreCLR -- `GetMethodTable`/`GetDeclaringType` answer with the `DynamicMethodTable`'s
+    /// synthetic type, which is how `Signature`'s constructor (RuntimeHandles.cs:2051) works on an
+    /// LCG method -- so this is a "not implemented yet" boundary rather than a caller bug, and it
+    /// says so. It is where the next increment of `Reflection.Emit` support will start.
     let resolveMetadataIdentityFromArg
         (operation : string)
         (state : IlMachineState)
@@ -442,6 +447,14 @@ module NativeRuntimeMethodHandle =
         =
         match resolveMethodHandleFromArg operation state arg with
         | MethodHandle.FromMetadata identity -> identity
+        | MethodHandle.FromDynamic dynamicHandle ->
+            let name =
+                MethodHandleRegistry.resolveDynamicMethod dynamicHandle state.MethodHandles
+                |> Option.map (fun definition -> definition.GetName ())
+                |> Option.defaultValue "<unregistered>"
+
+            failwith
+                $"TODO: %s{operation} was given %O{dynamicHandle} (%s{name}), a Reflection.Emit method with no MethodDef token to read; PawPrint mints these in ModuleHandle_GetDynamicMethod but cannot yet answer metadata queries about them"
 
     let private resolveMethodInfoFromHandleArg
         (operation : string)

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeFCall.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeFCall.fs
@@ -907,6 +907,9 @@ module NativeRuntimeTypeFCall =
             let identity =
                 match MethodHandleRegistry.resolveMethodFromId currentId state.MethodHandles with
                 | Some (MethodHandle.FromMetadata identity) -> identity
+                | Some (MethodHandle.FromDynamic dynamicHandle) ->
+                    failwith
+                        $"%s{operation}: registry id %d{currentId} names %O{dynamicHandle}, a Reflection.Emit method; the enumerator can only have been resumed from a method-table slot, so this is a bug in whatever produced the handle it was given"
                 | None -> failwith $"%s{operation}: registry id %d{currentId} did not resolve to a known MethodHandle"
 
             // The registry only stores handles whose declaring type was Concrete (GetFirst emits

--- a/docs/divergences.md
+++ b/docs/divergences.md
@@ -303,7 +303,9 @@ new DynamicMethod("f", typeof(int), Type.EmptyTypes, typeof(C));
 // PawPrint: PlatformNotSupportedException, from AssemblyBuilder.EnsureDynamicCodeSupported.
 ```
 
-**Where this lives in code**: `AppContextProperties.runtimeBaseline` and `withRuntimeBaseline` in `RuntimeConfig.fs`; applied in `Program.prepare` immediately before `AppContextSeed.prepareCall`. Pinned by `TestDynamicCodeSupport.fs` and by `sourcesImpure/DynamicCodeUnsupportedByDefault.cs` (the default) and `sourcesImpure/DynamicCodeSupportedOverride.cs` (the precedence). If Reflection.Emit is ever implemented — see the `DynamicMethod*` cases parked in `TestPureCases.unimplemented` — this entry and that baseline should be revisited together.
+**Where this lives in code**: `AppContextProperties.runtimeBaseline` and `withRuntimeBaseline` in `RuntimeConfig.fs`; applied in `Program.prepare` immediately before `AppContextSeed.prepareCall`. Pinned by `TestDynamicCodeSupport.fs` and by `sourcesImpure/DynamicCodeUnsupportedByDefault.cs` (the default) and `sourcesImpure/DynamicCodeSupportedOverride.cs` (the precedence).
+
+Reflection.Emit support has since begun, which sharpens rather than changes the entry above. `ModuleHandle_GetDynamicMethod` — the QCall behind `DynamicMethod.GetMethodDescriptor()` — is implemented (`NativeModuleHandle.fs`, pinned by `TestNativeGetDynamicMethod.fs` and `sourcesImpure/DynamicMethodStubFromModule.cs`), so a guest that overrides the switch to true can now *mint* a dynamic method and get back a `RuntimeMethodInfoStub` naming it. It still cannot execute one: the IL lives in the `DynamicResolver` and nothing reads it back, so `CreateDelegate` stops at the next primitive (`RuntimeTypeHandle_InternalAlloc`, measured). The baseline therefore stays `false`, and stays truthful — "can this runtime produce code at runtime?" is still "no". Revisit this entry and the baseline together when a dynamic method can actually run.
 
 ## `Activator.CreateInstance` rejection messages
 


### PR DESCRIPTION
`ModuleHandle_GetDynamicMethod` (coreclr/vm/runtimehandles.cpp:2388) is the QCall behind `DynamicMethod.GetMethodDescriptor()`: it mints CoreCLR's no-metadata `DynamicMethodDesc`, attaches the managed `DynamicResolver`, and writes back a `RuntimeMethodInfoStub` naming it. This implements it.

**This mints the method; it does not make it executable.** The IL lives in the resolver and nothing reads it back yet, so a guest that goes on to bind or invoke stops at the next primitive — `RuntimeTypeHandle_InternalAlloc`, measured rather than guessed — instead of running the wrong code. The `IsDynamicCodeSupported=false` baseline is unchanged and stays truthful; "can this runtime produce code at runtime?" is still no.

## Representation

`MethodHandle` gains the `FromDynamic` sibling its doc comment has been anticipating since the case was first written down. Its payload is deliberately nothing but the registry id: CoreCLR's identity for a dynamic method is its `DynamicMethodDesc`'s address, distinct for any two methods live at once, so two `DynamicMethod`s agreeing on name, signature and module are still different methods and must not collapse in a structural map. Descriptive data (name, signature blob, scope assembly, resolver) lives in a `DynamicMethods` side table, and dynamic handles stay out of both dedup indices — not by discipline but by construction, since the payloads are private and the only producers of dedup keys return `FromMetadata`.

The resolver is held as a plain address where CoreCLR holds a long weak handle. Unobservable here — PawPrint never collects — and documented at the type so a future collector has a flag to find.

## The five compile-forced match sites

Decided by kind rather than uniformly:

- `isDynamicMethod` → `true`.
- The introduced-method iterator and the custom-attribute constructor reject it as a **contract violation**: both can only have been handed a method-table slot or a blob token.
- `resolveMetadataIdentityFromArg` and reflection invocation report **not yet implemented**, naming the feature. Both are legal on a dynamic method in CoreCLR (`GetDeclaringType` on an LCG method is how `Signature`'s ctor works), so they are a boundary, not a bug — and they are where the next increment starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)