### PR TITLE
Run Task/Task<T>.ConfigureAwait(bool)'s IL

### DIFF
--- a/WoofWare.PawPrint.Test/sourcesPure/TaskConfigureAwaitBool.cs
+++ b/WoofWare.PawPrint.Test/sourcesPure/TaskConfigureAwaitBool.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Threading.Tasks;
+
+// `Task.ConfigureAwait(bool)` and `Task<TResult>.ConfigureAwait(bool)`. Both are `[Intrinsic]` for
+// the same runtime-async-peephole reason as the ValueTask pair covered by the sibling files, but
+// their body is a different shape — a bool-to-enum select rather than a struct copy:
+//
+//   ldarg.0; ldarg.1; brtrue.s L; ldc.i4.0; br.s M; L: ldc.i4.1
+//   M: newobj ConfiguredTaskAwaitable[`1]::.ctor(Task[`1], ConfigureAwaitOptions); ret
+//
+// so `true` maps to ConfigureAwaitOptions.ContinueOnCapturedContext (1) and `false` to None (0).
+//
+// That mapping is what the faulted cases below pin, and they are the reason this file is not just
+// "does the call return". ConfigureAwaitOptions.SuppressThrowing is 2, and awaiting under it
+// completes a faulted Task *successfully*; so a select that produced 2 for either input — an easy
+// way to get this subtly wrong — would make the non-generic faulted case swallow its exception, and
+// would make the generic one throw ArgumentOutOfRangeException instead (Task<T> rejects
+// SuppressThrowing). Asserting only on a successful result would miss both.
+//
+// Nothing here asserts which thread a continuation resumes on, which is all the flag itself
+// influences; every assertion is deterministic under PawPrint's scheduler and real .NET alike.
+public static class TaskConfigureAwaitBool
+{
+    // No await: the awaitable and awaiter are inspected directly, so a failure is attributable to
+    // ConfigureAwait rather than to the async state machine.
+    static int TestDirectGeneric()
+    {
+        Task<int> t = Task.FromResult(42);
+
+        var awaiter = t.ConfigureAwait(false).GetAwaiter();
+        if (!awaiter.IsCompleted) return 1;
+        if (awaiter.GetResult() != 42) return 2;
+
+        var awaiterTrue = t.ConfigureAwait(true).GetAwaiter();
+        if (!awaiterTrue.IsCompleted) return 3;
+        if (awaiterTrue.GetResult() != 42) return 4;
+
+        return 0;
+    }
+
+    static int TestDirectNonGeneric()
+    {
+        Task t = Task.CompletedTask;
+
+        var awaiter = t.ConfigureAwait(false).GetAwaiter();
+        if (!awaiter.IsCompleted) return 1;
+        awaiter.GetResult();
+
+        var awaiterTrue = t.ConfigureAwait(true).GetAwaiter();
+        if (!awaiterTrue.IsCompleted) return 2;
+        awaiterTrue.GetResult();
+
+        return 0;
+    }
+
+    static async Task<int> AwaitPoolScheduledAsync()
+    {
+        return await Task.Run(() => 41).ConfigureAwait(false);
+    }
+
+    // A genuinely pool-scheduled task, so the awaited task must survive into the awaiter rather
+    // than the awaitable answering from thin air.
+    static int TestAwaitPoolScheduled()
+    {
+        if (AwaitPoolScheduledAsync().Result != 41) return 1;
+        return 0;
+    }
+
+    static async Task AwaitFaultedNonGenericAsync()
+    {
+        await ((Task)Task.FromException(new InvalidOperationException("boom"))).ConfigureAwait(false);
+    }
+
+    // Pins that `false` maps to None rather than to SuppressThrowing: under SuppressThrowing this
+    // await would complete successfully and the fault would vanish.
+    static int TestAwaitFaultedNonGeneric()
+    {
+        try
+        {
+            AwaitFaultedNonGenericAsync().Wait();
+        }
+        catch (AggregateException e) when (e.InnerException is InvalidOperationException inner)
+        {
+            return inner.Message == "boom" ? 0 : 1;
+        }
+
+        return 2;
+    }
+
+    static async Task<int> AwaitFaultedGenericAsync()
+    {
+        return await Task.FromException<int>(new InvalidOperationException("bang")).ConfigureAwait(true);
+    }
+
+    // The Task<T> mirror, on the `true` input so that both halves of the select are covered by a
+    // faulted case. Task<T> rejects SuppressThrowing outright, so a select producing it would
+    // surface here as ArgumentOutOfRangeException rather than as the task's own fault.
+    static int TestAwaitFaultedGeneric()
+    {
+        try
+        {
+            _ = AwaitFaultedGenericAsync().Result;
+        }
+        catch (AggregateException e) when (e.InnerException is InvalidOperationException inner)
+        {
+            return inner.Message == "bang" ? 0 : 1;
+        }
+
+        return 2;
+    }
+
+    public static int Main(string[] args)
+    {
+        int result;
+
+        result = TestDirectGeneric();
+        if (result != 0) return 100 + result;
+
+        result = TestDirectNonGeneric();
+        if (result != 0) return 200 + result;
+
+        result = TestAwaitPoolScheduled();
+        if (result != 0) return 300 + result;
+
+        result = TestAwaitFaultedNonGeneric();
+        if (result != 0) return 400 + result;
+
+        result = TestAwaitFaultedGeneric();
+        if (result != 0) return 500 + result;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/IntrinsicMethodKeys.fs
+++ b/WoofWare.PawPrint/IntrinsicMethodKeys.fs
@@ -771,9 +771,10 @@ module IntrinsicMethodKeys =
             // interpretation here at all — the flag is merely stored, and only the *awaiter* later
             // reads it to decide how to schedule a continuation.
             //
-            // Deliberately not allowlisted alongside it: the four `Task`/`Task<T>` overloads, which
-            // are `[Intrinsic]` for the same pattern-match reason and have equally plain bodies, but
-            // which no test here reaches. They keep failing at the intrinsic dispatcher, naming
+            // Deliberately not allowlisted alongside it: the two `ConfigureAwaitOptions`-taking
+            // `Task`/`Task<T>` overloads, which are `[Intrinsic]` for the same pattern-match reason,
+            // but whose bodies validate their argument against a per-type mask and so want their own
+            // review and their own coverage. They keep failing at the intrinsic dispatcher, naming
             // themselves.
             // https://github.com/dotnet/runtime/blob/7706f546bac1a99b3d891afe3591dc88c67f0cc4/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ValueTask.cs#L829-L832
             // https://github.com/dotnet/runtime/blob/7706f546bac1a99b3d891afe3591dc88c67f0cc4/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs#L127
@@ -800,6 +801,39 @@ module IntrinsicMethodKeys =
             pattern
                 "System.Private.CoreLib"
                 "System.Threading.Tasks.ValueTask"
+                "ConfigureAwait"
+                [ IntrinsicParameterPattern.Exact "System.Boolean" ]
+            // The `Task`/`Task<TResult>` members of the same `ConfigureAwait` family. The
+            // `[Intrinsic]` reasoning above carries over verbatim — these are in fact the overloads
+            // the JIT's class-name test was *written* for — but the body is a different shape, so it
+            // gets its own review rather than riding on the ValueTask one:
+            //   ldarg.0; ldarg.1; brtrue.s L; ldc.i4.0; br.s M; L: ldc.i4.1
+            //   M: newobj ConfiguredTaskAwaitable[`1]::.ctor(Task[`1], ConfigureAwaitOptions)
+            //   ret
+            // i.e. the `bool` is selected into a `ConfigureAwaitOptions` — `true` to
+            // ContinueOnCapturedContext (1), `false` to None (0) — and handed with the task to the
+            // awaitable's constructor, whose whole body is `m_configuredTaskAwaiter = new
+            // ConfiguredTaskAwaiter(task, options)`: two field stores into a nested struct. No
+            // validation, no P/Invoke, and nothing that inspects the options — as with ValueTask,
+            // only the *awaiter* later reads them, when it decides how to schedule a continuation
+            // and (for SuppressThrowing, which this overload cannot produce) whether to propagate a
+            // fault.
+            //
+            // Both overloads of each type are listed by parameter shape rather than with
+            // `anyParams`, so that the `ConfigureAwaitOptions`-taking siblings — whose bodies do
+            // validate — are not swept in by accident.
+            // https://github.com/dotnet/runtime/blob/7706f546bac1a99b3d891afe3591dc88c67f0cc4/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs#L2450-L2454
+            // https://github.com/dotnet/runtime/blob/7706f546bac1a99b3d891afe3591dc88c67f0cc4/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs#L512-L516
+            // https://github.com/dotnet/runtime/blob/7706f546bac1a99b3d891afe3591dc88c67f0cc4/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs#L364-L368
+            pattern
+                "System.Private.CoreLib"
+                "System.Threading.Tasks.Task"
+                "ConfigureAwait"
+                [ IntrinsicParameterPattern.Exact "System.Boolean" ]
+            // https://github.com/dotnet/runtime/blob/7706f546bac1a99b3d891afe3591dc88c67f0cc4/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/TaskAwaiter.cs#L447-L450
+            pattern
+                "System.Private.CoreLib"
+                "System.Threading.Tasks.Task`1"
                 "ConfigureAwait"
                 [ IntrinsicParameterPattern.Exact "System.Boolean" ]
             // IL body is `ldsfld <Default>k__BackingField; ret`; the .cctor constructs the comparer.


### PR DESCRIPTION
Stacked on #963 — this PR's own diff is its second commit. One further PR (the `ConfigureAwaitOptions` overloads) is stacked on this one.

The `Task` half of the same `ConfigureAwait` family. The `[Intrinsic]` reasoning from the ValueTask entries carries over verbatim — these are in fact the overloads the JIT's class-name test was *written* for — but the body is a different shape, so it gets its own review rather than riding on the ValueTask one:

```
ldarg.0; ldarg.1; brtrue.s L; ldc.i4.0; br.s M; L: ldc.i4.1
M: newobj ConfiguredTaskAwaitable[`1]::.ctor(Task[`1], ConfigureAwaitOptions); ret
```

i.e. a bool-to-enum select (`true` → ContinueOnCapturedContext, `false` → None) feeding an awaitable constructor whose whole body is two field stores into a nested awaiter struct. No validation, no P/Invoke, and nothing that inspects the options.

Both entries are keyed by parameter shape rather than `anyParams`, so the `ConfigureAwaitOptions`-taking siblings — whose bodies *do* validate — are not swept in by accident. They still fail at the dispatcher, naming themselves.

### Coverage

The faulted cases are what make the new guest more than "does the call return". `ConfigureAwaitOptions.SuppressThrowing` is 2, and awaiting under it completes a faulted `Task` *successfully* — so a select that produced 2 for either input would make the non-generic case swallow its exception, and would make the generic one throw `ArgumentOutOfRangeException` instead (`Task<T>` rejects SuppressThrowing). Asserting only on a successful result would miss both, so both inputs of the select are covered by a faulted case.

Mutation-tested: making each awaited task complete successfully — exactly what a SuppressThrowing mapping would do — kills the corresponding case (exit 146 and 246, i.e. 402 and 502 truncated to 8 bits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)