### PR TITLE
Implement SystemNative_ConvertErrorPlatformToPal

### DIFF
--- a/WoofWare.PawPrint.Test/TestImpureCases.fs
+++ b/WoofWare.PawPrint.Test/TestImpureCases.fs
@@ -82,25 +82,6 @@ module TestImpureCases =
 
     let unimplemented : EndToEndTestCase list =
         [
-            // Both of these have a current directory whose UTF-8 encoding
-            // overflows the 256 bytes `Interop.Sys.GetCwd()` stackallocs, so
-            // `SystemNative_GetCwd` correctly returns NULL with errno=ERANGE
-            // and the guest takes its ArrayPool grow-and-retry branch. It then
-            // stops one call later, at `Interop.Sys.GetLastErrorInfo()`: that
-            // converts the raw errno to the `Interop.Error` PAL enum through
-            // `SystemNative_ConvertErrorPlatformToPal`, which has no handler
-            // registered in `Native/NativeDispatch.fs`, so this reaches
-            // `NativeCall.failUnimplemented`.
-            //
-            // That entry point is the runtime's shared errno<->PAL translation
-            // (an 84-case table in `src/native/libs/Common/pal_error_common.h`)
-            // used by every `SystemNative_*` shim rather than anything specific
-            // to getcwd, so it wants its own change. Un-park both when it lands
-            // — nothing else here is missing, and the short-path siblings in
-            // `cases` below already prove the success path end to end.
-            currentDirectoryCase longCurrentDirectory
-            currentDirectoryCase multiByteCurrentDirectory
-
             // A *short* non-ASCII directory, parked for an unrelated reason:
             // it fits the stackalloc, so `SystemNative_GetCwd` succeeds and
             // ERANGE never enters into it, but decoding the bytes back with
@@ -113,7 +94,6 @@ module TestImpureCases =
             // directory. `TestAbsoluteUnixPath` covers the UTF-8 encoding of
             // such a path directly in the meantime.
             currentDirectoryCase "/héllo/中文/🐶"
-
         ]
 
     /// Is this the concrete handle for `System.Runtime.ExceptionServices.ExceptionDispatchInfo`?
@@ -182,6 +162,24 @@ module TestImpureCases =
 
     let cases : EndToEndTestCase list =
         [
+            // Both of these have a current directory whose UTF-8 encoding
+            // overflows the 256 bytes `Interop.Sys.GetCwd()` stackallocs, so
+            // `SystemNative_GetCwd` returns NULL with errno=ERANGE and the
+            // guest takes its ArrayPool grow-and-retry branch. That branch runs
+            // through `Interop.Sys.GetLastErrorInfo()`, which converts the raw
+            // errno with `SystemNative_ConvertErrorPlatformToPal` and compares
+            // the result against `Interop.Error.ERANGE` to decide whether to
+            // retry or throw — so these are the cases that exercise that
+            // handler against *real* CoreLib, including its `Interop.Error`
+            // enum return type, rather than a hand-rolled P/Invoke declaration.
+            // They were parked until that entry point existed.
+            //
+            // Note the short non-ASCII sibling still in `unimplemented` below
+            // is parked for a genuinely different reason and was re-checked
+            // when these two were promoted: it still fails, on the
+            // TrailingZeroCount intrinsic.
+            currentDirectoryCase longCurrentDirectory
+            currentDirectoryCase multiByteCurrentDirectory
             {
                 // Pins the PawPrint-side contract of `ExceptionNative_GetFrozenStackTrace`.
                 // Impure because the claim is about interpreter state (the token and the frame
@@ -530,6 +528,25 @@ module TestImpureCases =
                 // property tests; this test verifies the wiring from the
                 // P/Invoke handler through to the registry.
                 FileName = "SystemNativeClose.cs"
+                ExpectedReturnCode = 0
+                KernelConfig = KernelConfig.Default
+                AppContext = AppContextProperties.empty
+                ExpectsUnhandledException = false
+                AssertTerminalState = None
+            }
+            {
+                // Exercises SystemNative_ConvertErrorPlatformToPal, the point
+                // at which PawPrint's raw errno vocabulary becomes the
+                // platform-independent `Interop.Error` CoreLib branches on.
+                // Impure by necessity rather than convenience: the PAL values
+                // are platform-independent but the *mapping* is not, because
+                // the real shim is compiled against one platform's <errno.h>
+                // (raw 39 is ENOTEMPTY on Linux, EDESTADDRREQ on Darwin). A
+                // cross-runtime oracle would therefore be asserting a
+                // host-specific fact. Covers both arms of the handler's
+                // return-type match: the enum CoreLib declares and the plain
+                // `int` a hand-rolled P/Invoke would use.
+                FileName = "SystemNativeConvertErrorPlatformToPal.cs"
                 ExpectedReturnCode = 0
                 KernelConfig = KernelConfig.Default
                 AppContext = AppContextProperties.empty

--- a/WoofWare.PawPrint.Test/TestUnixError.fs
+++ b/WoofWare.PawPrint.Test/TestUnixError.fs
@@ -200,31 +200,32 @@ module TestUnixError =
         UnixError.palOfRawErrno 0 |> shouldEqual UnixError.palSuccess
 
     [<Test>]
-    let ``rawErrnoOfPal maps SUCCESS to zero`` () : unit =
-        UnixError.rawErrnoOfPal UnixError.palSuccess |> shouldEqual 0
-
-    [<Test>]
     let ``palOfRawErrno inverts toRawErrno`` () : unit =
         for error in UnixError.all do
             UnixError.palOfRawErrno (UnixError.toRawErrno error)
             |> shouldEqual (UnixError.toPal error)
 
-    /// Upstream disclaims platform -> pal -> platform round-tripping, but the
-    /// pal -> platform -> pal direction is exactly what
-    /// `ConvertErrorPalToPlatform` is for ("to synthesize a platform number from
-    /// the fixed set above"), and it must be faithful.
+    /// ENOTBLK is 15 on both Linux and Darwin, so its meaning needs no platform
+    /// choice — but `Interop.Error` has no entry for it, so upstream's switch
+    /// falls through to ENONSTANDARD. We must do the same rather than crash:
+    /// this conversion is unambiguous, it simply has no PAL name. Today this is
+    /// the only raw errno in that class.
     [<Test>]
-    let ``rawErrnoOfPal inverts toPal`` () : unit =
-        for error in UnixError.all do
-            UnixError.rawErrnoOfPal (UnixError.toPal error)
-            |> shouldEqual (UnixError.toRawErrno error)
+    let ``palOfRawErrno reports ENONSTANDARD for a portable errno with no PAL name`` () : unit =
+        UnixError.palOfRawErrno 15 |> shouldEqual UnixError.palNonStandard
 
-    [<Test>]
-    let ``rawErrnoOfPal reports -1 for an unmapped PAL value`` () : unit =
-        // ENONSTANDARD is the value upstream itself falls through to; it has no
-        // raw number by construction.
-        UnixError.rawErrnoOfPal UnixError.palNonStandard |> shouldEqual -1
-        UnixError.rawErrnoOfPal 0x1003A |> shouldEqual -1 // ENOTEMPTY: real, but not portable.
+    /// POSIX requires errno values to be positive, so a negative number names an
+    /// error on no Unix we model and every platform's switch falls through to
+    /// ENONSTANDARD. Answering that needs no platform choice, so it must not
+    /// crash. -0x20001 and -0x20002 are upstream's synthetic EHOSTNOTFOUND and
+    /// ESOCKETERROR, which is how a negative most plausibly reaches here.
+    [<TestCase -1>]
+    [<TestCase -34>]
+    [<TestCase 0x80000000>]
+    [<TestCase -0x20001>]
+    [<TestCase -0x20002>]
+    let ``palOfRawErrno reports ENONSTANDARD for a negative errno`` (raw : int) : unit =
+        UnixError.palOfRawErrno raw |> shouldEqual UnixError.palNonStandard
 
     /// The crux of the design: an errno whose meaning depends on the platform
     /// must not be silently resolved. 11 and 35 are the transposed

--- a/WoofWare.PawPrint.Test/sourcesImpure/SystemNativeConvertErrorPlatformToPal.cs
+++ b/WoofWare.PawPrint.Test/sourcesImpure/SystemNativeConvertErrorPlatformToPal.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Runtime.InteropServices;
+
+// Exercises the SystemNative_ConvertErrorPlatformToPal handler, which turns a
+// raw <errno.h> number into the platform-independent Interop.Error value that
+// CoreLib actually switches on. Every BCL failure path goes through this:
+// Interop.Sys.GetLastErrorInfo() constructs ErrorInfo(Marshal.GetLastPInvokeError()),
+// whose constructor calls it.
+//
+// This is an *impure* test: it runs only inside PawPrint, never against the
+// real CLR. It could not be a cross-runtime test even in principle. The PAL
+// values are platform-independent, but the *mapping* is not: the real shim is
+// compiled against one platform's <errno.h>, so on macOS raw 39 is
+// EDESTADDRREQ while on Linux it is ENOTEMPTY. PawPrint deliberately models
+// only the errnos that mean the same thing on every Unix it models, so an
+// oracle comparison would be asserting a host-specific fact.
+//
+// Two declarations of the same entry point, deliberately: CoreLib declares the
+// return as the `Interop.Error` enum — nested in a class in the *global*
+// namespace — while a guest hand-rolling the P/Invoke would naturally write
+// `int`. Both must reach the handler, so both are covered here. `Codes.Error`
+// below is nested in the global namespace exactly as `Interop.Error` is, which
+// is what makes this test able to exercise the enum arm at all: the real
+// `Interop.Error` is internal to CoreLib and cannot be named from a guest.
+class Program
+{
+    // Mirrors the shape of CoreLib's Interop.Error: a nested enum, global
+    // namespace, int underlying type. Only the members this test needs.
+    internal static class Codes
+    {
+        internal enum Error
+        {
+            SUCCESS = 0,
+            EBADF = 0x10008,
+            ENOENT = 0x1002D,
+            ERANGE = 0x10047,
+        }
+    }
+
+    [DllImport("libSystem.Native", EntryPoint = "SystemNative_ConvertErrorPlatformToPal")]
+    static extern Codes.Error ConvertToPalEnum(int platformErrno);
+
+    [DllImport("libSystem.Native", EntryPoint = "SystemNative_ConvertErrorPlatformToPal")]
+    static extern int ConvertToPalInt(int platformErrno);
+
+    static int Main(string[] args)
+    {
+        // Raw 0 is "no error", and maps to Interop.Error.SUCCESS (also 0),
+        // which is the value CoreLib's `ErrorInfo` treats as "call succeeded".
+        if (ConvertToPalEnum(0) != Codes.Error.SUCCESS) return 1;
+
+        // The three portable errnos PawPrint's own handlers already report.
+        // These are deliberately spread across the errno range rather than
+        // adjacent, so an off-by-one or truncated table shows up.
+        if (ConvertToPalEnum(2) != Codes.Error.ENOENT) return 2;
+        if (ConvertToPalEnum(9) != Codes.Error.EBADF) return 3;
+        if (ConvertToPalEnum(34) != Codes.Error.ERANGE) return 4;
+
+        // The same entry point declared with an `int` return must agree; this
+        // covers the other arm of the handler's return-type match.
+        if (ConvertToPalInt(2) != (int)Codes.Error.ENOENT) return 5;
+        if (ConvertToPalInt(0) != 0) return 6;
+
+        // PAL values are deliberately numbered outside the raw errno range so
+        // the two cannot be confused. Guard that we are genuinely converting
+        // rather than echoing the input back.
+        if (ConvertToPalInt(9) == 9) return 7;
+
+        return 0;
+    }
+}

--- a/WoofWare.PawPrint/Native/NativeSystemNative.fs
+++ b/WoofWare.PawPrint/Native/NativeSystemNative.fs
@@ -43,6 +43,27 @@ module NativeSystemNative =
                                       generics) when generics.IsEmpty -> Some ()
         | _ -> None
 
+    /// Matches the type `Interop.Sys.ConvertErrorPlatformToPal` *returns*.
+    ///
+    /// CoreLib declares it as the PAL `Interop.Error` enum, which lives nested
+    /// inside the `Interop` static class in the *global* namespace — so it
+    /// concretises with an empty namespace and the bare name "Error" (nesting is
+    /// not reflected in `ConcreteType`'s name). A guest hand-rolling the
+    /// P/Invoke may instead declare the return as a plain `int`, which is the
+    /// same thing at the ABI, so both are accepted.
+    ///
+    /// Deliberately not assembly-qualified, unlike `PosixSignalParam` above.
+    /// `Interop.Error` is `internal` to CoreLib, so a guest cannot name *that*
+    /// type; requiring it would leave this arm reachable only by real BCL code
+    /// and hence untestable. The entry-point name already identifies the call
+    /// uniquely, so the assembly adds no discrimination here — it would only
+    /// cost the ability to test the arm.
+    let private (|PalErrorReturn|_|) (concreteTypes : AllConcreteTypes) (handle : ConcreteTypeHandle) : unit option =
+        match handle with
+        | ConcretePrimitive concreteTypes PrimitiveType.Int32 -> Some ()
+        | ConcreteType concreteTypes (_, "", "Error", generics) when generics.IsEmpty -> Some ()
+        | _ -> None
+
     /// Decode an `nint`-shaped Unix file-descriptor argument. CoreLib passes
     /// fds across the SystemNative boundary as plain `IntPtr` values (the low
     /// 32 bits of `SafeFileHandle.handle`); PawPrint represents these as
@@ -275,6 +296,32 @@ module NativeSystemNative =
           [],
           MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32) ->
             pushInt32 state.Kernel.LastSystemError ctx |> Some
+        | Some "SystemNative_ConvertErrorPlatformToPal",
+          [ ConcretePrimitive state.ConcreteTypes PrimitiveType.Int32 ],
+          MethodReturnType.Returns (PalErrorReturn state.ConcreteTypes) ->
+            // `int32_t SystemNative_ConvertErrorPlatformToPal(int32_t platformErrno)`
+            // (pal_errno.c:6) is a one-line wrapper around
+            // `ConvertErrorPlatformToPal` in `pal_error_common.h:146`, a pure
+            // switch from the host's raw `<errno.h>` number to the
+            // platform-independent `Interop.Error` value CoreLib switches on.
+            //
+            // Every BCL failure path goes through here: `Interop.Sys.
+            // GetLastErrorInfo()` builds `ErrorInfo(Marshal.GetLastPInvokeError())`,
+            // whose constructor calls this. So this is the single point at which
+            // PawPrint's raw errno vocabulary becomes something the BCL can
+            // branch on.
+            //
+            // `UnixError.palOfRawErrno` refuses errnos whose meaning is
+            // platform-dependent rather than answering `ENONSTANDARD` as the C
+            // does; see its doc comment for why that divergence is the honest
+            // one. In practice the only raw values reaching this are ones
+            // PawPrint itself stored via `UnixError.toRawErrno` (which admits
+            // only portable errnos) or ones a guest planted with
+            // `Marshal.SetLastSystemError`.
+            let raw =
+                NativeCall.int32Argument "SystemNative_ConvertErrorPlatformToPal" instruction.Arguments.[0]
+
+            pushInt32 (UnixError.palOfRawErrno raw) ctx |> Some
         | Some "SystemNative_GetCpuUtilization",
           [ ConcretePointer _ ],
           MethodReturnType.Returns (ConcretePrimitive state.ConcreteTypes PrimitiveType.Double) ->

--- a/WoofWare.PawPrint/UnixError.fs
+++ b/WoofWare.PawPrint/UnixError.fs
@@ -165,9 +165,11 @@ module UnixError =
 
     /// `Interop.Error.ENONSTANDARD`, which upstream's
     /// `ConvertErrorPlatformToPal` returns for any errno it does not recognise.
-    /// PawPrint does not currently return this — see `palOfRawErrno` for why —
-    /// but the value is here because that function's contract is stated in
-    /// terms of it.
+    /// PawPrint returns it in the one case where "unrecognised" is
+    /// platform-independent — a raw errno inside the portable range that the
+    /// PAL enum simply has no name for, today only `ENOTBLK`. Where
+    /// "unrecognised" instead means "means different things on different
+    /// Unixes", `palOfRawErrno` fails rather than answering this; see there.
     [<Literal>]
     let palNonStandard : int = 0x1FFFF
 
@@ -278,6 +280,32 @@ module UnixError =
     /// The error a raw `<errno.h>` number denotes, or `None` when this build
     /// cannot say. `None` means genuinely undecidable, not merely unmapped: see
     /// `palOfRawErrno`.
+    /// Is `raw` a number whose meaning PawPrint can state without first
+    /// deciding which Unix it is impersonating?
+    ///
+    /// Every value in 1-34 is defined on both Linux and Darwin, and they agree
+    /// on all of them except 11 (`EAGAIN` on Linux, `EDEADLK` on Darwin, and
+    /// vice versa at 35). From 35 up the two numbered independently, so nothing
+    /// there is answerable.
+    ///
+    /// Note this is deliberately conservative at the top end: a number above
+    /// *both* platforms' highest errno is in fact unambiguous — it is
+    /// nonstandard on either — but saying so would mean embedding both
+    /// platforms' maxima, which is more platform trivia than the honest answer
+    /// is worth. Such a value fails loudly instead, which is the safe direction.
+    ///
+    /// The bottom end is different, and is *not* left to fail: POSIX requires
+    /// errno values to be positive, so no platform defines a negative one and
+    /// both fall through to `ENONSTANDARD`. Establishing that needs no
+    /// per-platform table at all, which is exactly why it is answered here and
+    /// the top end is not. See `isUnambiguouslyNonStandardRawErrno`.
+    let private isPortableRawErrno (raw : int) : bool = raw >= 1 && raw <= 34 && raw <> 11
+
+    /// Raw values every Unix agrees are meaningless, and hence agrees convert to
+    /// `ENONSTANDARD`. POSIX errnos are positive, so a negative number names an
+    /// error on no platform we model and needs no platform choice to reject.
+    let private isUnambiguouslyNonStandardRawErrno (raw : int) : bool = raw < 0
+
     let ofRawErrno (raw : int) : UnixError option =
         all
         |> List.tryFind (fun error ->
@@ -289,23 +317,34 @@ module UnixError =
     /// PawPrint's `SystemNative_ConvertErrorPlatformToPal`: raw errno to PAL
     /// `Interop.Error`.
     ///
-    /// **Diverges from upstream, deliberately.** `ConvertErrorPlatformToPal` in
-    /// `pal_error_common.h` is total, falling back to `Error_ENONSTANDARD` for
-    /// anything it does not recognise. PawPrint cannot honestly do that for an
-    /// unrecognised value, because "unrecognised" here bundles together two very
-    /// different situations that we cannot tell apart without embedding both
-    /// platforms' complete errno tables:
+    /// Three outcomes, not two, because "not in the table" bundles together two
+    /// situations that must not be treated alike:
     ///
-    ///   * numbers that really are nonstandard on both platforms, where
-    ///     `ENONSTANDARD` is the right answer; and
-    ///   * numbers that name a perfectly ordinary error on each platform but a
-    ///     *different* one on each — every value from 35 up, plus 11. Answering
+    ///   * **Portable and named** — the ordinary case; answer its PAL value.
+    ///   * **Portable but unnamed** — the number means the same thing on every
+    ///     Unix we model, but the BCL's `Interop.Error` has no entry for it.
+    ///     `ENOTBLK` (15) is the only such value. Upstream's switch has no case
+    ///     for it either, so it falls through to `Error_ENONSTANDARD` — and that
+    ///     answer is platform-independent, so we can give it too. Crashing here
+    ///     would refuse a conversion that requires no choice at all.
+    ///   * **Negative** — POSIX errnos are positive, so every Unix we model
+    ///     falls through to `ENONSTANDARD` for these; that is unambiguous and
+    ///     needs no platform table, so we answer it. Reachable through
+    ///     `Marshal.SetLastSystemError`, and through the synthetic
+    ///     `EHOSTNOTFOUND` / `ESOCKETERROR` pseudo-errnos, which upstream
+    ///     defines as the fixed negatives `-0x20001` / `-0x20002`.
+    ///   * **Not portable** — 11, and everything from 35 up. Upstream answers
+    ///     these from whichever platform's `<errno.h>` it was compiled against;
+    ///     PawPrint has chosen no platform, so it cannot. Answering
     ///     `ENONSTANDARD` for raw 39 would be silently wrong on Linux, where
-    ///     upstream returns `Error_ENOTEMPTY`.
+    ///     upstream returns `Error_ENOTEMPTY`, so this fails loudly instead. A
+    ///     crash naming the value is recoverable; a guest that quietly took the
+    ///     wrong branch of `if (errorInfo.Error == Interop.Error.ENOTEMPTY)` is
+    ///     not.
     ///
-    /// So this fails instead. A crash naming the value is recoverable; a guest
-    /// that quietly took the wrong branch of `if (errorInfo.Error ==
-    /// Interop.Error.ENOTEMPTY)` is not.
+    /// Only the last case diverges from upstream; the others answer exactly what
+    /// the C does. The failure is confined to values whose meaning genuinely
+    /// depends on a platform PawPrint has not chosen.
     let palOfRawErrno (raw : int) : int =
         if raw = 0 then
             palSuccess
@@ -313,25 +352,10 @@ module UnixError =
 
         match ofRawErrno raw with
         | Some error -> toPal error
+        | None when isPortableRawErrno raw ->
+            // ENOTBLK, today the only member of this class.
+            palNonStandard
+        | None when isUnambiguouslyNonStandardRawErrno raw -> palNonStandard
         | None ->
             failwith
                 $"UnixError.palOfRawErrno: cannot convert raw errno %d{raw} to a PAL Interop.Error value. PawPrint only maps the errnos that name the same error on every Unix it models (1-34 except 11); outside that set a raw number is platform-dependent — 39 is ENOTEMPTY on Linux but EDESTADDRREQ on Darwin, and 11 is EAGAIN on Linux but EDEADLK on Darwin. Upstream's ConvertErrorPlatformToPal answers ENONSTANDARD here because it was compiled against one platform's <errno.h> and PawPrint has not chosen one. If a guest legitimately needs this errno, decide the numbering (see issue #956); if it reached here via Marshal.SetLastSystemError, the guest is asserting a platform PawPrint does not model."
-
-    /// PawPrint's `SystemNative_ConvertErrorPalToPlatform`: PAL `Interop.Error`
-    /// back to a raw errno.
-    ///
-    /// Upstream is explicit that this is *not* a round-trip inverse — its own
-    /// comment says "we should not use this function to round-trip platform ->
-    /// pal -> platform. It's here only to synthesize a platform number from the
-    /// fixed set above" — and it returns -1 (after a debug assert) for
-    /// `ENONSTANDARD` and for anything unrecognised. We match the -1, because
-    /// unlike the raw direction there is no ambiguity to hide: a PAL value we
-    /// do not map is one whose raw number we could not state anyway.
-    let rawErrnoOfPal (pal : int) : int =
-        if pal = palSuccess then
-            0
-        else
-
-        match all |> List.tryFind (fun error -> toPal error = pal) with
-        | Some error -> toRawErrno error
-        | None -> -1


### PR DESCRIPTION
Stacked on #969 (which is itself stacked on #962). **Review the top commit only.**

`int32_t SystemNative_ConvertErrorPlatformToPal(int32_t)` (`pal_errno.c:6`) is a one-line wrapper around `ConvertErrorPlatformToPal` in `pal_error_common.h:146`, turning a raw `<errno.h>` number into the platform-independent `Interop.Error` value CoreLib switches on. Every BCL failure path runs through it: `Interop.Sys.GetLastErrorInfo()` constructs `ErrorInfo(Marshal.GetLastPInvokeError())`, whose constructor calls this.

## Four outcomes, not two

"Not in the table" bundles several situations that must not be treated alike:

| input | answer | same as upstream? |
|---|---|---|
| portable and PAL-named | its PAL value | yes |
| portable but unnamed (`ENOTBLK`, 15) | `ENONSTANDARD` | yes |
| negative | `ENONSTANDARD` | yes |
| 11, or ≥ 35 | **fails loudly** | no — deliberate |

`ENOTBLK` is 15 on both Linux and Darwin, but `Interop.Error` has no entry for it, so upstream's switch also falls through to `ENONSTANDARD`; crashing would refuse a conversion needing no platform choice. Negatives are the same story from POSIX's guarantee that errnos are positive — and establishing *that* needs no per-platform table, which is precisely why it is answered while the top end (above both platforms' maxima; also unambiguous, but only provable by embedding those maxima) is left to fail.

Only the last row diverges, and it is confined to values whose meaning genuinely depends on a platform PawPrint has not chosen. Answering `ENONSTANDARD` for raw 39 would be silently wrong on Linux, where upstream returns `Error_ENOTEMPTY`.

## The return type

CoreLib declares the return as the `Interop.Error` enum, nested in the `Interop` static class in the *global* namespace, so it concretises with an empty namespace and the bare name `Error`. Rather than guess, a probe guest was run under the interpreter and the shape read straight off `failUnimplemented`'s diagnostic.

`PalErrorReturn` accepts that alongside a plain `int`, and is deliberately **not** assembly-qualified, unlike the neighbouring `PosixSignalParam`. `Interop.Error` is `internal` to CoreLib, so no guest can name that type; requiring the assembly would leave the enum arm reachable only by real BCL code. The entry-point name already identifies the call uniquely, so the qualifier would buy no discrimination and cost a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)