### PR TITLE
Seal the ManagedHeap representation behind a signature file

### DIFF
--- a/WoofWare.PawPrint.App/DebuggerServer.fs
+++ b/WoofWare.PawPrint.App/DebuggerServer.fs
@@ -883,13 +883,13 @@ module DebuggerServer =
         writer.WriteStartObject ()
         writer.WriteNumber ("address", heapAddressValue address)
 
-        match ManagedHeap.tryGet address state.ManagedHeap with
+        match HeapObserver.tryGetNonArrayObject address state.ManagedHeap with
         | Some object ->
             writer.WriteString ("kind", "object")
             writer.WriteString ("concreteType", string object.ConcreteType)
             writer.WriteString ("contents", string object.Contents)
-            writeOptionalString writer "string" (ManagedHeap.getStringContents address state.ManagedHeap)
-            writer.WriteString ("syncBlock", string (ManagedHeap.getSyncBlock address state.ManagedHeap))
+            writeOptionalString writer "string" (HeapObserver.getStringContents address state.ManagedHeap)
+            writer.WriteString ("syncBlock", string (HeapObserver.getSyncBlock address state.ManagedHeap))
         | None ->
             match HeapObserver.tryGetArray address state.ManagedHeap with
             | Some array ->
@@ -899,7 +899,7 @@ module DebuggerServer =
                 writeValueArray writer "elements" array.Elements writeCliType
                 // Arrays carry an object header exactly like any other heap object, so a
                 // `lock (array)` is visible here too.
-                writer.WriteString ("syncBlock", string (ManagedHeap.getSyncBlock address state.ManagedHeap))
+                writer.WriteString ("syncBlock", string (HeapObserver.getSyncBlock address state.ManagedHeap))
             | None ->
                 writer.WriteString ("kind", "missing")
                 writer.WriteString ("error", $"heap address %d{heapAddressValue address} does not exist")
@@ -909,7 +909,7 @@ module DebuggerServer =
     let private hasHeapAddress (session : SessionState) (address : ManagedHeapAddress) : bool =
         let state = sessionState session
 
-        ManagedHeap.isLive address state.ManagedHeap
+        HeapObserver.isLive address state.ManagedHeap
 
     type private DebuggerHttpResponse =
         {

--- a/WoofWare.PawPrint.App/DebuggerServer.fs
+++ b/WoofWare.PawPrint.App/DebuggerServer.fs
@@ -553,9 +553,9 @@ module DebuggerServer =
 
         writer.WritePropertyName "heap"
         writer.WriteStartObject ()
-        writer.WriteNumber ("nonArrayObjects", state.ManagedHeap.NonArrayObjects.Count)
-        writer.WriteNumber ("arrays", state.ManagedHeap.Arrays.Count)
-        writer.WriteNumber ("stringContents", state.ManagedHeap.StringContents.Count)
+        writer.WriteNumber ("nonArrayObjects", HeapObserver.nonArrayObjectCount state.ManagedHeap)
+        writer.WriteNumber ("arrays", HeapObserver.arrayCount state.ManagedHeap)
+        writer.WriteNumber ("stringContents", HeapObserver.stringContentCount state.ManagedHeap)
         writer.WriteEndObject ()
 
         writeValueArray
@@ -883,7 +883,7 @@ module DebuggerServer =
         writer.WriteStartObject ()
         writer.WriteNumber ("address", heapAddressValue address)
 
-        match state.ManagedHeap.NonArrayObjects |> Map.tryFind address with
+        match ManagedHeap.tryGet address state.ManagedHeap with
         | Some object ->
             writer.WriteString ("kind", "object")
             writer.WriteString ("concreteType", string object.ConcreteType)
@@ -891,7 +891,7 @@ module DebuggerServer =
             writeOptionalString writer "string" (ManagedHeap.getStringContents address state.ManagedHeap)
             writer.WriteString ("syncBlock", string (ManagedHeap.getSyncBlock address state.ManagedHeap))
         | None ->
-            match state.ManagedHeap.Arrays |> Map.tryFind address with
+            match HeapObserver.tryGetArray address state.ManagedHeap with
             | Some array ->
                 writer.WriteString ("kind", "array")
                 writer.WriteString ("concreteType", string array.Shape.ConcreteType)
@@ -909,8 +909,7 @@ module DebuggerServer =
     let private hasHeapAddress (session : SessionState) (address : ManagedHeapAddress) : bool =
         let state = sessionState session
 
-        (state.ManagedHeap.NonArrayObjects |> Map.containsKey address)
-        || (state.ManagedHeap.Arrays |> Map.containsKey address)
+        ManagedHeap.isLive address state.ManagedHeap
 
     type private DebuggerHttpResponse =
         {

--- a/WoofWare.PawPrint.App/Program.fs
+++ b/WoofWare.PawPrint.App/Program.fs
@@ -285,7 +285,7 @@ module AppProgram =
                     drainRemaining state
 
                     let exceptionTypeName =
-                        match ManagedHeap.tryGet exn.ExceptionObject state.ManagedHeap with
+                        match HeapObserver.tryGetNonArrayObject exn.ExceptionObject state.ManagedHeap with
                         | Some obj ->
                             match AllConcreteTypes.lookup obj.ConcreteType state.ConcreteTypes with
                             | Some ti -> $"{ti.Namespace}.{ti.Name}"

--- a/WoofWare.PawPrint.App/Program.fs
+++ b/WoofWare.PawPrint.App/Program.fs
@@ -285,7 +285,7 @@ module AppProgram =
                     drainRemaining state
 
                     let exceptionTypeName =
-                        match state.ManagedHeap.NonArrayObjects |> Map.tryFind exn.ExceptionObject with
+                        match ManagedHeap.tryGet exn.ExceptionObject state.ManagedHeap with
                         | Some obj ->
                             match AllConcreteTypes.lookup obj.ConcreteType state.ConcreteTypes with
                             | Some ti -> $"{ti.Namespace}.{ti.Name}"

--- a/WoofWare.PawPrint.Test/TestAssemblyNativeQCalls.fs
+++ b/WoofWare.PawPrint.Test/TestAssemblyNativeQCalls.fs
@@ -1008,7 +1008,10 @@ public static class StreamVersionLibrary
         (expected : byte array)
         : unit
         =
-        let array = state.ManagedHeap.Arrays.[addr]
+        let array =
+            match HeapObserver.tryGetArray addr state.ManagedHeap with
+            | Some array -> array
+            | None -> failwith $"expected a live byte array at %O{addr}"
 
         let byteHandle =
             AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes baseClassTypes.Byte

--- a/WoofWare.PawPrint.Test/TestContextSwitchPrior.fs
+++ b/WoofWare.PawPrint.Test/TestContextSwitchPrior.fs
@@ -101,9 +101,8 @@ module TestContextSwitchPrior =
         ]
 
     /// Ops whose only effect is on interpreter-internal mutable bookkeeping
-    /// (`PointerHashState` or `ManagedHeap.Arrays` reads via the byte-view
-    /// anchor path). Guest IL has no opcode that directly addresses these
-    /// structures.
+    /// (`PointerHashState`, or the array-shape reads on the byte-view anchor
+    /// path). Guest IL has no opcode that directly addresses these structures.
     let private nullaryInterpreterOnly : NullaryIlOp list =
         [
             // Reads `PointerHashState` to decide whether synthesised bits are a
@@ -124,8 +123,8 @@ module TestContextSwitchPrior =
             NullaryIlOp.Or
             NullaryIlOp.Xor
             // Anchor a byte-view on a plain-array byref via
-            // `anchorByteViewIfPlainArrayByref`, which reads
-            // `state.ManagedHeap.Arrays`.
+            // `anchorByteViewIfPlainArrayByref`, which reads the array's shape
+            // (`ManagedHeap.getArrayShape`) and never a cell.
             NullaryIlOp.Conv_I
             NullaryIlOp.Conv_U
         ]

--- a/WoofWare.PawPrint.Test/TestFieldHandleRegistry.fs
+++ b/WoofWare.PawPrint.Test/TestFieldHandleRegistry.fs
@@ -277,7 +277,7 @@ public class GenericHolder<T>
         let _, state = getOrAllocateField fixture fixture.Field fixture.State
 
         FieldHandleRegistry.resolveFieldIdFromAddress
-            (ManagedHeapAddress state.ManagedHeap.FirstAvailableAddress)
+            (ManagedHeapAddress (HeapObserver.nextAddress state.ManagedHeap))
             state.FieldHandles
         |> shouldEqual None
 
@@ -287,7 +287,7 @@ public class GenericHolder<T>
         |> shouldEqual None
 
         FieldHandleRegistry.resolveFieldIdFromAddress
-            (ManagedHeapAddress state.ManagedHeap.FirstAvailableAddress)
+            (ManagedHeapAddress (HeapObserver.nextAddress state.ManagedHeap))
             state.FieldHandles
         |> shouldEqual None
 

--- a/WoofWare.PawPrint.Test/TestImpureCases.fs
+++ b/WoofWare.PawPrint.Test/TestImpureCases.fs
@@ -137,8 +137,7 @@ module TestImpureCases =
     /// here.
     let private assertCapturedFrozenStackTrace (state : IlMachineState) : unit =
         let ediObjects =
-            state.ManagedHeap.NonArrayObjects
-            |> Map.toList
+            HeapObserver.nonArrayObjects state.ManagedHeap
             |> List.filter (fun (_, object) -> isExceptionDispatchInfo state object.ConcreteType)
 
         let _ediAddr, ediObject =

--- a/WoofWare.PawPrint.Test/TestManagedHeap.fs
+++ b/WoofWare.PawPrint.Test/TestManagedHeap.fs
@@ -1475,3 +1475,70 @@ module TestManagedHeap =
 
         HeapObserver.liveAddresses heap
         |> shouldEqual (Set.ofList [ arrAddr ; objAddr ])
+
+    [<Test>]
+    let ``HeapObserver mirrors agree with their ManagedHeap counterparts`` () : unit =
+        // Four `HeapObserver` functions answer exactly the same question as a `ManagedHeap`
+        // function of the same name, and deliberately do not delegate to it: under the
+        // planned access instrumentation, delegating would route an observer's read back
+        // through the emitting path. Nothing but this test stops the two copies drifting.
+        let property (ops : bool list) : bool =
+            let ops = ops |> List.truncate 8
+
+            let heap =
+                ops
+                |> List.fold
+                    (fun heap isArray ->
+                        if isArray then
+                            ManagedHeap.allocateArray (stubArray 1) heap |> snd
+                        else
+                            ManagedHeap.allocateNonArray stubNonArray heap |> snd
+                    )
+                    ManagedHeap.empty
+
+            // Give one object string contents and one a non-empty header, so the mirrors
+            // are compared on present values and not only on absent ones.
+            let heap =
+                match ManagedHeap.isLive (ManagedHeapAddress 1) heap with
+                | false -> heap
+                | true ->
+                    heap
+                    |> ManagedHeap.recordStringContents (ManagedHeapAddress 1) "contents"
+                    |> ManagedHeap.setSyncBlock (ManagedHeapAddress 1) (heldBy (ThreadId 3))
+
+            // Probe past the end too, so the "not live" answers are compared as well.
+            [ 1 .. ops.Length + 3 ]
+            |> List.forall (fun addr ->
+                let addr = ManagedHeapAddress addr
+
+                ManagedHeap.isLive addr heap = HeapObserver.isLive addr heap
+                // Compared by reference, not structurally: `stubNonArray`'s payload is
+                // deliberately null, so a structural comparison would read it and NRE. This
+                // is the stronger claim anyway — the same record, not merely an equal one.
+                && (
+                    match ManagedHeap.tryGet addr heap, HeapObserver.tryGetNonArrayObject addr heap with
+                    | None, None -> true
+                    | Some a, Some b -> System.Object.ReferenceEquals (a, b)
+                    | Some _, None
+                    | None, Some _ -> false
+                )
+                && ManagedHeap.getStringContents addr heap = HeapObserver.getStringContents addr heap
+                && (if ManagedHeap.isLive addr heap then
+                        ManagedHeap.getSyncBlock addr heap = HeapObserver.getSyncBlock addr heap
+                    else
+                        // Both must refuse, and say so rather than inventing a header.
+                        let failed (f : unit -> SyncBlock) : bool =
+                            try
+                                f () |> ignore
+                                false
+                            with _ ->
+                                true
+
+                        failed (fun () -> ManagedHeap.getSyncBlock addr heap)
+                        && failed (fun () -> HeapObserver.getSyncBlock addr heap))
+            )
+
+        Check.One (
+            Config.QuickThrowOnFailure.WithMaxTest 200,
+            Prop.forAll (ArbMap.defaults |> ArbMap.arbitrary) property
+        )

--- a/WoofWare.PawPrint.Test/TestManagedHeap.fs
+++ b/WoofWare.PawPrint.Test/TestManagedHeap.fs
@@ -37,6 +37,15 @@ module TestManagedHeap =
     /// The zero of the element type used by the hand-built allocations in this fixture.
     let private int32Zero : CliType = CliType.Numeric (CliNumericType.Int32 0)
 
+    /// The whole allocation record for the array at `addr`, shape and cells together.
+    /// Tests that need to check the shape and the backing store *against each other* go
+    /// through this; a test that only wants one of the two should use the narrower
+    /// `ManagedHeap.getArrayShape` / `getArrayValue` instead.
+    let private arrayRecord (addr : ManagedHeapAddress) (heap : ManagedHeap) : AllocatedArray =
+        match HeapObserver.tryGetArray addr heap with
+        | Some arr -> arr
+        | None -> failwith $"expected a live array at %O{addr}"
+
     /// An `ArrayShape` whose element facts are derived from `elementZero`, so a fixture
     /// cannot violate the stride/zero agreement `allocateArray` enforces except on purpose.
     let private shapeOf
@@ -263,7 +272,7 @@ module TestManagedHeap =
         let addr, state =
             IlMachineState.allocateMultiDimArray arrayHandle (fun () -> zero) lengths state
 
-        let array = state.ManagedHeap.Arrays.[addr]
+        let array = arrayRecord addr state.ManagedHeap
         array.Shape.ConcreteType |> shouldEqual arrayHandle
         array.Shape.Length |> shouldEqual 12
         array.Shape.Lengths |> shouldEqual lengths
@@ -285,7 +294,7 @@ module TestManagedHeap =
         let addr, state =
             IlMachineState.allocateMultiDimArray arrayHandle (fun () -> zero) lengths state
 
-        let array = state.ManagedHeap.Arrays.[addr]
+        let array = arrayRecord addr state.ManagedHeap
         array.Shape.Length |> shouldEqual 0
         array.Shape.Lengths |> shouldEqual lengths
         array.Elements.Length |> shouldEqual 0
@@ -328,7 +337,7 @@ module TestManagedHeap =
         let addr, state =
             IlMachineState.allocateMultiDimArray arrayHandle (fun () -> zero) lengths state
 
-        let array = state.ManagedHeap.Arrays.[addr]
+        let array = arrayRecord addr state.ManagedHeap
         array.Shape.Length |> shouldEqual 0
         array.Shape.Lengths |> shouldEqual lengths
         array.Elements.Length |> shouldEqual 0
@@ -545,10 +554,9 @@ module TestManagedHeap =
                     )
                     ManagedHeap.empty
 
-            let live =
-                Set.union (heap.NonArrayObjects |> Map.keys |> Set.ofSeq) (heap.Arrays |> Map.keys |> Set.ofSeq)
+            let live = HeapObserver.liveAddresses heap
 
-            let withSyncBlocks = heap.SyncBlocks |> Map.keys |> Set.ofSeq
+            let withSyncBlocks = HeapObserver.syncBlockAddresses heap
 
             live = withSyncBlocks
             && live.Count = ops.Length
@@ -1266,10 +1274,204 @@ module TestManagedHeap =
             [ 1 .. ops.Length + 3 ]
             |> List.forall (fun addr ->
                 let addr = ManagedHeapAddress addr
-                ManagedHeap.isLive addr heap = heap.SyncBlocks.ContainsKey addr
+                ManagedHeap.isLive addr heap = HeapObserver.hasSyncBlock addr heap
             )
 
         Check.One (
             Config.QuickThrowOnFailure.WithMaxTest 200,
             Prop.forAll (ArbMap.defaults |> ArbMap.arbitrary) property
         )
+
+    // ---------------------------------------------------------------------
+    // Sync-block queries. Both were open-coded at their single call site
+    // before; the ordering each guarantees is what makes them worth naming.
+    // ---------------------------------------------------------------------
+
+    /// Three live addresses, allocated in ascending order, with the given headers.
+    let private heapWithSyncBlocks (blocks : SyncBlock list) : ManagedHeapAddress list * ManagedHeap =
+        let addrs, heap =
+            blocks
+            |> List.fold
+                (fun (addrs, heap) _ ->
+                    let addr, heap = ManagedHeap.allocateNonArray stubNonArray heap
+                    addrs @ [ addr ], heap
+                )
+                ([], ManagedHeap.empty)
+
+        let heap =
+            List.zip addrs blocks
+            |> List.fold (fun heap (addr, block) -> ManagedHeap.setSyncBlock addr block heap) heap
+
+        addrs, heap
+
+    let private heldBy (thread : ThreadId) : SyncBlock =
+        {
+            Lock =
+                SyncBlockLock.Held
+                    {
+                        LockingThread = thread
+                        ReentrancyCount = 1
+                        AcquireQueue = []
+                    }
+            WaitQueue = []
+        }
+
+    [<Test>]
+    let ``syncBlocksHeldBy selects only that thread's held locks, in address order`` () : unit =
+        // The three non-matching shapes are all present at once: a block held by another
+        // thread, a `Free` block, and (via the `waiting` entry) a block with a waiter but
+        // no owner — `Monitor.Wait` releases the lock, so "someone is queued here" must
+        // not be mistaken for "this thread owns it".
+        let t0 = ThreadId 0
+        let t1 = ThreadId 1
+
+        let waiting =
+            {
+                Lock = SyncBlockLock.Free
+                WaitQueue = [ t0, 3 ]
+            }
+
+        let addrs, heap =
+            heapWithSyncBlocks [ heldBy t1 ; heldBy t0 ; SyncBlock.Empty ; waiting ; heldBy t0 ]
+
+        let held = ManagedHeap.syncBlocksHeldBy t0 heap
+
+        held |> List.map fst |> shouldEqual [ addrs.[1] ; addrs.[4] ]
+
+        held
+        |> List.map (fun (_, locked) -> locked.LockingThread)
+        |> shouldEqual [ t0 ; t0 ]
+
+        ManagedHeap.syncBlocksHeldBy t1 heap
+        |> List.map fst
+        |> shouldEqual [ addrs.[0] ]
+
+        ManagedHeap.syncBlocksHeldBy (ThreadId 9) heap |> shouldEqual []
+
+    [<Test>]
+    let ``syncBlockWaiters enumerates in address order, then FIFO within an object`` () : unit =
+        // The ordering is the whole contract: `applySpuriousWakeups` folds a wake over this
+        // list, so a different order is a different interleaving for the same seed. The
+        // second object is given its waiters in an order that a per-object sort by thread id
+        // would reverse, so such a sort fails here rather than silently changing schedules.
+        let t0 = ThreadId 0
+        let t1 = ThreadId 1
+        let t2 = ThreadId 2
+
+        let first =
+            {
+                Lock = SyncBlockLock.Free
+                WaitQueue = [ t1, 1 ]
+            }
+
+        let second =
+            {
+                Lock = SyncBlockLock.Free
+                WaitQueue = [ t2, 1 ; t0, 4 ]
+            }
+
+        let addrs, heap = heapWithSyncBlocks [ first ; SyncBlock.Empty ; second ]
+
+        ManagedHeap.syncBlockWaiters heap
+        |> shouldEqual [ addrs.[0], t1 ; addrs.[2], t2 ; addrs.[2], t0 ]
+
+    [<Test>]
+    let ``syncBlockWaiters ignores lock ownership`` () : unit =
+        // A held lock with an acquire queue has contenders, but they are parked in
+        // `BlockedOnSyncBlockAcquire`, not in a `Monitor.Wait`. Only the latter can be
+        // spuriously woken, so neither the owner nor the acquire queue may appear here.
+        let owner = ThreadId 0
+
+        let contended =
+            {
+                Lock =
+                    SyncBlockLock.Held
+                        {
+                            LockingThread = owner
+                            ReentrancyCount = 2
+                            AcquireQueue = [ ThreadId 1, None ; ThreadId 2, Some 3 ]
+                        }
+                WaitQueue = []
+            }
+
+        let _, heap = heapWithSyncBlocks [ contended ]
+
+        ManagedHeap.syncBlockWaiters heap |> shouldEqual []
+
+    [<Test>]
+    let ``tryGetStringDataOffset answers None rather than failing, and getStringDataOffset still fails`` () : unit =
+        let addr = ManagedHeapAddress 42
+
+        ManagedHeap.tryGetStringDataOffset addr ManagedHeap.empty |> shouldEqual None
+
+        let heap = ManagedHeap.recordStringDataOffset addr 7 ManagedHeap.empty
+        ManagedHeap.tryGetStringDataOffset addr heap |> shouldEqual (Some 7)
+        ManagedHeap.getStringDataOffset addr heap |> shouldEqual 7
+
+        Assert.Throws<System.Exception> (fun () ->
+            ManagedHeap.getStringDataOffset (ManagedHeapAddress 43) heap |> ignore
+        )
+        |> ignore
+
+    // ---------------------------------------------------------------------
+    // HeapObserver. These are projections, so the risk is not that one is
+    // subtly wrong but that one answers about the wrong table.
+    // ---------------------------------------------------------------------
+
+    [<Test>]
+    let ``HeapObserver counts each table separately`` () : unit =
+        let heap = ManagedHeap.empty
+        HeapObserver.nonArrayObjectCount heap |> shouldEqual 0
+        HeapObserver.arrayCount heap |> shouldEqual 0
+        HeapObserver.stringContentCount heap |> shouldEqual 0
+
+        let _, heap = ManagedHeap.allocateNonArray stubNonArray heap
+        let objAddr, heap = ManagedHeap.allocateNonArray stubNonArray heap
+        let _, heap = ManagedHeap.allocateArray (stubArray 3) heap
+        let heap = ManagedHeap.recordStringContents objAddr "hi" heap
+
+        // Distinct values throughout, so a projection that reads the wrong table fails.
+        HeapObserver.nonArrayObjectCount heap |> shouldEqual 2
+        HeapObserver.arrayCount heap |> shouldEqual 1
+        HeapObserver.stringContentCount heap |> shouldEqual 1
+
+    [<Test>]
+    let ``HeapObserver nextAddress names an address that is not yet live`` () : unit =
+        let _, heap = ManagedHeap.allocateNonArray stubNonArray ManagedHeap.empty
+
+        let next = HeapObserver.nextAddress heap
+        ManagedHeap.isLive (ManagedHeapAddress next) heap |> shouldEqual false
+
+        let allocated, heap = ManagedHeap.allocateNonArray stubNonArray heap
+        allocated |> shouldEqual (ManagedHeapAddress next)
+        ManagedHeap.isLive allocated heap |> shouldEqual true
+
+    [<Test>]
+    let ``HeapObserver tryGetArray answers only for arrays`` () : unit =
+        let arrAddr, heap = ManagedHeap.allocateArray (stubArray 3) ManagedHeap.empty
+        let objAddr, heap = ManagedHeap.allocateNonArray stubNonArray heap
+
+        (HeapObserver.tryGetArray arrAddr heap).Value.Elements.Length |> shouldEqual 3
+        HeapObserver.tryGetArray objAddr heap |> shouldEqual None
+        HeapObserver.tryGetArray (ManagedHeapAddress 99) heap |> shouldEqual None
+
+    [<Test>]
+    let ``HeapObserver nonArrayObjects lists non-arrays only, in address order`` () : unit =
+        let _, heap = ManagedHeap.allocateArray (stubArray 1) ManagedHeap.empty
+        let obj1, heap = ManagedHeap.allocateNonArray stubNonArray heap
+        let _, heap = ManagedHeap.allocateArray (stubArray 1) heap
+        let obj2, heap = ManagedHeap.allocateNonArray stubNonArray heap
+
+        HeapObserver.nonArrayObjects heap |> List.map fst |> shouldEqual [ obj1 ; obj2 ]
+
+    [<Test>]
+    let ``HeapObserver liveAddresses spans both payload tables`` () : unit =
+        // Guards the half of the `isLive` invariant property that a union-of-one-table
+        // implementation would still pass: that property compares `liveAddresses` against
+        // the header table, and both would be wrong together only if `allocateArray` also
+        // stopped registering a header.
+        let arrAddr, heap = ManagedHeap.allocateArray (stubArray 1) ManagedHeap.empty
+        let objAddr, heap = ManagedHeap.allocateNonArray stubNonArray heap
+
+        HeapObserver.liveAddresses heap
+        |> shouldEqual (Set.ofList [ arrAddr ; objAddr ])

--- a/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
+++ b/WoofWare.PawPrint.Test/TestMethodTableProjection.fs
@@ -319,9 +319,18 @@ public interface IOpenInterface<T>
         (state : IlMachineState)
         : CliValueType
         =
-        match state.ManagedHeap.Arrays.[addr].Elements.[index] with
+        match ManagedHeap.getArrayValue addr index state.ManagedHeap with
         | CliType.ValueType vt -> vt
         | other -> failwith $"Expected array element %d{index} at %O{addr} to be a value type, got %O{other}"
+
+    /// The whole allocation record for the array at `addr`. Used only by the identity
+    /// assertions below, which check that a byte-identical write left the record itself
+    /// untouched rather than rebuilding an equal one, so they need the reference and not
+    /// just the cells.
+    let private arrayRecord (addr : ManagedHeapAddress) (state : IlMachineState) : AllocatedArray =
+        match HeapObserver.tryGetArray addr state.ManagedHeap with
+        | Some arr -> arr
+        | None -> failwith $"expected a live array at %O{addr}"
 
     let private assertReadWriteByteViewRejected
         (state : IlMachineState)
@@ -1939,7 +1948,7 @@ public unsafe struct PointerWrapper
             let boxedAddr, state = allocateBoxedIntPtr sample.Initial state
             let valueType = boxedPayloadValueType boxedAddr state
             let arrayAddr, state = allocateSingleValueTypeArray valueType state
-            let arrayBefore = state.ManagedHeap.Arrays.[arrayAddr]
+            let arrayBefore = arrayRecord arrayAddr state
             let payloadBefore = arrayElementValueType arrayAddr 0 state
             let initialBytes = System.BitConverter.GetBytes sample.Initial
             let payload = System.BitConverter.ToUInt16 (initialBytes, sample.Offset)
@@ -1960,7 +1969,7 @@ public unsafe struct PointerWrapper
                     ptr
                     (CliType.Numeric (CliNumericType.UInt16 payload))
 
-            let arrayAfter = state.ManagedHeap.Arrays.[arrayAddr]
+            let arrayAfter = arrayRecord arrayAddr state
             let payloadAfter = arrayElementValueType arrayAddr 0 state
 
             System.Object.ReferenceEquals (arrayAfter, arrayBefore) |> shouldEqual true
@@ -2022,11 +2031,11 @@ public unsafe struct PointerWrapper
         let arrayAddr, state =
             IlMachineState.allocateArray doubleArrayHandle (fun () -> nan) 1 state
 
-        let arrayBefore = state.ManagedHeap.Arrays.[arrayAddr]
+        let arrayBefore = arrayRecord arrayAddr state
         let ptr = ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arrayAddr, 0), [])
 
         let state = IlMachineState.writeManagedByrefBytesOrTypedCell bct state ptr nan
-        let arrayAfter = state.ManagedHeap.Arrays.[arrayAddr]
+        let arrayAfter = arrayRecord arrayAddr state
 
         System.Object.ReferenceEquals (arrayAfter, arrayBefore) |> shouldEqual true
 
@@ -2040,7 +2049,7 @@ public unsafe struct PointerWrapper
         let arrayAddr, state =
             IlMachineState.allocateArray ushortArrayHandle (fun () -> initial) 1 state
 
-        let arrayBefore = state.ManagedHeap.Arrays.[arrayAddr]
+        let arrayBefore = arrayRecord arrayAddr state
 
         let ptr =
             ManagedPointerSource.Byref (
@@ -2051,7 +2060,7 @@ public unsafe struct PointerWrapper
         let state =
             IlMachineState.writeManagedByrefWithBase bct state ptr shortWithSameBytes
 
-        let arrayAfter = state.ManagedHeap.Arrays.[arrayAddr]
+        let arrayAfter = arrayRecord arrayAddr state
 
         System.Object.ReferenceEquals (arrayAfter, arrayBefore) |> shouldEqual true
         IlMachineState.getArrayValue arrayAddr 0 state |> shouldEqual initial
@@ -2069,7 +2078,7 @@ public unsafe struct PointerWrapper
             |> IlMachineState.setArrayValue arrayAddr first 0
             |> IlMachineState.setArrayValue arrayAddr second 1
 
-        let arrayBefore = state.ManagedHeap.Arrays.[arrayAddr]
+        let arrayBefore = arrayRecord arrayAddr state
 
         let writtenBytes =
             [| yield! CliType.ToBytes first ; yield! CliType.ToBytes second |]
@@ -2081,7 +2090,7 @@ public unsafe struct PointerWrapper
 
         let ptr = ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arrayAddr, 0), [])
         let state = IlMachineState.writeManagedByrefBytesOrTypedCell bct state ptr written
-        let arrayAfter = state.ManagedHeap.Arrays.[arrayAddr]
+        let arrayAfter = arrayRecord arrayAddr state
 
         System.Object.ReferenceEquals (arrayAfter, arrayBefore) |> shouldEqual true
         IlMachineState.getArrayValue arrayAddr 0 state |> shouldEqual first

--- a/WoofWare.PawPrint.Test/TestNativeEnum.fs
+++ b/WoofWare.PawPrint.Test/TestNativeEnum.fs
@@ -339,7 +339,10 @@ public static class Entry
         let expectedElementHandle =
             AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes expectedElementType
 
-        let array = state.ManagedHeap.Arrays.[arrayAddr]
+        let array =
+            match HeapObserver.tryGetArray arrayAddr state.ManagedHeap with
+            | Some array -> array
+            | None -> failwith $"expected a live array at %O{arrayAddr}"
 
         array.Shape.ConcreteType
         |> shouldEqual (ConcreteTypeHandle.OneDimArrayZero expectedElementHandle)
@@ -356,13 +359,19 @@ public static class Entry
             namesArray
             |> Option.defaultWith (fun () -> failwith "expected names array to be populated")
 
-        let array = state.ManagedHeap.Arrays.[namesArray]
+        let array =
+            match HeapObserver.tryGetArray namesArray state.ManagedHeap with
+            | Some array -> array
+            | None -> failwith $"expected a live names array at %O{namesArray}"
 
         let actualNames =
             array.Elements
             |> Seq.map (fun element ->
                 match element with
-                | CliType.ObjectRef (Some addr) -> state.ManagedHeap.StringContents.[addr]
+                | CliType.ObjectRef (Some addr) ->
+                    match ManagedHeap.getStringContents addr state.ManagedHeap with
+                    | Some contents -> contents
+                    | None -> failwith $"names array element %O{addr} has no recorded string contents"
                 | other -> failwith $"expected string object ref in names array, got %O{other}"
             )
             |> Seq.toList

--- a/WoofWare.PawPrint.Test/TestNativeSignature.fs
+++ b/WoofWare.PawPrint.Test/TestNativeSignature.fs
@@ -693,9 +693,9 @@ public sealed class MethodSignatureHost
             | other -> failwith $"Expected _arguments to be a RuntimeType[] object ref, got %O{other}"
 
         let array =
-            match state.ManagedHeap.Arrays.TryGetValue arrayAddr with
-            | true, array -> array
-            | false, _ -> failwith $"_arguments pointed at %O{arrayAddr}, which is not an array"
+            match HeapObserver.tryGetArray arrayAddr state.ManagedHeap with
+            | Some array -> array
+            | None -> failwith $"_arguments pointed at %O{arrayAddr}, which is not an array"
 
         [
             for index in 0 .. array.Shape.Length - 1 do

--- a/WoofWare.PawPrint.Test/TestSyncBlockMonitor.fs
+++ b/WoofWare.PawPrint.Test/TestSyncBlockMonitor.fs
@@ -721,7 +721,7 @@ module TestSyncBlockMonitor =
     /// is not equality-comparable (it embeds MethodStates with structural
     /// non-equality), so we compare what we care about explicitly.
     let private wakeupVisibleState (state : IlMachineState) =
-        let blocks = state.ManagedHeap.SyncBlocks
+        let blocks = HeapObserver.syncBlocks state.ManagedHeap
 
         let statuses = state.ThreadState |> Map.map (fun _ ts -> ts.Status)
         blocks, statuses

--- a/WoofWare.PawPrint.Test/TestVariableSizeNewobj.fs
+++ b/WoofWare.PawPrint.Test/TestVariableSizeNewobj.fs
@@ -50,15 +50,16 @@ module TestVariableSizeNewobj =
     /// Returns the addresses that violate that invariant, with which side-table
     /// each is missing from.
     let private unregisteredStringObjects (state : IlMachineState) : (ManagedHeapAddress * string) list =
-        state.ManagedHeap.NonArrayObjects
-        |> Map.toList
+        HeapObserver.nonArrayObjects state.ManagedHeap
         |> List.choose (fun (addr, object) ->
             if not (isSystemString state object.ConcreteType) then
                 None
             else
 
-            let hasContents = state.ManagedHeap.StringContents.ContainsKey addr
-            let hasDataOffset = state.ManagedHeap.StringDataOffsets.ContainsKey addr
+            let hasContents = (ManagedHeap.getStringContents addr state.ManagedHeap).IsSome
+
+            let hasDataOffset =
+                (ManagedHeap.tryGetStringDataOffset addr state.ManagedHeap).IsSome
 
             if hasContents && hasDataOffset then
                 None
@@ -67,10 +68,9 @@ module TestVariableSizeNewobj =
         )
 
     let private countStringObjects (state : IlMachineState) : int =
-        state.ManagedHeap.NonArrayObjects
-        |> Map.toSeq
-        |> Seq.filter (fun (_, object) -> isSystemString state object.ConcreteType)
-        |> Seq.length
+        HeapObserver.nonArrayObjects state.ManagedHeap
+        |> List.filter (fun (_, object) -> isSystemString state object.ConcreteType)
+        |> List.length
 
     /// Compile `source` and run it through PawPrint, returning the final machine
     /// state. Fails the test if the guest does not exit cleanly with code 0.

--- a/WoofWare.PawPrint/IlMachineThreadState.fs
+++ b/WoofWare.PawPrint/IlMachineThreadState.fs
@@ -730,7 +730,7 @@ module IlMachineThreadState =
             // is `protected internal`, `System.String` is sealed and never calls it, and PawPrint
             // intercepts the `String` methods that would. Refuse rather than hand back a string
             // whose characters have silently vanished.
-            if state.ManagedHeap.StringContents.ContainsKey source then
+            if (ManagedHeap.getStringContents source state.ManagedHeap).IsSome then
                 failwith
                     $"TODO: MemberwiseClone of the string at %O{source}; PawPrint keys string character data by heap address, so the clone would have none. Copy StringContents and the StringArrayData range if this becomes reachable."
 

--- a/WoofWare.PawPrint/ManagedHeap.fs
+++ b/WoofWare.PawPrint/ManagedHeap.fs
@@ -2,159 +2,6 @@ namespace WoofWare.PawPrint
 
 open System.Collections.Immutable
 
-/// State carried when an object's monitor is `Held` by some thread.
-/// `AcquireQueue` is the FIFO list of (thread, optional re-entry depth) pairs
-/// parked in `BlockedOnSyncBlockAcquire` waiting for ownership to be transferred
-/// to them when `LockingThread` calls `Monitor.Exit`. FIFO order is load-bearing
-/// for fairness: switching to LIFO or arbitrary order would change the
-/// observable interleaving for guests that race multiple threads into the same
-/// `lock` block.
-///
-/// The `int option` snapshot on each `AcquireQueue` entry distinguishes the
-/// two flavours of waiter:
-///   * `None` — a fresh entrant from `Monitor.Enter`. On ownership transfer it
-///     becomes the new owner with `ReentrancyCount = 1`.
-///   * `Some depth` — a waiter that was woken from `Monitor.Wait` by
-///     `Monitor.Pulse` / `PulseAll` (or a spurious wake). `Wait` snapshots its
-///     prior `ReentrancyCount` so that on re-acquire the depth it had before
-///     parking is restored verbatim. Storing the depth inline next to the
-///     thread keeps the "what's waiting and what depth do they need" coupling
-///     visible at every read site; a separate map would let a transition lose
-///     the pairing silently.
-///
-/// `ReentrancyCount` is the depth of nested `Monitor.Enter` calls by
-/// `LockingThread` and must reach exactly zero before ownership can transfer.
-type LockedSyncBlock =
-    {
-        LockingThread : ThreadId
-        ReentrancyCount : int
-        AcquireQueue : (ThreadId * int option) list
-    }
-
-/// Ownership state of an object's monitor — distinct from its `WaitQueue`
-/// because `Monitor.Wait` fully releases the lock (`Free`) while leaving its
-/// caller parked in the SyncBlock's `WaitQueue`.
-type SyncBlockLock =
-    | Free
-    | Held of LockedSyncBlock
-
-/// Per-object monitor metadata. `Lock` describes ownership and FIFO of
-/// `Monitor.Enter` contenders. `WaitQueue` is the FIFO list of (thread,
-/// snapshot depth) pairs currently parked in `BlockedOnSyncBlockWait` from a
-/// `Monitor.Wait` call; they do NOT contend for the lock until a `Pulse` /
-/// `PulseAll` moves them onto `AcquireQueue` (FIFO tail), at which point they
-/// re-enter via the normal ownership-transfer path. The two fields are
-/// orthogonal: a non-empty `WaitQueue` can coexist with `Lock = Free` (the
-/// owner called `Wait`, releasing the lock, but the waiter is still parked).
-/// Pulse on an empty wait queue is a documented no-op (matches CoreCLR's
-/// `SyncBlock`).
-type SyncBlock =
-    {
-        Lock : SyncBlockLock
-        WaitQueue : (ThreadId * int) list
-    }
-
-    /// Initial state for a freshly-allocated object: lock free, no waiters.
-    static member Empty : SyncBlock =
-        {
-            Lock = SyncBlockLock.Free
-            WaitQueue = []
-        }
-
-type AllocatedNonArrayObject =
-    {
-        // TODO: this is a slightly odd domain; the same type for value types as class types!
-        Contents : CliValueType
-        ConcreteType : ConcreteTypeHandle
-    }
-
-    static member DereferenceField (name : string) (f : AllocatedNonArrayObject) : CliType =
-        CliValueType.DereferenceField name f.Contents
-
-    static member DereferenceFieldById (field : FieldId) (f : AllocatedNonArrayObject) : CliType =
-        CliValueType.DereferenceFieldById field f.Contents
-
-    static member SetField (name : string) (v : CliType) (f : AllocatedNonArrayObject) : AllocatedNonArrayObject =
-        { f with
-            Contents = CliValueType.WithFieldSet name v f.Contents
-        }
-
-    static member SetFieldById (field : FieldId) (v : CliType) (f : AllocatedNonArrayObject) : AllocatedNonArrayObject =
-        { f with
-            Contents = CliValueType.WithFieldSetById field v f.Contents
-        }
-
-/// Everything about an array except its contents: the element type, the total element
-/// count, the per-dimension lengths, and the two element-type facts the access paths need —
-/// the byte stride between cells and the element's zero value. All of them are fixed when
-/// the array is allocated and never change afterwards, so reading them is not a
-/// guest-visible memory access — unlike reading a cell, which is.
-///
-/// The absence of an `Elements` field is the point. A caller that needs only the rank or
-/// the length holds a value from which no cell can be reached, so a shape query cannot
-/// silently become a data read as the code around it changes. Cell reads go through
-/// `ManagedHeap.getArrayValue`.
-type ArrayShape =
-    {
-        ConcreteType : ConcreteTypeHandle
-        /// Total element count, equal to the product of `Lengths`.
-        Length : int
-        /// Per-dimension lengths in row-major order; length 1 for szarrays, else the rank.
-        Lengths : ImmutableArray<int>
-        /// The byte distance between consecutive cells.
-        ///
-        /// A property of the *element type*, not of any stored value: CoreCLR fixes it when
-        /// the array type is laid out, and no store into a cell can change it. It is recorded
-        /// here at allocation, from the element zero the allocator was handed, rather than
-        /// recovered later by measuring a cell — measuring a cell would be a read of guest
-        /// memory to answer a question about a type, showing up as an access with no
-        /// counterpart in the program under test, and it has no answer at all for an empty
-        /// array.
-        ///
-        /// Always strictly positive: every CLI type occupies at least one byte, a fieldless
-        /// struct included (CoreCLR pads it to 1, and `CliValueType.SizeOfFieldStorage`
-        /// follows). Consumers divide by it — see `floorDivRem` — so a zero here would be a
-        /// silent wrong answer rather than a loud one.
-        ///
-        /// `ManagedHeap.allocateArray` checks positivity, checks the value against
-        /// `ElementZero`, and checks it against cell 0 of every non-empty allocation, so it
-        /// can never drift from either.
-        ElementStride : int
-        /// The zero value of the element type: what every cell held immediately after
-        /// allocation, and the canonical witness for "what shape is a cell of this array".
-        ///
-        /// Like `ElementStride`, a property of the element type rather than of any stored
-        /// value, recorded from the zero factory the allocator was handed. Callers asking a
-        /// *type* question — is this store whole-cell-shaped, what template should this
-        /// decoded value take — read this instead of sampling cell 0. Sampling cell 0 is
-        /// wrong in three separate ways: it is a guest-visible read performed to answer a
-        /// question about a type, it has no answer for an empty array, and cell 0 is only a
-        /// sample, so a store to cell 5 ends up validated against whatever provenance cell 0
-        /// happens to be carrying.
-        ///
-        /// Not a substitute for reading a cell. A cell legitimately drifts from this shape —
-        /// an `IntPtr[]` slot holding a `TypeHandlePtr` after a typed store through a fixed
-        /// pointer — so anything that cares what is *actually stored* must still go through
-        /// `getArrayValue`.
-        ///
-        /// `ElementStride` is exactly `CliType.sizeOf ElementZero`, checked at
-        /// `allocateArray`. It is stored rather than recomputed because `CliType.sizeOf`
-        /// walks a value type's whole field tree, and the stride is read on every byte-view
-        /// array access.
-        ElementZero : CliType
-    }
-
-type AllocatedArray =
-    {
-        /// Identity and dimensions, fixed at allocation. Held as a nested record rather
-        /// than inlined so that a caller wanting only the shape can be handed a value
-        /// from which no cell is reachable; see `ArrayShape`.
-        Shape : ArrayShape
-        /// Backing store in row-major order. For multi-dim arrays the element at
-        /// `(i_0, ..., i_{n-1})` lives at flat offset
-        /// `((((i_0)*d_1)+i_1)*d_2 + i_2)*...*d_{n-1} + i_{n-1}`, where `d_k = Lengths.[k]`.
-        Elements : ImmutableArray<CliType>
-    }
 
 type ManagedHeap =
     {
@@ -222,6 +69,34 @@ module ManagedHeap =
         { heap with
             SyncBlocks = heap.SyncBlocks |> Map.add addr syncValue
         }
+
+    /// Every object whose monitor is currently `Held` by `thread`, with the ownership
+    /// state, in ascending address order.
+    ///
+    /// Ownership is a property of the object header rather than of any object's payload,
+    /// so this is monitor bookkeeping and not a read of guest memory.
+    let syncBlocksHeldBy (thread : ThreadId) (heap : ManagedHeap) : (ManagedHeapAddress * LockedSyncBlock) list =
+        heap.SyncBlocks
+        |> Map.toList
+        |> List.choose (fun (addr, syncBlock) ->
+            match syncBlock.Lock with
+            | SyncBlockLock.Held locked when locked.LockingThread = thread -> Some (addr, locked)
+            | SyncBlockLock.Held _
+            | SyncBlockLock.Free -> None
+        )
+
+    /// Every (object, thread) pair where `thread` is parked in the object's `WaitQueue`
+    /// from a `Monitor.Wait`, in ascending address order and then in wait-queue (FIFO)
+    /// order within each object.
+    ///
+    /// The ordering is load-bearing, which is why it lives here rather than at the call
+    /// sites: `SyncBlockMonitor.applySpuriousWakeups` folds a wake over this list, and a
+    /// different enumeration order would give a different interleaving for the same seed.
+    /// Objects with an empty wait queue contribute nothing.
+    let syncBlockWaiters (heap : ManagedHeap) : (ManagedHeapAddress * ThreadId) list =
+        heap.SyncBlocks
+        |> Map.toList
+        |> List.collect (fun (addr, syncBlock) -> syncBlock.WaitQueue |> List.map (fun (tid, _) -> addr, tid))
 
     /// Allocate `ty` at a fresh address.
     ///
@@ -364,10 +239,18 @@ module ManagedHeap =
         | true, s -> Some s
         | false, _ -> None
 
-    let getStringDataOffset (addr : ManagedHeapAddress) (heap : ManagedHeap) : int =
+    /// The index in `StringArrayData` of the first character of the string object at
+    /// `addr`, or None if none was recorded — a string allocated off the standard path,
+    /// or an address that is not a string at all.
+    let tryGetStringDataOffset (addr : ManagedHeapAddress) (heap : ManagedHeap) : int option =
         match heap.StringDataOffsets.TryGetValue addr with
-        | true, offset -> offset
-        | false, _ -> failwith $"string data offset for %O{addr} was not recorded"
+        | true, offset -> Some offset
+        | false, _ -> None
+
+    let getStringDataOffset (addr : ManagedHeapAddress) (heap : ManagedHeap) : int =
+        match tryGetStringDataOffset addr heap with
+        | Some offset -> offset
+        | None -> failwith $"string data offset for %O{addr} was not recorded"
 
     let private requireStringContents (operation : string) (addr : ManagedHeapAddress) (heap : ManagedHeap) : string =
         match getStringContents addr heap with
@@ -616,3 +499,69 @@ module ManagedHeap =
         { heap with
             Arrays = newArrs
         }
+
+/// Read-only introspection of the heap by code that is *not the running guest*: the
+/// debugger server, crash reporting, and tests.
+///
+/// The split from `ManagedHeap` is by *caller identity*, not by what is read. A debugger
+/// dumping an array reads exactly the cells `ManagedHeap.getArrayValue` reads; the
+/// difference is that the guest did not ask for them, and so a race detector must not
+/// treat them as an access by any thread. Keeping the two sets of functions in separate
+/// modules means that boundary is visible at every call site and mechanical to act on:
+/// when heap accesses come to emit events, `ManagedHeap`'s functions are the ones that
+/// emit and `HeapObserver`'s are the ones that deliberately do not.
+///
+/// Consequently these functions must stay pure reads. Anything the interpreter proper
+/// needs belongs in `ManagedHeap`, even if a test is its only current caller.
+[<RequireQualifiedAccess>]
+module HeapObserver =
+    /// The number of live non-array objects, arrays excluded.
+    let nonArrayObjectCount (heap : ManagedHeap) : int = heap.NonArrayObjects.Count
+
+    /// The number of live arrays.
+    let arrayCount (heap : ManagedHeap) : int = heap.Arrays.Count
+
+    /// The number of objects with recorded string content. Not the number of live
+    /// `System.String` instances as such: it counts exactly those registered via
+    /// `ManagedHeap.recordStringContents`.
+    let stringContentCount (heap : ManagedHeap) : int = heap.StringContents.Count
+
+    /// The address the next allocation will be given. Exposed for tests that need to name
+    /// an address which is guaranteed *not* to be live.
+    let nextAddress (heap : ManagedHeap) : int = heap.FirstAvailableAddress
+
+    /// The whole array at `addr`, cells included, or None if `addr` is not a live array.
+    ///
+    /// The only accessor that hands out every cell at once, because dumping an array is
+    /// the one thing an observer legitimately wants and the guest never does. Interpreter
+    /// code reads one cell at a time through `ManagedHeap.getArrayValue`.
+    let tryGetArray (addr : ManagedHeapAddress) (heap : ManagedHeap) : AllocatedArray option =
+        match heap.Arrays.TryGetValue addr with
+        | true, arr -> Some arr
+        | false, _ -> None
+
+    /// Every live non-array object with its payload, in ascending address order.
+    let nonArrayObjects (heap : ManagedHeap) : (ManagedHeapAddress * AllocatedNonArrayObject) list =
+        heap.NonArrayObjects |> Map.toList
+
+    /// The addresses of all live allocations, arrays and non-arrays alike.
+    ///
+    /// Derived from the two payload maps, deliberately *not* from `SyncBlocks`, so that it
+    /// remains an independent answer to the same question `syncBlockAddresses` answers.
+    /// Tests compare the two to check the header-table invariant; implementing either in
+    /// terms of the other would turn that check into a tautology.
+    let liveAddresses (heap : ManagedHeap) : Set<ManagedHeapAddress> =
+        Set.union (heap.NonArrayObjects |> Map.keys |> Set.ofSeq) (heap.Arrays |> Map.keys |> Set.ofSeq)
+
+    /// The addresses that have an object header. See `liveAddresses` for why this is
+    /// computed from `SyncBlocks` alone.
+    let syncBlockAddresses (heap : ManagedHeap) : Set<ManagedHeapAddress> =
+        heap.SyncBlocks |> Map.keys |> Set.ofSeq
+
+    /// Whether `addr` has an object header. Computed from `SyncBlocks` alone; see
+    /// `liveAddresses`.
+    let hasSyncBlock (addr : ManagedHeapAddress) (heap : ManagedHeap) : bool = heap.SyncBlocks.ContainsKey addr
+
+    /// Every object header, keyed by address. Exposed as a whole so that a test can
+    /// compare monitor state across two machine states in one equality.
+    let syncBlocks (heap : ManagedHeap) : Map<ManagedHeapAddress, SyncBlock> = heap.SyncBlocks

--- a/WoofWare.PawPrint/ManagedHeap.fs
+++ b/WoofWare.PawPrint/ManagedHeap.fs
@@ -513,6 +513,14 @@ module ManagedHeap =
 ///
 /// Consequently these functions must stay pure reads. Anything the interpreter proper
 /// needs belongs in `ManagedHeap`, even if a test is its only current caller.
+///
+/// Several of these mirror a `ManagedHeap` function of the same name and answer exactly
+/// the same question. That is not accidental duplication: the two must stay distinct
+/// *functions* precisely so that one can come to emit an access event and the other cannot.
+/// For the same reason they read the representation directly rather than delegating to
+/// their `ManagedHeap` counterpart, which would route an observer's read straight back
+/// through the emitting path. `HeapObserver mirrors agree with their ManagedHeap
+/// counterparts` pins them together.
 [<RequireQualifiedAccess>]
 module HeapObserver =
     /// The number of live non-array objects, arrays excluded.
@@ -543,6 +551,32 @@ module HeapObserver =
     /// Every live non-array object with its payload, in ascending address order.
     let nonArrayObjects (heap : ManagedHeap) : (ManagedHeapAddress * AllocatedNonArrayObject) list =
         heap.NonArrayObjects |> Map.toList
+
+    /// The non-array object at `addr`, or None if there is no live non-array object there
+    /// — including when `addr` is a live *array*.
+    let tryGetNonArrayObject (addr : ManagedHeapAddress) (heap : ManagedHeap) : AllocatedNonArrayObject option =
+        match heap.NonArrayObjects.TryGetValue addr with
+        | true, v -> Some v
+        | false, _ -> None
+
+    /// The character content of the string object at `addr`, or None if none was recorded.
+    let getStringContents (addr : ManagedHeapAddress) (heap : ManagedHeap) : string option =
+        match heap.StringContents.TryGetValue addr with
+        | true, s -> Some s
+        | false, _ -> None
+
+    /// The object header of the object at `addr`. Fails for an address that is not a live
+    /// allocation.
+    let getSyncBlock (addr : ManagedHeapAddress) (heap : ManagedHeap) : SyncBlock =
+        match heap.SyncBlocks.TryGetValue addr with
+        | true, v -> v
+        | false, _ ->
+            failwith
+                $"HeapObserver.getSyncBlock: %O{addr} is not a live managed heap allocation, so has no object header"
+
+    /// Whether `addr` is a live heap allocation of either kind.
+    let isLive (addr : ManagedHeapAddress) (heap : ManagedHeap) : bool =
+        heap.NonArrayObjects.ContainsKey addr || heap.Arrays.ContainsKey addr
 
     /// The addresses of all live allocations, arrays and non-arrays alike.
     ///

--- a/WoofWare.PawPrint/ManagedHeap.fs
+++ b/WoofWare.PawPrint/ManagedHeap.fs
@@ -76,13 +76,17 @@ module ManagedHeap =
     /// Ownership is a property of the object header rather than of any object's payload,
     /// so this is monitor bookkeeping and not a read of guest memory.
     let syncBlocksHeldBy (thread : ThreadId) (heap : ManagedHeap) : (ManagedHeapAddress * LockedSyncBlock) list =
-        heap.SyncBlocks
-        |> Map.toList
-        |> List.choose (fun (addr, syncBlock) ->
+        // Folded rather than `Map.toList |> List.choose`, which would allocate a tuple and a
+        // cons cell for every object on the heap before discarding all but the matches — and
+        // a terminating thread almost never holds any. `Map.foldBack` visits keys in
+        // descending order, so consing during the fold produces the ascending list directly
+        // and allocates only for matches. Same reasoning as `Scheduler.runnableThreads`.
+        (heap.SyncBlocks, [])
+        ||> Map.foldBack (fun addr syncBlock acc ->
             match syncBlock.Lock with
-            | SyncBlockLock.Held locked when locked.LockingThread = thread -> Some (addr, locked)
+            | SyncBlockLock.Held locked when locked.LockingThread = thread -> (addr, locked) :: acc
             | SyncBlockLock.Held _
-            | SyncBlockLock.Free -> None
+            | SyncBlockLock.Free -> acc
         )
 
     /// Every (object, thread) pair where `thread` is parked in the object's `WaitQueue`
@@ -94,9 +98,15 @@ module ManagedHeap =
     /// different enumeration order would give a different interleaving for the same seed.
     /// Objects with an empty wait queue contribute nothing.
     let syncBlockWaiters (heap : ManagedHeap) : (ManagedHeapAddress * ThreadId) list =
-        heap.SyncBlocks
-        |> Map.toList
-        |> List.collect (fun (addr, syncBlock) -> syncBlock.WaitQueue |> List.map (fun (tid, _) -> addr, tid))
+        // Folded rather than `Map.toList |> List.collect`, for the same reason as
+        // `syncBlocksHeldBy`: most objects have no waiters, so the intermediate would be one
+        // entry per object on the heap to produce a handful. The inner `List.foldBack`
+        // preserves each queue's FIFO order while prepending it.
+        (heap.SyncBlocks, [])
+        ||> Map.foldBack (fun addr syncBlock acc ->
+            (syncBlock.WaitQueue, acc)
+            ||> List.foldBack (fun (tid, _) acc -> (addr, tid) :: acc)
+        )
 
     /// Allocate `ty` at a fresh address.
     ///

--- a/WoofWare.PawPrint/ManagedHeap.fsi
+++ b/WoofWare.PawPrint/ManagedHeap.fsi
@@ -178,6 +178,10 @@ module ManagedHeap =
 ///
 /// Consequently these must stay pure reads. Anything the interpreter proper needs belongs
 /// in `ManagedHeap`, even if a test is its only current caller.
+///
+/// Several of these mirror a `ManagedHeap` function of the same name and answer exactly the
+/// same question. The duplication is the design: the two must stay distinct functions
+/// precisely so that one can come to emit an access event and the other cannot.
 [<RequireQualifiedAccess>]
 module HeapObserver =
     /// The number of live non-array objects, arrays excluded.
@@ -200,6 +204,22 @@ module HeapObserver =
 
     /// Every live non-array object with its payload, in ascending address order.
     val nonArrayObjects : heap : ManagedHeap -> (ManagedHeapAddress * AllocatedNonArrayObject) list
+
+    /// The non-array object at `addr`, or None if there is no live non-array object there —
+    /// including when `addr` is a live *array*. Mirrors `ManagedHeap.tryGet`.
+    val tryGetNonArrayObject : addr : ManagedHeapAddress -> heap : ManagedHeap -> AllocatedNonArrayObject option
+
+    /// The character content of the string object at `addr`, or None if none was recorded.
+    /// Mirrors `ManagedHeap.getStringContents`.
+    val getStringContents : addr : ManagedHeapAddress -> heap : ManagedHeap -> string option
+
+    /// The object header of the object at `addr`. Fails for an address that is not a live
+    /// allocation. Mirrors `ManagedHeap.getSyncBlock`.
+    val getSyncBlock : addr : ManagedHeapAddress -> heap : ManagedHeap -> SyncBlock
+
+    /// Whether `addr` is a live heap allocation of either kind. Mirrors
+    /// `ManagedHeap.isLive`.
+    val isLive : addr : ManagedHeapAddress -> heap : ManagedHeap -> bool
 
     /// The addresses of all live allocations, arrays and non-arrays alike. Computed from
     /// the payload tables, independently of `syncBlockAddresses`.

--- a/WoofWare.PawPrint/ManagedHeap.fsi
+++ b/WoofWare.PawPrint/ManagedHeap.fsi
@@ -1,0 +1,218 @@
+namespace WoofWare.PawPrint
+
+/// The guest's managed memory: every live object, array and string, together with the
+/// object headers that carry their monitors.
+///
+/// The representation is deliberately hidden. Every read of guest memory must be
+/// attributable to a caller and a reason, because a race detector has to distinguish the
+/// guest touching a field from the interpreter answering a question about a type, and from
+/// a debugger dumping state on the side. A caller that reached into the maps directly would
+/// be invisible to that machinery, so the type system removes the option: `ManagedHeap`
+/// below is the interpreter's surface, and `HeapObserver` is the outside-the-guest one.
+///
+/// The payload records the accessors hand back (`AllocatedArray`, `ArrayShape`,
+/// `AllocatedNonArrayObject`, `SyncBlock`) stay transparent — the constraint is on reaching
+/// the heap, not on inspecting what it gave you.
+[<Sealed>]
+type ManagedHeap
+
+/// Accessors for the *interpreter*: the emulated CLR acting on the guest's behalf.
+///
+/// This is where guest-visible memory accesses come from, and so where any future
+/// instrumentation of them belongs. Contrast `HeapObserver`.
+[<RequireQualifiedAccess>]
+module ManagedHeap =
+    /// A heap with nothing allocated. The first address handed out is 1, so 0 is never a
+    /// live address.
+    val empty : ManagedHeap
+
+    /// The object header of the object at `addr`. Every live heap object has one, whatever
+    /// its payload kind; fails for an address that is not a live allocation.
+    val getSyncBlock : addr : ManagedHeapAddress -> heap : ManagedHeap -> SyncBlock
+
+    /// Overwrite the object header of the object at `addr`. Fails for an address that is
+    /// not a live allocation rather than conjuring a header for it.
+    val setSyncBlock : addr : ManagedHeapAddress -> syncValue : SyncBlock -> heap : ManagedHeap -> ManagedHeap
+
+    /// Every object whose monitor is currently `Held` by `thread`, with the ownership
+    /// state, in ascending address order.
+    val syncBlocksHeldBy : thread : ThreadId -> heap : ManagedHeap -> (ManagedHeapAddress * LockedSyncBlock) list
+
+    /// Every (object, thread) pair where `thread` is parked in the object's `WaitQueue`
+    /// from a `Monitor.Wait`, in ascending address order and then in wait-queue (FIFO)
+    /// order within each object. Threads merely contending for the lock do not appear.
+    ///
+    /// The ordering is part of the contract: callers fold scheduling decisions over this
+    /// list, so a different order is a different interleaving.
+    val syncBlockWaiters : heap : ManagedHeap -> (ManagedHeapAddress * ThreadId) list
+
+    /// Allocate `ty` at a fresh address, registering an empty object header for it.
+    ///
+    /// This is the single chokepoint through which every array reaches the heap, and it
+    /// checks the denormalised facts on `ty.Shape` rather than trusting them: the stride is
+    /// positive, the stride agrees with `ElementZero` and with cell 0, the length agrees
+    /// with the cell count, and the length agrees with the product of the per-dimension
+    /// lengths. Callers read those facts instead of measuring a cell, which would be
+    /// worthless if the recorded values could be wrong.
+    val allocateArray : ty : AllocatedArray -> heap : ManagedHeap -> ManagedHeapAddress * ManagedHeap
+
+    /// Allocate `ty` at a fresh address, registering an empty object header for it.
+    val allocateNonArray : ty : AllocatedNonArrayObject -> heap : ManagedHeap -> ManagedHeapAddress * ManagedHeap
+
+    /// Allocate a fresh array that is a shallow copy of the array at `source`, as
+    /// `System.Array.Clone` promises. The clone gets its own empty object header, so it
+    /// never inherits the source's monitor ownership.
+    val cloneArray : source : ManagedHeapAddress -> heap : ManagedHeap -> ManagedHeapAddress * ManagedHeap
+
+    /// The concrete type of the object at `alloc`, whichever payload kind it has, or None
+    /// if `alloc` is not live.
+    val tryGetObjectConcreteType : alloc : ManagedHeapAddress -> heap : ManagedHeap -> ConcreteTypeHandle option
+
+    /// The concrete type of the object at `alloc`, whichever payload kind it has. Fails if
+    /// `alloc` is not live.
+    val getObjectConcreteType : alloc : ManagedHeapAddress -> heap : ManagedHeap -> ConcreteTypeHandle
+
+    /// Reserve `len + 1` characters of string storage — the trailing slot is the null
+    /// terminator CoreCLR's string layout requires — and return the index at which it
+    /// starts.
+    val allocateString : len : int -> heap : ManagedHeap -> int * ManagedHeap
+
+    /// Blit `contents` into string storage starting at index `addr`. Does not touch the
+    /// null terminator, and does not update any `StringContents` registration.
+    val setStringData : addr : int -> contents : string -> heap : ManagedHeap -> ManagedHeap
+
+    /// Record the full character content of the string object at `addr`, so that
+    /// string-level operations (equality, hashing) can read it back.
+    val recordStringContents : addr : ManagedHeapAddress -> contents : string -> heap : ManagedHeap -> ManagedHeap
+
+    /// Record where the string object at `addr` has its UTF-16 data in string storage.
+    val recordStringDataOffset : addr : ManagedHeapAddress -> dataOffset : int -> heap : ManagedHeap -> ManagedHeap
+
+    /// The character content of the string object at `addr`, or None if none was recorded
+    /// — a string allocated off the standard path, or an address that is not a string.
+    val getStringContents : addr : ManagedHeapAddress -> heap : ManagedHeap -> string option
+
+    /// The index in string storage of the first character of the string at `addr`, or None
+    /// if none was recorded.
+    val tryGetStringDataOffset : addr : ManagedHeapAddress -> heap : ManagedHeap -> int option
+
+    /// The index in string storage of the first character of the string at `addr`. Fails if
+    /// none was recorded.
+    val getStringDataOffset : addr : ManagedHeapAddress -> heap : ManagedHeap -> int
+
+    /// Update one character of the string at `addr`. `charIndex` equal to the string length
+    /// addresses the null terminator, which updates the character storage but not the
+    /// logical string value; beyond that is rejected.
+    val setStringChar :
+        addr : ManagedHeapAddress -> charIndex : int -> value : char -> heap : ManagedHeap -> ManagedHeap
+
+    /// Read one character of the string at `addr`. `charIndex` equal to the string length
+    /// addresses the null terminator; beyond that is rejected, since it would walk into
+    /// unrelated string storage.
+    val getStringChar : addr : ManagedHeapAddress -> charIndex : int -> heap : ManagedHeap -> char
+
+    /// Value equality between two managed strings, with the semantics of
+    /// `System.String.Equals(string, string)`. Fails if the contents are genuinely needed
+    /// and either address is not a registered string.
+    val stringsEqual : a1 : ManagedHeapAddress -> a2 : ManagedHeapAddress -> heap : ManagedHeap -> bool
+
+    /// Whether `addr` is a live array. False both for a live non-array object and for an
+    /// address that was never allocated; `tryGetObjectConcreteType` tells those apart.
+    val isArray : addr : ManagedHeapAddress -> heap : ManagedHeap -> bool
+
+    /// Whether `addr` is a live heap allocation of either kind.
+    val isLive : addr : ManagedHeapAddress -> heap : ManagedHeap -> bool
+
+    /// The dimensions and element type of the array at `addr`, or None if `addr` is not a
+    /// live array. Carries no cells, so this is not a read of guest memory.
+    val tryGetArrayShape : addr : ManagedHeapAddress -> heap : ManagedHeap -> ArrayShape option
+
+    /// The dimensions and element type of the array at `addr`. Carries no cells, so this is
+    /// not a read of guest memory. Reports "not an array" and "not allocated" distinctly.
+    val getArrayShape : addr : ManagedHeapAddress -> heap : ManagedHeap -> ArrayShape
+
+    /// The byte distance between consecutive cells of the array at `addr`. Well defined for
+    /// an empty array, and never a read of a cell.
+    val getArrayElementStride : addr : ManagedHeapAddress -> heap : ManagedHeap -> int
+
+    /// The zero value of the element type of the array at `addr`: the witness for questions
+    /// about what shape a cell of this array has. Well defined for an empty array, and
+    /// never a read of a cell — which is the point. Use `getArrayValue` to learn what a
+    /// cell actually holds.
+    val getArrayElementZero : addr : ManagedHeapAddress -> heap : ManagedHeap -> CliType
+
+    /// The value in cell `offset` of the array at `alloc`, bounds-checked against the
+    /// array's length. A read of guest memory.
+    val getArrayValue : alloc : ManagedHeapAddress -> offset : int -> heap : ManagedHeap -> CliType
+
+    /// Store `v` into cell `offset` of the array at `alloc`, bounds-checked against the
+    /// array's length. A write to guest memory.
+    val setArrayValue : alloc : ManagedHeapAddress -> offset : int -> v : CliType -> heap : ManagedHeap -> ManagedHeap
+
+    /// The non-array object at `alloc`, or None if there is no live non-array object there
+    /// — including when `alloc` is a live *array*, which has no such payload.
+    val tryGet : alloc : ManagedHeapAddress -> heap : ManagedHeap -> AllocatedNonArrayObject option
+
+    /// The non-array object at `alloc`. Reports "is an array" and "not allocated"
+    /// distinctly.
+    val get : alloc : ManagedHeapAddress -> heap : ManagedHeap -> AllocatedNonArrayObject
+
+    /// Replace the payload of the non-array object at `alloc`. Fails if `alloc` is not a
+    /// live non-array object.
+    val set : alloc : ManagedHeapAddress -> v : AllocatedNonArrayObject -> heap : ManagedHeap -> ManagedHeap
+
+    /// Store `value` into field `field` of the non-array object at `alloc`. Reports "is an
+    /// array" and "not allocated" distinctly.
+    val setFieldById :
+        alloc : ManagedHeapAddress -> field : FieldId -> value : CliType -> heap : ManagedHeap -> ManagedHeap
+
+/// Read-only introspection of the heap by code that is *not the running guest*: the
+/// debugger server, crash reporting, and tests.
+///
+/// The split from `ManagedHeap` is by *caller identity*, not by what is read. A debugger
+/// dumping an array reads exactly the cells `ManagedHeap.getArrayValue` reads; the
+/// difference is that the guest did not ask for them, and so a race detector must not treat
+/// them as an access by any thread. Keeping the two in separate modules makes that boundary
+/// visible at every call site: when heap accesses come to emit events, `ManagedHeap`'s
+/// functions emit and `HeapObserver`'s deliberately do not.
+///
+/// Consequently these must stay pure reads. Anything the interpreter proper needs belongs
+/// in `ManagedHeap`, even if a test is its only current caller.
+[<RequireQualifiedAccess>]
+module HeapObserver =
+    /// The number of live non-array objects, arrays excluded.
+    val nonArrayObjectCount : heap : ManagedHeap -> int
+
+    /// The number of live arrays.
+    val arrayCount : heap : ManagedHeap -> int
+
+    /// The number of objects with recorded string content. Not the number of live
+    /// `System.String` instances as such.
+    val stringContentCount : heap : ManagedHeap -> int
+
+    /// The address the next allocation will be given, and hence an address guaranteed not
+    /// to be live.
+    val nextAddress : heap : ManagedHeap -> int
+
+    /// The whole array at `addr`, cells included, or None if `addr` is not a live array.
+    /// The only accessor that hands out every cell at once.
+    val tryGetArray : addr : ManagedHeapAddress -> heap : ManagedHeap -> AllocatedArray option
+
+    /// Every live non-array object with its payload, in ascending address order.
+    val nonArrayObjects : heap : ManagedHeap -> (ManagedHeapAddress * AllocatedNonArrayObject) list
+
+    /// The addresses of all live allocations, arrays and non-arrays alike. Computed from
+    /// the payload tables, independently of `syncBlockAddresses`.
+    val liveAddresses : heap : ManagedHeap -> Set<ManagedHeapAddress>
+
+    /// The addresses that have an object header. Computed from the header table,
+    /// independently of `liveAddresses`; the two agreeing is an invariant worth testing
+    /// rather than assuming.
+    val syncBlockAddresses : heap : ManagedHeap -> Set<ManagedHeapAddress>
+
+    /// Whether `addr` has an object header. Computed from the header table alone; see
+    /// `syncBlockAddresses`.
+    val hasSyncBlock : addr : ManagedHeapAddress -> heap : ManagedHeap -> bool
+
+    /// Every object header, keyed by address.
+    val syncBlocks : heap : ManagedHeap -> Map<ManagedHeapAddress, SyncBlock>

--- a/WoofWare.PawPrint/ManagedHeapTypes.fs
+++ b/WoofWare.PawPrint/ManagedHeapTypes.fs
@@ -1,0 +1,157 @@
+namespace WoofWare.PawPrint
+
+open System.Collections.Immutable
+
+/// State carried when an object's monitor is `Held` by some thread.
+/// `AcquireQueue` is the FIFO list of (thread, optional re-entry depth) pairs
+/// parked in `BlockedOnSyncBlockAcquire` waiting for ownership to be transferred
+/// to them when `LockingThread` calls `Monitor.Exit`. FIFO order is load-bearing
+/// for fairness: switching to LIFO or arbitrary order would change the
+/// observable interleaving for guests that race multiple threads into the same
+/// `lock` block.
+///
+/// The `int option` snapshot on each `AcquireQueue` entry distinguishes the
+/// two flavours of waiter:
+///   * `None` — a fresh entrant from `Monitor.Enter`. On ownership transfer it
+///     becomes the new owner with `ReentrancyCount = 1`.
+///   * `Some depth` — a waiter that was woken from `Monitor.Wait` by
+///     `Monitor.Pulse` / `PulseAll` (or a spurious wake). `Wait` snapshots its
+///     prior `ReentrancyCount` so that on re-acquire the depth it had before
+///     parking is restored verbatim. Storing the depth inline next to the
+///     thread keeps the "what's waiting and what depth do they need" coupling
+///     visible at every read site; a separate map would let a transition lose
+///     the pairing silently.
+///
+/// `ReentrancyCount` is the depth of nested `Monitor.Enter` calls by
+/// `LockingThread` and must reach exactly zero before ownership can transfer.
+type LockedSyncBlock =
+    {
+        LockingThread : ThreadId
+        ReentrancyCount : int
+        AcquireQueue : (ThreadId * int option) list
+    }
+
+/// Ownership state of an object's monitor — distinct from its `WaitQueue`
+/// because `Monitor.Wait` fully releases the lock (`Free`) while leaving its
+/// caller parked in the SyncBlock's `WaitQueue`.
+type SyncBlockLock =
+    | Free
+    | Held of LockedSyncBlock
+
+/// Per-object monitor metadata. `Lock` describes ownership and FIFO of
+/// `Monitor.Enter` contenders. `WaitQueue` is the FIFO list of (thread,
+/// snapshot depth) pairs currently parked in `BlockedOnSyncBlockWait` from a
+/// `Monitor.Wait` call; they do NOT contend for the lock until a `Pulse` /
+/// `PulseAll` moves them onto `AcquireQueue` (FIFO tail), at which point they
+/// re-enter via the normal ownership-transfer path. The two fields are
+/// orthogonal: a non-empty `WaitQueue` can coexist with `Lock = Free` (the
+/// owner called `Wait`, releasing the lock, but the waiter is still parked).
+/// Pulse on an empty wait queue is a documented no-op (matches CoreCLR's
+/// `SyncBlock`).
+type SyncBlock =
+    {
+        Lock : SyncBlockLock
+        WaitQueue : (ThreadId * int) list
+    }
+
+    /// Initial state for a freshly-allocated object: lock free, no waiters.
+    static member Empty : SyncBlock =
+        {
+            Lock = SyncBlockLock.Free
+            WaitQueue = []
+        }
+
+type AllocatedNonArrayObject =
+    {
+        // TODO: this is a slightly odd domain; the same type for value types as class types!
+        Contents : CliValueType
+        ConcreteType : ConcreteTypeHandle
+    }
+
+    static member DereferenceField (name : string) (f : AllocatedNonArrayObject) : CliType =
+        CliValueType.DereferenceField name f.Contents
+
+    static member DereferenceFieldById (field : FieldId) (f : AllocatedNonArrayObject) : CliType =
+        CliValueType.DereferenceFieldById field f.Contents
+
+    static member SetField (name : string) (v : CliType) (f : AllocatedNonArrayObject) : AllocatedNonArrayObject =
+        { f with
+            Contents = CliValueType.WithFieldSet name v f.Contents
+        }
+
+    static member SetFieldById (field : FieldId) (v : CliType) (f : AllocatedNonArrayObject) : AllocatedNonArrayObject =
+        { f with
+            Contents = CliValueType.WithFieldSetById field v f.Contents
+        }
+
+/// Everything about an array except its contents: the element type, the total element
+/// count, the per-dimension lengths, and the two element-type facts the access paths need —
+/// the byte stride between cells and the element's zero value. All of them are fixed when
+/// the array is allocated and never change afterwards, so reading them is not a
+/// guest-visible memory access — unlike reading a cell, which is.
+///
+/// The absence of an `Elements` field is the point. A caller that needs only the rank or
+/// the length holds a value from which no cell can be reached, so a shape query cannot
+/// silently become a data read as the code around it changes. Cell reads go through
+/// `ManagedHeap.getArrayValue`.
+type ArrayShape =
+    {
+        ConcreteType : ConcreteTypeHandle
+        /// Total element count, equal to the product of `Lengths`.
+        Length : int
+        /// Per-dimension lengths in row-major order; length 1 for szarrays, else the rank.
+        Lengths : ImmutableArray<int>
+        /// The byte distance between consecutive cells.
+        ///
+        /// A property of the *element type*, not of any stored value: CoreCLR fixes it when
+        /// the array type is laid out, and no store into a cell can change it. It is recorded
+        /// here at allocation, from the element zero the allocator was handed, rather than
+        /// recovered later by measuring a cell — measuring a cell would be a read of guest
+        /// memory to answer a question about a type, showing up as an access with no
+        /// counterpart in the program under test, and it has no answer at all for an empty
+        /// array.
+        ///
+        /// Always strictly positive: every CLI type occupies at least one byte, a fieldless
+        /// struct included (CoreCLR pads it to 1, and `CliValueType.SizeOfFieldStorage`
+        /// follows). Consumers divide by it — see `floorDivRem` — so a zero here would be a
+        /// silent wrong answer rather than a loud one.
+        ///
+        /// `ManagedHeap.allocateArray` checks positivity, checks the value against
+        /// `ElementZero`, and checks it against cell 0 of every non-empty allocation, so it
+        /// can never drift from either.
+        ElementStride : int
+        /// The zero value of the element type: what every cell held immediately after
+        /// allocation, and the canonical witness for "what shape is a cell of this array".
+        ///
+        /// Like `ElementStride`, a property of the element type rather than of any stored
+        /// value, recorded from the zero factory the allocator was handed. Callers asking a
+        /// *type* question — is this store whole-cell-shaped, what template should this
+        /// decoded value take — read this instead of sampling cell 0. Sampling cell 0 is
+        /// wrong in three separate ways: it is a guest-visible read performed to answer a
+        /// question about a type, it has no answer for an empty array, and cell 0 is only a
+        /// sample, so a store to cell 5 ends up validated against whatever provenance cell 0
+        /// happens to be carrying.
+        ///
+        /// Not a substitute for reading a cell. A cell legitimately drifts from this shape —
+        /// an `IntPtr[]` slot holding a `TypeHandlePtr` after a typed store through a fixed
+        /// pointer — so anything that cares what is *actually stored* must still go through
+        /// `getArrayValue`.
+        ///
+        /// `ElementStride` is exactly `CliType.sizeOf ElementZero`, checked at
+        /// `allocateArray`. It is stored rather than recomputed because `CliType.sizeOf`
+        /// walks a value type's whole field tree, and the stride is read on every byte-view
+        /// array access.
+        ElementZero : CliType
+    }
+
+type AllocatedArray =
+    {
+        /// Identity and dimensions, fixed at allocation. Held as a nested record rather
+        /// than inlined so that a caller wanting only the shape can be handed a value
+        /// from which no cell is reachable; see `ArrayShape`.
+        Shape : ArrayShape
+        /// Backing store in row-major order. For multi-dim arrays the element at
+        /// `(i_0, ..., i_{n-1})` lives at flat offset
+        /// `((((i_0)*d_1)+i_1)*d_2 + i_2)*...*d_{n-1} + i_{n-1}`, where `d_k = Lengths.[k]`.
+        Elements : ImmutableArray<CliType>
+    }

--- a/WoofWare.PawPrint/Scheduler.fs
+++ b/WoofWare.PawPrint/Scheduler.fs
@@ -598,15 +598,7 @@ module Scheduler =
         // transfer from a dead owner. Mirrors the LowLevelMonitor check above —
         // RAII-style release is the guest's responsibility, and a loud failure is far
         // easier to diagnose than a silent deadlock.
-        let orphanedSyncBlocks =
-            state.ManagedHeap.SyncBlocks
-            |> Map.toSeq
-            |> Seq.choose (fun (addr, syncBlock) ->
-                match syncBlock.Lock with
-                | SyncBlockLock.Held locked when locked.LockingThread = terminated -> Some (addr, locked)
-                | _ -> None
-            )
-            |> Seq.toList
+        let orphanedSyncBlocks = ManagedHeap.syncBlocksHeldBy terminated state.ManagedHeap
 
         match orphanedSyncBlocks with
         | [] -> ()

--- a/WoofWare.PawPrint/SyncBlockMonitor.fs
+++ b/WoofWare.PawPrint/SyncBlockMonitor.fs
@@ -433,11 +433,7 @@ module SyncBlockMonitor =
         | SyncBlockSpuriousWakeupStrategy.Disabled -> state
 
         | SyncBlockSpuriousWakeupStrategy.AlwaysAll ->
-            state.ManagedHeap.SyncBlocks
-            |> Map.toSeq
-            |> Seq.sortBy (fun (ManagedHeapAddress aid, _) -> aid)
-            |> Seq.collect (fun (addr, syncBlock) -> syncBlock.WaitQueue |> List.map (fun (tid, _) -> addr, tid))
-            |> Seq.toList
+            ManagedHeap.syncBlockWaiters state.ManagedHeap
             |> List.fold (fun acc (addr, tid) -> spuriousWake addr tid acc) state
 
         | SyncBlockSpuriousWakeupStrategy.Random (seed, probability) ->
@@ -445,12 +441,8 @@ module SyncBlockMonitor =
                 failwith
                     $"SyncBlockSpuriousWakeupStrategy.Random: probability %f{probability} is outside [0.0, 1.0] (NaN or out of range)."
 
-            state.ManagedHeap.SyncBlocks
-            |> Map.toSeq
-            |> Seq.sortBy (fun (ManagedHeapAddress aid, _) -> aid)
-            |> Seq.collect (fun (addr, syncBlock) -> syncBlock.WaitQueue |> List.map (fun (tid, _) -> addr, tid))
-            |> Seq.filter (fun (addr, tid) -> coinFlip seed tick addr tid < probability)
-            |> Seq.toList
+            ManagedHeap.syncBlockWaiters state.ManagedHeap
+            |> List.filter (fun (addr, tid) -> coinFlip seed tick addr tid < probability)
             |> List.fold (fun acc (addr, tid) -> spuriousWake addr tid acc) state
 
         | SyncBlockSpuriousWakeupStrategy.Scripted wakeups ->

--- a/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
+++ b/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
@@ -43,6 +43,8 @@
     <Compile Include="TypeHandleRegistry.fs" />
     <Compile Include="FieldHandleRegistry.fs" />
     <Compile Include="MethodHandleRegistry.fs" />
+    <Compile Include="ManagedHeapTypes.fs" />
+    <Compile Include="ManagedHeap.fsi" />
     <Compile Include="ManagedHeap.fs" />
     <Compile Include="ArrayElementType.fs" />
     <Compile Include="TypeInitialisation.fs" />


### PR DESCRIPTION
Closes the guest-memory access seam. `ManagedHeap` is now an opaque type: nothing outside `ManagedHeap.fs` can reach `Arrays`, `NonArrayObjects`, `StringContents`, `StringDataOffsets`, `SyncBlocks` or `FirstAvailableAddress` — in this assembly or any other.

That is the property Stage 1 needs. When heap accesses come to emit events, instrumenting the accessors will provably catch every one, because there is no other route to guest memory.

## Two modules, split by caller identity

**`ManagedHeap`** — the interpreter acting on the guest's behalf. This is where guest-visible accesses come from, and so where instrumentation will go. It gains:

- `syncBlocksHeldBy` / `syncBlockWaiters`, replacing open-coded enumerations in `Scheduler` and `SyncBlockMonitor`. Both are monitor bookkeeping, not guest reads. `syncBlockWaiters` documents its ordering as load-bearing — `applySpuriousWakeups` folds over it, so a different order is a different interleaving for the same seed.
- `tryGetStringDataOffset`, with `getStringDataOffset` now defined on it.

**`HeapObserver`** — new, for code outside the guest: the debugger server, crash reporting, tests. A debugger dumping an array reads exactly the cells `getArrayValue` reads; the difference is that *the guest did not ask for them*, so a race detector must not attribute them to any thread. The module name is that claim, which makes Stage 1's boundary mechanical rather than a per-function judgement.

`liveAddresses` and `syncBlockAddresses` are computed from different tables and neither is defined in terms of the other: two existing property tests compare them as independent oracles for the header-table invariant, and collapsing them would leave both passing vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
