### PR TITLE
Implement the RuntimeTypeHandle_InternalAlloc QCall

### DIFF
--- a/WoofWare.PawPrint.Test/TestInternalAlloc.fs
+++ b/WoofWare.PawPrint.Test/TestInternalAlloc.fs
@@ -1,0 +1,539 @@
+namespace WoofWare.PawPrint.Test
+
+open System.Collections.Immutable
+open System.IO
+open System.Reflection.Metadata
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.DotnetRuntimeLocator
+open WoofWare.PawPrint
+
+/// Tests for `RuntimeTypeHandle_InternalAlloc` (reflectioninvocation.cpp:119), which is
+/// `pMT->Allocate()`: the checked counterpart of the `InternalAllocNoChecks` QCall that
+/// `TestInternalAllocNoChecks.fs` covers. Same allocation; `MethodTable::Allocate`
+/// (methodtable.cpp:4056) additionally runs `EnsureInstanceActive` and a class initialiser.
+///
+/// The two files are deliberately near-identical, because the *difference* between them is the
+/// point. `AllocateNoChecks` exists precisely so that a caller who already knows the type is
+/// initialised can skip that work, so "does allocating run the `.cctor`?" must have opposite
+/// answers here and there, and each file pins its own. A change that made the two handlers agree
+/// would be caught by whichever file it broke.
+///
+/// There is no end-to-end guest coverage yet, and cannot be until a delegate can be bound: the
+/// sole managed caller is `Delegate.InternalAlloc` (Delegate.CoreCLR.cs:435), reached from all
+/// four `Delegate.CreateDelegate` overloads and from `CreateDelegateInternal`, and every one of
+/// them goes on to `Delegate_BindToMethodName`/`Delegate_BindToMethodInfo` — neither of which is
+/// implemented — one statement later. So this drives the handler directly, in the shape
+/// `TestAssemblyNativeQCalls` established for the same reason.
+[<TestFixture>]
+[<Parallelizable(ParallelScope.All)>]
+module TestInternalAlloc =
+
+    /// The corpus is chosen so that each claim below has something to fail on:
+    ///
+    /// * `Base` has fields of two different shapes, one of them a reference, so "the object came
+    ///   back zeroed" is not satisfiable by a single default.
+    /// * `Derived` inherits those fields and adds one, so a handler that collected only the
+    ///   type's *own* fields cannot serve it.
+    /// * `WithCctor` declares an explicit static constructor — which is what strips
+    ///   `beforefieldinit`, making it a precise-init type, the kind `MethodTable::Allocate` really
+    ///   does initialise — so "allocating ran the type initialiser" has a witness. This is the one
+    ///   claim that must come out the opposite way from `TestInternalAllocNoChecks`.
+    /// * `SomeStruct` is a value type, for the refusal.
+    let private guestSource =
+        """
+public class Base
+{
+    public int BaseInt;
+    public string BaseRef;
+}
+
+public class Derived : Base
+{
+    public long DerivedLong;
+}
+
+public class WithCctor
+{
+    public static int Sentinel;
+    public int Field;
+
+    static WithCctor()
+    {
+        Sentinel = 7;
+    }
+}
+
+public struct SomeStruct
+{
+    public int Value;
+}
+
+public static class Program
+{
+    public static int Main(string[] args)
+    {
+        return 0;
+    }
+}
+"""
+
+    let private prepareGuest
+        (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
+        (image : byte[])
+        : Program.PreparedProgram
+        =
+        let dotnetRuntimes =
+            DotnetRuntime.SelectForDll (typeof<RunResult>.Assembly.Location)
+            |> ImmutableArray.CreateRange
+
+        use peImage = new MemoryStream (image)
+
+        match
+            Program.prepare loggerFactory (Some "InternalAllocTestGuest.cs") peImage (HostConfig.Default dotnetRuntimes)
+        with
+        | Program.ProgramStartResult.Ready prepared -> prepared
+        | Program.ProgramStartResult.CompletedBeforeMain outcome ->
+            failwith $"expected guest to be ready before Main, but got %O{outcome}"
+
+    let private requiredTopLevelType
+        (assembly : DumpedAssembly)
+        (namespaceName : string)
+        (typeName : string)
+        : TypeInfo<GenericParamFromMetadata, TypeDefn>
+        =
+        assembly.TryGetTopLevelTypeDef namespaceName typeName
+        |> Option.defaultWith (fun () ->
+            failwith $"type %s{namespaceName}.%s{typeName} not found in %s{assembly.Name.Name}"
+        )
+
+    /// The guest's own `DumpedAssembly`, read from the same image `prepareGuest` loaded, so
+    /// that the type identities below name types the machine already knows about.
+    let private readGuestAssembly
+        (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
+        (image : byte[])
+        : DumpedAssembly
+        =
+        use peImage = new MemoryStream (image)
+        Assembly.read loggerFactory None peImage
+
+    let private concretiseGuestClass
+        (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (guestAssembly : DumpedAssembly)
+        (typeName : string)
+        (state : IlMachineState)
+        : ConcreteTypeHandle * IlMachineState
+        =
+        let typeInfo = requiredTopLevelType guestAssembly "" typeName
+
+        let state, handle =
+            IlMachineState.concretizeType
+                loggerFactory
+                baseClassTypes
+                state
+                guestAssembly.Name
+                ImmutableArray.Empty
+                ImmutableArray.Empty
+                (TypeDefn.FromDefinition (typeInfo.Identity, SignatureTypeKind.Class))
+
+        handle, state
+
+    /// A `MethodTable*` argument, in the shape `RuntimeHelpers.GetMethodTable` produces.
+    let private methodTablePointer (handle : ConcreteTypeHandle) : CliType =
+        RuntimeTypeHandleTarget.Closed handle
+        |> NativeIntSource.MethodTablePtr
+        |> CliNumericType.NativeInt
+        |> CliType.Numeric
+
+    /// How to pick the `System.RuntimeTypeHandle` member to drive. The QCall shares its *name*
+    /// with the managed wrapper that calls it, so name alone cannot address it. Selecting the
+    /// QCall by its import metadata is also what the interpreter itself keys on.
+    type private MemberSelector =
+        | ByName of name : string
+        | ByQCallEntryPoint of entryPoint : string
+
+        override this.ToString () : string =
+            match this with
+            | MemberSelector.ByName name -> name
+            | MemberSelector.ByQCallEntryPoint entryPoint -> entryPoint
+
+    /// Locates a member of corelib's `System.RuntimeTypeHandle` and concretizes it, so the
+    /// handler sees the same `ExecutingMethod` signature the interpreter would hand it.
+    let private runtimeTypeHandleMethod
+        (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (selector : MemberSelector)
+        (state : IlMachineState)
+        : IlMachineState *
+          TypeInfo<GenericParamFromMetadata, TypeDefn> *
+          MethodInfo<ConcreteTypeHandle, ConcreteTypeHandle, ConcreteTypeHandle>
+        =
+        let declaringType =
+            requiredTopLevelType baseClassTypes.Corelib "System" "RuntimeTypeHandle"
+
+        let matches
+            (method : WoofWare.PawPrint.MethodInfo<GenericParamFromMetadata, GenericParamFromMetadata, TypeDefn>)
+            : bool
+            =
+            match selector with
+            | MemberSelector.ByName name -> method.Name = name
+            | MemberSelector.ByQCallEntryPoint entryPoint ->
+                match method.TryNativeImport with
+                | Some import -> import.ModuleName = "QCall" && import.EntryPointName = entryPoint
+                | None -> false
+
+        let rawMethod =
+            declaringType.Methods
+            |> List.filter matches
+            |> function
+                | [ method ] -> method
+                | [] -> failwith $"member %O{selector} not found on System.RuntimeTypeHandle"
+                | methods ->
+                    failwith
+                        $"member %O{selector} was ambiguous on System.RuntimeTypeHandle: %d{methods.Length} matches"
+
+        let state, method, _ =
+            ExecutionConcretization.concretizeMethodWithTypeGenerics
+                loggerFactory
+                baseClassTypes
+                ImmutableArray.Empty
+                rawMethod
+                None
+                baseClassTypes.Corelib.Name
+                ImmutableArray.Empty
+                state
+
+        state, declaringType, method
+
+    /// Runs the selected `System.RuntimeTypeHandle` native with the given arguments.
+    ///
+    /// Deliberately through `NativeDispatch.tryExecute` — the interpreter's own entry point —
+    /// rather than at the owning module. That is what makes "the handler exists but was never
+    /// registered" a failure here; registration is otherwise an entirely silent mistake, and
+    /// for the QCall it is `NativeDispatch` that derives the entry point from the method's
+    /// import metadata rather than from anything this test says.
+    let private invokeNative
+        (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
+        (prepared : Program.PreparedProgram)
+        (selector : MemberSelector)
+        (arguments : CliType list)
+        (state : IlMachineState)
+        : IlMachineState
+        =
+        let baseClassTypes = prepared.BaseClassTypes
+
+        let state, declaringTypeInfo, method =
+            runtimeTypeHandleMethod loggerFactory baseClassTypes selector state
+
+        let instruction =
+            { state.ThreadState.[prepared.EntryThread].MethodState with
+                ExecutingMethod = method
+                Arguments = ImmutableArray.CreateRange arguments
+            }
+
+        let ctx : NativeCallContext =
+            {
+                LoggerFactory = loggerFactory
+                BaseClassTypes = baseClassTypes
+                Thread = prepared.EntryThread
+                State = state
+                Instruction = instruction
+                TargetAssembly = baseClassTypes.Corelib
+                TargetType = declaringTypeInfo
+            }
+
+        match NativeDispatch.tryExecute ctx with
+        | Some (NativeHandlerResult.Completed (state, _)) -> state
+        | Some result -> failwith $"unexpected %O{selector} execution result: %O{result}"
+        | None -> failwith $"%O{selector} did not match any handler, or is not registered in NativeDispatch"
+
+    /// An `object[1]` cell standing in for the caller's local, wrapped in an
+    /// `ObjectHandleOnStack`. Seeded with a *non-null* object, so a handler that never wrote
+    /// through the handle is distinguishable from one that wrote null — with the C# wrapper's
+    /// own `object? result = null` a "never wrote" bug would read back exactly as the caller
+    /// initialised it and look like a legitimate answer.
+    let private objectHandleOnStackValue
+        (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        : CliType * ManagedPointerSource * ManagedHeapAddress * IlMachineState
+        =
+        let sentinelAddr, state =
+            IlMachineState.allocateManagedString loggerFactory baseClassTypes "unwritten" state
+
+        let objectHandle =
+            AllConcreteTypes.getRequiredNonGenericHandle state.ConcreteTypes baseClassTypes.Object
+
+        let arrayAddr, state =
+            IlMachineState.allocateArray
+                (ConcreteTypeHandle.OneDimArrayZero objectHandle)
+                (fun () -> CliType.ObjectRef (Some sentinelAddr))
+                1
+                state
+
+        let target = ManagedPointerSource.Byref (ByrefRoot.ArrayElement (arrayAddr, 0), [])
+
+        let handleType =
+            requiredTopLevelType baseClassTypes.Corelib "System.Runtime.CompilerServices" "ObjectHandleOnStack"
+
+        let state, handle =
+            IlMachineState.concretizeType
+                loggerFactory
+                baseClassTypes
+                state
+                baseClassTypes.Corelib.Name
+                ImmutableArray.Empty
+                ImmutableArray.Empty
+                (TypeDefn.FromDefinition (handleType.Identity, SignatureTypeKind.ValueType))
+
+        let zero, state = IlMachineState.cliTypeZeroOfHandle state baseClassTypes handle
+
+        match zero with
+        | CliType.ValueType vt ->
+            let ptrField = IlMachineState.requiredOwnInstanceFieldId state handle "_ptr"
+
+            let value =
+                CliValueType.WithFieldSetById ptrField (CliType.RuntimePointer (CliRuntimePointer.Managed target)) vt
+                |> CliType.ValueType
+
+            value, target, sentinelAddr, state
+        | other -> failwith $"ObjectHandleOnStack zero value was not a value type: %O{other}"
+
+    /// Reads back what the QCall wrote through its `ObjectHandleOnStack`.
+    let private readAllocated
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (state : IlMachineState)
+        (target : ManagedPointerSource)
+        : ManagedHeapAddress
+        =
+        match IlMachineState.readManagedByref baseClassTypes state target with
+        | CliType.ObjectRef (Some addr) -> addr
+        | CliType.ObjectRef None -> failwith "handler wrote a null reference through the ObjectHandleOnStack"
+        | other -> failwith $"expected an ObjectRef behind the ObjectHandleOnStack, got %O{other}"
+
+    /// Allocates one instance of `typeName` through the QCall and hands back its address.
+    let private allocate
+        (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
+        (prepared : Program.PreparedProgram)
+        (handle : ConcreteTypeHandle)
+        (state : IlMachineState)
+        : ManagedHeapAddress * IlMachineState
+        =
+        let baseClassTypes = prepared.BaseClassTypes
+
+        let handleValue, target, sentinelAddr, state =
+            objectHandleOnStackValue loggerFactory baseClassTypes state
+
+        let state =
+            invokeNative
+                loggerFactory
+                prepared
+                (MemberSelector.ByQCallEntryPoint "RuntimeTypeHandle_InternalAlloc")
+                [ methodTablePointer handle ; handleValue ]
+                state
+
+        let addr = readAllocated baseClassTypes state target
+
+        // The slot really was written, rather than left holding what the caller put there.
+        addr |> shouldNotEqual sentinelAddr
+
+        addr, state
+
+
+    /// As `concretiseGuestClass`, but for a value type. `SignatureTypeKind` is not cosmetic here:
+    /// it is what `DumpedAssembly.isValueType` — and so the handler's refusal — keys on.
+    let private concretiseGuestStruct
+        (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
+        (baseClassTypes : BaseClassTypes<DumpedAssembly>)
+        (guestAssembly : DumpedAssembly)
+        (typeName : string)
+        (state : IlMachineState)
+        : ConcreteTypeHandle * IlMachineState
+        =
+        let typeInfo = requiredTopLevelType guestAssembly "" typeName
+
+        let state, handle =
+            IlMachineState.concretizeType
+                loggerFactory
+                baseClassTypes
+                state
+                guestAssembly.Name
+                ImmutableArray.Empty
+                ImmutableArray.Empty
+                (TypeDefn.FromDefinition (typeInfo.Identity, SignatureTypeKind.ValueType))
+
+        handle, state
+
+    /// `invokeNative`, but handing back the handler's result rather than insisting it completed.
+    /// Allocating a type that needs initialising suspends instead of completing, and that
+    /// suspension is a fact worth asserting rather than an inconvenience to route around.
+    let private invokeNativeRaw
+        (loggerFactory : Microsoft.Extensions.Logging.ILoggerFactory)
+        (prepared : Program.PreparedProgram)
+        (arguments : CliType list)
+        (state : IlMachineState)
+        : NativeHandlerResult
+        =
+        let baseClassTypes = prepared.BaseClassTypes
+
+        let state, declaringTypeInfo, method =
+            runtimeTypeHandleMethod
+                loggerFactory
+                baseClassTypes
+                (MemberSelector.ByQCallEntryPoint "RuntimeTypeHandle_InternalAlloc")
+                state
+
+        let instruction =
+            { state.ThreadState.[prepared.EntryThread].MethodState with
+                ExecutingMethod = method
+                Arguments = ImmutableArray.CreateRange arguments
+            }
+
+        let ctx : NativeCallContext =
+            {
+                LoggerFactory = loggerFactory
+                BaseClassTypes = baseClassTypes
+                Thread = prepared.EntryThread
+                State = state
+                Instruction = instruction
+                TargetAssembly = baseClassTypes.Corelib
+                TargetType = declaringTypeInfo
+            }
+
+        match NativeDispatch.tryExecute ctx with
+        | Some result -> result
+        | None -> failwith "RuntimeTypeHandle_InternalAlloc did not match any handler"
+
+    [<Test>]
+    let ``allocates an object of the MethodTable's type, zeroed`` () : unit =
+        let _messages, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+
+        let image = Roslyn.compile [ guestSource ]
+        let prepared = prepareGuest loggerFactory image
+        let guestAssembly = readGuestAssembly loggerFactory image
+
+        let handle, state =
+            concretiseGuestClass loggerFactory prepared.BaseClassTypes guestAssembly "Base" prepared.State
+
+        let addr, state = allocate loggerFactory prepared handle state
+
+        let heapObj = ManagedHeap.get addr state.ManagedHeap
+        heapObj.ConcreteType |> shouldEqual handle
+
+        AllocatedNonArrayObject.DereferenceField "BaseInt" heapObj
+        |> CliType.unwrapPrimitiveLikeDeep
+        |> shouldEqual (CliType.Numeric (CliNumericType.Int32 0))
+
+        AllocatedNonArrayObject.DereferenceField "BaseRef" heapObj
+        |> shouldEqual (CliType.ObjectRef None)
+
+    /// A handler that collected only the type's *own* fields would serve `Base` and fail here.
+    [<Test>]
+    let ``an inherited field is present and zeroed`` () : unit =
+        let _messages, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+
+        let image = Roslyn.compile [ guestSource ]
+        let prepared = prepareGuest loggerFactory image
+        let guestAssembly = readGuestAssembly loggerFactory image
+
+        let handle, state =
+            concretiseGuestClass loggerFactory prepared.BaseClassTypes guestAssembly "Derived" prepared.State
+
+        let addr, state = allocate loggerFactory prepared handle state
+
+        let heapObj = ManagedHeap.get addr state.ManagedHeap
+
+        AllocatedNonArrayObject.DereferenceField "DerivedLong" heapObj
+        |> CliType.unwrapPrimitiveLikeDeep
+        |> shouldEqual (CliType.Numeric (CliNumericType.Int64 (Int64Source.Verbatim 0L)))
+
+        AllocatedNonArrayObject.DereferenceField "BaseRef" heapObj
+        |> shouldEqual (CliType.ObjectRef None)
+
+    [<Test>]
+    let ``each call allocates a fresh object`` () : unit =
+        let _messages, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+
+        let image = Roslyn.compile [ guestSource ]
+        let prepared = prepareGuest loggerFactory image
+        let guestAssembly = readGuestAssembly loggerFactory image
+
+        let handle, state =
+            concretiseGuestClass loggerFactory prepared.BaseClassTypes guestAssembly "Base" prepared.State
+
+        let first, state = allocate loggerFactory prepared handle state
+        let second, _state = allocate loggerFactory prepared handle state
+
+        first |> shouldNotEqual second
+
+    /// The claim that separates this QCall from `InternalAllocNoChecks`, and the direct opposite
+    /// of `TestInternalAllocNoChecks`'s `allocating does not run the type initialiser`.
+    ///
+    /// `MethodTable::Allocate` (methodtable.cpp:4070) runs `CheckRunClassInitAsIfConstructingThrowing`
+    /// for a type with precise-init cctors, which `WithCctor` is. PawPrint initialises
+    /// unconditionally — see the handler's comment — so this witnesses the initialisation, not the
+    /// precise-init predicate.
+    [<Test>]
+    let ``allocating runs the type initialiser`` () : unit =
+        let _messages, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+
+        let image = Roslyn.compile [ guestSource ]
+        let prepared = prepareGuest loggerFactory image
+        let guestAssembly = readGuestAssembly loggerFactory image
+
+        let handle, state =
+            concretiseGuestClass loggerFactory prepared.BaseClassTypes guestAssembly "WithCctor" prepared.State
+
+        // Precondition: the assertion below is about this call, not about the order the fixture
+        // happened to run in.
+        TypeInitTable.tryGet handle state.TypeInitTable |> shouldEqual None
+
+        let handleValue, target, _sentinel, state =
+            objectHandleOnStackValue loggerFactory prepared.BaseClassTypes state
+
+        // The initialiser is guest code, so the handler cannot run it inline: it suspends, the
+        // dispatch loop runs the `.cctor`, and the QCall is re-entered. Asserting the suspension
+        // rather than routing around it is what distinguishes "ran the initialiser" from "ignored
+        // the question and allocated anyway".
+        let state =
+            match invokeNativeRaw loggerFactory prepared [ methodTablePointer handle ; handleValue ] state with
+            | NativeHandlerResult.SuspendedForClassInit (state, _) -> state
+            | other -> failwith $"expected the handler to suspend for class init, got %O{other}"
+
+        TypeInitTable.tryGet handle state.TypeInitTable |> shouldNotEqual None
+
+        // Nothing was written through the result handle on the suspending pass: the caller's
+        // local must not be left holding a half-built answer while the `.cctor` runs.
+        readAllocated prepared.BaseClassTypes state target |> ignore<ManagedHeapAddress>
+
+    /// `Delegate.InternalAlloc` asserts its argument derives from `MulticastDelegate`, so a value
+    /// type cannot arrive through the only caller. Allocating one anyway would put an object on
+    /// the heap that no reader could interpret as a box, so refuse by name.
+    [<Test>]
+    let ``a value type is refused`` () : unit =
+        let _messages, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+
+        let image = Roslyn.compile [ guestSource ]
+        let prepared = prepareGuest loggerFactory image
+        let guestAssembly = readGuestAssembly loggerFactory image
+
+        let handle, state =
+            concretiseGuestStruct loggerFactory prepared.BaseClassTypes guestAssembly "SomeStruct" prepared.State
+
+        let handleValue, _target, _sentinel, state =
+            objectHandleOnStackValue loggerFactory prepared.BaseClassTypes state
+
+        let ex =
+            Assert.Throws<System.Exception> (fun () ->
+                invokeNativeRaw loggerFactory prepared [ methodTablePointer handle ; handleValue ] state
+                |> ignore<NativeHandlerResult>
+            )
+
+        ex.Message |> shouldContainText "SomeStruct"
+        ex.Message |> shouldContainText "value type"

--- a/WoofWare.PawPrint.Test/TestInternalAlloc.fs
+++ b/WoofWare.PawPrint.Test/TestInternalAlloc.fs
@@ -40,6 +40,8 @@ module TestInternalAlloc =
     ///   `beforefieldinit`, making it a precise-init type, the kind `MethodTable::Allocate` really
     ///   does initialise — so "allocating ran the type initialiser" has a witness. This is the one
     ///   claim that must come out the opposite way from `TestInternalAllocNoChecks`.
+    /// * `DerivedFromCctorBase` has no initialiser of its own but inherits one, so "allocating
+    ///   walked the parent chain" has a witness distinct from "allocating initialised the type".
     /// * `SomeStruct` is a value type, for the refusal.
     let private guestSource =
         """
@@ -63,6 +65,21 @@ public class WithCctor
     {
         Sentinel = 7;
     }
+}
+
+public class WithCctorBase
+{
+    public static int BaseSentinel;
+
+    static WithCctorBase()
+    {
+        BaseSentinel = 11;
+    }
+}
+
+public class DerivedFromCctorBase : WithCctorBase
+{
+    public int Field;
 }
 
 public struct SomeStruct
@@ -494,7 +511,7 @@ public static class Program
         // happened to run in.
         TypeInitTable.tryGet handle state.TypeInitTable |> shouldEqual None
 
-        let handleValue, target, _sentinel, state =
+        let handleValue, target, sentinel, state =
             objectHandleOnStackValue loggerFactory prepared.BaseClassTypes state
 
         // The initialiser is guest code, so the handler cannot run it inline: it suspends, the
@@ -508,13 +525,18 @@ public static class Program
 
         TypeInitTable.tryGet handle state.TypeInitTable |> shouldNotEqual None
 
-        // Nothing was written through the result handle on the suspending pass: the caller's
-        // local must not be left holding a half-built answer while the `.cctor` runs.
-        readAllocated prepared.BaseClassTypes state target |> ignore<ManagedHeapAddress>
+        // Nothing was written through the result handle on the suspending pass: the caller's local
+        // must still hold exactly what it held before, not a half-built answer parked there while
+        // the `.cctor` runs. Compared against the seeded sentinel rather than merely checked for
+        // non-nullness — the seed is itself non-null, so a weaker check passes against a handler
+        // that allocated and wrote before suspending, which a mutation run confirmed.
+        readAllocated prepared.BaseClassTypes state target |> shouldEqual sentinel
 
-    /// `Delegate.InternalAlloc` asserts its argument derives from `MulticastDelegate`, so a value
-    /// type cannot arrive through the only caller. Allocating one anyway would put an object on
-    /// the heap that no reader could interpret as a box, so refuse by name.
+    /// Neither caller can pass a non-nullable value type: `Delegate.InternalAlloc` asserts its
+    /// argument derives from `MulticastDelegate`, and `ReboxToNullable` asserts its argument is a
+    /// nullable. So this pins the guard that catches a *third* caller appearing, rather than a gap
+    /// with a known consumer — allocating one would put an object on the heap that no reader could
+    /// interpret as a box.
     [<Test>]
     let ``a value type is refused`` () : unit =
         let _messages, loggerFactory = LoggerFactory.makeTest ()
@@ -595,3 +617,45 @@ public static class Program
         // the fact that distinguishes them: this refusal is about there being no object with the
         // nullable's layout to write into.
         ex.Message |> shouldContainText "Unbox_Nullable"
+
+    /// `MethodTable::Allocate` initialises *as if constructing*
+    /// (`CheckRunClassInitAsIfConstructingThrowing`, methodtable.cpp:4034), which walks the whole
+    /// parent chain rather than stopping at the requested type. This is the only place in PawPrint
+    /// where that stronger rule applies: `loadClass` deliberately does not initialise base types,
+    /// and is right not to for ordinary static access, so the walk is the handler's own and needs
+    /// its own witness.
+    ///
+    /// `DerivedFromCctorBase` declares no initialiser, so a handler that initialised only the
+    /// requested type would find nothing to do and complete without suspending — which is exactly
+    /// what the `SuspendedForClassInit` match below rejects.
+    [<Test>]
+    let ``allocating runs an inherited type initialiser`` () : unit =
+        let _messages, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+
+        let image = Roslyn.compile [ guestSource ]
+        let prepared = prepareGuest loggerFactory image
+        let guestAssembly = readGuestAssembly loggerFactory image
+
+        let derivedHandle, state =
+            concretiseGuestClass
+                loggerFactory
+                prepared.BaseClassTypes
+                guestAssembly
+                "DerivedFromCctorBase"
+                prepared.State
+
+        let baseHandle, state =
+            concretiseGuestClass loggerFactory prepared.BaseClassTypes guestAssembly "WithCctorBase" state
+
+        TypeInitTable.tryGet baseHandle state.TypeInitTable |> shouldEqual None
+
+        let handleValue, _target, _sentinel, state =
+            objectHandleOnStackValue loggerFactory prepared.BaseClassTypes state
+
+        let state =
+            match invokeNativeRaw loggerFactory prepared [ methodTablePointer derivedHandle ; handleValue ] state with
+            | NativeHandlerResult.SuspendedForClassInit (state, _) -> state
+            | other -> failwith $"expected the handler to suspend for the base type's class init, got %O{other}"
+
+        TypeInitTable.tryGet baseHandle state.TypeInitTable |> shouldNotEqual None

--- a/WoofWare.PawPrint.Test/TestInternalAlloc.fs
+++ b/WoofWare.PawPrint.Test/TestInternalAlloc.fs
@@ -19,12 +19,13 @@ open WoofWare.PawPrint
 /// answers here and there, and each file pins its own. A change that made the two handlers agree
 /// would be caught by whichever file it broke.
 ///
-/// There is no end-to-end guest coverage yet, and cannot be until a delegate can be bound: the
-/// sole managed caller is `Delegate.InternalAlloc` (Delegate.CoreCLR.cs:435), reached from all
-/// four `Delegate.CreateDelegate` overloads and from `CreateDelegateInternal`, and every one of
-/// them goes on to `Delegate_BindToMethodName`/`Delegate_BindToMethodInfo` — neither of which is
-/// implemented — one statement later. So this drives the handler directly, in the shape
-/// `TestAssemblyNativeQCalls` established for the same reason.
+/// There are two managed callers. `Delegate.InternalAlloc` (Delegate.CoreCLR.cs:435) is reached
+/// from all four `Delegate.CreateDelegate` overloads and from `CreateDelegateInternal`, and every
+/// one of them goes on to `Delegate_BindToMethodName`/`Delegate_BindToMethodInfo` — neither of
+/// which is implemented — one statement later, so there is no end-to-end guest coverage of the
+/// working path yet. `RuntimeMethodHandle.ReboxToNullable` (RuntimeHandles.cs:1200) is the other,
+/// and PawPrint refuses it; see `a Nullable is refused` below. So this drives the handler
+/// directly, in the shape `TestAssemblyNativeQCalls` established for the same reason.
 [<TestFixture>]
 [<Parallelizable(ParallelScope.All)>]
 module TestInternalAlloc =
@@ -537,3 +538,60 @@ public static class Program
 
         ex.Message |> shouldContainText "SomeStruct"
         ex.Message |> shouldContainText "value type"
+
+    /// The other managed caller, and a genuine gap rather than an unreachable guard.
+    ///
+    /// `RuntimeMethodHandle.ReboxToNullable` (RuntimeHandles.cs:1200) allocates through this QCall
+    /// with a `Nullable<T>` MethodTable and then `Unbox_Nullable`s into the result's raw data.
+    /// PawPrint boxes a nullable as its underlying value, so there is no object here with the
+    /// nullable's own layout for that write to land in. A guest reaches this by calling
+    /// `MethodInfo.Invoke` on a method with a `Nullable<T>` parameter, so the refusal is
+    /// provokeable — and this provokes it directly, since reflection cannot yet get that far.
+    ///
+    /// The fix is a layout-preserving boxed-Nullable heap representation, which is the same thing
+    /// `TestInternalAllocNoChecks`'s `refuses to put a Nullable on the heap` is waiting for. When
+    /// it lands, both tests are the ones to revisit.
+    [<Test>]
+    let ``a Nullable is refused`` () : unit =
+        let _messages, loggerFactory = LoggerFactory.makeTest ()
+        use _loggerFactoryResource = loggerFactory
+
+        let image = Roslyn.compile [ guestSource ]
+        let prepared = prepareGuest loggerFactory image
+        let baseClassTypes = prepared.BaseClassTypes
+
+        let nullableType = requiredTopLevelType baseClassTypes.Corelib "System" "Nullable`1"
+
+        let nullableDefn =
+            TypeDefn.GenericInstantiation (
+                TypeDefn.FromDefinition (nullableType.Identity, SignatureTypeKind.ValueType),
+                ImmutableArray.Create (TypeDefn.PrimitiveType PrimitiveType.Int32)
+            )
+
+        let state, handle =
+            IlMachineState.concretizeType
+                loggerFactory
+                baseClassTypes
+                prepared.State
+                baseClassTypes.Corelib.Name
+                ImmutableArray.Empty
+                ImmutableArray.Empty
+                nullableDefn
+
+        let handleValue, _target, _sentinel, state =
+            objectHandleOnStackValue loggerFactory baseClassTypes state
+
+        let ex =
+            Assert.Throws<System.Exception> (fun () ->
+                invokeNativeRaw loggerFactory prepared [ methodTablePointer handle ; handleValue ] state
+                |> ignore<NativeHandlerResult>
+            )
+
+        // Deliberately *not* asserted on "Nullable" or "ReboxToNullable": a `Nullable<T>` is a
+        // value type, so deleting this arm entirely would drop through to the generic value-type
+        // refusal below it — whose message names `ReboxToNullable` too, as one of the callers that
+        // cannot reach it. Both of those assertions therefore pass against the wrong arm, which a
+        // mutation run caught. `Unbox_Nullable` appears only in the nullable arm's message, and is
+        // the fact that distinguishes them: this refusal is about there being no object with the
+        // nullable's layout to write into.
+        ex.Message |> shouldContainText "Unbox_Nullable"

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -87,6 +87,7 @@
     <Compile Include="TestManifestResources.fs" />
     <Compile Include="TestAssemblyNativeQCalls.fs" />
     <Compile Include="TestInternalAllocNoChecks.fs" />
+    <Compile Include="TestInternalAlloc.fs" />
     <Compile Include="TestNativeEnum.fs" />
     <Compile Include="TestMethodHandleRegistry.fs" />
     <Compile Include="TestNativeGetDynamicMethod.fs" />

--- a/WoofWare.PawPrint/Native/NativeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeQCall.fs
@@ -32,6 +32,7 @@ module NativeQCall =
             NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_CreateInstanceForAnotherGenericParameter"
             "RuntimeTypeHandle_GetActivationInfo",
             NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_GetActivationInfo"
+            "RuntimeTypeHandle_InternalAlloc", NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_InternalAlloc"
             "RuntimeTypeHandle_InternalAllocNoChecks",
             NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_InternalAllocNoChecks"
             "RuntimeTypeHandle_GetConstraints", NativeRuntimeType.tryExecuteQCall "RuntimeTypeHandle_GetConstraints"

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
@@ -1951,6 +1951,111 @@ module NativeRuntimeTypeQCall =
                 IlMachineState.writeManagedByrefWithBase ctx.BaseClassTypes state result (CliType.ObjectRef (Some addr))
 
             NativeHandlerResult.completed state |> Some
+        | "RuntimeTypeHandle_InternalAlloc",
+          "System.Private.CoreLib",
+          "System",
+          "RuntimeTypeHandle",
+          "InternalAlloc",
+          [ ConcretePointer (ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                                               "System.Runtime.CompilerServices",
+                                                               "MethodTable",
+                                                               methodTableGenerics))
+            ConcreteType state.ConcreteTypes ("System.Private.CoreLib",
+                                              "System.Runtime.CompilerServices",
+                                              "ObjectHandleOnStack",
+                                              objectHandleGenerics) ],
+          MethodReturnType.Void when methodTableGenerics.IsEmpty && objectHandleGenerics.IsEmpty ->
+            // CoreCLR: `RuntimeTypeHandle_InternalAlloc`, reflectioninvocation.cpp:119, which is
+            // `pMT->Allocate()`. The checked counterpart of `RuntimeTypeHandle_InternalAllocNoChecks`
+            // above: same allocation, but `MethodTable::Allocate` (methodtable.cpp:4056) first
+            // runs `EnsureInstanceActive` and, for a type with precise-init cctors, a class
+            // initialiser.
+            //
+            // Every caller is delegate creation: `Delegate.InternalAlloc` (Delegate.CoreCLR.cs:435)
+            // is the sole caller of the managed `RuntimeTypeHandle.InternalAlloc`, and all four
+            // `Delegate.CreateDelegate` overloads plus `CreateDelegateInternal` reach it. It
+            // allocates the delegate object; a separate `Delegate_BindToMethodName`/
+            // `Delegate_BindToMethodInfo` QCall then binds it to a target.
+            let operation = "RuntimeTypeHandle.InternalAlloc"
+
+            if instruction.Arguments.Length <> 2 then
+                failwith $"%s{operation}: expected two native arguments, got %d{instruction.Arguments.Length}"
+
+            let typeHandle =
+                NativeCall.methodTableOfEvalStackValue operation (instruction.Arguments.[0] |> EvalStackValue.ofCliType)
+
+            // No `Nullable<T>` guard here, unlike the "NoChecks" arm above. That one has a caller
+            // (`AsyncHelpers.AllocContinuationResultBox`) that deliberately passes a nullable's
+            // MethodTable, so it needs one. This entry point's only caller is
+            // `Delegate.InternalAlloc`, which asserts its argument is assignable to
+            // `MulticastDelegate`, so the shape cannot arrive. The invariant properly belongs at
+            // the `IlMachineState.allocateUninitialisedInstance` chokepoint either way; see the
+            // sibling's comment.
+            let concreteType =
+                AllConcreteTypes.lookup typeHandle state.ConcreteTypes
+                |> Option.defaultWith (fun () ->
+                    failwith $"%s{operation}: MethodTable handle was not registered: %O{typeHandle}"
+                )
+
+            let assembly =
+                state.LoadedAssembly concreteType.Assembly
+                |> Option.defaultWith (fun () ->
+                    failwith $"%s{operation}: assembly is not loaded: %s{concreteType.Assembly.FullName}"
+                )
+
+            let typeInfo = assembly.TypeDefs.[concreteType.Definition.Get]
+
+            if DumpedAssembly.isValueType ctx.BaseClassTypes state._LoadedAssemblies typeInfo then
+                // `pMT->Allocate()` on a value-type MethodTable produces a box, and PawPrint's
+                // heap has no representation for one that came from here rather than from `box`.
+                // Unreachable through the only caller — `Delegate.InternalAlloc` asserts its
+                // argument derives from `MulticastDelegate` — so refuse rather than invent a
+                // representation for a shape nothing can produce.
+                failwith
+                    $"TODO: %s{operation} was asked to allocate the value type %s{typeInfo.Namespace}.%s{typeInfo.Name}; only reference types reach CoreCLR's Delegate.InternalAlloc, and PawPrint has no boxed representation for an object allocated here"
+
+            // `MethodTable::Allocate` runs the class initialiser only for a type with precise-init
+            // cctors, i.e. one that is *not* `beforefieldinit`. PawPrint initialises
+            // unconditionally, which is the convention its `newobj` already follows and which
+            // `docs/divergences.md` records: ECMA-335 II.10.5.3.2 permits an eager schedule, and
+            // being consistent with `newobj` beats having two different rules for allocating an
+            // object. The difference is only observable for a `beforefieldinit` type that both has
+            // a `.cctor` and is allocated through *this* entry point, which no caller can arrange:
+            // delegate types carry no static constructor.
+            //
+            // This suspension needs no re-entry marker. Nothing has been written to the result
+            // handle and no managed call is outstanding, so re-entry simply re-runs this arm from
+            // the top and `ensureTypeInitialised` answers `Executed` the second time.
+            let state, typeInit =
+                IlMachineStateExecution.ensureTypeInitialised
+                    ctx.LoggerFactory
+                    ctx.BaseClassTypes
+                    ctx.Thread
+                    typeHandle
+                    state
+
+            match typeInit with
+            | WhatWeDid.SuspendedForClassInit -> NativeHandlerResult.suspendedForClassInit state |> Some
+            | WhatWeDid.BlockedOnClassInit blockedBy -> NativeHandlerResult.blockedOnClassInit blockedBy state |> Some
+            | WhatWeDid.ThrowingTypeInitializationException ->
+                NativeHandlerResult.throwingTypeInitializationException state |> Some
+            | WhatWeDid.SuspendedForManagedCall ->
+                failwith
+                    $"logic error: %s{operation}: ensureTypeInitialised cannot suspend for an arbitrary managed call"
+            | WhatWeDid.VoluntaryYield _ ->
+                failwith $"logic error: %s{operation}: ensureTypeInitialised cannot produce a VoluntaryYield"
+            | WhatWeDid.Executed ->
+
+            let result =
+                NativeCall.objectHandleOnStackTarget operation state "result" instruction.Arguments.[1]
+
+            let addr, state =
+                IlMachineState.allocateUninitialisedInstance ctx.LoggerFactory ctx.BaseClassTypes typeHandle state
+
+            let state =
+                IlMachineState.writeManagedByrefWithBase ctx.BaseClassTypes state result (CliType.ObjectRef (Some addr))
+
+            NativeHandlerResult.completed state |> Some
         | "RuntimeTypeHandle_GetActivationInfo",
           "System.Private.CoreLib",
           "System",

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
@@ -1971,11 +1971,18 @@ module NativeRuntimeTypeQCall =
             // runs `EnsureInstanceActive` and, for a type with precise-init cctors, a class
             // initialiser.
             //
-            // Every caller is delegate creation: `Delegate.InternalAlloc` (Delegate.CoreCLR.cs:435)
-            // is the sole caller of the managed `RuntimeTypeHandle.InternalAlloc`, and all four
-            // `Delegate.CreateDelegate` overloads plus `CreateDelegateInternal` reach it. It
-            // allocates the delegate object; a separate `Delegate_BindToMethodName`/
-            // `Delegate_BindToMethodInfo` QCall then binds it to a target.
+            // Two managed callers, and they want different things:
+            //
+            //  * `Delegate.InternalAlloc` (Delegate.CoreCLR.cs:435), reached from all four
+            //    `Delegate.CreateDelegate` overloads and from `CreateDelegateInternal`. It
+            //    allocates the delegate object; a separate `Delegate_BindToMethodName`/
+            //    `Delegate_BindToMethodInfo` QCall then binds it to a target. This is the caller
+            //    that works.
+            //  * `RuntimeMethodHandle.ReboxToNullable` (RuntimeHandles.cs:1200), reached from
+            //    `RuntimeType.CheckValue` whenever reflection has to coerce an argument to a
+            //    `Nullable<T>` parameter — `MethodInfo.Invoke` on a method taking `int?`, say. It
+            //    passes a *nullable's* MethodTable and then `Unbox_Nullable`s into the raw data of
+            //    what comes back. This is the caller that is refused below.
             let operation = "RuntimeTypeHandle.InternalAlloc"
 
             if instruction.Arguments.Length <> 2 then
@@ -1984,13 +1991,6 @@ module NativeRuntimeTypeQCall =
             let typeHandle =
                 NativeCall.methodTableOfEvalStackValue operation (instruction.Arguments.[0] |> EvalStackValue.ofCliType)
 
-            // No `Nullable<T>` guard here, unlike the "NoChecks" arm above. That one has a caller
-            // (`AsyncHelpers.AllocContinuationResultBox`) that deliberately passes a nullable's
-            // MethodTable, so it needs one. This entry point's only caller is
-            // `Delegate.InternalAlloc`, which asserts its argument is assignable to
-            // `MulticastDelegate`, so the shape cannot arrive. The invariant properly belongs at
-            // the `IlMachineState.allocateUninitialisedInstance` chokepoint either way; see the
-            // sibling's comment.
             let concreteType =
                 AllConcreteTypes.lookup typeHandle state.ConcreteTypes
                 |> Option.defaultWith (fun () ->
@@ -2005,14 +2005,35 @@ module NativeRuntimeTypeQCall =
 
             let typeInfo = assembly.TypeDefs.[concreteType.Definition.Get]
 
-            if DumpedAssembly.isValueType ctx.BaseClassTypes state._LoadedAssemblies typeInfo then
-                // `pMT->Allocate()` on a value-type MethodTable produces a box, and PawPrint's
-                // heap has no representation for one that came from here rather than from `box`.
-                // Unreachable through the only caller — `Delegate.InternalAlloc` asserts its
-                // argument derives from `MulticastDelegate` — so refuse rather than invent a
-                // representation for a shape nothing can produce.
+            // The `ReboxToNullable` caller lands here, and PawPrint cannot serve it. A boxed
+            // `Nullable<T>` in PawPrint is a box of the *underlying* `T`: `box`/`unbox`
+            // special-case nullables before allocating (UnaryMetadataObjectOps), so nothing on
+            // the heap ever carries a nullable MethodTable and no reader is prepared for one.
+            // `ReboxToNullable` needs precisely the opposite — an object whose raw data has the
+            // nullable's own layout, so that `CastHelpers.Unbox_Nullable` can write the has-value
+            // flag and the payload into it. Producing an ordinary box of `T` here would satisfy
+            // the allocation and then be silently corrupted by that write.
+            //
+            // So this is a real gap, not an unreachable guard: a guest calling `MethodInfo.Invoke`
+            // on a method with a `Nullable<T>` parameter reaches it. The fix is a layout-preserving
+            // boxed-Nullable heap representation, which is the same thing the "NoChecks" arm above
+            // says it needs for `AsyncHelpers.AllocContinuationResultBox`; one representation would
+            // serve both, and neither is in scope here. Refusing loudly beats corrupting.
+            match InternalTypeKind.kind ctx.BaseClassTypes concreteType with
+            | InternalTypeKind.Nullable ->
                 failwith
-                    $"TODO: %s{operation} was asked to allocate the value type %s{typeInfo.Namespace}.%s{typeInfo.Name}; only reference types reach CoreCLR's Delegate.InternalAlloc, and PawPrint has no boxed representation for an object allocated here"
+                    $"TODO: %s{operation} was asked to allocate the Nullable %s{typeInfo.Namespace}.%s{typeInfo.Name}, as RuntimeMethodHandle.ReboxToNullable does when reflection coerces an argument to a Nullable<T> parameter; PawPrint boxes the underlying value instead, so there is no object here whose raw data Unbox_Nullable could write the nullable's layout into"
+            | _ -> ()
+
+            if DumpedAssembly.isValueType ctx.BaseClassTypes state._LoadedAssemblies typeInfo then
+                // Any other value type: `pMT->Allocate()` produces a box, and PawPrint's heap has
+                // no representation for one that arrived here rather than through `box`. Neither
+                // caller can produce this — `Delegate.InternalAlloc` asserts its argument derives
+                // from `MulticastDelegate`, and `ReboxToNullable` asserts its argument is a
+                // nullable — so this is the guard that catches a *third* caller appearing, rather
+                // than a gap with a known consumer.
+                failwith
+                    $"TODO: %s{operation} was asked to allocate the value type %s{typeInfo.Namespace}.%s{typeInfo.Name}; neither Delegate.InternalAlloc nor RuntimeMethodHandle.ReboxToNullable can pass one, and PawPrint has no boxed representation for an object allocated here"
 
             // `MethodTable::Allocate` runs the class initialiser only for a type with precise-init
             // cctors, i.e. one that is *not* `beforefieldinit`. PawPrint initialises

--- a/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
+++ b/WoofWare.PawPrint/Native/NativeRuntimeTypeQCall.fs
@@ -2035,25 +2035,51 @@ module NativeRuntimeTypeQCall =
                 failwith
                     $"TODO: %s{operation} was asked to allocate the value type %s{typeInfo.Namespace}.%s{typeInfo.Name}; neither Delegate.InternalAlloc nor RuntimeMethodHandle.ReboxToNullable can pass one, and PawPrint has no boxed representation for an object allocated here"
 
-            // `MethodTable::Allocate` runs the class initialiser only for a type with precise-init
-            // cctors, i.e. one that is *not* `beforefieldinit`. PawPrint initialises
-            // unconditionally, which is the convention its `newobj` already follows and which
-            // `docs/divergences.md` records: ECMA-335 II.10.5.3.2 permits an eager schedule, and
-            // being consistent with `newobj` beats having two different rules for allocating an
-            // object. The difference is only observable for a `beforefieldinit` type that both has
-            // a `.cctor` and is allocated through *this* entry point, which no caller can arrange:
-            // delegate types carry no static constructor.
+            // `MethodTable::Allocate` initialises *as if constructing*
+            // (`CheckRunClassInitAsIfConstructingThrowing`, methodtable.cpp:4034), which is a
+            // stronger rule than the one that governs ordinary static access: it walks the whole
+            // parent chain, running each non-`beforefieldinit` ancestor's `.cctor`. This is the
+            // only place in PawPrint where that rule applies, which is why the walk is open-coded
+            // here rather than folded into `ensureTypeInitialised` — `loadClass` deliberately does
+            // *not* initialise base types (IlMachineStateExecution.fs), and it is right not to:
+            // the CLR does not run a base initialiser just because a derived type's did.
             //
-            // This suspension needs no re-entry marker. Nothing has been written to the result
-            // handle and no managed call is outstanding, so re-entry simply re-runs this arm from
-            // the top and `ensureTypeInitialised` answers `Executed` the second time.
-            let state, typeInit =
-                IlMachineStateExecution.ensureTypeInitialised
-                    ctx.LoggerFactory
-                    ctx.BaseClassTypes
-                    ctx.Thread
-                    typeHandle
-                    state
+            // PawPrint runs every ancestor's initialiser rather than only the non-`beforefieldinit`
+            // ones, so it is uniformly more eager than CoreCLR here rather than modelling the
+            // `beforefieldinit` predicate. That matches the convention `newobj` already follows and
+            // `docs/divergences.md` records, and ECMA-335 II.10.5.3.2 permits an eager schedule.
+            // The difference needs a `beforefieldinit` ancestor that has a `.cctor` *and* an
+            // allocation through this entry point; neither caller can arrange one, since the
+            // delegate hierarchy carries no static constructor at all.
+            //
+            // The suspension needs no re-entry marker. Nothing has been written to the result
+            // handle and no managed call is outstanding, so re-entry re-runs this arm from the top;
+            // ancestors already initialised answer `Executed`, so the walk resumes where it left
+            // off and terminates.
+            let rec initialiseWithAncestors
+                (ty : ConcreteTypeHandle)
+                (state : IlMachineState)
+                : IlMachineState * WhatWeDid
+                =
+                let state, typeInit =
+                    IlMachineStateExecution.ensureTypeInitialised
+                        ctx.LoggerFactory
+                        ctx.BaseClassTypes
+                        ctx.Thread
+                        ty
+                        state
+
+                match typeInit with
+                | WhatWeDid.Executed ->
+                    let state, baseType =
+                        IlMachineState.resolveBaseConcreteType ctx.LoggerFactory ctx.BaseClassTypes state ty
+
+                    match baseType with
+                    | None -> state, WhatWeDid.Executed
+                    | Some baseType -> initialiseWithAncestors baseType state
+                | other -> state, other
+
+            let state, typeInit = initialiseWithAncestors typeHandle state
 
             match typeInit with
             | WhatWeDid.SuspendedForClassInit -> NativeHandlerResult.suspendedForClassInit state |> Some


### PR DESCRIPTION
Next step in the Reflection.Emit workstream (#849). `RuntimeTypeHandle_InternalAlloc` (reflectioninvocation.cpp:119) is `pMT->Allocate()`: the checked counterpart of the `InternalAllocNoChecks` QCall PawPrint already has. Same allocation, plus `EnsureInstanceActive` and a class initialiser.

It is not emit-specific. `Delegate.InternalAlloc` (Delegate.CoreCLR.cs:435) reaches it from all four `Delegate.CreateDelegate` overloads and from `CreateDelegateInternal`; it allocates the delegate object, and a separate `Delegate_BindToMethodInfo` QCall — still unimplemented — then binds it.

### Class initialisation

`MethodTable::Allocate` initialises *as if constructing* (`CheckRunClassInitAsIfConstructingThrowing`, methodtable.cpp:4034), a stronger rule than the one governing ordinary static access: it walks the whole parent chain. PawPrint's `loadClass` deliberately does not initialise base types, and is right not to — the CLR does not run a base initialiser just because a derived type's did — so the walk is open-coded in this handler rather than folded into `ensureTypeInitialised`. It is the only place in PawPrint where that rule applies.

The walk runs every ancestor's initialiser rather than only the non-`beforefieldinit` ones, so PawPrint stays uniformly more eager than CoreCLR instead of modelling a predicate it models nowhere else. That matches the convention `newobj` already follows and `docs/divergences.md` records; ECMA-335 II.10.5.3.2 permits an eager schedule. Reaching the difference needs a `beforefieldinit` ancestor with a `.cctor` allocated through this entry point, which neither caller can arrange.

🤖 Generated with [Claude Code](https://claude.com/claude-code)