### PR TITLE
Model guest-supplied paths as parsed components

### DIFF
--- a/WoofWare.PawPrint.Test/TestAbsoluteUnixPath.fs
+++ b/WoofWare.PawPrint.Test/TestAbsoluteUnixPath.fs
@@ -64,6 +64,21 @@ module TestAbsoluteUnixPath =
         | Ok path -> failwith $"expected %s{candidate} to be rejected, but it parsed as %O{path}"
         | Error error -> error
 
+    /// A constant pattern accepts a `[<Literal>]` value and nothing else, so
+    /// this file stops compiling if `separator` is ever downgraded to an
+    /// ordinary `let` binding. That matters because it is public surface of a
+    /// published package: the downgrade breaks downstream code that uses it in
+    /// a constant position, while breaking nothing inside this repository.
+    let private classify (c : char) : string =
+        match c with
+        | AbsoluteUnixPath.separator -> "separator"
+        | _ -> "other"
+
+    [<Test>]
+    let ``separator is a literal, so it works in a constant pattern`` () : unit =
+        classify '/' |> shouldEqual "separator"
+        classify 'a' |> shouldEqual "other"
+
     [<Test>]
     let ``The root parses and renders as "/"`` () : unit =
         AbsoluteUnixPath.toString AbsoluteUnixPath.root |> shouldEqual "/"

--- a/WoofWare.PawPrint.Test/TestUnixPath.fs
+++ b/WoofWare.PawPrint.Test/TestUnixPath.fs
@@ -1,0 +1,512 @@
+namespace WoofWare.PawPrint.Test
+
+open System
+open System.Text
+open FsCheck
+open FsCheck.FSharp
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestUnixPath =
+
+    let private config : Config = Config.QuickThrowOnFailure.WithMaxTest 500
+
+    /// An ordinary entry name: non-empty, separator-free, NUL-free, no
+    /// unpaired surrogate, and not "." or "..". Draws from FsCheck's own `char`
+    /// generator rather than an ASCII alphabet so multi-byte UTF-8 and
+    /// well-formed surrogate pairs are exercised.
+    let private nameGen : Gen<string> =
+        gen {
+            let! chars =
+                ArbMap.defaults
+                |> ArbMap.generate<char>
+                |> Gen.filter (fun c -> c <> '/' && c <> '\000' && not (Char.IsSurrogate c))
+                |> Gen.nonEmptyListOf
+
+            // Astral characters are the interesting UTF-8 case (4 bytes, and a
+            // surrogate *pair* in UTF-16), and the filter above excludes them,
+            // so splice one in explicitly rather than hoping for it.
+            let! includeAstral = Gen.frequency [ 1, Gen.constant true ; 4, Gen.constant false ]
+
+            let chars =
+                if includeAstral then
+                    chars @ [ '\uD83D' ; '\uDC36' ]
+                else
+                    chars
+
+            let candidate = System.String (List.toArray chars)
+
+            return
+                if candidate = "." || candidate = ".." then
+                    candidate + "x"
+                else
+                    candidate
+        }
+
+    /// A path segment as a guest might write one, weighted so that "." and ".."
+    /// appear far more often than chance would give them: they are the whole
+    /// reason this type keeps components rather than a normalised string.
+    let private segmentGen : Gen<string> =
+        Gen.frequency [ 3, nameGen ; 1, Gen.constant "." ; 1, Gen.constant ".." ]
+
+    /// A run of separators, so that the collapsing rule is exercised rather
+    /// than assumed.
+    let private separatorRunGen : Gen<string> =
+        Gen.frequency [ 6, Gen.constant "/" ; 2, Gen.constant "//" ; 1, Gen.constant "///" ]
+
+    /// A whole guest-supplied path: optionally rooted, optionally
+    /// trailing-separated, with arbitrary separator runs between segments.
+    let private pathStringGen : Gen<string> =
+        gen {
+            let! rooted = Gen.elements [ true ; false ]
+            let! segments = Gen.listOf segmentGen
+            let! trailing = Gen.elements [ true ; false ]
+
+            let! joiners = Gen.listOfLength (max 0 (List.length segments - 1)) separatorRunGen
+
+            let body =
+                segments
+                |> List.mapi (fun i segment -> if i = 0 then segment else joiners.[i - 1] + segment)
+                |> String.concat ""
+
+            let! prefix = if rooted then separatorRunGen else Gen.constant ""
+
+            let! suffix =
+                if trailing && not (List.isEmpty segments) then
+                    separatorRunGen
+                else
+                    Gen.constant ""
+
+            return prefix + body + suffix
+        }
+
+    /// A string in exactly the shape `AbsoluteUnixPath` accepts: rooted, single
+    /// separators, no "." or "..", no trailing separator. `pathStringGen` hits
+    /// this shape only by luck, so the cross-check against that type needs its
+    /// own generator or it degenerates into testing the rejection path.
+    let private absolutePathStringGen : Gen<string> =
+        Gen.listOf nameGen
+        |> Gen.map (fun segments -> "/" + System.String.Join ("/", segments))
+
+    let private parseOk (candidate : string) : UnixPath =
+        match UnixPath.parse candidate with
+        | Ok path -> path
+        | Error error -> failwith $"expected %s{candidate} to parse, but: %s{UnixPath.describe error}"
+
+    let private parseError (candidate : string) : UnixPathError =
+        match UnixPath.parse candidate with
+        | Ok path -> failwith $"expected %s{candidate} to be rejected, but it parsed as %s{UnixPath.toString path}"
+        | Error error -> error
+
+    let private componentStrings (path : UnixPath) : string list =
+        UnixPath.components path
+        |> List.map (fun component_ ->
+            match component_ with
+            | PathComponent.Current -> "."
+            | PathComponent.Parent -> ".."
+            | PathComponent.Name name -> FileName.toString name
+        )
+
+    // ---------------------------------------------------------------- FileName
+
+    [<Test>]
+    let ``FileName rejects the names no directory entry can have`` () : unit =
+        FileName.parse null |> shouldEqual (Error FileNameError.Empty)
+        FileName.parse "" |> shouldEqual (Error FileNameError.Empty)
+        FileName.parse "." |> shouldEqual (Error (FileNameError.Reserved "."))
+        FileName.parse ".." |> shouldEqual (Error (FileNameError.Reserved ".."))
+        FileName.parse "/" |> shouldEqual (Error (FileNameError.ContainsSeparator 0))
+        FileName.parse "a/b" |> shouldEqual (Error (FileNameError.ContainsSeparator 1))
+        FileName.parse "ab/" |> shouldEqual (Error (FileNameError.ContainsSeparator 2))
+
+        FileName.parse "a\000b"
+        |> shouldEqual (Error (FileNameError.Text (UnixPathTextDefect.ContainsNul 1)))
+
+        // Built from `char` values rather than a literal: the F# lexer replaces
+        // a lone surrogate in a string literal with U+FFFD, so a literal here
+        // would silently test a replacement character instead.
+        FileName.parse (System.String [| 'a' ; char 0xD83D ; 'b' |])
+        |> shouldEqual (Error (FileNameError.Text (UnixPathTextDefect.UnpairedSurrogate 1)))
+
+    [<Test>]
+    let ``FileName accepts names that merely start with dots`` () : unit =
+        for candidate in [ ".a" ; "..a" ; "a." ; "a.." ; "..." ; ".hidden" ] do
+            match FileName.parse candidate with
+            | Ok name -> FileName.toString name |> shouldEqual candidate
+            | Error error -> failwith $"expected %s{candidate} to parse: %s{FileName.describe error}"
+
+    [<Test>]
+    let ``FileName round-trips through parse and toString`` () : unit =
+        let property (candidate : string) : unit =
+            match FileName.parse candidate with
+            | Error error -> FileName.describe error |> ignore<string>
+            | Ok name ->
+                FileName.toString name |> shouldEqual candidate
+                FileName.toString name |> FileName.parse |> shouldEqual (Ok name)
+
+        Check.One (config, Prop.forAll (Arb.fromGen nameGen) property)
+
+    [<Test>]
+    let ``FileName encodes to NUL-free UTF-8 that decodes back`` () : unit =
+        let property (candidate : string) : unit =
+            match FileName.parse candidate with
+            | Error error -> failwith $"expected %s{candidate} to parse: %s{FileName.describe error}"
+            | Ok name ->
+                let bytes = FileName.toUtf8 name |> Seq.toArray
+                bytes |> Array.contains 0uy |> shouldEqual false
+                // A strict decoder, so a malformed encoding fails rather than
+                // silently producing U+FFFD and comparing unequal for the
+                // wrong reason.
+                UTF8Encoding(false, true).GetString bytes |> shouldEqual candidate
+
+        Check.One (config, Prop.forAll (Arb.fromGen nameGen) property)
+
+    [<Test>]
+    let ``FileName parse never throws, whatever the input`` () : unit =
+        let property (candidate : string) : unit =
+            match FileName.parse candidate with
+            | Ok _ -> ()
+            | Error error -> FileName.describe error |> ignore<string>
+
+        Check.One (config, property)
+
+    [<Test>]
+    let ``FileName parseOrFail names the offending boundary`` () : unit =
+        let exn =
+            Assert.Throws<Exception> (fun () -> FileName.parseOrFail "seed manifest entry" ".." |> ignore<FileName>)
+
+        exn.Message |> shouldContainText "seed manifest entry"
+        exn.Message |> shouldContainText ".."
+
+    // ---------------------------------------------------------------- UnixPath
+
+    [<Test>]
+    let ``Null is rejected, but the empty path is not`` () : unit =
+        parseError null |> shouldEqual UnixPathError.Null
+
+        let empty = parseOk ""
+        empty |> shouldEqual UnixPath.empty
+        UnixPath.isEmpty empty |> shouldEqual true
+        UnixPath.isRooted empty |> shouldEqual false
+        UnixPath.components empty |> shouldEqual []
+        UnixPath.hasTrailingSeparator empty |> shouldEqual false
+
+    [<Test>]
+    let ``The root parses as rooted with no components`` () : unit =
+        for candidate in [ "/" ; "//" ; "///" ] do
+            let path = parseOk candidate
+            path |> shouldEqual UnixPath.root
+            UnixPath.isRooted path |> shouldEqual true
+            UnixPath.components path |> shouldEqual []
+            // The separator that roots "/" is not a *trailing* one; treating it
+            // as such would make the root the only path that demands its own
+            // final component be a directory.
+            UnixPath.hasTrailingSeparator path |> shouldEqual false
+            UnixPath.isEmpty path |> shouldEqual false
+            UnixPath.toString path |> shouldEqual "/"
+
+    [<Test>]
+    let ``Dot and dot-dot survive parsing as their own components`` () : unit =
+        componentStrings (parseOk "/a/./b/../c")
+        |> shouldEqual [ "a" ; "." ; "b" ; ".." ; "c" ]
+
+        UnixPath.components (parseOk "a/../..")
+        |> shouldEqual
+            [
+                PathComponent.Name (FileName.parseOrFail "test" "a")
+                PathComponent.Parent
+                PathComponent.Parent
+            ]
+
+    [<Test>]
+    let ``Repeated separators collapse, everywhere they can appear`` () : unit =
+        componentStrings (parseOk "//a///b//") |> shouldEqual [ "a" ; "b" ]
+        UnixPath.isRooted (parseOk "//a///b//") |> shouldEqual true
+        UnixPath.hasTrailingSeparator (parseOk "//a///b//") |> shouldEqual true
+        UnixPath.toString (parseOk "//a///b//") |> shouldEqual "/a/b/"
+
+    [<Test>]
+    let ``A trailing separator is recorded, and only when something precedes it`` () : unit =
+        let property (candidate : string) : unit =
+            let path = parseOk candidate
+
+            let expected =
+                not (List.isEmpty (UnixPath.components path))
+                && candidate.EndsWith ("/", StringComparison.Ordinal)
+
+            UnixPath.hasTrailingSeparator path |> shouldEqual expected
+
+        Check.One (config, Prop.forAll (Arb.fromGen pathStringGen) property)
+
+    [<Test>]
+    let ``Appending a separator changes only the trailing flag`` () : unit =
+        let property (candidate : string) : unit =
+            let path = parseOk candidate
+
+            // A path with no components has no final component to constrain, so
+            // appending a separator is absorbed rather than recorded.
+            if not (List.isEmpty (UnixPath.components path)) then
+                let appended = parseOk (candidate + "/")
+                UnixPath.components appended |> shouldEqual (UnixPath.components path)
+                UnixPath.isRooted appended |> shouldEqual (UnixPath.isRooted path)
+                UnixPath.hasTrailingSeparator appended |> shouldEqual true
+
+        Check.One (config, Prop.forAll (Arb.fromGen pathStringGen) property)
+
+    [<Test>]
+    let ``Rootedness is exactly a leading separator`` () : unit =
+        let property (candidate : string) : unit =
+            UnixPath.isRooted (parseOk candidate)
+            |> shouldEqual (candidate.StartsWith ("/", StringComparison.Ordinal))
+
+        Check.One (config, Prop.forAll (Arb.fromGen pathStringGen) property)
+
+    [<Test>]
+    let ``Components are the non-empty segments, in order`` () : unit =
+        let property (candidate : string) : unit =
+            let expected =
+                candidate.Split '/' |> Array.filter (fun s -> s <> "") |> Array.toList
+
+            componentStrings (parseOk candidate) |> shouldEqual expected
+
+        Check.One (config, Prop.forAll (Arb.fromGen pathStringGen) property)
+
+    [<Test>]
+    let ``Every parsed path round-trips through toString and parse`` () : unit =
+        let property (candidate : string) : unit =
+            let once = parseOk candidate
+            UnixPath.parse (UnixPath.toString once) |> shouldEqual (Ok once)
+
+        Check.One (config, Prop.forAll (Arb.fromGen pathStringGen) property)
+
+    [<Test>]
+    let ``Rendering is normalised: it re-renders to itself`` () : unit =
+        let property (candidate : string) : unit =
+            let once = UnixPath.toString (parseOk candidate)
+            let twice = UnixPath.toString (parseOk once)
+            twice |> shouldEqual once
+
+        Check.One (config, Prop.forAll (Arb.fromGen pathStringGen) property)
+
+    [<Test>]
+    let ``The empty path is the only one that names nothing`` () : unit =
+        let property (candidate : string) : unit =
+            UnixPath.isEmpty (parseOk candidate) |> shouldEqual (candidate = "")
+
+        Check.One (config, Prop.forAll (Arb.fromGen pathStringGen) property)
+
+    [<Test>]
+    let ``Parse never throws, whatever the input`` () : unit =
+        let property (candidate : string) : unit =
+            match UnixPath.parse candidate with
+            | Ok _ -> ()
+            | Error error -> UnixPath.describe error |> ignore<string>
+
+        Check.One (config, property)
+
+    [<Test>]
+    let ``A NUL anywhere is rejected, at the index of its first occurrence`` () : unit =
+        let withNulGen : Gen<string * int> =
+            gen {
+                let! candidate = pathStringGen
+                let! index = Gen.choose (0, candidate.Length)
+
+                // Inserting between the halves of a surrogate pair would break
+                // the pair, and the resulting unpaired *high* surrogate sits at
+                // an earlier index than the NUL — so the scan would truthfully
+                // report UnpairedSurrogate first. Step past such a position
+                // rather than assert the wrong error.
+                let index =
+                    if index < candidate.Length && Char.IsLowSurrogate candidate.[index] then
+                        index + 1
+                    else
+                        index
+
+                return candidate.Insert (index, "\000"), index
+            }
+
+        let property (withNul : string, index : int) : unit =
+            parseError withNul
+            |> shouldEqual (UnixPathError.Text (UnixPathTextDefect.ContainsNul index))
+
+        Check.One (config, Prop.forAll (Arb.fromGen withNulGen) property)
+
+    [<Test>]
+    let ``An unpaired surrogate is rejected`` () : unit =
+        let highOnly = System.String [| '/' ; 'a' ; char 0xD83D ; 'b' |]
+        let lowOnly = System.String [| '/' ; 'a' ; char 0xDC36 ; 'b' |]
+        // A high surrogate at the very end has no successor at all, which is a
+        // different branch from "successor is not a low surrogate".
+        let highAtEnd = System.String [| '/' ; 'a' ; char 0xD83D |]
+
+        for candidate in [ highOnly ; lowOnly ; highAtEnd ] do
+            parseError candidate
+            |> shouldEqual (UnixPathError.Text (UnixPathTextDefect.UnpairedSurrogate 2))
+
+        // A well-formed pair in the same position must *not* be rejected, and
+        // in particular the low half must not be reported as unpaired.
+        UnixPath.toString (parseOk "/a🐶b") |> shouldEqual "/a🐶b"
+
+    [<Test>]
+    let ``No parsed component is ever a reserved name in disguise`` () : unit =
+        let property (candidate : string) : unit =
+            for component_ in UnixPath.components (parseOk candidate) do
+                match component_ with
+                | PathComponent.Current
+                | PathComponent.Parent -> ()
+                | PathComponent.Name name ->
+                    let text = FileName.toString name
+                    text |> shouldNotEqual "."
+                    text |> shouldNotEqual ".."
+                    // The name must survive its own parser, which is what makes
+                    // it usable as a directory-entry key.
+                    FileName.parse text |> shouldEqual (Ok name)
+
+        Check.One (config, Prop.forAll (Arb.fromGen pathStringGen) property)
+
+    [<Test>]
+    let ``parseOrFail names the offending boundary`` () : unit =
+        let exn =
+            Assert.Throws<Exception> (fun () -> UnixPath.parseOrFail "seed manifest path" "a\000b" |> ignore<UnixPath>)
+
+        exn.Message |> shouldContainText "seed manifest path"
+
+    // ------------------------------------------- agreement with AbsoluteUnixPath
+
+    [<Test>]
+    let ``Every AbsoluteUnixPath is a UnixPath with the same rendering`` () : unit =
+        // AbsoluteUnixPath has an independently-written parser with a stricter
+        // grammar, so agreeing with it is a real cross-check rather than a
+        // restatement of this parser's own rules.
+        let property (candidate : string) : unit =
+            match AbsoluteUnixPath.parse candidate with
+            | Error error ->
+                failwith
+                    $"absolutePathStringGen produced %s{candidate}, which is not absolute: %s{AbsoluteUnixPath.describe error}"
+            | Ok absolute ->
+                let widened = UnixPath.ofAbsolute absolute
+                UnixPath.toString widened |> shouldEqual candidate
+                UnixPath.isRooted widened |> shouldEqual true
+                UnixPath.hasTrailingSeparator widened |> shouldEqual false
+
+                // A fully-resolved path has no navigation components left.
+                for component_ in UnixPath.components widened do
+                    match component_ with
+                    | PathComponent.Name _ -> ()
+                    | other -> failwith $"%A{other} survived in a fully-resolved path"
+
+        Check.One (config, Prop.forAll (Arb.fromGen absolutePathStringGen) property)
+
+    [<Test>]
+    let ``A UnixPath is absolute exactly when it is rooted, resolved and unterminated`` () : unit =
+        let property (candidate : string) : unit =
+            let path = parseOk candidate
+
+            let looksAbsolute =
+                UnixPath.isRooted path
+                && not (UnixPath.hasTrailingSeparator path)
+                && UnixPath.components path
+                   |> List.forall (fun component_ ->
+                       match component_ with
+                       | PathComponent.Name _ -> true
+                       | PathComponent.Current
+                       | PathComponent.Parent -> false
+                   )
+
+            let rendered = UnixPath.toString path
+
+            match AbsoluteUnixPath.parse rendered with
+            | Ok absolute ->
+                looksAbsolute |> shouldEqual true
+                UnixPath.ofAbsolute absolute |> shouldEqual path
+            | Error _ -> looksAbsolute |> shouldEqual false
+
+        Check.One (config, Prop.forAll (Arb.fromGen pathStringGen) property)
+
+    // ------------------------------------------------------------------ concat
+
+    [<Test>]
+    let ``concat ignores its base when the suffix is rooted`` () : unit =
+        let property (basePath : string, relative : string) : unit =
+            let relative = parseOk ("/" + relative)
+            UnixPath.concat (parseOk basePath) relative |> shouldEqual relative
+
+        Check.One (config, Prop.forAll (Arb.fromGen (Gen.zip pathStringGen pathStringGen)) property)
+
+    [<Test>]
+    let ``concat is lexical joining by a separator`` () : unit =
+        let property (basePath : string, relative : string) : unit =
+            let basePath = parseOk basePath
+            let relative = parseOk relative
+
+            // The restrictions are about what a *string*-level join means, not
+            // about `concat`: joining onto nothing would make the separator
+            // root the result, and joining nothing on would make the separator
+            // trail it. Neither is what concatenating the component lists does.
+            // A rooted suffix discards the base entirely, which the dedicated
+            // property above covers.
+            if
+                not (UnixPath.isEmpty basePath)
+                && not (UnixPath.isRooted relative)
+                && not (List.isEmpty (UnixPath.components relative))
+            then
+                let joined = UnixPath.toString basePath + "/" + UnixPath.toString relative
+
+                UnixPath.concat basePath relative |> shouldEqual (parseOk joined)
+
+        Check.One (config, Prop.forAll (Arb.fromGen (Gen.zip pathStringGen pathStringGen)) property)
+
+    [<Test>]
+    let ``concat preserves components, rootedness and the trailing flag`` () : unit =
+        let property (basePath : string, relative : string) : unit =
+            let basePath = parseOk basePath
+            let relative = parseOk relative
+            let joined = UnixPath.concat basePath relative
+
+            if not (UnixPath.isRooted relative) then
+                UnixPath.components joined
+                |> shouldEqual (UnixPath.components basePath @ UnixPath.components relative)
+
+                UnixPath.isRooted joined |> shouldEqual (UnixPath.isRooted basePath)
+
+                // The separator between the halves absorbs any that trailed the
+                // base, so the base's flag survives only when the suffix
+                // contributed no components of its own.
+                let expectedTrailing =
+                    if List.isEmpty (UnixPath.components relative) then
+                        UnixPath.hasTrailingSeparator basePath
+                    else
+                        UnixPath.hasTrailingSeparator relative
+
+                UnixPath.hasTrailingSeparator joined |> shouldEqual expectedTrailing
+
+        Check.One (config, Prop.forAll (Arb.fromGen (Gen.zip pathStringGen pathStringGen)) property)
+
+    [<Test>]
+    let ``concat with the empty path is the identity on both sides`` () : unit =
+        let property (candidate : string) : unit =
+            let path = parseOk candidate
+            UnixPath.concat path UnixPath.empty |> shouldEqual path
+
+            // The left identity holds only for a relative suffix: prefixing a
+            // rooted path with anything is still that rooted path, which the
+            // rooted case above already covers.
+            if not (UnixPath.isRooted path) then
+                UnixPath.concat UnixPath.empty path |> shouldEqual path
+
+        Check.One (config, Prop.forAll (Arb.fromGen pathStringGen) property)
+
+    [<Test>]
+    let ``concat is associative`` () : unit =
+        let property (a : string, b : string, c : string) : unit =
+            let a = parseOk a
+            let b = parseOk b
+            let c = parseOk c
+
+            UnixPath.concat (UnixPath.concat a b) c
+            |> shouldEqual (UnixPath.concat a (UnixPath.concat b c))
+
+        Check.One (config, Prop.forAll (Arb.fromGen (Gen.zip3 pathStringGen pathStringGen pathStringGen)) property)

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -59,6 +59,7 @@
     <Compile Include="TestStackMemoryPool.fs" />
     <Compile Include="TestNativeMemoryPool.fs" />
     <Compile Include="TestAbsoluteUnixPath.fs" />
+    <Compile Include="TestUnixPath.fs" />
     <Compile Include="TestRuntimeConfig.fs" />
     <Compile Include="TestDynamicCodeSupport.fs" />
     <Compile Include="TestSwitchIlOp.fs" />

--- a/WoofWare.PawPrint/AbsoluteUnixPath.fs
+++ b/WoofWare.PawPrint/AbsoluteUnixPath.fs
@@ -2,7 +2,6 @@ namespace WoofWare.PawPrint
 
 open System
 open System.Collections.Immutable
-open System.Text
 
 /// Why a candidate string is not a path `getcwd(3)` could ever have returned.
 [<RequireQualifiedAccess>]
@@ -54,8 +53,7 @@ type AbsoluteUnixPath =
 module AbsoluteUnixPath =
     /// The Unix directory separator. There is only one — unlike Windows,
     /// Unix has no alternate separator to normalise away.
-    [<Literal>]
-    let separator : char = '/'
+    let separator : char = UnixPathText.separator
 
     /// The root directory, "/". The one absolute path that is legally
     /// separator-terminated, and the only one guaranteed to exist on any Unix.
@@ -65,33 +63,17 @@ module AbsoluteUnixPath =
         match path with
         | AbsoluteUnixPath path -> path
 
-    /// First per-character defect in `candidate`, scanning left to right, or
-    /// `None` if there is none. Separate from the segment rules because it has
-    /// to consider surrogate *pairs*, so it cannot be a per-character predicate.
+    /// First encoding defect in `candidate`, scanning left to right, or `None`
+    /// if there is none. Shared with `UnixPath` via `UnixPathText`, so that the
+    /// two path shapes cannot drift on which strings survive the `char*`
+    /// boundary; only the mapping into this type's error DU is local.
     let private firstCharacterDefect (candidate : string) : AbsoluteUnixPathError option =
-        let mutable i = 0
-        let mutable result = None
-
-        while result.IsNone && i < candidate.Length do
-            let c = candidate.[i]
-
-            if c = '\000' then
-                result <- Some (AbsoluteUnixPathError.ContainsNul i)
-            elif Char.IsHighSurrogate c then
-                if i + 1 < candidate.Length && Char.IsLowSurrogate candidate.[i + 1] then
-                    // A well-formed pair; step over its low half too, so that
-                    // the low surrogate is not itself reported as unpaired.
-                    i <- i + 1
-                else
-                    result <- Some (AbsoluteUnixPathError.UnpairedSurrogate i)
-            elif Char.IsLowSurrogate c then
-                // A low surrogate not consumed by the branch above has no high
-                // half preceding it.
-                result <- Some (AbsoluteUnixPathError.UnpairedSurrogate i)
-
-            i <- i + 1
-
-        result
+        UnixPathText.firstDefect candidate
+        |> Option.map (fun defect ->
+            match defect with
+            | UnixPathTextDefect.ContainsNul index -> AbsoluteUnixPathError.ContainsNul index
+            | UnixPathTextDefect.UnpairedSurrogate index -> AbsoluteUnixPathError.UnpairedSurrogate index
+        )
 
     /// First defect in `candidate`'s segment structure, or `None` if there is
     /// none. `candidate` must already be known non-empty and separator-rooted.
@@ -192,16 +174,9 @@ module AbsoluteUnixPath =
         | Ok path -> path
         | Error error -> failwith $"%s{context}: %s{describe error} (got %s{candidate})"
 
-    /// Strict UTF-8 encoder. `parse` has already rejected the only inputs that
-    /// could trigger a fallback (unpaired surrogates), so the throwing
-    /// configuration is an assertion that the type's invariant holds rather
-    /// than a reachable error path — a silent U+FFFD substitution here would
-    /// hand the guest bytes that do not decode back to the configured path.
-    let private utf8 : UTF8Encoding = UTF8Encoding (false, true)
-
     /// The path as the NUL-free byte string a Unix kernel would hand back.
     /// Note this is the encoding *without* a terminator; callers that need a C
     /// string append the NUL themselves, because whether there is room for it
     /// is exactly what `getcwd`'s ERANGE check is about.
     let toUtf8 (path : AbsoluteUnixPath) : ImmutableArray<byte> =
-        toString path |> utf8.GetBytes |> ImmutableArray.CreateRange
+        toString path |> UnixPathText.utf8.GetBytes |> ImmutableArray.CreateRange

--- a/WoofWare.PawPrint/AbsoluteUnixPath.fs
+++ b/WoofWare.PawPrint/AbsoluteUnixPath.fs
@@ -53,6 +53,12 @@ type AbsoluteUnixPath =
 module AbsoluteUnixPath =
     /// The Unix directory separator. There is only one — unlike Windows,
     /// Unix has no alternate separator to normalise away.
+    ///
+    /// Defined from `UnixPathText.separator` so there is a single source of
+    /// truth, but kept `[<Literal>]`: this is public surface of a published
+    /// package, and a downstream use in a constant position (a pattern, an
+    /// attribute argument, another literal) would stop compiling without it.
+    [<Literal>]
     let separator : char = UnixPathText.separator
 
     /// The root directory, "/". The one absolute path that is legally

--- a/WoofWare.PawPrint/UnixPath.fs
+++ b/WoofWare.PawPrint/UnixPath.fs
@@ -1,0 +1,348 @@
+namespace WoofWare.PawPrint
+
+open System.Collections.Immutable
+
+/// Why a string is not usable as a single Unix directory-entry name.
+[<RequireQualifiedAccess>]
+type FileNameError =
+    /// The candidate was null or empty. No directory contains an entry with
+    /// the empty name; a path that appears to ask for one ("a//b", "a/") has a
+    /// zero-length *segment*, which `UnixPath.parse` collapses rather than
+    /// turning into a name.
+    | Empty
+    /// The candidate contained a separator at this index, so it names a path
+    /// rather than a single entry within one directory.
+    | ContainsSeparator of index : int
+    /// The candidate could not survive the `char*` boundary; see
+    /// `UnixPathTextDefect`.
+    | Text of defect : UnixPathTextDefect
+    /// The candidate was "." or "..". Both are legal path *components*, and
+    /// `PathComponent` carries them as their own cases — but neither is ever
+    /// the name of an entry a directory holds in PawPrint's model, which
+    /// derives both from the directory graph rather than storing them.
+    | Reserved of name : string
+
+/// A single component of a Unix path that names an actual directory entry:
+/// non-empty, separator-free, NUL-free, UTF-8-encodable, and neither "." nor
+/// "..".
+///
+/// Construct via `FileName.parse`. Keeping this distinct from `string` is what
+/// stops a caller from binding "a/b" or ".." as a directory entry, which would
+/// make the inode graph describe a filesystem no kernel could produce.
+[<Struct>]
+type FileName =
+    private
+    | FileName of name : string
+
+    /// Round-trippable string representation.
+    override this.ToString () : string =
+        match this with
+        | FileName name -> name
+
+[<RequireQualifiedAccess>]
+module FileName =
+    let toString (name : FileName) : string =
+        match name with
+        | FileName name -> name
+
+    /// Parse a single directory-entry name, or explain why the candidate is
+    /// not one. Total: never throws, for any input including null.
+    let parse (candidate : string) : Result<FileName, FileNameError> =
+        if System.String.IsNullOrEmpty candidate then
+            Error FileNameError.Empty
+        else
+
+        let separatorIndex = candidate.IndexOf UnixPathText.separator
+
+        if separatorIndex >= 0 then
+            Error (FileNameError.ContainsSeparator separatorIndex)
+        else
+
+        match UnixPathText.firstDefect candidate with
+        | Some defect -> Error (FileNameError.Text defect)
+        | None ->
+
+        if candidate = "." || candidate = ".." then
+            Error (FileNameError.Reserved candidate)
+        else
+            Ok (FileName candidate)
+
+    /// Human-readable rendering of a rejection.
+    let describe (error : FileNameError) : string =
+        match error with
+        | FileNameError.Empty -> "name is null or empty, but no directory holds an entry with the empty name"
+        | FileNameError.ContainsSeparator index ->
+            $"name contains '%c{UnixPathText.separator}' at index %d{index}, so it is a path rather than a single entry name"
+        | FileNameError.Text defect -> $"name %s{UnixPathText.describe defect}"
+        | FileNameError.Reserved name ->
+            $"\"%s{name}\" is a path component, not an entry name; PawPrint derives it from the directory graph rather than storing it"
+
+    /// Parse, or fail loudly naming the boundary at fault. For callers with no
+    /// way to recover — a bad literal in PawPrint's own source, or a
+    /// malformed seed manifest, is a host bug rather than a runtime condition.
+    let parseOrFail (context : string) (candidate : string) : FileName =
+        match parse candidate with
+        | Ok name -> name
+        | Error error -> failwith $"%s{context}: %s{describe error} (got %s{candidate})"
+
+    /// The name as the NUL-free byte string a Unix kernel would hand back from
+    /// `readdir`. Without a terminator; callers that need a C string append
+    /// the NUL themselves.
+    let toUtf8 (name : FileName) : ImmutableArray<byte> =
+        toString name |> UnixPathText.utf8.GetBytes |> ImmutableArray.CreateRange
+
+/// One component of a guest-supplied path, between two separators.
+///
+/// A DU rather than a string because the three cases mean structurally
+/// different things to a resolution walk — `Current` and `Parent` are
+/// navigation, `Name` is a lookup — and because the kernel reports different
+/// errors for them in the final position (`mkdir("a/..")` is EEXIST, not a
+/// request to create an entry called "..").
+[<RequireQualifiedAccess>]
+type PathComponent =
+    /// ".". Not a no-op: it constrains what precedes it to be a directory, so
+    /// "a/." and "a" resolve differently when "a" is a regular file.
+    | Current
+    /// "..". Resolved against the *physical* parent recorded in the directory
+    /// graph, never against the lexical predecessor in the path — after a walk
+    /// crosses a symlink, the two differ, and only the physical answer matches
+    /// the kernel.
+    | Parent
+    /// An ordinary entry name, to be looked up in the directory reached so far.
+    | Name of name : FileName
+
+/// Why a string is not usable as a guest-supplied Unix path.
+///
+/// Far more permissive than `AbsoluteUnixPathError`: a guest may legitimately
+/// pass a relative path, repeated separators, a trailing separator, and "." or
+/// ".." components, all of which the kernel accepts. Only the two boundary
+/// rules remain.
+[<RequireQualifiedAccess>]
+type UnixPathError =
+    /// The candidate was null. Distinct from the *empty* path, which is a
+    /// legal C string that the kernel rejects with ENOENT at resolution time
+    /// rather than at parse time — so `parse ""` succeeds.
+    | Null
+    /// The candidate could not survive the `char*` boundary; see
+    /// `UnixPathTextDefect`.
+    | Text of defect : UnixPathTextDefect
+
+/// A path exactly as a guest handed it to a syscall: possibly relative,
+/// possibly containing "." and ".." components, possibly with a trailing
+/// separator. This is the shape every `SystemNative_*` path argument takes,
+/// and the input to the `VirtualFileSystem` resolution walk.
+///
+/// Contrast `AbsoluteUnixPath`, which is the strictly narrower shape
+/// `getcwd(3)` can *return*: rooted, fully resolved, no trailing separator.
+/// Every `AbsoluteUnixPath` is a `UnixPath` (see `UnixPath.ofAbsolute`); the
+/// converse holds only for paths a resolution walk has already reduced.
+///
+/// Construct via `UnixPath.parse`.
+type UnixPath =
+    private
+        {
+            /// True when the path began with a separator, so resolution starts
+            /// at the filesystem root rather than at a directory the caller
+            /// supplies.
+            IsRooted : bool
+            /// The path's components in order, with zero-length segments
+            /// (produced by repeated separators) already dropped. "." and ".."
+            /// are *not* dropped: both are load-bearing during resolution.
+            Components : PathComponent list
+            /// True when the path ended with a separator and named at least one
+            /// component, e.g. "a/" or "/a/b/". POSIX makes such a path
+            /// equivalent to the same path with "/." appended, which forces the
+            /// final component to resolve to a directory — so this cannot be
+            /// normalised away without changing which paths succeed.
+            ///
+            /// False for the root "/" (whose sole separator is the one that
+            /// roots it, not a trailing one) and for the empty path.
+            HasTrailingSeparator : bool
+        }
+
+[<RequireQualifiedAccess>]
+module UnixPath =
+    /// True when the path began with a separator, so resolution starts at the
+    /// filesystem root rather than at a caller-supplied directory.
+    let isRooted (path : UnixPath) : bool = path.IsRooted
+
+    /// The path's components in order: no zero-length segments, but "." and
+    /// ".." preserved as `PathComponent.Current` and `PathComponent.Parent`.
+    let components (path : UnixPath) : PathComponent list = path.Components
+
+    /// True when the path ended with a separator and named at least one
+    /// component. See the field's own documentation for why this survives
+    /// parsing.
+    let hasTrailingSeparator (path : UnixPath) : bool = path.HasTrailingSeparator
+
+    /// The empty path: neither rooted nor naming any component. A legal C
+    /// string, and one a guest really can pass, so it parses — but no
+    /// resolution of it can succeed, and the kernel reports ENOENT.
+    let empty : UnixPath =
+        {
+            IsRooted = false
+            Components = []
+            HasTrailingSeparator = false
+        }
+
+    /// True for the one path that names nothing at all. Callers resolving a
+    /// path must check this first: POSIX requires ENOENT for the empty path,
+    /// which is *not* what a walk over zero components would otherwise
+    /// produce (that would silently mean "the directory I started from").
+    let isEmpty (path : UnixPath) : bool =
+        not path.IsRooted && List.isEmpty path.Components
+
+    /// The root, "/".
+    let root : UnixPath =
+        {
+            IsRooted = true
+            Components = []
+            HasTrailingSeparator = false
+        }
+
+    /// Parse a guest-supplied path. Total: never throws, for any input
+    /// including null.
+    ///
+    /// Deliberately *normalises* only what the kernel itself normalises —
+    /// zero-length segments, which arise from repeated separators and which
+    /// every Unix collapses. It does not resolve "." or "..", because
+    /// resolving ".." lexically is only correct in the absence of symlinks;
+    /// that is the resolution walk's job, against the real directory graph.
+    ///
+    /// Note POSIX leaves a path beginning with exactly two separators
+    /// implementation-defined (it may denote a distinct namespace). Every Unix
+    /// PawPrint models treats it as the root, and so does this.
+    let parse (candidate : string) : Result<UnixPath, UnixPathError> =
+        if isNull candidate then
+            Error UnixPathError.Null
+        else
+
+        match UnixPathText.firstDefect candidate with
+        | Some defect -> Error (UnixPathError.Text defect)
+        | None ->
+
+        let isRooted = candidate.Length > 0 && candidate.[0] = UnixPathText.separator
+
+        let segments =
+            candidate.Split UnixPathText.separator
+            |> Array.filter (fun segment -> segment.Length > 0)
+
+        let components =
+            segments
+            |> Array.map (fun segment ->
+                match segment with
+                | "." -> PathComponent.Current
+                | ".." -> PathComponent.Parent
+                | _ ->
+                    // Every rule `FileName.parse` enforces has already been
+                    // discharged: the segment is non-empty (filtered), holds no
+                    // separator (it came from a split on one), carries no text
+                    // defect (the whole candidate was scanned), and is neither
+                    // "." nor ".." (matched above).
+                    match FileName.parse segment with
+                    | Ok name -> PathComponent.Name name
+                    | Error error ->
+                        failwith
+                            $"UnixPath.parse: segment \"%s{segment}\" of \"%s{candidate}\" was rejected as an entry name (%s{FileName.describe error}), but parsing has already excluded every reason a segment could be rejected"
+            )
+            |> Array.toList
+
+        // The final separator of "/" is the one that roots it, so it is not a
+        // trailing separator; likewise there is nothing to trail in "" or "//".
+        let hasTrailingSeparator =
+            not (List.isEmpty components)
+            && candidate.[candidate.Length - 1] = UnixPathText.separator
+
+        Ok
+            {
+                IsRooted = isRooted
+                Components = components
+                HasTrailingSeparator = hasTrailingSeparator
+            }
+
+    /// Human-readable rendering of a rejection.
+    let describe (error : UnixPathError) : string =
+        match error with
+        | UnixPathError.Null ->
+            "path is null; the empty path is legal at this boundary, but a null one never reached the kernel at all"
+        | UnixPathError.Text defect -> $"path %s{UnixPathText.describe defect}"
+
+    /// Parse, or fail loudly naming the boundary at fault. For callers with no
+    /// way to recover; a path arriving from a *guest* must not use this, since
+    /// a guest passing a NUL-bearing path is a runtime condition the kernel
+    /// answers with an error, not a host bug.
+    let parseOrFail (context : string) (candidate : string) : UnixPath =
+        match parse candidate with
+        | Ok path -> path
+        | Error error -> failwith $"%s{context}: %s{describe error} (got %s{candidate})"
+
+    /// Render back to the string a guest would have passed. Round-trips:
+    /// `parse (toString p) = Ok p` for every `p` that `parse` produced.
+    ///
+    /// This is *not* the inverse of `parse` on strings — the normalisation
+    /// `parse` performs is deliberately lossy, so "a//b" renders back as
+    /// "a/b". It is the inverse on the normalised image, which is what makes
+    /// it usable for diagnostics without misreporting what will be resolved.
+    let toString (path : UnixPath) : string =
+        let rendered =
+            path.Components
+            |> List.map (fun component_ ->
+                match component_ with
+                | PathComponent.Current -> "."
+                | PathComponent.Parent -> ".."
+                | PathComponent.Name name -> FileName.toString name
+            )
+            |> String.concat (string UnixPathText.separator)
+
+        let prefix = if path.IsRooted then string UnixPathText.separator else ""
+
+        let suffix =
+            if path.HasTrailingSeparator then
+                string UnixPathText.separator
+            else
+                ""
+
+        prefix + rendered + suffix
+
+    /// Widen a fully-resolved absolute path into the guest-supplied shape, for
+    /// callers that need to resolve one — notably the current directory, which
+    /// is where every relative path a guest passes starts from.
+    ///
+    /// Total: `AbsoluteUnixPath`'s invariant is strictly stronger than
+    /// `UnixPath`'s, so this cannot fail. The `failwith` asserts that, and can
+    /// only fire for a forged value (see `AbsoluteUnixPath.assertValid`).
+    let ofAbsolute (path : AbsoluteUnixPath) : UnixPath =
+        let rendered = AbsoluteUnixPath.toString path
+
+        match parse rendered with
+        | Ok parsed -> parsed
+        | Error error ->
+            failwith
+                $"UnixPath.ofAbsolute: %s{describe error} (got %s{rendered}). Every AbsoluteUnixPath satisfies UnixPath's invariant, so this value cannot have come from AbsoluteUnixPath.parse."
+
+    /// The path obtained by resolving `relative` against `basePath`: `relative`
+    /// itself when it is rooted, and otherwise `basePath`'s components followed
+    /// by `relative`'s.
+    ///
+    /// This is *lexical* concatenation, not resolution — no "." or ".."
+    /// component is interpreted, and no symlink is followed. It exists for the
+    /// resolution walk to splice a symlink's target into the path it is
+    /// walking, which is exactly the operation POSIX describes.
+    let concat (basePath : UnixPath) (relative : UnixPath) : UnixPath =
+        if relative.IsRooted then
+            relative
+        else
+
+        {
+            IsRooted = basePath.IsRooted
+            Components = basePath.Components @ relative.Components
+            // A separator between the two halves absorbs any that trailed the
+            // base, so only the suffix's own trailing separator survives —
+            // unless the suffix contributed nothing, in which case the base's
+            // does. ("a/" ++ "b" is "a/b"; "a/" ++ "" is "a/".)
+            HasTrailingSeparator =
+                if List.isEmpty relative.Components then
+                    basePath.HasTrailingSeparator
+                else
+                    relative.HasTrailingSeparator
+        }

--- a/WoofWare.PawPrint/UnixPathText.fs
+++ b/WoofWare.PawPrint/UnixPathText.fs
@@ -1,0 +1,85 @@
+namespace WoofWare.PawPrint
+
+open System
+open System.Text
+
+/// A defect that makes a candidate string unusable as *any* Unix path,
+/// absolute or relative, whole path or single component. These are the two
+/// rules that come from the boundary rather than from path syntax: they hold
+/// wherever a `string` has to survive the trip through the `char*`-shaped
+/// `SystemNative_*` interface.
+///
+/// Path *syntax* rules — rootedness, empty segments, unresolved "." and ".."
+/// segments — are not here, because they differ between the shapes PawPrint
+/// models: `AbsoluteUnixPath` rejects all of them, while a guest-supplied
+/// `UnixPath` accepts all of them.
+[<RequireQualifiedAccess>]
+type UnixPathTextDefect =
+    /// A NUL at this UTF-16 index. NUL terminates a C string, so a path
+    /// containing one could not survive the boundary intact: the kernel would
+    /// see a shorter path than the guest named.
+    | ContainsNul of index : int
+    /// An unpaired UTF-16 surrogate at this index, so the string has no UTF-8
+    /// encoding at all. Real Unix paths are arbitrary non-NUL byte strings;
+    /// PawPrint models the UTF-8-encodable subset, which is precisely the set
+    /// CoreLib can round-trip back to a `string` through
+    /// `Marshal.PtrToStringUTF8`.
+    | UnpairedSurrogate of index : int
+
+[<RequireQualifiedAccess>]
+module UnixPathText =
+    /// The Unix directory separator. There is only one — unlike Windows, Unix
+    /// has no alternate separator to normalise away.
+    [<Literal>]
+    let separator : char = '/'
+
+    /// First defect in `candidate`, scanning left to right, or `None` if there
+    /// is none. Total: never throws, and treats `null` as defect-free (it has
+    /// no characters to object to; callers reject it on their own grounds).
+    ///
+    /// Cannot be expressed as a per-character predicate, because well-formed
+    /// surrogate *pairs* are legal and their halves are not legal alone.
+    let firstDefect (candidate : string) : UnixPathTextDefect option =
+        if isNull candidate then
+            None
+        else
+
+        let mutable i = 0
+        let mutable result = None
+
+        while result.IsNone && i < candidate.Length do
+            let c = candidate.[i]
+
+            if c = '\000' then
+                result <- Some (UnixPathTextDefect.ContainsNul i)
+            elif Char.IsHighSurrogate c then
+                if i + 1 < candidate.Length && Char.IsLowSurrogate candidate.[i + 1] then
+                    // A well-formed pair; step over its low half too, so that
+                    // the low surrogate is not itself reported as unpaired.
+                    i <- i + 1
+                else
+                    result <- Some (UnixPathTextDefect.UnpairedSurrogate i)
+            elif Char.IsLowSurrogate c then
+                // A low surrogate not consumed by the branch above has no high
+                // half preceding it.
+                result <- Some (UnixPathTextDefect.UnpairedSurrogate i)
+
+            i <- i + 1
+
+        result
+
+    /// Human-readable rendering of a defect, for the diagnostics of whichever
+    /// path type did the parsing.
+    let describe (defect : UnixPathTextDefect) : string =
+        match defect with
+        | UnixPathTextDefect.ContainsNul index ->
+            $"contains a NUL at index %d{index}, which cannot survive a C string boundary"
+        | UnixPathTextDefect.UnpairedSurrogate index ->
+            $"contains an unpaired UTF-16 surrogate at index %d{index}, so it has no UTF-8 encoding"
+
+    /// Strict UTF-8 encoder. `firstDefect` has already rejected the only inputs
+    /// that could trigger a fallback (unpaired surrogates), so the throwing
+    /// configuration is an assertion that the caller's invariant holds rather
+    /// than a reachable error path — a silent U+FFFD substitution here would
+    /// hand the guest bytes that do not decode back to the path it named.
+    let utf8 : UTF8Encoding = UTF8Encoding (false, true)

--- a/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
+++ b/WoofWare.PawPrint/WoofWare.PawPrint.fsproj
@@ -38,7 +38,9 @@
     <Compile Include="FieldIdentity.fs" />
     <Compile Include="GcHandleRegistry.fs" />
     <Compile Include="UnixError.fs" />
+    <Compile Include="UnixPathText.fs" />
     <Compile Include="AbsoluteUnixPath.fs" />
+    <Compile Include="UnixPath.fs" />
     <Compile Include="FileDescriptorRegistry.fs" />
     <Compile Include="TypeHandleRegistry.fs" />
     <Compile Include="FieldHandleRegistry.fs" />


### PR DESCRIPTION
First code stage of the emulated filesystem (#956), and the prerequisite for the inode graph: the vocabulary for the paths a guest actually hands to `open`, `stat` and friends.

PawPrint already has `AbsoluteUnixPath`, but that is deliberately the narrow shape `getcwd(3)` can *return* — rooted, fully resolved, no trailing separator. Guest paths are a much wider language, and the difference is load-bearing rather than cosmetic.

### What is kept, and why not normalising it

- **`.` is kept as a component.** It is not a no-op: it constrains what precedes it to be a directory, so `a/.` and `a` resolve differently when `a` is a regular file.
- **`..` is kept, unresolved.** Resolving it lexically at parse time is only correct in the absence of symlinks. The walk has to resolve it against the *physical* parent in the directory graph, which is a different answer once a walk has crossed a symlink.
- **The trailing separator is recorded.** POSIX makes `a/` equivalent to `a/.`, forcing the final component to resolve to a directory, so normalising it away would change which paths succeed.

Zero-length segments *are* collapsed, because that is normalisation the kernel itself performs. (POSIX leaves a leading `//` implementation-defined; every Unix PawPrint models treats it as the root, and so does this.)

### `FileName`

The companion type for a single directory entry name: non-empty, separator-free, and neither `.` nor `..`. Those last two are legal path *components* but never entry names, because the model derives both from the directory graph rather than storing them. Keeping the types distinct is what stops a later stage binding `..` as a real directory entry and describing a filesystem no kernel could produce.

### Shared boundary rules

The two rules that were private to `AbsoluteUnixPath` — no NUL, no unpaired surrogate — move to `UnixPathText` and are now shared, so the two path shapes cannot drift on which strings survive the `char*` boundary. `AbsoluteUnixPath.separator` stays `[<Literal>]` (F# lets a literal be defined from another literal): it is public surface of a published package, so losing that would break downstream uses in constant positions while breaking nothing here. A constant pattern in the test file makes that mechanical — without the attribute it fails to compile with FS0689.

🤖 Generated with [Claude Code](https://claude.com/claude-code)