### PR TITLE
Decode a dynamic method's signature blob

### DIFF
--- a/WoofWare.PawPrint.Domain/LocalSignatureDecoding.fs
+++ b/WoofWare.PawPrint.Domain/LocalSignatureDecoding.fs
@@ -52,7 +52,7 @@ module LocalSignatureDecoding =
         // `SignatureHelper.GetLocalVarSigHelper()` whether or not `DeclareLocal` is ever called,
         // and `InternalGetSignatureArray` then writes a count of zero — so it is the common case
         // rather than a malformed one. Read the count first and answer it here.
-        let localCount =
+        let localCount, bytesAfterCount =
             let mutable probe : BlobReader = BlobReader (bytes, blob.Length)
             let header = probe.ReadSignatureHeader ()
 
@@ -60,7 +60,18 @@ module LocalSignatureDecoding =
                 failwith
                     $"expected a local variable signature (LOCAL_SIG, 0x07), but the blob's calling convention is %O{header.Kind}"
 
-            probe.ReadCompressedInteger ()
+            let localCount = probe.ReadCompressedInteger ()
+            localCount, probe.RemainingBytes
+
+        // Diagnosability, not safety: `SignatureDecoder` refuses an absurd declared count promptly
+        // and without a large allocation, but it refuses it with a bare `BadImageFormatException`,
+        // which the catch below reports as the likely `ELEMENT_TYPE_INTERNAL` cause -- pointing at
+        // a missing encoding when the blob is merely truncated. Every local occupies at least one
+        // byte, so the count can never exceed what is left to spell them in, and saying so here
+        // names the real problem. Same reasoning as `MethodSignatureDecoding`'s parameter bound.
+        if localCount > bytesAfterCount then
+            failwith
+                $"local variable signature blob declares %d{localCount} local(s) but has only %d{bytesAfterCount} byte(s) left to spell them in; it is truncated or corrupt"
 
         if localCount = 0 then
             ImmutableArray.Empty
@@ -74,20 +85,4 @@ module LocalSignatureDecoding =
         try
             decoder.DecodeLocalSignature &reader
         with :? BadImageFormatException as e ->
-            // The overwhelmingly likely cause, and the one worth naming, is a signature built by
-            // `SignatureHelper` with no module to spell types against: `AddOneArgTypeHelper` then
-            // takes its `m_module == null` branch and emits `ELEMENT_TYPE_INTERNAL` (0x21)
-            // followed by the raw bytes of the type's handle, which is not a signature element
-            // `MetadataReader` knows how to read. That encoding is a separate piece of work; see
-            // "Prerequisites that are not emit" in the Reflection.Emit tracking issue.
-            //
-            // Deliberately not narrowed to "the blob contains a 0x21 byte": 0x21 is also a
-            // perfectly ordinary payload byte inside a compressed integer or a type name, so such
-            // a test would be wrong in both directions. A genuinely malformed blob gets this
-            // message too, which is why it is phrased as the likely cause rather than the finding.
-            raise (
-                Exception (
-                    "could not decode a local variable signature blob. If it came from a DynamicMethod, the likely cause is ELEMENT_TYPE_INTERNAL (0x21), which SignatureHelper emits for any type that is not one of the primitives, object or string, and which PawPrint cannot yet read.",
-                    e
-                )
-            )
+            SignatureBlobDecoding.reraiseAsUndecodable "local variable signature blob" e

--- a/WoofWare.PawPrint.Domain/MethodSignatureDecoding.fs
+++ b/WoofWare.PawPrint.Domain/MethodSignatureDecoding.fs
@@ -1,0 +1,192 @@
+namespace WoofWare.PawPrint
+
+// `fixed`, to pin the signature bytes for the BlobReader below.
+#nowarn "9"
+
+open System
+open System.Reflection
+open System.Reflection.Metadata
+open System.Reflection.Metadata.Ecma335
+
+/// <summary>
+/// Decoding of a MethodDefSig (ECMA-335 II.23.2.1) from its raw blob bytes.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A method defined in a PE image reaches its signature through its <c>MethodDefinition</c> row,
+/// so <c>MethodDefinition.DecodeSignature</c> suffices and this module has nothing to say about
+/// it. A method minted by <c>Reflection.Emit</c> has no such row: <c>DynamicILGenerator</c> passes
+/// <c>ModuleHandle.GetDynamicMethod</c> the bytes <c>SignatureHelper</c> produced
+/// (DynamicILGenerator.cs:24-31), PawPrint records them verbatim on the
+/// <c>DynamicMethodDefinition</c>, and there is nowhere to look them up. Hence this entry point,
+/// which takes the blob directly. It is the method-signature counterpart of
+/// <see cref="LocalSignatureDecoding" />, which exists for the same reason.
+/// </para>
+/// <para>
+/// The alphabet a dynamic method's signature can be spelled in is narrower than metadata's,
+/// because <c>SignatureHelper</c> builds it with a null module. It classifies a type by
+/// <c>RuntimeType.GetCorElementType()</c> and takes the "simple" branch for anything up to
+/// <c>ELEMENT_TYPE_STRING</c> plus <c>TYPEDBYREF</c>/<c>I</c>/<c>U</c>/<c>OBJECT</c>
+/// (SignatureHelper.cs:653-659). Anything it cannot spell that way takes the
+/// <c>ELEMENT_TYPE_INTERNAL</c> branch (SignatureHelper.cs:449-452) -- a raw type-handle pointer,
+/// which is not something <c>MetadataReader</c> can read, and which is refused loudly here rather
+/// than decoded to something plausible.
+/// </para>
+/// <para>
+/// The alphabet is wider than that list, though, because it is closed under three constructors:
+/// <c>IsByRef</c>, <c>IsPointer</c> and <c>IsArray</c> are each tested *before* the simple-type
+/// check and recurse into the element type (SignatureHelper.cs:392-424). So <c>int[]</c>,
+/// <c>ref int</c> and <c>int**</c> are all perfectly spellable -- which matters, since emitting a
+/// dynamic method over an array is an entirely ordinary thing to do, and reading this as "simple
+/// types only" would wrongly say it could not be bound. An array of an unspellable element is
+/// still unspellable.
+/// </para>
+/// <para>
+/// An enum is <em>not</em> an exception to that, despite <c>IsSimpleType</c> classifying by
+/// element type: measured against the real encoder, a parameter typed as an enum is spelled
+/// <c>ELEMENT_TYPE_INTERNAL</c> like any other value type, whatever its underlying integer.
+/// <c>TestMethodSignatureDecoding</c> pins that for two enums of different underlying width, so
+/// this claim cannot rot into a lie -- and it is worth pinning, because the natural guess is the
+/// opposite.
+/// </para>
+/// </remarks>
+[<RequireQualifiedAccess>]
+module MethodSignatureDecoding =
+
+    /// <summary>
+    /// Decode a MethodDefSig blob into its return type and parameter types.
+    /// </summary>
+    /// <param name="assembly">
+    /// The token universe any <c>TypeDef</c>/<c>TypeRef</c>/<c>TypeSpec</c> in the blob is drawn
+    /// from, and the assembly the resulting <see cref="TypeDefn" />s name themselves against.
+    /// </param>
+    /// <param name="metadataReader">
+    /// The reader those same tokens are resolved against. Must be the reader of
+    /// <paramref name="assembly" />: a signature decoded against a second image's tables would
+    /// silently name whichever rows happened to sit at those indices.
+    /// </param>
+    /// <remarks>
+    /// <para>
+    /// The result is faithful, not filtered: a vararg signature comes back with
+    /// <c>Header.CallingConvention</c> saying so and <c>RequiredParameterCount</c> distinguishing
+    /// the fixed parameters from the rest, and a generic method's arity comes back in
+    /// <c>GenericParameterCount</c>. Neither is rejected here. Whether PawPrint can *do* anything
+    /// with such a method is a question for whoever is asking -- binding a delegate to it, say --
+    /// and that consumer has the context to say why not; a decoder that refused them would be
+    /// discarding information the returned type already carries perfectly well, and would be
+    /// answering a question it was not asked.
+    /// </para>
+    /// <para>
+    /// What is refused is a blob this cannot decode *honestly*: one that is not a method signature
+    /// at all, one whose types are spelled in an encoding PawPrint cannot read, one whose declared
+    /// parameter count exceeds the bytes available to spell those parameters in, and one with
+    /// bytes left over.
+    /// </para>
+    /// <para>
+    /// Those last two are corruption checks, and it is worth being precise about how corrupt a
+    /// blob can actually get here, because that bounds how much validation is worth doing. No
+    /// guest supplies these bytes directly: <c>ModuleHandle.GetDynamicMethod</c> is internal, and
+    /// every route to it (<c>DynamicMethod.GetILGenerator</c>, <c>GetDynamicILInfo</c>) builds the
+    /// signature with <c>SignatureHelper</c> from the <c>Type</c>s passed to the
+    /// <c>DynamicMethod</c> constructor. So this decodes <c>SignatureHelper</c> output in
+    /// practice, and these checks exist to turn interpreter-level corruption into a diagnosable
+    /// failure rather than to defend a hostile boundary.
+    /// </para>
+    /// <para>
+    /// That is also why there is no check that the decoded *types* are ones <c>SignatureHelper</c>
+    /// could have produced. A hand-crafted blob can spell <c>ELEMENT_TYPE_FNPTR</c>, for which
+    /// <c>SignatureHelper</c> has no branch at all -- a function-pointer type fails
+    /// <c>IsSimpleType</c> and so would take the <c>ELEMENT_TYPE_INTERNAL</c> branch -- so such a
+    /// signature cannot have come from a real dynamic method. It nonetheless decodes into a
+    /// well-formed <c>TypeDefn.FunctionPointer</c>, and consumers that cannot handle one already
+    /// refuse it by name. Screening the decoded shape against the encoder's reachable output would
+    /// mean a whitelist walk over every <see cref="TypeDefn" /> case; that is the right change if
+    /// this entry point ever becomes reachable with guest-chosen bytes, and disproportionate
+    /// until then.
+    /// </para>
+    /// </remarks>
+    let decode (assembly : AssemblyName) (metadataReader : MetadataReader) (blob : byte[]) : MethodSignature<TypeDefn> =
+        // `BlobReader` accepts a null pointer precisely when the length is zero, which is what
+        // `fixed` yields for an empty array. An empty blob is not a valid MethodDefSig at all, and
+        // CoreCLR agrees: `DynamicMethodTable::GetDynamicMethod` carries `PRECONDITION(sigSize >
+        // 0)` (dynamicmethod.cpp:229). Report it rather than letting `BlobReader` decide.
+        if blob.Length = 0 then
+            failwith "method signature blob is empty; every MethodDefSig carries at least a calling-convention byte"
+
+        use bytes = fixed blob
+
+        // Check the calling convention before decoding rather than after. `DecodeMethodSignature`
+        // reads the header and then keeps going, so handing it a LocalVarSig or a FieldSig
+        // produces a confident, wrong answer (a field signature's type would be read as a
+        // parameter count) instead of an error.
+        let headerKind, declaredParameters, bytesAfterCounts =
+            let mutable probe : BlobReader = BlobReader (bytes, blob.Length)
+            let header = probe.ReadSignatureHeader ()
+
+            if header.Kind <> SignatureKind.Method then
+                // Read nothing further: the counts below are only where they are because this is
+                // a method signature.
+                header.Kind, 0, 0
+            else
+
+            // A generic method's arity precedes the parameter count.
+            if header.IsGeneric then
+                probe.ReadCompressedInteger () |> ignore
+
+            let declaredParameters = probe.ReadCompressedInteger ()
+            header.Kind, declaredParameters, probe.RemainingBytes
+
+        if headerKind <> SignatureKind.Method then
+            failwith
+                $"expected a method signature (one of the METHOD calling conventions), but the blob's calling convention is %O{headerKind}"
+
+        // This is a diagnosability check, not a safety one, and it is worth saying which because
+        // the obvious reason to write it is wrong. `SignatureDecoder` does *not* blow up on an
+        // absurd declared count: measured, a blob declaring half a billion parameters is refused
+        // in under a millisecond with no large allocation attempted. What it is refused *with* is
+        // the problem -- a bare `BadImageFormatException`, which this module's catch then reports
+        // as the likely `ELEMENT_TYPE_INTERNAL` cause, sending whoever reads it hunting for a
+        // missing encoding when the blob is merely truncated.
+        //
+        // Deciding it here instead is exact rather than a magic cap: every parameter occupies at
+        // least one byte, and so does the return type, so a signature declaring N parameters needs
+        // strictly more than N bytes after its counts. That is decidable without reading them.
+        if declaredParameters >= bytesAfterCounts then
+            failwith
+                $"method signature blob declares %d{declaredParameters} parameter(s) but has only %d{bytesAfterCounts} byte(s) left to spell them and the return type in; it is truncated or corrupt"
+
+        let mutable reader : BlobReader = BlobReader (bytes, blob.Length)
+
+        let decoder =
+            SignatureDecoder<TypeDefn, unit> (TypeDefn.typeProvider assembly, metadataReader, ())
+
+        let decoded =
+            try
+                decoder.DecodeMethodSignature &reader
+            with :? BadImageFormatException as e ->
+                SignatureBlobDecoding.reraiseAsUndecodable "method signature blob" e
+
+        // `DecodeMethodSignature` stops as soon as it has read the declared number of parameters,
+        // so a blob that is a valid signature followed by anything at all decodes "successfully"
+        // and the tail is silently dropped. That is precisely the shape a corrupted or
+        // concatenated blob has, and these bytes come from guest memory, so say so instead.
+        //
+        // One trailing byte is expected and legal, though, and it is what every real dynamic
+        // method carries: `DynamicMethod.GetILGenerator` builds the blob with
+        // `SignatureHelper.GetSignature(true)` (DynamicMethod.CoreCLR.cs:161-162), whose `true`
+        // means "append ELEMENT_TYPE_END" (SignatureHelper.cs:870-881). ECMA-335 II.23.2.1 does
+        // not put that byte in a MethodDefSig, so a blob without it is equally valid and is what
+        // the public `SignatureHelper.GetSignature()` produces; accept either.
+        match reader.RemainingBytes with
+        | 0 -> ()
+        | 1 ->
+            let trailing = reader.ReadByte ()
+
+            if trailing <> 0uy then
+                failwith
+                    $"method signature blob has one byte left over after its %d{decoded.ParameterTypes.Length} declared parameter(s), and it is 0x%02x{trailing} rather than the ELEMENT_TYPE_END (0x00) that SignatureHelper appends"
+        | remaining ->
+            failwith
+                $"method signature blob has %d{remaining} bytes left over after its %d{decoded.ParameterTypes.Length} declared parameter(s); at most one trailing ELEMENT_TYPE_END is expected, so this blob is truncated, corrupt, or several signatures concatenated"
+
+        decoded

--- a/WoofWare.PawPrint.Domain/SignatureBlobDecoding.fs
+++ b/WoofWare.PawPrint.Domain/SignatureBlobDecoding.fs
@@ -1,0 +1,48 @@
+namespace WoofWare.PawPrint
+
+open System
+open System.Reflection.Metadata
+
+/// <summary>
+/// Shared machinery for decoding a raw signature blob that arrived without a metadata row to own
+/// it.
+/// </summary>
+/// <remarks>
+/// A signature read out of a PE image is reached through a handle into the tables that produced
+/// it, so <c>MetadataReader</c> can find its bytes. A signature minted by <c>Reflection.Emit</c>
+/// has no such row: it is a bare <c>byte[]</c> handed across the runtime boundary, so it has to be
+/// decoded from the bytes directly. <see cref="LocalSignatureDecoding" /> and
+/// <see cref="MethodSignatureDecoding" /> are the two entry points that do so, and they fail in
+/// the same way for the same reason; this is that shared failure.
+/// </remarks>
+[<RequireQualifiedAccess>]
+module SignatureBlobDecoding =
+
+    /// <summary>
+    /// Re-raise a <see cref="System.BadImageFormatException" /> from <c>SignatureDecoder</c> as an
+    /// exception naming the cause a <c>Reflection.Emit</c>-produced blob is overwhelmingly likely
+    /// to have.
+    /// </summary>
+    /// <param name="what">
+    /// What was being decoded, phrased to complete "could not decode a ...": for example
+    /// <c>"local variable signature blob"</c>.
+    /// </param>
+    /// <remarks>
+    /// Deliberately not narrowed to "the blob contains a 0x21 byte": 0x21 is also a perfectly
+    /// ordinary payload byte inside a compressed integer or a type name, so such a test would be
+    /// wrong in both directions. A genuinely malformed blob gets this message too, which is why it
+    /// is phrased as the likely cause rather than as the finding.
+    /// </remarks>
+    let reraiseAsUndecodable (what : string) (e : BadImageFormatException) : 'a =
+        // The overwhelmingly likely cause, and the one worth naming, is a signature built by
+        // `SignatureHelper` with no module to spell types against: `AddOneArgTypeHelper` then
+        // takes its `m_module == null` branch and emits `ELEMENT_TYPE_INTERNAL` (0x21) followed by
+        // the raw bytes of the type's handle, which is not a signature element `MetadataReader`
+        // knows how to read. That encoding is a separate piece of work; see "Prerequisites that
+        // are not emit" in the Reflection.Emit tracking issue.
+        raise (
+            Exception (
+                $"could not decode a %s{what}. If it came from a DynamicMethod, the likely cause is ELEMENT_TYPE_INTERNAL (0x21), which SignatureHelper emits for any type that is not one of the primitives, object or string, and which PawPrint cannot yet read.",
+                e
+            )
+        )

--- a/WoofWare.PawPrint.Domain/WoofWare.PawPrint.Domain.fsproj
+++ b/WoofWare.PawPrint.Domain/WoofWare.PawPrint.Domain.fsproj
@@ -35,7 +35,9 @@
         <Compile Include="ComparableGenericParameterHandle.fs" />
         <Compile Include="TypeIdentity.fs" />
         <Compile Include="TypeDefn.fs" />
+        <Compile Include="SignatureBlobDecoding.fs" />
         <Compile Include="LocalSignatureDecoding.fs" />
+        <Compile Include="MethodSignatureDecoding.fs" />
         <Compile Include="CustomAttribute.fs" />
         <Compile Include="GenericParameter.fs" />
         <Compile Include="ConcreteType.fs" />

--- a/WoofWare.PawPrint.Test/TestLocalSignatureDecoding.fs
+++ b/WoofWare.PawPrint.Test/TestLocalSignatureDecoding.fs
@@ -1,0 +1,78 @@
+namespace WoofWare.PawPrint.Test
+
+open System
+open System.IO
+open System.Reflection
+open System.Reflection.Emit
+open System.Reflection.Metadata
+open System.Reflection.PortableExecutable
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+/// <summary>
+/// Tests for <see cref="LocalSignatureDecoding" />, the locals counterpart of
+/// <see cref="MethodSignatureDecoding" />.
+/// </summary>
+/// <remarks>
+/// This module predates <c>MethodSignatureDecoding</c> and was covered only indirectly, through
+/// the dynamic-method minting tests. These are the direct ones, added alongside a declared-count
+/// bound that the two modules now share the reasoning for.
+/// </remarks>
+[<TestFixture>]
+module TestLocalSignatureDecoding =
+
+    let private corelibReader : PEReader =
+        new PEReader (File.OpenRead typeof<obj>.Assembly.Location)
+
+    let private metadataReader : MetadataReader = corelibReader.GetMetadataReader ()
+
+    let private assemblyName : AssemblyName =
+        metadataReader.GetAssemblyDefinition().GetAssemblyName ()
+
+    let private decode (blob : byte[]) : Collections.Immutable.ImmutableArray<TypeDefn> =
+        LocalSignatureDecoding.decode assemblyName metadataReader blob
+
+    /// The real encoder, driven exactly as `DynamicILGenerator.DeclareLocal` drives it.
+    let private encode (localTypes : Type list) : byte[] =
+        let helper = SignatureHelper.GetLocalVarSigHelper ()
+
+        for t in localTypes do
+            helper.AddArgument t
+
+        helper.GetSignature ()
+
+    [<Test>]
+    let ``locals round-trip in order`` () : unit =
+        decode (encode [ typeof<int> ; typeof<string> ; typeof<double> ])
+        |> Seq.toList
+        |> shouldEqual
+            [
+                TypeDefn.PrimitiveType PrimitiveType.Int32
+                TypeDefn.PrimitiveType PrimitiveType.String
+                TypeDefn.PrimitiveType PrimitiveType.Double
+            ]
+
+    /// The case `MetadataReader.DecodeLocalSignature` refuses outright, and which every dynamic
+    /// method that declares no locals produces.
+    [<Test>]
+    let ``a zero-count signature decodes to no locals`` () : unit =
+        decode (encode []) |> Seq.toList |> shouldEqual []
+
+    /// The locals counterpart of `a parameter count exceeding the blob is reported as truncation`:
+    /// `SignatureDecoder` already refuses this, but with a message blaming the
+    /// `ELEMENT_TYPE_INTERNAL` gap rather than the truncation that actually occurred.
+    [<Test>]
+    let ``a local count exceeding the blob is reported as truncation`` () : unit =
+        // LOCAL_SIG (0x07), then 0x1FFFFFFF as a four-byte compressed integer.
+        let absurd = [| 0x07uy ; 0xDFuy ; 0xFFuy ; 0xFFuy ; 0xFFuy |]
+
+        let exn = Assert.Throws<Exception> (fun () -> decode absurd |> ignore)
+
+        exn.Message |> shouldContainText "truncated or corrupt"
+        exn.Message |> shouldContainText "536870911"
+
+    /// The bound must not reject a legitimate signature whose locals are one byte each.
+    [<Test>]
+    let ``the local-count bound admits a maximally tight signature`` () : unit =
+        decode (encode (List.replicate 8 typeof<int>)) |> Seq.length |> shouldEqual 8

--- a/WoofWare.PawPrint.Test/TestMethodSignatureDecoding.fs
+++ b/WoofWare.PawPrint.Test/TestMethodSignatureDecoding.fs
@@ -1,0 +1,392 @@
+namespace WoofWare.PawPrint.Test
+
+open System
+open System.IO
+open System.Reflection
+open System.Reflection.Emit
+open System.Reflection.Metadata
+open System.Reflection.PortableExecutable
+open FsCheck
+open FsCheck.FSharp
+open FsUnitTyped
+open NUnit.Framework
+open WoofWare.PawPrint
+
+/// An enum whose underlying type is not the default `int`, so that
+/// `refuses an enum, whatever its underlying type` covers two widths rather than one. Declared
+/// here because corelib's enums are almost all Int32-backed.
+type ByteBackedEnum =
+    | Zero = 0uy
+    | One = 1uy
+
+/// <summary>
+/// Tests for <see cref="MethodSignatureDecoding" />, the decoder for a MethodDefSig blob that
+/// arrived without a metadata row to own it.
+/// </summary>
+/// <remarks>
+/// The oracle throughout is the real <c>System.Reflection.Emit.SignatureHelper</c>, driven with a
+/// null module so that it takes exactly the branch <c>DynamicMethod</c> drives it down. That
+/// matters: the interesting claims this module makes are about which types
+/// <c>SignatureHelper</c> can spell and how, and reading those off the encoder rather than
+/// asserting them by hand is what stops the tests agreeing with a wrong belief. It is the same
+/// discipline as decoding against a real image rather than a hand-built byte array -- an
+/// expectation taken from outside the code under test.
+/// </remarks>
+[<TestFixture>]
+module TestMethodSignatureDecoding =
+
+    /// A real metadata reader for the decoder to resolve tokens against. A blob whose types are
+    /// all simple element types never consults it, but the entry point requires one, and
+    /// supplying a genuine one means the "not consulted" claim is tested rather than assumed: a
+    /// decoder that *did* reach for a token would find a real table and could quietly succeed
+    /// against the wrong row, which is exactly the failure a stub reader would mask.
+    let private corelibReader : PEReader =
+        new PEReader (File.OpenRead typeof<obj>.Assembly.Location)
+
+    let private metadataReader : MetadataReader = corelibReader.GetMetadataReader ()
+
+    let private assemblyName : AssemblyName =
+        metadataReader.GetAssemblyDefinition().GetAssemblyName ()
+
+    /// The null module is the whole point: it is what makes `SignatureHelper` take the
+    /// `ELEMENT_TYPE_INTERNAL` branch for anything it cannot spell as a simple element type, and
+    /// so it is what makes these blobs the ones `DynamicMethod` actually produces.
+    let private nullModule : Module = null
+
+    /// Build a MethodDefSig blob exactly as `DynamicMethod` does.
+    ///
+    /// The trailing `ELEMENT_TYPE_END` is not decoration: `DynamicMethod.GetILGenerator` builds
+    /// its signature with the internal `SignatureHelper.GetSignature(true)`
+    /// (DynamicMethod.CoreCLR.cs:161-162), and that `true` means "append ELEMENT_TYPE_END"
+    /// (SignatureHelper.cs:870-881). Only the `false` overload is public, so appending the byte
+    /// here is what makes these blobs the ones PawPrint is actually handed rather than a shape no
+    /// dynamic method ever produces. `both the trailing-END and bare forms decode` pins that the
+    /// two differ by exactly this byte, so this cannot silently stop reproducing the real thing.
+    let private encode (returnType : Type) (parameterTypes : Type list) : byte[] =
+        let helper =
+            SignatureHelper.GetMethodSigHelper (nullModule, returnType, List.toArray parameterTypes)
+
+        Array.append (helper.GetSignature ()) [| 0x00uy |]
+
+    /// The same blob without the appended terminator: what the public `GetSignature()` returns,
+    /// and a perfectly valid MethodDefSig in its own right (ECMA-335 II.23.2.1 has no trailing
+    /// END).
+    let private encodeBare (returnType : Type) (parameterTypes : Type list) : byte[] =
+        SignatureHelper.GetMethodSigHelper(nullModule, returnType, List.toArray parameterTypes).GetSignature ()
+
+    let private decode (blob : byte[]) : MethodSignature<TypeDefn> =
+        MethodSignatureDecoding.decode assemblyName metadataReader blob
+
+    /// The types `SignatureHelper.IsSimpleType` accepts, paired with the `TypeDefn` each must
+    /// decode to. `void` is absent because it is legal only as a return type; it is covered
+    /// separately.
+    let private simpleAlphabet : (Type * TypeDefn) list =
+        [
+            typeof<bool>, TypeDefn.PrimitiveType PrimitiveType.Boolean
+            typeof<char>, TypeDefn.PrimitiveType PrimitiveType.Char
+            typeof<sbyte>, TypeDefn.PrimitiveType PrimitiveType.SByte
+            typeof<byte>, TypeDefn.PrimitiveType PrimitiveType.Byte
+            typeof<int16>, TypeDefn.PrimitiveType PrimitiveType.Int16
+            typeof<uint16>, TypeDefn.PrimitiveType PrimitiveType.UInt16
+            typeof<int32>, TypeDefn.PrimitiveType PrimitiveType.Int32
+            typeof<uint32>, TypeDefn.PrimitiveType PrimitiveType.UInt32
+            typeof<int64>, TypeDefn.PrimitiveType PrimitiveType.Int64
+            typeof<uint64>, TypeDefn.PrimitiveType PrimitiveType.UInt64
+            typeof<single>, TypeDefn.PrimitiveType PrimitiveType.Single
+            typeof<double>, TypeDefn.PrimitiveType PrimitiveType.Double
+            typeof<string>, TypeDefn.PrimitiveType PrimitiveType.String
+            typeof<obj>, TypeDefn.PrimitiveType PrimitiveType.Object
+            typeof<nativeint>, TypeDefn.PrimitiveType PrimitiveType.IntPtr
+            typeof<unativeint>, TypeDefn.PrimitiveType PrimitiveType.UIntPtr
+        ]
+
+    [<Test>]
+    let ``every simple type round-trips through the real encoder`` () : unit =
+        for clrType, expected in simpleAlphabet do
+            let decoded = decode (encode clrType [ clrType ])
+
+            decoded.ReturnType |> shouldEqual expected
+            decoded.ParameterTypes |> Seq.toList |> shouldEqual [ expected ]
+
+    [<Test>]
+    let ``a void return decodes to Void`` () : unit =
+        let decoded = decode (encode typeof<Void> [ typeof<int> ])
+
+        decoded.ReturnType |> shouldEqual TypeDefn.Void
+
+        decoded.ParameterTypes
+        |> Seq.toList
+        |> shouldEqual [ TypeDefn.PrimitiveType PrimitiveType.Int32 ]
+
+    /// The shape the whole dynamic-IL workstream is aimed at: `int -> int`, the signature of the
+    /// doubling method the end-to-end guest builds.
+    [<Test>]
+    let ``the doubling method's signature decodes`` () : unit =
+        let decoded = decode (encode typeof<int> [ typeof<int> ])
+
+        decoded.ReturnType |> shouldEqual (TypeDefn.PrimitiveType PrimitiveType.Int32)
+
+        decoded.ParameterTypes
+        |> Seq.toList
+        |> shouldEqual [ TypeDefn.PrimitiveType PrimitiveType.Int32 ]
+
+        decoded.RequiredParameterCount |> shouldEqual 1
+        decoded.GenericParameterCount |> shouldEqual 0
+
+    /// Parameter *order* and *arity* are the two things a decoder can get subtly wrong while
+    /// every single-parameter test still passes, so sweep both. The alphabet is the one the
+    /// encoder actually admits, which is a real restriction rather than one chosen to make the
+    /// property hold: `refuses a type SignatureHelper cannot spell` below pins where the boundary
+    /// is.
+    [<Test>]
+    let ``parameter lists round-trip in order and arity`` () : unit =
+        let config = Config.QuickThrowOnFailure.WithMaxTest 300
+
+        let gen : Gen<(Type * TypeDefn) * ((Type * TypeDefn) list)> =
+            gen {
+                let! ret = Gen.elements simpleAlphabet
+                // Up to eight parameters: enough that a decoder mishandling the compressed
+                // parameter count, or reversing the list, cannot pass by luck.
+                let! count = Gen.choose (0, 8)
+                let! parameters = Gen.listOfLength count (Gen.elements simpleAlphabet)
+                return ret, parameters
+            }
+
+        let property ((ret, parameters) : (Type * TypeDefn) * ((Type * TypeDefn) list)) : bool =
+            let decoded = decode (encode (fst ret) (List.map fst parameters))
+
+            decoded.ReturnType = snd ret
+            && (decoded.ParameterTypes |> Seq.toList) = List.map snd parameters
+            && decoded.RequiredParameterCount = parameters.Length
+
+        Check.One (config, Prop.forAll (Arb.fromGen gen) property)
+
+    /// An enum takes the `ELEMENT_TYPE_INTERNAL` branch like any other value type, and is
+    /// therefore refused.
+    ///
+    /// This one is measured, and the measurement overturned the obvious guess. `IsSimpleType`
+    /// classifies by *element type*, and `RuntimeType.GetCorElementType()` for an enum is widely
+    /// (and in other CoreCLR contexts correctly) said to be the underlying integer's -- which
+    /// would make an enum parameter arrive here indistinguishable from an `int`. It does not: the
+    /// encoder spells it `ELEMENT_TYPE_INTERNAL`. Both underlying widths are checked, so this
+    /// cannot be passing for a reason peculiar to Int32-backed enums.
+    ///
+    /// The distinction matters to whoever binds a delegate to such a method: "an enum parameter
+    /// decodes to its underlying integer" would have meant enum-typed dynamic methods bind
+    /// today, and they do not.
+    [<Test>]
+    let ``refuses an enum, whatever its underlying type`` () : unit =
+        for enumType in [ typeof<DayOfWeek> ; typeof<ByteBackedEnum> ] do
+            let blob = encode typeof<int> [ enumType ]
+
+            // Check the premise, so this cannot pass because the encoder started spelling enums
+            // some third way: 0x21 is ELEMENT_TYPE_INTERNAL.
+            blob |> Array.contains 0x21uy |> shouldEqual true
+
+            let exn = Assert.Throws<Exception> (fun () -> decode blob |> ignore)
+            exn.Message |> shouldContainText "ELEMENT_TYPE_INTERNAL"
+
+    /// The boundary of the alphabet, from the far side. A user-defined struct has element type
+    /// `ELEMENT_TYPE_VALUETYPE`, which is not simple, so with a null module `SignatureHelper`
+    /// emits `ELEMENT_TYPE_INTERNAL` followed by a raw handle -- and that is not a signature
+    /// `MetadataReader` can read.
+    [<Test>]
+    let ``refuses a type SignatureHelper cannot spell`` () : unit =
+        let blob = encode typeof<int> [ typeof<DateTime> ]
+
+        // First check the premise, so that this test cannot pass because the encoder quietly
+        // started spelling `DateTime` some other way: 0x21 is ELEMENT_TYPE_INTERNAL.
+        blob |> Array.contains 0x21uy |> shouldEqual true
+
+        let exn = Assert.Throws<Exception> (fun () -> decode blob |> ignore)
+
+        exn.Message |> shouldContainText "ELEMENT_TYPE_INTERNAL"
+        exn.InnerException |> shouldNotEqual null
+
+    [<Test>]
+    let ``refuses an empty blob`` () : unit =
+        let exn = Assert.Throws<Exception> (fun () -> decode [||] |> ignore)
+
+        exn.Message |> shouldContainText "empty"
+
+    /// A LocalVarSig and a MethodDefSig differ only in their leading calling-convention byte, and
+    /// `DynamicResolver` hands PawPrint both. Decoding one as the other would read a *type* as a
+    /// parameter count and answer confidently, so the header is checked before decoding starts.
+    [<Test>]
+    let ``refuses a local variable signature`` () : unit =
+        // LOCAL_SIG (0x07), one local, of type int32.
+        let localSig = [| 0x07uy ; 0x01uy ; 0x08uy |]
+
+        let exn = Assert.Throws<Exception> (fun () -> decode localSig |> ignore)
+
+        exn.Message |> shouldContainText "LocalVariables"
+
+    /// A vararg signature decodes rather than being rejected: `RequiredParameterCount` says where
+    /// the fixed parameters stop. Pinned because `MethodSignatureDecoding` deliberately declines
+    /// to filter such signatures -- the decoder's job is to say what the blob contains, and
+    /// whether PawPrint can bind a delegate to a vararg method is the *binder's* question. If
+    /// that policy is ever moved into the decoder, this test is the one that should change.
+    [<Test>]
+    let ``a vararg signature decodes faithfully`` () : unit =
+        let helper =
+            SignatureHelper.GetMethodSigHelper (nullModule, CallingConventions.VarArgs, typeof<int>)
+
+        helper.AddArgument typeof<int>
+        helper.AddSentinel ()
+        helper.AddArgument typeof<string>
+
+        let decoded = decode (helper.GetSignature ())
+
+        decoded.Header.CallingConvention
+        |> shouldEqual SignatureCallingConvention.VarArgs
+
+        decoded.RequiredParameterCount |> shouldEqual 1
+
+        decoded.ParameterTypes
+        |> Seq.toList
+        |> shouldEqual
+            [
+                TypeDefn.PrimitiveType PrimitiveType.Int32
+                TypeDefn.PrimitiveType PrimitiveType.String
+            ]
+
+    /// The same policy claim as above, for generic arity. Hand-built, because `SignatureHelper`
+    /// has no way to emit a generic method signature: the calling convention is
+    /// `IMAGE_CEE_CS_CALLCONV_GENERIC` (0x10), followed by the arity, then the parameter count.
+    [<Test>]
+    let ``a generic method signature decodes faithfully`` () : unit =
+        // GENERIC (0x10), arity 2, one parameter, returning !!0, taking !!1.
+        let genericSig = [| 0x10uy ; 0x02uy ; 0x01uy ; 0x1Euy ; 0x00uy ; 0x1Euy ; 0x01uy |]
+
+        let decoded = decode genericSig
+
+        decoded.GenericParameterCount |> shouldEqual 2
+        decoded.ReturnType |> shouldEqual (TypeDefn.GenericMethodParameter 0)
+
+        decoded.ParameterTypes
+        |> Seq.toList
+        |> shouldEqual [ TypeDefn.GenericMethodParameter 1 ]
+
+    /// Arrays, byrefs and pointers are *not* covered by the simple-type rule, and are spellable
+    /// anyway: `AddOneArgTypeHelperWorker` tests `IsByRef`/`IsPointer`/`IsArray` before it ever
+    /// reaches `IsSimpleType` (SignatureHelper.cs:392-424), emitting the element type and
+    /// recursing. So the alphabet is closed under those constructors rather than being just the
+    /// sixteen simple types -- which matters, because a dynamic method taking `int[]` is an
+    /// entirely ordinary thing to emit, and reading the summary as "simple types only" would say
+    /// it cannot bind.
+    ///
+    /// The nesting is what makes this non-vacuous: a decoder that dropped one constructor level
+    /// would still answer for the single-level cases.
+    [<Test>]
+    let ``the alphabet is closed under array, byref and pointer`` () : unit =
+        let int32Defn = TypeDefn.PrimitiveType PrimitiveType.Int32
+
+        let cases : (Type * TypeDefn) list =
+            [
+                typeof<int[]>, TypeDefn.OneDimensionalArrayLowerBoundZero int32Defn
+                typeof<int[][]>,
+                TypeDefn.OneDimensionalArrayLowerBoundZero (TypeDefn.OneDimensionalArrayLowerBoundZero int32Defn)
+                typeof<string[]>,
+                TypeDefn.OneDimensionalArrayLowerBoundZero (TypeDefn.PrimitiveType PrimitiveType.String)
+                typeof<int>.MakeByRefType (), TypeDefn.Byref int32Defn
+                typeof<int>.MakePointerType (), TypeDefn.Pointer int32Defn
+                typeof<int>.MakePointerType().MakePointerType (), TypeDefn.Pointer (TypeDefn.Pointer int32Defn)
+            ]
+
+        for clrType, expected in cases do
+            let decoded = decode (encode typeof<int> [ clrType ])
+
+            decoded.ParameterTypes |> Seq.toList |> shouldEqual [ expected ]
+
+    /// The other half of that claim: an array *of* something unspellable is still unspellable, so
+    /// the closure is over the alphabet rather than a blanket exemption for arrays.
+    [<Test>]
+    let ``an array of an unspellable type is still refused`` () : unit =
+        let blob = encode typeof<int> [ typeof<DateTime[]> ]
+
+        blob |> Array.contains 0x21uy |> shouldEqual true
+
+        let exn = Assert.Throws<Exception> (fun () -> decode blob |> ignore)
+        exn.Message |> shouldContainText "ELEMENT_TYPE_INTERNAL"
+
+    /// The two encoder modes differ by exactly one `ELEMENT_TYPE_END` byte, and both decode to the
+    /// same thing. This is what keeps `encode` honest: if the public `GetSignature()` ever started
+    /// appending the terminator itself, `encode` would be producing a double-terminated blob that
+    /// no dynamic method emits, and this test is what notices.
+    [<Test>]
+    let ``both the trailing-END and bare forms decode`` () : unit =
+        let withEnd = encode typeof<int> [ typeof<int> ; typeof<string> ]
+        let bare = encodeBare typeof<int> [ typeof<int> ; typeof<string> ]
+
+        withEnd |> shouldEqual (Array.append bare [| 0x00uy |])
+
+        let expected =
+            [
+                TypeDefn.PrimitiveType PrimitiveType.Int32
+                TypeDefn.PrimitiveType PrimitiveType.String
+            ]
+
+        (decode withEnd).ParameterTypes |> Seq.toList |> shouldEqual expected
+        (decode bare).ParameterTypes |> Seq.toList |> shouldEqual expected
+
+    /// A valid signature followed by junk is not a valid blob. `DecodeMethodSignature` stops after
+    /// the declared parameters, so without an explicit check the tail is silently dropped and a
+    /// concatenated or corrupt blob decodes as though it were the first signature in it -- and
+    /// these bytes come from guest memory, so that is a real hazard rather than a theoretical one.
+    [<Test>]
+    let ``refuses trailing bytes after a complete signature`` () : unit =
+        let valid = encodeBare typeof<int> [ typeof<int> ]
+
+        // Two extra bytes: one over the single ELEMENT_TYPE_END that is legitimately tolerated.
+        let exn =
+            Assert.Throws<Exception> (fun () -> decode (Array.append valid [| 0x00uy ; 0x00uy |]) |> ignore)
+
+        exn.Message |> shouldContainText "bytes left over"
+
+        // ...and a single trailing byte that is *not* ELEMENT_TYPE_END is refused too, so the
+        // tolerance is for the terminator specifically rather than for "one spare byte".
+        let exn =
+            Assert.Throws<Exception> (fun () -> decode (Array.append valid [| 0x08uy |]) |> ignore)
+
+        exn.Message |> shouldContainText "ELEMENT_TYPE_END"
+
+    /// A blob claiming more parameters than it carries is truncated, not merely short: the
+    /// decoder must not silently return the parameters it managed to read. Distinct from the
+    /// trailing-bytes case above, and reached through a different failure inside SRM.
+    [<Test>]
+    let ``refuses a truncated signature`` () : unit =
+        // DEFAULT calling convention, 3 parameters declared, int32 return, only one parameter.
+        let truncated = [| 0x00uy ; 0x03uy ; 0x08uy ; 0x08uy |]
+
+        Assert.Throws<Exception> (fun () -> decode truncated |> ignore) |> ignore
+
+    /// A blob declaring more parameters than it has bytes to spell them in is truncated, and must
+    /// say so. `SignatureDecoder` already refuses it -- promptly, and without the large allocation
+    /// one might expect from a length prefix -- but it refuses it with a bare
+    /// `BadImageFormatException`, which this module's catch reports as the likely
+    /// `ELEMENT_TYPE_INTERNAL` cause. That message points at a missing encoding rather than at a
+    /// truncated blob, so the check exists to name the real problem.
+    ///
+    /// The assertion is therefore on *which* diagnostic comes back, not on whether one does:
+    /// remove the bound and this still throws, just misleadingly.
+    [<Test>]
+    let ``a parameter count exceeding the blob is reported as truncation`` () : unit =
+        // DEFAULT calling convention, then 0x1FFFFFFF as a four-byte compressed integer, then a
+        // void return. 536,870,911 parameters, in a six-byte blob.
+        let absurd = [| 0x00uy ; 0xDFuy ; 0xFFuy ; 0xFFuy ; 0xFFuy ; 0x01uy |]
+
+        let exn = Assert.Throws<Exception> (fun () -> decode absurd |> ignore)
+
+        exn.Message |> shouldContainText "truncated or corrupt"
+        exn.Message |> shouldContainText "536870911"
+
+    /// The bound must not reject legitimate signatures at the boundary. A blob whose parameters
+    /// are exactly one byte each is the tightest a real signature gets, so it is where an
+    /// off-by-one in the bound would show up.
+    [<Test>]
+    let ``the parameter-count bound admits a maximally tight signature`` () : unit =
+        let parameters = List.replicate 8 typeof<int>
+
+        let decoded = decode (encodeBare typeof<int> parameters)
+
+        decoded.ParameterTypes.Length |> shouldEqual 8

--- a/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
+++ b/WoofWare.PawPrint.Test/WoofWare.PawPrint.Test.fsproj
@@ -85,6 +85,8 @@
     <Compile Include="TestNativeKernel32.fs" />
     <Compile Include="TestFieldHandleRegistry.fs" />
     <Compile Include="TestNativeMetadataImport.fs" />
+    <Compile Include="TestLocalSignatureDecoding.fs" />
+    <Compile Include="TestMethodSignatureDecoding.fs" />
     <Compile Include="TestNativeSignature.fs" />
     <Compile Include="TestNativeCustomAttribute.fs" />
     <Compile Include="TestManifestResources.fs" />


### PR DESCRIPTION
A method defined in a PE image reaches its signature through its `MethodDefinition` row, so `DecodeSignature` suffices. A method minted by `Reflection.Emit` has no such row: `DynamicILGenerator` hands `ModuleHandle.GetDynamicMethod` the bytes `SignatureHelper` produced, PawPrint records them verbatim on the `DynamicMethodDefinition`, and there is nowhere to look them up. `MethodSignatureDecoding` now decodes them directly, as `LocalSignatureDecoding` already does for the locals of the same method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)