### PR TITLE
Route array cell access through ManagedHeap accessors

### DIFF
--- a/WoofWare.PawPrint.Domain/ContextSwitchPrior.fs
+++ b/WoofWare.PawPrint.Domain/ContextSwitchPrior.fs
@@ -158,9 +158,10 @@ module ContextSwitchPrior =
         | NullaryIlOp.Xor
         // `Conv_I` and `Conv_U` may call
         // `ManagedPointerByteView.anchorByteViewIfPlainArrayByref`, which
-        // reads `state.ManagedHeap.Arrays` to decide whether to anchor a
-        // byte-view projection. Reading the (post-publication, immutable)
-        // array spine is bookkeeping rather than a guest sync event.
+        // calls `ManagedHeap.getArrayShape` to decide whether to anchor a
+        // byte-view projection. That is a query against the array's shape —
+        // fixed at allocation and carrying no cells at all — rather than a
+        // read of any element, so it is bookkeeping, not a guest sync event.
         | NullaryIlOp.Conv_I
         | NullaryIlOp.Conv_U -> ContextSwitchPrior.InterpreterOnly
 

--- a/WoofWare.PawPrint.Test/TestBinaryArithmetic.fs
+++ b/WoofWare.PawPrint.Test/TestBinaryArithmetic.fs
@@ -73,6 +73,7 @@ module TestBinaryArithmetic =
                     Length = values.Length
                     Lengths = ImmutableArray.Create values.Length
                     ElementStride = sizeof<int32>
+                    ElementZero = CliType.Numeric (CliNumericType.Int32 0)
                 }
             Elements = elements
         }

--- a/WoofWare.PawPrint.Test/TestEmptyArrayByrefWalks.fs
+++ b/WoofWare.PawPrint.Test/TestEmptyArrayByrefWalks.fs
@@ -1,6 +1,7 @@
 namespace WoofWare.PawPrint.Test
 
 open System.Collections.Immutable
+open System.Runtime.InteropServices
 open FsUnitTyped
 open NUnit.Framework
 open WoofWare.PawPrint
@@ -122,18 +123,31 @@ module TestEmptyArrayByrefWalks =
         | [ ByrefProjection.ReinterpretAs _ ; ByrefProjection.ByteOffset 2 ] -> ()
         | other -> failwith $"expected a trailing 2-byte cursor, got %O{other}"
 
-    /// An array whose element stride is `stride`, with no cells. `allocateArray`'s
-    /// stride-versus-cell-0 check is skipped when there are no cells, which is what lets a
-    /// test mint an odd stride without a matching 3-byte element type in corelib.
+    /// An array whose element stride is `stride`, with no cells. Corelib has no 3-byte
+    /// element type, so the element zero is a fieldless struct with an explicit `Size`:
+    /// `CliValueType.SizeOfFieldStorage` gives that exactly the width we want, which
+    /// `allocateArray` then agrees with rather than rejecting.
+    ///
+    /// The declared handle is `System.Byte`'s only so that the fixture needs no type of its
+    /// own; nothing here reads it back, and the walk under test consults the stride alone.
     let private emptyArrayWithStride (stride : int) (heap : ManagedHeap) : ManagedHeapAddress * ManagedHeap =
+        let elementHandle = handleFor baseClassTypes.Byte
+
+        let elementZero =
+            CliValueType.OfFields baseClassTypes concreteTypes elementHandle (Layout.Custom (stride, 1)) CharSet.Ansi []
+            |> CliType.ValueType
+
+        CliType.sizeOf elementZero |> shouldEqual stride
+
         let allocation : AllocatedArray =
             {
                 Shape =
                     {
-                        ConcreteType = ConcreteTypeHandle.OneDimArrayZero (handleFor baseClassTypes.Byte)
+                        ConcreteType = ConcreteTypeHandle.OneDimArrayZero elementHandle
                         Length = 0
                         Lengths = ImmutableArray.Create 0
                         ElementStride = stride
+                        ElementZero = elementZero
                     }
                 Elements = ImmutableArray.Empty
             }

--- a/WoofWare.PawPrint.Test/TestManagedHeap.fs
+++ b/WoofWare.PawPrint.Test/TestManagedHeap.fs
@@ -34,6 +34,43 @@ module TestManagedHeap =
             ConcreteTypes = concreteTypes
         }
 
+    /// The zero of the element type used by the hand-built allocations in this fixture.
+    let private int32Zero : CliType = CliType.Numeric (CliNumericType.Int32 0)
+
+    /// An `ArrayShape` whose element facts are derived from `elementZero`, so a fixture
+    /// cannot violate the stride/zero agreement `allocateArray` enforces except on purpose.
+    let private shapeOf
+        (concreteType : ConcreteTypeHandle)
+        (elementZero : CliType)
+        (lengths : ImmutableArray<int>)
+        : ArrayShape
+        =
+        {
+            ConcreteType = concreteType
+            Length = Seq.fold (*) 1 lengths
+            Lengths = lengths
+            ElementStride = CliType.sizeOf elementZero
+            ElementZero = elementZero
+        }
+
+    /// A szarray shape of `length` `int32` cells.
+    let private int32ShapeOf (concreteType : ConcreteTypeHandle) (length : int) : ArrayShape =
+        shapeOf concreteType int32Zero (ImmutableArray.Create length)
+
+    /// The zero of a fieldless value type of exactly `size` bytes — what
+    /// `[StructLayout(LayoutKind.Sequential, Size = n)]` produces. Lets a test name a width
+    /// corelib has no type for, so that each of `allocateArray`'s checks can be provoked
+    /// without tripping one of the others first.
+    let private sizedZero (size : int) : CliType =
+        CliValueType.OfFields
+            baseClassTypes
+            concreteTypes
+            (ConcreteTypeHandle.Concrete 1)
+            (Layout.Custom (size, 1))
+            CharSet.Ansi
+            []
+        |> CliType.ValueType
+
     [<Test>]
     let ``allocateArray preserves concrete array type for empty arrays`` () : unit =
         let intHandle = ConcreteTypeHandle.Concrete 1
@@ -43,25 +80,13 @@ module TestManagedHeap =
 
         let intArray : AllocatedArray =
             {
-                Shape =
-                    {
-                        ConcreteType = intArrayHandle
-                        Length = 0
-                        Lengths = ImmutableArray.Create 0
-                        ElementStride = sizeof<int32>
-                    }
+                Shape = int32ShapeOf intArrayHandle 0
                 Elements = ImmutableArray.Empty
             }
 
         let stringArray : AllocatedArray =
             {
-                Shape =
-                    {
-                        ConcreteType = stringArrayHandle
-                        Length = 0
-                        Lengths = ImmutableArray.Create 0
-                        ElementStride = NATIVE_INT_SIZE
-                    }
+                Shape = shapeOf stringArrayHandle (CliType.ObjectRef None) (ImmutableArray.Create 0)
                 Elements = ImmutableArray.Empty
             }
 
@@ -81,13 +106,7 @@ module TestManagedHeap =
 
         let array : AllocatedArray =
             {
-                Shape =
-                    {
-                        ConcreteType = arrayHandle
-                        Length = 0
-                        Lengths = ImmutableArray.Create 0
-                        ElementStride = sizeof<int32>
-                    }
+                Shape = int32ShapeOf arrayHandle 0
                 Elements = ImmutableArray.Empty
             }
 
@@ -388,16 +407,8 @@ module TestManagedHeap =
 
     let private stubArray (length : int) : AllocatedArray =
         {
-            Shape =
-                {
-                    ConcreteType = ConcreteTypeHandle.OneDimArrayZero (ConcreteTypeHandle.Concrete 1)
-                    Length = length
-                    Lengths = ImmutableArray.Create length
-                    ElementStride = sizeof<int32>
-                }
-            Elements =
-                Seq.replicate length (CliType.Numeric (CliNumericType.Int32 0))
-                |> ImmutableArray.CreateRange
+            Shape = int32ShapeOf (ConcreteTypeHandle.OneDimArrayZero (ConcreteTypeHandle.Concrete 1)) length
+            Elements = Seq.replicate length int32Zero |> ImmutableArray.CreateRange
         }
 
     /// A placeholder non-array object whose payload is never inspected by the
@@ -567,16 +578,8 @@ module TestManagedHeap =
 
         let allocation : AllocatedArray =
             {
-                Shape =
-                    {
-                        ConcreteType = arrayHandle
-                        Length = 12
-                        Lengths = lengths
-                        ElementStride = sizeof<int32>
-                    }
-                Elements =
-                    Seq.replicate 12 (CliType.Numeric (CliNumericType.Int32 0))
-                    |> ImmutableArray.CreateRange
+                Shape = shapeOf arrayHandle int32Zero lengths
+                Elements = Seq.replicate 12 int32Zero |> ImmutableArray.CreateRange
             }
 
         let addr, heap = ManagedHeap.allocateArray allocation ManagedHeap.empty
@@ -627,12 +630,17 @@ module TestManagedHeap =
         // field-for-field, never derive or normalise. `Length` in particular is stored,
         // not recomputed from `Lengths`, and the projection must not start recomputing it.
         //
-        // The backing store is deliberately left empty while `Length` is not. That is an
-        // inconsistent allocation, which is the point: it distinguishes a projection that
-        // reads the stored `Length` from one that derives it from `Elements.Length`, and
-        // it keeps the generator from ever materialising a large array. Bounding the rank
-        // to 6 dimensions of at most 4 keeps the product well inside Int32 too, so no
-        // seed can make this test fail for reasons unrelated to the property.
+        // This used to allocate `Length = total` with an *empty* backing store, so that a
+        // projection deriving `Length` from `Elements.Length` would be caught. That
+        // discrimination has moved: `allocateArray` now rejects a length that disagrees with
+        // the cell count outright (see the test below), because `getArrayValue` bounds-checks
+        // against the shape and then indexes the cells, which is only sound while the two
+        // agree. Distinguishing stored from derived is no longer possible here — and no
+        // longer meaningful, since the allocator makes them provably equal.
+        //
+        // Bounding the rank to 6 dimensions of at most 4 keeps the product well inside Int32
+        // and the materialised array small, so no seed can make this test fail for reasons
+        // unrelated to the property.
         let property (lengths : int list) : bool =
             let lengths = lengths |> List.truncate 6 |> List.map (fun n -> (abs (n % 5)))
 
@@ -641,13 +649,11 @@ module TestManagedHeap =
             let allocation : AllocatedArray =
                 {
                     Shape =
-                        {
-                            ConcreteType = ConcreteTypeHandle.Array (ConcreteTypeHandle.Concrete 1, lengths.Length)
-                            Length = total
-                            Lengths = ImmutableArray.CreateRange lengths
-                            ElementStride = sizeof<int32>
-                        }
-                    Elements = ImmutableArray.Empty
+                        shapeOf
+                            (ConcreteTypeHandle.Array (ConcreteTypeHandle.Concrete 1, lengths.Length))
+                            int32Zero
+                            (ImmutableArray.CreateRange lengths)
+                    Elements = Seq.replicate total int32Zero |> ImmutableArray.CreateRange
                 }
 
             let addr, heap = ManagedHeap.allocateArray allocation ManagedHeap.empty
@@ -657,6 +663,7 @@ module TestManagedHeap =
             && shape.Length = allocation.Shape.Length
             && shape.Lengths = allocation.Shape.Lengths
             && shape.ElementStride = allocation.Shape.ElementStride
+            && shape.ElementZero = allocation.Shape.ElementZero
 
         Check.One (
             Config.QuickThrowOnFailure.WithMaxTest 200,
@@ -923,11 +930,17 @@ module TestManagedHeap =
     let ``allocateArray rejects a stride that disagrees with the cells`` () : unit =
         // The check that makes reading the stride, rather than measuring a cell, safe.
         // Without it the field is an honour-system claim.
+        //
+        // The element zero is widened to match the bogus stride, so that the zero-versus-
+        // stride check below passes and this one is what actually fires. Each of
+        // `allocateArray`'s guards has to be provokable on its own, or the later ones are
+        // untested and could be deleted without any test noticing.
         let wrong : AllocatedArray =
             { stubArray 3 with
                 Shape =
                     { (stubArray 3).Shape with
                         ElementStride = sizeof<int32> + 1
+                        ElementZero = sizedZero (sizeof<int32> + 1)
                     }
             }
 
@@ -937,10 +950,70 @@ module TestManagedHeap =
         exn.Message |> shouldContainText "but its first cell measures"
 
     [<Test>]
+    let ``allocateArray rejects a stride that disagrees with the element zero`` () : unit =
+        // The stride is *defined* as the size of the element zero, and is stored separately
+        // only because recomputing it walks a value type's whole field tree on every
+        // byte-view access. That makes the two a denormalisation, and this is what keeps
+        // them from drifting. Checked on an empty array, where the cell comparison above has
+        // nothing to say and this is the only thing standing between the two fields.
+        let wrong : AllocatedArray =
+            { stubArray 0 with
+                Shape =
+                    { (stubArray 0).Shape with
+                        ElementStride = sizeof<int32> + 1
+                    }
+            }
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> ManagedHeap.allocateArray wrong ManagedHeap.empty |> ignore)
+
+        exn.Message |> shouldContainText "but its element zero"
+
+    [<Test>]
+    let ``allocateArray rejects a length that disagrees with the cell count`` () : unit =
+        // `getArrayValue` bounds-checks the index against `Shape.Length` and then indexes
+        // `Elements`. Splitting the shape out of the payload record is what made it possible
+        // for those to be different numbers; without this check the two would silently
+        // disagree and an in-bounds-by-the-shape index would come back as a raw
+        // `IndexOutOfRangeException` from beneath the interpreter.
+        let tooFew : AllocatedArray =
+            { stubArray 3 with
+                Elements = Seq.replicate 2 int32Zero |> ImmutableArray.CreateRange
+            }
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> ManagedHeap.allocateArray tooFew ManagedHeap.empty |> ignore)
+
+        exn.Message |> shouldContainText "carries 2 cell(s)"
+
+    [<Test>]
+    let ``allocateArray rejects a length that disagrees with the per-dimension lengths`` () : unit =
+        // `Length` is documented as the product of `Lengths`, and the multi-dimensional
+        // accessors depend on it: array `Get`/`Set`/`Address` bounds-check each index against
+        // `Lengths` and then index by the flattened offset, which `getArrayValue` checks
+        // against `Length`. A disagreement lets an index that every per-dimension check
+        // accepts fall outside the cells.
+        let wrong : AllocatedArray =
+            {
+                Shape =
+                    { int32ShapeOf (ConcreteTypeHandle.Array (ConcreteTypeHandle.Concrete 1, 2)) 6 with
+                        Lengths = ImmutableArray.CreateRange [ 2 ; 4 ]
+                    }
+                Elements = Seq.replicate 6 int32Zero |> ImmutableArray.CreateRange
+            }
+
+        let exn =
+            Assert.Throws<System.Exception> (fun () -> ManagedHeap.allocateArray wrong ManagedHeap.empty |> ignore)
+
+        exn.Message |> shouldContainText "multiply to 8"
+
+    [<Test>]
     let ``allocateArray rejects a non-positive stride`` () : unit =
-        // Checked separately from the cell comparison because an empty array has no cell to
-        // compare against, so this is the only guard standing between a nonsense stride and
-        // the `floorDivRem` that will later divide by it.
+        // The element-zero check subsumes this one — it forces the stride to equal a
+        // `CliType.sizeOf`, which is never below 1 — so this fires only because it runs
+        // first. It is kept as a direct assertion of what consumers depend on: `floorDivRem`
+        // divides by the stride, and that shouldn't rest on a two-step argument through a
+        // different check in a different file.
         //
         // Zero is rejected as well as negative, and is the more dangerous of the two: it is
         // the plausible-looking value for "an array with nothing in it", and it fails
@@ -989,6 +1062,117 @@ module TestManagedHeap =
 
         ManagedHeap.getArrayElementStride clone state.ManagedHeap
         |> shouldEqual sizeof<int64>
+
+    // ---------------------------------------------------------------------
+    // Element zero.
+    //
+    // The witness for "what shape is a cell of this array". Cell 0 used to
+    // serve, which was wrong three ways: it is a guest-visible read performed
+    // to answer a question about a type, it does not exist for an empty
+    // array, and it is only a *sample* — a store to cell 5 was validated
+    // against whatever provenance cell 0 had picked up.
+    // ---------------------------------------------------------------------
+
+    /// Allocate a `len`-element array of `elementHandle` and report its recorded element
+    /// zero.
+    let private elementZeroOfArray
+        (elementHandle : ConcreteTypeHandle)
+        (len : int)
+        (state : IlMachineState)
+        : CliType * IlMachineState
+        =
+        let zero, state =
+            IlMachineState.cliTypeZeroOfHandle state baseClassTypes elementHandle
+
+        let addr, state =
+            IlMachineState.allocateArray (ConcreteTypeHandle.OneDimArrayZero elementHandle) (fun () -> zero) len state
+
+        ManagedHeap.getArrayElementZero addr state.ManagedHeap, state
+
+    [<Test>]
+    let ``recorded element zero is the element type's zero, for an empty array too`` () : unit =
+        // The oracle is `cliTypeZeroOfHandle` — the same thing every cell of a fresh array
+        // is initialised to — asked independently of the allocation. An empty array must
+        // give the same answer as a populated one, which is the whole reason this is
+        // recorded rather than sampled off cell 0.
+        let _, loggerFactory = LoggerFactory.makeTest ()
+
+        let mutable state = state loggerFactory
+
+        for name, selector, _ in strideOracle do
+            let handle =
+                AllConcreteTypes.getRequiredNonGenericHandle concreteTypes (selector baseClassTypes)
+
+            let expected, s0 = IlMachineState.cliTypeZeroOfHandle state baseClassTypes handle
+            let populated, s1 = elementZeroOfArray handle 3 s0
+            let empty, s2 = elementZeroOfArray handle 0 s1
+            state <- s2
+
+            if populated <> expected then
+                failwith $"array of %s{name} recorded element zero %O{populated}, but the type's zero is %O{expected}"
+
+            if empty <> populated then
+                failwith
+                    $"empty array of %s{name} records element zero %O{empty}, but a populated one records %O{populated}"
+
+    [<Test>]
+    let ``a stored cell may drift from the element zero, and does not change it`` () : unit =
+        // Why the element zero cannot simply be read back off cell 0, stated as a property
+        // of the heap rather than as a comment: a cell legitimately holds something other
+        // than the element type's zero the moment anything is written to it, while the
+        // element zero is a fact about the type and never moves.
+        let _, loggerFactory = LoggerFactory.makeTest ()
+        let state = state loggerFactory
+
+        let handle =
+            AllConcreteTypes.getRequiredNonGenericHandle concreteTypes baseClassTypes.Int32
+
+        let zero, state = IlMachineState.cliTypeZeroOfHandle state baseClassTypes handle
+
+        let addr, state =
+            IlMachineState.allocateArray (ConcreteTypeHandle.OneDimArrayZero handle) (fun () -> zero) 3 state
+
+        let state =
+            IlMachineState.setArrayValue addr (CliType.Numeric (CliNumericType.Int32 7)) 0 state
+
+        ManagedHeap.getArrayValue addr 0 state.ManagedHeap
+        |> shouldEqual (CliType.Numeric (CliNumericType.Int32 7))
+
+        ManagedHeap.getArrayElementZero addr state.ManagedHeap |> shouldEqual zero
+
+    [<Test>]
+    let ``getArrayElementZero fails loudly for a non-array and for a dangling address`` () : unit =
+        let objAddr, heap = ManagedHeap.allocateNonArray stubNonArray ManagedHeap.empty
+
+        let notAnArray =
+            Assert.Throws<System.Exception> (fun () -> ManagedHeap.getArrayElementZero objAddr heap |> ignore)
+
+        notAnArray.Message |> shouldContainText "is not an array"
+
+        let dangling =
+            Assert.Throws<System.Exception> (fun () ->
+                ManagedHeap.getArrayElementZero (ManagedHeapAddress 42) heap |> ignore
+            )
+
+        dangling.Message |> shouldContainText "not a live managed heap allocation"
+
+    [<Test>]
+    let ``cloneArray distinguishes a non-array from a dangling address`` () : unit =
+        // Same discrimination as `getArrayShape` / `get`, for the same reason: a non-array
+        // address means the caller misjudged the kind of the reference it holds, whereas an
+        // unallocated address means the reference itself is bogus. Before `cloneArray` moved
+        // into `ManagedHeap` it reached into `Arrays` directly from the state layer.
+        let objAddr, heap = ManagedHeap.allocateNonArray stubNonArray ManagedHeap.empty
+
+        let notAnArray =
+            Assert.Throws<System.Exception> (fun () -> ManagedHeap.cloneArray objAddr heap |> ignore)
+
+        notAnArray.Message |> shouldContainText "is a non-array object"
+
+        let dangling =
+            Assert.Throws<System.Exception> (fun () -> ManagedHeap.cloneArray (ManagedHeapAddress 42) heap |> ignore)
+
+        dangling.Message |> shouldContainText "not a live managed heap allocation"
 
     [<Test>]
     let ``getArrayElementStride fails loudly for a non-array and for a dangling address`` () : unit =

--- a/WoofWare.PawPrint.Test/TestSyncBlockMonitor.fs
+++ b/WoofWare.PawPrint.Test/TestSyncBlockMonitor.fs
@@ -107,6 +107,7 @@ module TestSyncBlockMonitor =
                         Length = 0
                         Lengths = ImmutableArray.Create 0
                         ElementStride = sizeof<int32>
+                        ElementZero = CliType.Numeric (CliNumericType.Int32 0)
                     }
                 Elements = ImmutableArray.Empty
             }

--- a/WoofWare.PawPrint/IlMachineManagedByref.fs
+++ b/WoofWare.PawPrint/IlMachineManagedByref.fs
@@ -645,12 +645,12 @@ module IlMachineManagedByref =
         : CliType
         =
         let targetSize = CliType.sizeOf targetTemplate
-        let arrObj = state.ManagedHeap.Arrays.[arr]
+        let shape = ManagedHeap.getArrayShape arr state.ManagedHeap
 
         // Kept now that the stride no longer needs a cell: every byte-view read of an empty
         // array is out of bounds anyway, and refusing here keeps a zero-width read from
         // quietly succeeding against storage that has no bytes at all.
-        if arrObj.Shape.Length = 0 then
+        if shape.Length = 0 then
             failwith $"TODO: byte-view read from empty array %O{arr} at index %d{index} offset %d{byteOffset}"
 
         // The stride comes from the array's recorded element stride, not from measuring a
@@ -662,18 +662,17 @@ module IlMachineManagedByref =
         // exactly we return the typed cell directly, preserving provenance; everything else
         // falls through to the byte-scatter loop, which validates byte addressability per
         // cell as it gathers.
-        let stride = arrObj.Shape.ElementStride
+        let stride = shape.ElementStride
         let cellAdvance, inCellStart = floorDivRem byteOffset stride
 
         let shortCircuitCell =
             if inCellStart = 0 && targetSize = stride then
                 let targetCell = index + cellAdvance
 
-                if targetCell < 0 || targetCell >= arrObj.Shape.Length then
-                    failwith
-                        $"TODO: byte-view read past array bounds at cell %d{targetCell} of length %d{arrObj.Shape.Length}"
+                if targetCell < 0 || targetCell >= shape.Length then
+                    failwith $"TODO: byte-view read past array bounds at cell %d{targetCell} of length %d{shape.Length}"
 
-                let cellValue = arrObj.Elements.[targetCell]
+                let cellValue = ManagedHeap.getArrayValue arr targetCell state.ManagedHeap
 
                 // Mirror `readStackMemoryBytesAs` / `tryReadHeapValueFieldPrecise`:
                 // propagate the stored cell only when it (a) is non-byte-addressable
@@ -704,11 +703,11 @@ module IlMachineManagedByref =
 
             let targetCell = index + cellAdvance
 
-            if targetCell < 0 || targetCell >= arrObj.Shape.Length then
+            if targetCell < 0 || targetCell >= shape.Length then
                 ValueNone
             else
 
-            let cellValue = arrObj.Elements.[targetCell]
+            let cellValue = ManagedHeap.getArrayValue arr targetCell state.ManagedHeap
 
             tryNameCellForByrefAccess inCellStart cellValue targetTemplate
             |> Option.map (fun path -> CliType.getCellAtPath path cellValue)
@@ -724,22 +723,18 @@ module IlMachineManagedByref =
             let mutable inCellOffset = inCellStart
 
             while filled < targetSize do
-                if cell < 0 || cell >= arrObj.Shape.Length then
+                if cell < 0 || cell >= shape.Length then
                     failwith
-                        $"TODO: byte-view read past array bounds at cell %d{cell} of length %d{arrObj.Shape.Length} while gathering %d{targetSize} bytes"
+                        $"TODO: byte-view read past array bounds at cell %d{cell} of length %d{shape.Length} while gathering %d{targetSize} bytes"
 
-                let cellSize =
-                    byteAddressableCellSize $"array %O{arr} element %d{cell}" arrObj.Elements.[cell]
+                let cellValue = ManagedHeap.getArrayValue arr cell state.ManagedHeap
+                let cellSize = byteAddressableCellSize $"array %O{arr} element %d{cell}" cellValue
 
                 let canTake = cellSize - inCellOffset
                 let take = min canTake (targetSize - filled)
 
                 let bytes =
-                    byteAddressableCellBytesAt
-                        $"array %O{arr} element %d{cell}"
-                        inCellOffset
-                        take
-                        arrObj.Elements.[cell]
+                    byteAddressableCellBytesAt $"array %O{arr} element %d{cell}" inCellOffset take cellValue
 
                 Array.blit bytes 0 buf filled take
                 filled <- filled + take
@@ -1626,11 +1621,11 @@ module IlMachineManagedByref =
         (bytes : byte[])
         : IlMachineState
         =
-        let arrObj = state.ManagedHeap.Arrays.[arr]
+        let shape = ManagedHeap.getArrayShape arr state.ManagedHeap
 
         // Kept for the same reason as on the read side: an empty array has no bytes to
         // write, and a zero-byte write must not quietly become a no-op.
-        if arrObj.Shape.Length = 0 then
+        if shape.Length = 0 then
             failwith $"TODO: byte-view write to empty array %O{arr} at index %d{index} offset %d{byteOffset}"
 
         // Mirrors `readArrayBytesAs`: the stride is the array's recorded element stride, and
@@ -1640,7 +1635,7 @@ module IlMachineManagedByref =
         // non-byte-addressable provenance, then `p[1] = IntPtr.Zero` byte-scatters into
         // element 1: only the cells the loop actually touches need to be byte-addressable,
         // validated per iteration below.
-        let stride = arrObj.Shape.ElementStride
+        let stride = shape.ElementStride
 
         let cellAdvance, inCellStart = floorDivRem byteOffset stride
         let mutable state = state
@@ -1649,10 +1644,13 @@ module IlMachineManagedByref =
         let mutable inCellOffset = inCellStart
 
         while filled < bytes.Length do
-            if cell < 0 || cell >= arrObj.Shape.Length then
-                failwith $"TODO: byte-view write past array bounds at cell %d{cell} of length %d{arrObj.Shape.Length}"
+            if cell < 0 || cell >= shape.Length then
+                failwith $"TODO: byte-view write past array bounds at cell %d{cell} of length %d{shape.Length}"
 
-            let existing = state.ManagedHeap.Arrays.[arr].Elements.[cell]
+            // Re-read from the *current* state each iteration, not from a snapshot: the loop
+            // writes as it goes, and a multi-cell write whose range revisits a cell must see
+            // its own earlier store.
+            let existing = ManagedHeap.getArrayValue arr cell state.ManagedHeap
 
             // Deriving how much of this cell the write covers doesn't require the cell to be
             // byte-renderable, for the same reason the stride above doesn't; the byte-view
@@ -2009,13 +2007,13 @@ module IlMachineManagedByref =
             None
         else
 
-        let arrObj = state.ManagedHeap.Arrays.[arr]
+        let shape = ManagedHeap.getArrayShape arr state.ManagedHeap
 
-        if index < 0 || index >= arrObj.Shape.Length then
+        if index < 0 || index >= shape.Length then
             None
         else
 
-        let existing = arrObj.Elements.[index]
+        let existing = ManagedHeap.getArrayValue arr index state.ManagedHeap
 
         if CliType.sizeOf existing <> CliType.sizeOf newValue then
             None
@@ -2232,41 +2230,36 @@ module IlMachineManagedByref =
         //
         // Shape acceptance uses the shared `cellShapeMatches` (see its
         // docstring for why declared-handle equality is the right rule for
-        // user structs). Use `CliType.sizeOf` (not `byteAddressableCellSize`)
-        // for stride derivation because element 0 itself may already carry
-        // non-byte-renderable provenance from a prior typed store.
+        // user structs), against the element type's zero rather than against
+        // cell 0. "Is this value shaped like a cell of this array" is a
+        // question about the element type, and cell 0 answers it only by
+        // accident: it is a sample, so a store to cell 5 was being validated
+        // against whatever provenance cell 0 had picked up, and an empty array
+        // had no sample at all and was declined outright.
         let arrayElementTypedCellWrite =
             match src with
             | ManagedPointerSource.Byref (ByrefRoot.ArrayElement _, _) ->
                 match splitTrailingByteView src with
                 | ValueSome (ByrefRoot.ArrayElement (arr, index), [], byteOffset) ->
-                    let arrObj = state.ManagedHeap.Arrays.[arr]
+                    let shape = ManagedHeap.getArrayShape arr state.ManagedHeap
+                    let cellSize = shape.ElementStride
+                    let cellAdvance, inCellStart = floorDivRem byteOffset cellSize
+                    let newSize = CliType.sizeOf newValue
 
-                    // The stride is the array's recorded one, but the shape test below still
-                    // consults cell 0, so an empty array has nothing to match against and is
-                    // declined here as before. (Whether a cell's *shape* is likewise
-                    // derivable from the element type is a separate question from its
-                    // stride, and is left alone here.)
-                    if arrObj.Shape.Length = 0 then
-                        None
-                    else
-                        let cellSize = arrObj.Shape.ElementStride
-                        let cellAdvance, inCellStart = floorDivRem byteOffset cellSize
-                        let newSize = CliType.sizeOf newValue
+                    if
+                        inCellStart = 0
+                        && newSize = cellSize
+                        && cellShapeMatches shape.ElementZero newValue
+                    then
+                        let targetCell = index + cellAdvance
 
-                        if
-                            inCellStart = 0
-                            && newSize = cellSize
-                            && cellShapeMatches arrObj.Elements.[0] newValue
-                        then
-                            let targetCell = index + cellAdvance
-
-                            if targetCell < 0 || targetCell >= arrObj.Shape.Length then
-                                None
-                            else
-                                Some (IlMachineThreadState.setArrayValue arr newValue targetCell state)
-                        else
+                        // Subsumes the empty-array case: no cell index is in bounds there.
+                        if targetCell < 0 || targetCell >= shape.Length then
                             None
+                        else
+                            Some (IlMachineThreadState.setArrayValue arr newValue targetCell state)
+                    else
+                        None
                 | _ -> None
             | _ -> None
 
@@ -3008,34 +3001,31 @@ module IlMachineManagedByref =
                 // Int32` and `Numeric NativeInt` differ at the unwrapped
                 // constructor level.
                 //
-                // Use `CliType.sizeOf` rather than `byteAddressableCellSize`
-                // because the cell itself may already carry non-byte-
-                // renderable provenance.
-                let arrObj = state.ManagedHeap.Arrays.[arr]
-
-                if arrObj.Shape.Length = 0 then
-                    failwith
-                        $"TODO: byte-view typed store into empty array %O{arr} at index %d{index} offset %d{byteOffset}"
-
-                let cellSize = arrObj.Shape.ElementStride
+                // As in `arrayElementTypedCellWrite`, the shape witness is the element type's
+                // zero rather than cell 0: the question is whether the payload is shaped like
+                // a cell of *this array*, which cell 0 answers only as a sample and an empty
+                // array could not answer at all.
+                let shape = ManagedHeap.getArrayShape arr state.ManagedHeap
+                let cellSize = shape.ElementStride
                 let cellAdvance, inCellStart = floorDivRem byteOffset cellSize
                 let newSize = CliType.sizeOf newValue
 
                 if
                     inCellStart = 0
                     && newSize = cellSize
-                    && haveSameCliShape arrObj.Elements.[0] newValue
+                    && haveSameCliShape shape.ElementZero newValue
                 then
                     let targetCell = index + cellAdvance
 
-                    if targetCell < 0 || targetCell >= arrObj.Shape.Length then
+                    // Subsumes the empty-array case: no cell index is in bounds there.
+                    if targetCell < 0 || targetCell >= shape.Length then
                         failwith
-                            $"TODO: byte-view typed store past array bounds at cell %d{targetCell} of length %d{arrObj.Shape.Length}"
+                            $"TODO: byte-view typed store past array bounds at cell %d{targetCell} of length %d{shape.Length}"
 
                     IlMachineThreadState.setArrayValue arr newValue targetCell state
                 else
                     failwith
-                        $"TODO: primitive indirect store of %O{newValue} through byte-view byref %O{src} cannot preserve %s{reason}: write size %d{newSize}, cell size %d{cellSize}, in-cell offset %d{inCellStart}, cell shape %O{arrObj.Elements.[0]}"
+                        $"TODO: primitive indirect store of %O{newValue} through byte-view byref %O{src} cannot preserve %s{reason}: write size %d{newSize}, cell size %d{cellSize}, in-cell offset %d{inCellStart}, element shape %O{shape.ElementZero}"
             | ValueSome _ ->
                 failwith
                     $"TODO: primitive indirect store of %O{newValue} through byte-view byref %O{src} cannot preserve %s{reason}"
@@ -3180,51 +3170,51 @@ module IlMachineManagedByref =
                     // store — the new value is the byte-addressable zero
                     // but the cell still holds a `TypeHandlePtr`, which the
                     // byte-scatter path would refuse.
-                    let arrObj = state.ManagedHeap.Arrays.[arr]
+                    let shape = ManagedHeap.getArrayShape arr state.ManagedHeap
 
                     let typedCellOverride =
-                        if arrObj.Shape.Length = 0 then
-                            ValueNone
-                        else
-                            let cellSize = arrObj.Shape.ElementStride
-                            let cellAdvance, inCellStart = floorDivRem byteOffset cellSize
+                        let cellSize = shape.ElementStride
+                        let cellAdvance, inCellStart = floorDivRem byteOffset cellSize
 
-                            if inCellStart = 0 && CliType.sizeOf newValue = cellSize then
-                                let targetCell = index + cellAdvance
+                        if inCellStart = 0 && CliType.sizeOf newValue = cellSize then
+                            let targetCell = index + cellAdvance
 
-                                if targetCell >= 0 && targetCell < arrObj.Shape.Length then
-                                    // Same destination-side test as the non-array arm below: the
-                                    // *routing* question is about the cell, so both sites must
-                                    // ask it the same way. (What the two do once routed still
-                                    // differs: the array path in
-                                    // `writeExactWidthPrimitiveTypedStore` demands
-                                    // `haveSameCliShape` and fails loudly otherwise, while the
-                                    // non-array path checks width only and restamps the cell with
-                                    // the payload's shape. That asymmetry predates this change.)
-                                    // An array element cell really can be a
-                                    // `CliType.RuntimePointer` — C# has no `int*[]` syntax, but
-                                    // `Array.CreateInstance(typeof(int*), n)` succeeds and
-                                    // `MemoryMarshal.GetArrayDataReference(Array)` hands out a
-                                    // byte-view byref over one.
-                                    //
-                                    // This does not make that case *work*: measured, a pointer
-                                    // cell that gets past the payload gate reaches
-                                    // `writeExactWidthPrimitiveTypedStore` and stops at its
-                                    // `haveSameCliShape` check, because a `stind.i` payload
-                                    // arrives as `Numeric NativeInt` while the cell is a
-                                    // `RuntimePointer`. That is a separate, pre-existing gap in
-                                    // the byte-view typed store, and it fails loudly with a
-                                    // message naming the shapes. Routing here is still the honest
-                                    // classification, and it only ever diverts cases that
-                                    // previously failed too.
-                                    match byteAddressabilityRejection arrObj.Elements.[targetCell] with
-                                    | Some rejection when destinationNeedsWholeCellStore newValue rejection ->
-                                        ValueSome (arrObj.Elements.[targetCell], rejection)
-                                    | _ -> ValueNone
-                                else
-                                    ValueNone
+                            // Subsumes the empty-array case: nothing is in bounds there.
+                            if targetCell >= 0 && targetCell < shape.Length then
+                                // Same destination-side test as the non-array arm below: the
+                                // *routing* question is about the cell, so both sites must
+                                // ask it the same way. (What the two do once routed still
+                                // differs: the array path in
+                                // `writeExactWidthPrimitiveTypedStore` demands
+                                // `haveSameCliShape` and fails loudly otherwise, while the
+                                // non-array path checks width only and restamps the cell with
+                                // the payload's shape. That asymmetry predates this change.)
+                                // An array element cell really can be a
+                                // `CliType.RuntimePointer` — C# has no `int*[]` syntax, but
+                                // `Array.CreateInstance(typeof(int*), n)` succeeds and
+                                // `MemoryMarshal.GetArrayDataReference(Array)` hands out a
+                                // byte-view byref over one.
+                                //
+                                // This does not make that case *work*: measured, a pointer
+                                // cell that gets past the payload gate reaches
+                                // `writeExactWidthPrimitiveTypedStore` and stops at its
+                                // `haveSameCliShape` check, because a `stind.i` payload
+                                // arrives as `Numeric NativeInt` while the cell is a
+                                // `RuntimePointer`. That is a separate, pre-existing gap in
+                                // the byte-view typed store, and it fails loudly with a
+                                // message naming the shapes. Routing here is still the honest
+                                // classification, and it only ever diverts cases that
+                                // previously failed too.
+                                let cellValue = ManagedHeap.getArrayValue arr targetCell state.ManagedHeap
+
+                                match byteAddressabilityRejection cellValue with
+                                | Some rejection when destinationNeedsWholeCellStore newValue rejection ->
+                                    ValueSome (cellValue, rejection)
+                                | _ -> ValueNone
                             else
                                 ValueNone
+                        else
+                            ValueNone
 
                     match typedCellOverride with
                     | ValueSome (existing, rejection) ->

--- a/WoofWare.PawPrint/IlMachineThreadState.fs
+++ b/WoofWare.PawPrint/IlMachineThreadState.fs
@@ -593,9 +593,11 @@ module IlMachineThreadState =
         let initialisation =
             (fun _ -> zeroOfType ()) |> Seq.init len |> ImmutableArray.CreateRange
 
-        // The element zero is the stride's definition, so it is taken from the factory
-        // rather than measured off a cell: an empty array has no cell to measure and still
-        // has a stride. One extra factory call, against `len` for the backing store.
+        // The element zero defines both the stride and the cell shape, so it is taken from
+        // the factory rather than sampled off a cell: an empty array has no cell to sample
+        // and still has both. One extra factory call, against `len` for the backing store.
+        let elementZero = zeroOfType ()
+
         let o : AllocatedArray =
             {
                 Shape =
@@ -603,7 +605,8 @@ module IlMachineThreadState =
                         ConcreteType = arrayType
                         Length = len
                         Lengths = ImmutableArray.Create len
-                        ElementStride = CliType.sizeOf (zeroOfType ())
+                        ElementStride = CliType.sizeOf elementZero
+                        ElementZero = elementZero
                     }
                 Elements = initialisation
             }
@@ -668,6 +671,9 @@ module IlMachineThreadState =
         let initialisation =
             (fun _ -> zeroOfType ()) |> Seq.init totalLength |> ImmutableArray.CreateRange
 
+        // See `allocateArray`: the element zero comes from the factory, not from a cell.
+        let elementZero = zeroOfType ()
+
         let o : AllocatedArray =
             {
                 Shape =
@@ -675,7 +681,8 @@ module IlMachineThreadState =
                         ConcreteType = arrayType
                         Length = totalLength
                         Lengths = dimensionLengths
-                        ElementStride = CliType.sizeOf (zeroOfType ())
+                        ElementStride = CliType.sizeOf elementZero
+                        ElementZero = elementZero
                     }
                 Elements = initialisation
             }
@@ -689,32 +696,17 @@ module IlMachineThreadState =
 
         alloc, state
 
-    /// Allocate a fresh array object that is a shallow copy of the array at `source`: same
-    /// element type, same rank, same per-dimension lengths, and the same element values.
-    /// `CliType` cells are immutable, so sharing the backing `ImmutableArray` gives exactly
-    /// the shallow-copy semantics `System.Array.Clone` promises: a later write through
-    /// either array replaces only that array's cell, while reference-typed elements continue
-    /// to name the same heap objects from both arrays.
+    /// `ManagedHeap.cloneArray` lifted to a whole machine state; see there for the semantics.
     /// Fails if `source` is not an array — callers must have established that already.
     let cloneArray (source : ManagedHeapAddress) (state : IlMachineState) : ManagedHeapAddress * IlMachineState =
-        match state.ManagedHeap.Arrays.TryGetValue source with
-        | false, _ ->
-            let what =
-                if (ManagedHeap.tryGet source state.ManagedHeap).IsSome then
-                    "a non-array object"
-                else
-                    "not allocated"
+        let alloc, heap = ManagedHeap.cloneArray source state.ManagedHeap
 
-            failwith $"cloneArray: address %O{source} is %s{what} on the managed heap, so has no array to clone"
-        | true, source ->
-            let alloc, heap = state.ManagedHeap |> ManagedHeap.allocateArray source
+        let state =
+            { state with
+                ManagedHeap = heap
+            }
 
-            let state =
-                { state with
-                    ManagedHeap = heap
-                }
-
-            alloc, state
+        alloc, state
 
     /// Allocate a fresh object that is a shallow copy of whatever is at `source`: the primitive
     /// behind `Object.MemberwiseClone`.

--- a/WoofWare.PawPrint/Intrinsics.fs
+++ b/WoofWare.PawPrint/Intrinsics.fs
@@ -2034,14 +2034,10 @@ module Intrinsics =
                 )
             | Some rvaData ->
 
-            // Keeps the whole allocation: the RVA-decoding fold below reads element `i` as a
-            // *template* for `readPeByteRangeBytesAs`, which is a type query rather than a
-            // guest-visible cell read. Splitting that out is left to the follow-up that
-            // introduces a dedicated accessor for cell-type witnesses.
-            let arr = state.ManagedHeap.Arrays.[arrayAddr]
+            let shape = ManagedHeap.getArrayShape arrayAddr state.ManagedHeap
 
             let elementHandle : ConcreteTypeHandle =
-                match arr.Shape.ConcreteType with
+                match shape.ConcreteType with
                 | ConcreteTypeHandle.OneDimArrayZero element -> element
                 | ConcreteTypeHandle.Array (element, _) -> element
                 | other ->
@@ -2124,7 +2120,7 @@ module Intrinsics =
                 IlMachineState.cliTypeZeroOfHandle state baseClassTypes elementHandle
 
             let elementStride : int = CliType.sizeOf elementZero
-            let totalSize : int64 = int64 elementStride * int64 arr.Shape.Length
+            let totalSize : int64 = int64 elementStride * int64 shape.Length
 
             // `// make certain you don't go off the end of the rva static
             //  if (totalSize > size) throw new ArgumentException(SR.Argument_BadFieldForInitializeArray);`
@@ -2145,15 +2141,17 @@ module Intrinsics =
             // encoding used everywhere else, so enums — and anything else it later learns to
             // reconstruct — need no decoder of their own here.
             //
-            // The template is the element's current value, which after `newarr` is the zero of
-            // the element type and so has exactly the right shape for that slot. Multi-dimensional
-            // arrays are stored flat in row-major order, matching the CLR's own layout, so the
-            // same flat walk serves them.
+            // The template is the element type's zero — the same value the stride above was
+            // measured from — rather than the cell's current contents. Every cell is overwritten
+            // here regardless, so what one happens to hold on the way in is not information this
+            // decode wants; reading it would be a guest-visible read performed to answer a
+            // question about a type. Multi-dimensional arrays are stored flat in row-major order,
+            // matching the CLR's own layout, so the same flat walk serves them.
             let state =
-                (state, seq { 0 .. arr.Shape.Length - 1 })
+                (state, seq { 0 .. shape.Length - 1 })
                 ||> Seq.fold (fun (state : IlMachineState) (i : int) ->
                     let decoded =
-                        IlMachineState.readPeByteRangeBytesAs state rvaData (i * elementStride) arr.Elements.[i]
+                        IlMachineState.readPeByteRangeBytesAs state rvaData (i * elementStride) elementZero
 
                     IlMachineState.setArrayValue arrayAddr decoded i state
                 )

--- a/WoofWare.PawPrint/ManagedHeap.fs
+++ b/WoofWare.PawPrint/ManagedHeap.fs
@@ -85,8 +85,9 @@ type AllocatedNonArrayObject =
         }
 
 /// Everything about an array except its contents: the element type, the total element
-/// count, the per-dimension lengths, and the byte stride between cells. All of them are
-/// fixed when the array is allocated and never change afterwards, so reading them is not a
+/// count, the per-dimension lengths, and the two element-type facts the access paths need —
+/// the byte stride between cells and the element's zero value. All of them are fixed when
+/// the array is allocated and never change afterwards, so reading them is not a
 /// guest-visible memory access — unlike reading a cell, which is.
 ///
 /// The absence of an `Elements` field is the point. A caller that needs only the rank or
@@ -115,9 +116,32 @@ type ArrayShape =
         /// follows). Consumers divide by it — see `floorDivRem` — so a zero here would be a
         /// silent wrong answer rather than a loud one.
         ///
-        /// `ManagedHeap.allocateArray` checks positivity, and checks the value itself
-        /// against cell 0 of every non-empty allocation, so the two can never drift apart.
+        /// `ManagedHeap.allocateArray` checks positivity, checks the value against
+        /// `ElementZero`, and checks it against cell 0 of every non-empty allocation, so it
+        /// can never drift from either.
         ElementStride : int
+        /// The zero value of the element type: what every cell held immediately after
+        /// allocation, and the canonical witness for "what shape is a cell of this array".
+        ///
+        /// Like `ElementStride`, a property of the element type rather than of any stored
+        /// value, recorded from the zero factory the allocator was handed. Callers asking a
+        /// *type* question — is this store whole-cell-shaped, what template should this
+        /// decoded value take — read this instead of sampling cell 0. Sampling cell 0 is
+        /// wrong in three separate ways: it is a guest-visible read performed to answer a
+        /// question about a type, it has no answer for an empty array, and cell 0 is only a
+        /// sample, so a store to cell 5 ends up validated against whatever provenance cell 0
+        /// happens to be carrying.
+        ///
+        /// Not a substitute for reading a cell. A cell legitimately drifts from this shape —
+        /// an `IntPtr[]` slot holding a `TypeHandlePtr` after a typed store through a fixed
+        /// pointer — so anything that cares what is *actually stored* must still go through
+        /// `getArrayValue`.
+        ///
+        /// `ElementStride` is exactly `CliType.sizeOf ElementZero`, checked at
+        /// `allocateArray`. It is stored rather than recomputed because `CliType.sizeOf`
+        /// walks a value type's whole field tree, and the stride is read on every byte-view
+        /// array access.
+        ElementZero : CliType
     }
 
 type AllocatedArray =
@@ -201,16 +225,31 @@ module ManagedHeap =
 
     /// Allocate `ty` at a fresh address.
     ///
-    /// `ty.Shape.ElementStride` is checked against cell 0 here rather than trusted. The
-    /// stride is the one piece of `ArrayShape` that duplicates information also derivable
-    /// from the cells, and this is the single chokepoint through which every array reaches
-    /// the heap — including `cloneArray`, which reuses a source record verbatim. Callers
-    /// read the stride instead of measuring a cell precisely so that they never touch guest
-    /// memory to learn it, which would be worthless if the recorded value could be wrong.
+    /// The element-type facts on `ty.Shape` are checked here rather than trusted. They are
+    /// the parts of `ArrayShape` that duplicate information also derivable from the cells,
+    /// and this is the single chokepoint through which every array reaches the heap —
+    /// including `cloneArray`, which reuses a source record verbatim. Callers read them
+    /// instead of measuring a cell precisely so that they never touch guest memory to learn
+    /// them, which would be worthless if the recorded values could be wrong.
+    ///
+    /// Cell 0 is checked by *size* only. A cell's CLI shape legitimately drifts from
+    /// `ElementZero`'s — an `IntPtr[]` slot holding a `TypeHandlePtr` — whereas its width
+    /// never may, since the array's layout depends on it.
     let allocateArray (ty : AllocatedArray) (heap : ManagedHeap) : ManagedHeapAddress * ManagedHeap =
+        // Strictly, the element-zero check below subsumes this one: it forces the stride to
+        // equal a `CliType.sizeOf`, which is never less than 1. This stays as a direct
+        // assertion of the property consumers actually depend on — `floorDivRem` divides by
+        // the stride — rather than leaving that to a two-step argument across two files. It
+        // also names the specific failure, which the size-mismatch message would not.
         if ty.Shape.ElementStride <= 0 then
             failwith
                 $"allocateArray: array of %O{ty.Shape.ConcreteType} declares a non-positive element stride %d{ty.Shape.ElementStride}; every CLI type occupies at least one byte"
+
+        let zeroSize = CliType.sizeOf ty.Shape.ElementZero
+
+        if zeroSize <> ty.Shape.ElementStride then
+            failwith
+                $"allocateArray: array of %O{ty.Shape.ConcreteType} declares element stride %d{ty.Shape.ElementStride} but its element zero %O{ty.Shape.ElementZero} measures %d{zeroSize}; the stride is by definition the size of the element zero"
 
         if not ty.Elements.IsEmpty then
             let cellSize = CliType.sizeOf ty.Elements.[0]
@@ -218,6 +257,29 @@ module ManagedHeap =
             if cellSize <> ty.Shape.ElementStride then
                 failwith
                     $"allocateArray: array of %O{ty.Shape.ConcreteType} declares element stride %d{ty.Shape.ElementStride} but its first cell measures %d{cellSize}; the stride must be the element type's size, so one of the two is wrong"
+
+        // `getArrayValue` bounds-checks the index against the *shape* and then indexes the
+        // *cells*, which is only sound while the two agree. Splitting the shape out of the
+        // payload record is what made it possible for them not to.
+        if ty.Elements.Length <> ty.Shape.Length then
+            failwith
+                $"allocateArray: array of %O{ty.Shape.ConcreteType} declares length %d{ty.Shape.Length} but carries %d{ty.Elements.Length} cell(s)"
+
+        // `Length` is documented as the product of `Lengths`, and the multi-dimensional
+        // accessors rely on it being so: `UnaryMetadataCallOps`' array `Get`/`Set`/`Address`
+        // bounds-check each index against `Lengths`, flatten to a row-major offset, and hand
+        // that to `getArrayValue`, which bounds-checks against `Length`. If the two disagree,
+        // an index every per-dimension check accepts can still fall outside the cells.
+        //
+        // Accumulated in int64 so that a caller's overflowing dimensions are reported here
+        // rather than wrapping into an apparently-agreeing product. Callers that build a
+        // length from guest input reject the overflow themselves, with the guest exception
+        // CoreCLR raises; see `allocateMultiDimArray`.
+        let product = ty.Shape.Lengths |> Seq.fold (fun acc d -> acc * int64<int> d) 1L
+
+        if product <> int64<int> ty.Shape.Length then
+            failwith
+                $"allocateArray: array of %O{ty.Shape.ConcreteType} declares length %d{ty.Shape.Length} but its per-dimension lengths multiply to %d{product}"
 
         let addr = heap.FirstAvailableAddress
 
@@ -421,6 +483,13 @@ module ManagedHeap =
     let getArrayElementStride (addr : ManagedHeapAddress) (heap : ManagedHeap) : int =
         (getArrayShape addr heap).ElementStride
 
+    /// The zero value of the element type of the array at `addr`: the witness for questions
+    /// about what shape a cell of this array has. Well defined for an empty array, and never
+    /// a read of a cell — which is the point; see `ArrayShape.ElementZero`. Use
+    /// `getArrayValue` when you want to know what a cell actually holds.
+    let getArrayElementZero (addr : ManagedHeapAddress) (heap : ManagedHeap) : CliType =
+        (getArrayShape addr heap).ElementZero
+
     let getArrayValue (alloc : ManagedHeapAddress) (offset : int) (heap : ManagedHeap) : CliType =
         match heap.Arrays.TryGetValue alloc with
         | false, _ -> failwith $"TODO: array not on heap (no array registered at %O{alloc})"
@@ -456,6 +525,30 @@ module ManagedHeap =
                 failwith $"get: %O{alloc} is an array, so has no non-array object payload"
             else
                 failwith $"get: %O{alloc} is not a live managed heap allocation"
+
+    /// Allocate a fresh array object that is a shallow copy of the array at `source`: same
+    /// element type, same rank, same per-dimension lengths, and the same element values.
+    /// `CliType` cells are immutable, so sharing the backing `ImmutableArray` gives exactly
+    /// the shallow-copy semantics `System.Array.Clone` promises: a later write through
+    /// either array replaces only that array's cell, while reference-typed elements continue
+    /// to name the same heap objects from both arrays.
+    ///
+    /// Reuses the source `AllocatedArray` wholesale, so the clone is *identical* rather than
+    /// merely equivalent — there is no second construction of the shape to get wrong. The
+    /// clone still gets a fresh address, and with it a fresh `SyncBlock`: the source's
+    /// monitor state belongs to the source's identity, not to its contents.
+    ///
+    /// The two rejection cases are reported differently because they are different bugs: a
+    /// non-array address means the caller misjudged the kind of the reference it was handed,
+    /// whereas an unallocated address means the reference itself is bogus.
+    let cloneArray (source : ManagedHeapAddress) (heap : ManagedHeap) : ManagedHeapAddress * ManagedHeap =
+        match heap.Arrays.TryGetValue source with
+        | true, arr -> allocateArray arr heap
+        | false, _ ->
+            if heap.NonArrayObjects.ContainsKey source then
+                failwith $"cloneArray: %O{source} is a non-array object, so has no array to clone"
+            else
+                failwith $"cloneArray: %O{source} is not a live managed heap allocation, so has no array to clone"
 
     /// Replace the entire payload of the non-array object at `alloc`. Rejects an address
     /// that is not already a live non-array object rather than conjuring one there:
@@ -509,10 +602,10 @@ module ManagedHeap =
                     | Some arr ->
                         if offset < 0 then
                             failwith
-                                $"TODO: raise IndexOutOfRangeException: negative array index %d{offset} on array at %O{alloc} (length %d{arr.Elements.Length}). A negative index here typically means a byref obtained via `RawData::Data` on an array was written without first applying the canonical `+sizeof(nint)` skip past the length-header region."
-                        elif offset >= arr.Elements.Length then
+                                $"TODO: raise IndexOutOfRangeException: negative array index %d{offset} on array at %O{alloc} (length %d{arr.Shape.Length}). A negative index here typically means a byref obtained via `RawData::Data` on an array was written without first applying the canonical `+sizeof(nint)` skip past the length-header region."
+                        elif offset >= arr.Shape.Length then
                             failwith
-                                $"TODO: raise IndexOutOfRangeException: array index %d{offset} >= length %d{arr.Elements.Length} on array at %O{alloc}"
+                                $"TODO: raise IndexOutOfRangeException: array index %d{offset} >= length %d{arr.Shape.Length} on array at %O{alloc}"
 
                         { arr with
                             Elements = arr.Elements.SetItem (offset, v)

--- a/WoofWare.PawPrint/UnaryMetadataArrayOps.fs
+++ b/WoofWare.PawPrint/UnaryMetadataArrayOps.fs
@@ -359,14 +359,7 @@ module internal UnaryMetadataArrayOps =
             | Some addr -> addr
             | None -> failwith "expected heap allocation for array, got null"
 
-        let toPush =
-            match state.ManagedHeap.Arrays.TryGetValue arr with
-            | false, _ -> failwith $"unexpectedly failed to find array allocation {arr} in Ldelem"
-            | true, v ->
-                if 0 <= index && index < v.Elements.Length then
-                    v.Elements.[index]
-                else
-                    failwith "TODO: raise an out of bounds"
+        let toPush = ManagedHeap.getArrayValue arr index state.ManagedHeap
 
         IlMachineState.pushToEvalStack toPush thread state
         |> IlMachineState.advanceProgramCounter thread


### PR DESCRIPTION
Slice C2/C3 of the guest-memory access seam (after #938, #940, #942, #943, #948, #950, #951). After this, **no code outside `ManagedHeap.fs` touches `ManagedHeap.Arrays` or an `AllocatedArray`'s `Elements`** anywhere in the library. The only remaining direct readers are `DebuggerServer` and the tests, which is slice D's business.

Unlike C1, this one contains no bug. It is a seam slice: the same behaviour, reached through accessors, with three special cases deleted because they existed only to work around a missing fact.

## The two kinds of `Elements` read

Ten sites reached into an array's cells. They were not all doing the same thing, and separating them is the whole content of this PR.

**Genuine cell reads** — the caller wants to know what is *stored*. Seven sites, now routed through `ManagedHeap.getArrayValue`: the byte-scatter read and write loops, the whole-cell short-circuits, `tryWriteArrayElementPrecise`, the typed-cell override, and `Ldelem`.

`Ldelem` is the one with a visible improvement. It open-coded its own bounds check ending in `failwith "TODO: raise an out of bounds"`, which named neither the index nor the length; `getArrayValue` reports both, and its negative-index arm carries the `RawData::Data` diagnosis that has been earned elsewhere.

**Cell 0 as a type witness** — the caller wants to know what shape a cell *has*, and was sampling one to find out. Three sites: two shape gates on the byte-view typed store, and `InitializeArray`'s RVA decode template.

Sampling is wrong three ways, and only the first is about this seam:
- it is a guest-visible read performed to answer a question about a type;
- it has no answer for an empty array — hence three separate `if Length = 0` special cases;
- **cell 0 is a sample.** A store to cell 5 was validated against whatever provenance cell 0 happened to have picked up.

So `ArrayShape` now records `ElementZero : CliType` alongside `ElementStride`, from the same zero factory the allocator already calls per element. All three witnesses read it, and all three `Length = 0` special cases are deleted: the bounds check on the target cell already declines an empty array, since no index is in bounds there.

## Why `ElementStride` survives rather than becoming `sizeOf ElementZero`

`ElementStride` is now exactly `CliType.sizeOf ElementZero`, so it is a denormalisation. The alternative — one field, stride computed on demand — is more obviously correct, and I did not take it: `CliType.SizeOf` on a value type walks its whole field tree (and `ContainsObjectReferences` recurses again), while the stride is read on *every* byte-view array access. That is the cost #948 removed by recording it.

The denormalisation is closed at the chokepoint instead. `allocateArray` now runs four checks, each provoked by its own test:

| check | why |
|---|---|
| `sizeOf ElementZero = ElementStride` | new — the two fields are one fact; this is what stops them drifting |
| `sizeOf Elements[0] = ElementStride` | the recorded stride agrees with the storage (pre-existing) |
| `Elements.Length = Shape.Length` | new — see below |
| `product Lengths = Shape.Length` | new — see below |

Cell 0 is checked by *size* only, never by shape: a cell's CLI shape legitimately drifts from the element zero's (an `IntPtr[]` slot holding a `TypeHandlePtr`), whereas its width never may.

## Two length checks, for a hazard this seam created

`getArrayValue` bounds-checks the index against `Shape.Length` and then indexes `Elements`. Splitting the shape out of the payload record is what made those two different numbers, and a disagreement would surface as a raw `IndexOutOfRangeException` from beneath the interpreter rather than the intended error.

The `Lengths` product is the same hazard one level up, and it is not hypothetical: `UnaryMetadataCallOps`' multi-dimensional `Get` / `Set` / `Address` bounds-check each index against `Lengths`, flatten to a row-major offset, and hand that to `getArrayValue`, which checks against `Length`. If the two disagree, an index that every per-dimension check accepts still falls outside the cells. The product accumulates in int64 so overflowing dimensions are reported rather than wrapping into an apparently-agreeing total.

The cell-count check cost an existing test its premise. `array shape is exactly the allocation minus its elements` deliberately allocated `Length = total` with an *empty* backing store, to catch a projection that derived `Length` from `Elements.Length`. That allocation is now rejected outright, so the test populates its cells and the discrimination moves to `allocateArray rejects a length that disagrees with the cell count` — a stronger statement than "the wrong value is projected faithfully".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
