### PR TITLE
Run ValueTask<T>.ConfigureAwait's IL instead of refusing it

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/ValueTaskConfigureAwait.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/ValueTaskConfigureAwait.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Sources;
+
+// `ValueTask<T>.ConfigureAwait(bool)` (issue #957). The method is `[Intrinsic]`, so before this
+// file every guest touching it died at "TODO: implement JIT intrinsic
+// System.Threading.Tasks.ValueTask`1.ConfigureAwait(System.Boolean)"; PawPrint now runs the managed
+// body, which is what the JIT does too outside the runtime-async await peephole (see the
+// safe-intrinsic allowlist entry for the citation).
+//
+// The body copies `_obj`, `_result`, `_token` and the new flag into a fresh ValueTask<T> and wraps
+// it in a ConfiguredValueTaskAwaitable<T>, so each test below is chosen to fail if one of those
+// three carried fields is lost rather than merely if the call aborts:
+//   * the result-backed cases pin `_result` (losing it yields 0, not 42);
+//   * the task-backed case pins `_obj` (losing it yields 0, not 41, and never blocks);
+//   * the IValueTaskSource case pins `_token` (the source answers -1 for any other token).
+// Nothing here asserts anything about *which* thread a continuation resumes on, which is the only
+// thing `continueOnCapturedContext` actually influences; both values are exercised for reachability
+// only, and every assertion is deterministic under PawPrint's scheduler and under real .NET alike.
+public static class ValueTaskConfigureAwait
+{
+    // A synchronously-succeeded IValueTaskSource<int> that only answers correctly for the token it
+    // was handed to the ValueTask<int> with, so a ConfigureAwait that dropped `_token` is visible.
+    private sealed class TokenCheckingSource : IValueTaskSource<int>
+    {
+        public const short Token = 7;
+
+        public int GetResult(short token) => token == Token ? 33 : -1;
+
+        public ValueTaskSourceStatus GetStatus(short token) => ValueTaskSourceStatus.Succeeded;
+
+        public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+        {
+            // Never reached: GetStatus reports the operation is already complete.
+        }
+    }
+
+    // No await at all: the awaitable and its awaiter are inspected directly, so a failure here is
+    // attributable to ConfigureAwait rather than to the async state machine.
+    static int TestDirect()
+    {
+        ValueTask<int> vt = new ValueTask<int>(42);
+        var awaiter = vt.ConfigureAwait(false).GetAwaiter();
+        if (!awaiter.IsCompleted) return 1;
+        if (awaiter.GetResult() != 42) return 2;
+
+        // continueOnCapturedContext: true is the other half of the flag's domain, and is the value
+        // an unconfigured await would have used.
+        var awaiterTrue = vt.ConfigureAwait(true).GetAwaiter();
+        if (!awaiterTrue.IsCompleted) return 3;
+        if (awaiterTrue.GetResult() != 42) return 4;
+
+        return 0;
+    }
+
+    static async Task<int> AwaitResultBackedAsync()
+    {
+        int x = await new ValueTask<int>(20).ConfigureAwait(false);
+        return x + 21;
+    }
+
+    // The compiler-generated state machine's awaiter is ConfiguredValueTaskAwaiter rather than
+    // ValueTaskAwaiter, so this covers the await path in addition to TestDirect's direct one.
+    static int TestAwaitResultBacked()
+    {
+        if (AwaitResultBackedAsync().Result != 41) return 1;
+        return 0;
+    }
+
+    static async Task<int> AwaitTaskBackedAsync()
+    {
+        return await new ValueTask<int>(Task.Run(() => 41)).ConfigureAwait(false);
+    }
+
+    // Backed by a Task rather than by a result, so `_obj` must survive the copy: a ValueTask<int>
+    // that lost it would be an already-completed one carrying default(int).
+    static int TestAwaitTaskBacked()
+    {
+        if (AwaitTaskBackedAsync().Result != 41) return 1;
+        return 0;
+    }
+
+    static async Task<int> AwaitSourceBackedAsync()
+    {
+        return await new ValueTask<int>(new TokenCheckingSource(), TokenCheckingSource.Token).ConfigureAwait(false);
+    }
+
+    static int TestAwaitSourceBacked()
+    {
+        if (AwaitSourceBackedAsync().Result != 33) return 1;
+        return 0;
+    }
+
+    public static int Main(string[] args)
+    {
+        int result;
+
+        result = TestDirect();
+        if (result != 0) return 100 + result;
+
+        result = TestAwaitResultBacked();
+        if (result != 0) return 200 + result;
+
+        result = TestAwaitTaskBacked();
+        if (result != 0) return 300 + result;
+
+        result = TestAwaitSourceBacked();
+        if (result != 0) return 400 + result;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/IntrinsicMethodKeys.fs
+++ b/WoofWare.PawPrint/IntrinsicMethodKeys.fs
@@ -741,6 +741,47 @@ module IntrinsicMethodKeys =
             pattern "System.Private.CoreLib" "System.Threading.Thread" "get_CurrentThread" []
             // IL body is `ldarg.0; ldfld _managedThreadId; ret` — pure field access.
             pattern "System.Private.CoreLib" "System.Threading.Thread" "get_ManagedThreadId" []
+            // `ValueTask<TResult>.ConfigureAwait(bool)` — the awaitable-configuring member every
+            // `await something.ConfigureAwait(false)` over a `ValueTask<T>` goes through.
+            //
+            // Its `[Intrinsic]` is not an implementation at all: `lookupNamedIntrinsic` maps
+            // `ConfigureAwait` to `NI_System_Threading_Tasks_Task_ConfigureAwait`
+            // (importercalls.cpp:11200-11209), and the only place in the whole JIT that ever *reads*
+            // that enumerator is `impMatchTaskAwaitPattern` (importer.cpp:6027), which recognises the
+            // `call <Method>; ldc.i4.0/1; call <ConfigureAwait>; call <AsyncHelpers.Await>` IL
+            // shape a *runtime-async* method compiles to, and rewrites the trio into a single call
+            // to the runtime-async counterpart of `Method`. There is no `impIntrinsic` case for it,
+            // so outside that peephole the JIT emits the ordinary call and the managed body is the
+            // semantic definition. (For this member the peephole cannot fire even in principle: the
+            // class-name test upstream compares against "ValuTask`1" — importercalls.cpp:11205, a
+            // typo for "ValueTask`1" — so `ValueTask<T>`'s own overload is never recognised at all.
+            // We do not rely on that: the reasoning above holds for the whole family.)
+            //
+            // That body is:
+            //   ldarg.0; ldfld _obj; ldarg.0; ldfld _result; ldarg.0; ldfld _token; ldarg.1
+            //   newobj ValueTask`1::.ctor(object, !TResult, int16, bool)
+            //   stloc.0; ldloca.s 0
+            //   newobj ConfiguredValueTaskAwaitable`1::.ctor(ValueTask`1&)
+            //   ret
+            // i.e. three field reads through the `this` byref, the private "non-verified
+            // initialization" constructor — four plain field stores, no validation — and the
+            // awaitable's own constructor, whose body is the single `_value = value` copy from the
+            // `in` parameter. Every step is ordinary value-type IL over fields PawPrint already
+            // models; there is no P/Invoke, no vectorisation, and no `continueOnCapturedContext`
+            // interpretation here at all — the flag is merely stored, and only the *awaiter* later
+            // reads it to decide how to schedule a continuation.
+            //
+            // Deliberately not allowlisted alongside it: the non-generic `ValueTask.ConfigureAwait`
+            // and the four `Task`/`Task<T>` overloads, which are `[Intrinsic]` for the same
+            // pattern-match reason and have equally plain bodies, but which no test here reaches.
+            // They keep failing at the intrinsic dispatcher, naming themselves.
+            // https://github.com/dotnet/runtime/blob/7706f546bac1a99b3d891afe3591dc88c67f0cc4/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ValueTask.cs#L829-L832
+            // https://github.com/dotnet/runtime/blob/7706f546bac1a99b3d891afe3591dc88c67f0cc4/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs#L127
+            pattern
+                "System.Private.CoreLib"
+                "System.Threading.Tasks.ValueTask`1"
+                "ConfigureAwait"
+                [ IntrinsicParameterPattern.Exact "System.Boolean" ]
             // IL body is `ldsfld <Default>k__BackingField; ret`; the .cctor constructs the comparer.
             pattern "System.Private.CoreLib" "System.Collections.Generic.EqualityComparer`1" "get_Default" []
             // Same shape as its EqualityComparer sibling above: the IL body is


### PR DESCRIPTION
Closes #957.

`ValueTask<TResult>.ConfigureAwait(bool)` carries `[Intrinsic]`, so every guest that reached it — including any plain `await something.ConfigureAwait(false)` over a `ValueTask<T>` — stopped at `TODO: implement JIT intrinsic System.Private.CoreLib System.Threading.Tasks.ValueTask\`1.ConfigureAwait(System.Boolean), or add it to safeIntrinsics after reviewing its IL`.

### Why running the IL is the right answer

The attribute is not an implementation. `lookupNamedIntrinsic` maps `ConfigureAwait` to `NI_System_Threading_Tasks_Task_ConfigureAwait` (importercalls.cpp:11200-11209), and the only place in the whole JIT that ever *reads* that enumerator is `impMatchTaskAwaitPattern` (importer.cpp:6027) — the runtime-async peephole that recognises `call <M>; ldc.i4.0/1; call <ConfigureAwait>; call <AsyncHelpers.Await>` and rewrites the trio into a single call to `M`'s runtime-async counterpart. There is no `impIntrinsic` case for it, so outside that peephole the JIT emits the ordinary call and the managed body is the semantic definition.

(For this member the peephole cannot fire even in principle: the class-name test upstream compares against `"ValuTask` + backtick + `1"` — importercalls.cpp:11205, a typo — so `ValueTask<T>`'s own overload is never recognised at all. The reasoning above does not depend on that; it holds for the whole family.)

The body is three field reads through the `this` byref, the private "non-verified initialization" constructor (four plain field stores, no validation), and the awaitable's single `_value = value` copy from its `in` parameter. No P/Invoke, no vectorisation, and no interpretation of `continueOnCapturedContext` at all — the flag is merely stored, and only the *awaiter* later reads it to decide how to schedule a continuation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)